### PR TITLE
test: migrate rust_version and rustc* to snapbox

### DIFF
--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -1,8 +1,7 @@
 //! Tests for targets with `rust-version`.
 
-#![allow(deprecated)]
-
-use cargo_test_support::{cargo_process, project, registry::Package};
+use cargo_test_support::prelude::*;
+use cargo_test_support::{cargo_process, project, registry::Package, str};
 
 #[cargo_test]
 fn rust_version_satisfied() {
@@ -47,16 +46,15 @@ fn rust_version_error() {
         .build()
         .cargo("check")
         .with_status(101)
-        .with_stderr(
-            "\
-[ERROR] unexpected version requirement, expected a version like \"1.32\"
+        .with_stderr_data(str![[r#"
+[ERROR] unexpected version requirement, expected a version like "1.32"
  --> Cargo.toml:7:28
   |
-7 |             rust-version = \"^1.43\"
+7 |             rust-version = "^1.43"
   |                            ^^^^^^^
   |
-",
-        )
+
+"#]])
         .run();
 }
 
@@ -80,8 +78,13 @@ fn rust_version_older_than_edition() {
         .build()
         .cargo("check")
         .with_status(101)
-        .with_stderr_contains("  rust-version 1.1 is older than first version (1.31.0) required by the specified edition (2018)",
-        )
+        .with_stderr_data(str![[r#"
+[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
+
+Caused by:
+  rust-version 1.1 is older than first version (1.31.0) required by the specified edition (2018)
+
+"#]])
         .run();
 }
 
@@ -106,13 +109,12 @@ fn lint_self_incompatible_with_rust_version() {
 
     p.cargo("check")
         .with_status(101)
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [ERROR] rustc [..] is not supported by the following package:
   foo@0.0.1 requires rustc 1.9876.0
 
-",
-        )
+
+"#]])
         .run();
     p.cargo("check --ignore-rust-version").run();
 }
@@ -152,21 +154,19 @@ fn lint_dep_incompatible_with_rust_version() {
         .build();
 
     p.cargo("generate-lockfile")
-        .with_stderr(
-            "\
-[UPDATING] `[..]` index
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
 [LOCKING] 4 packages to latest compatible versions
-",
-        )
+
+"#]])
         .run();
     p.cargo("check")
         .with_status(101)
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [DOWNLOADING] crates ...
-[DOWNLOADED] too_new_parent v0.0.1 (registry `[..]`)
-[DOWNLOADED] too_new_child v0.0.1 (registry `[..]`)
-[DOWNLOADED] rustc_compatible v0.0.1 (registry `[..]`)
+[DOWNLOADED] too_new_parent v0.0.1 (registry `dummy-registry`)
+[DOWNLOADED] too_new_child v0.0.1 (registry `dummy-registry`)
+[DOWNLOADED] rustc_compatible v0.0.1 (registry `dummy-registry`)
 [ERROR] rustc [..] is not supported by the following packages:
   too_new_child@0.0.1 requires rustc 1.2345.0
   too_new_parent@0.0.1 requires rustc 1.2345.0
@@ -174,8 +174,8 @@ Either upgrade rustc or select compatible dependency versions with
 `cargo update <name>@<current-ver> --precise <compatible-ver>`
 where `<compatible-ver>` is the latest version supporting rustc [..]
 
-",
-        )
+
+"#]])
         .run();
     p.cargo("check --ignore-rust-version").run();
 }
@@ -221,21 +221,19 @@ fn resolve_with_rust_version() {
         )
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest compatible versions
-",
-        )
+
+"#]])
         .run();
     p.cargo("tree")
-        .with_stdout(
-            "\
-foo v0.0.1 ([CWD])
+        .with_stdout_data(str![[r#"
+foo v0.0.1 ([ROOT]/foo)
 ├── newer-and-older v1.6.0
 └── only-newer v1.6.0
-",
-        )
+
+"#]])
         .run();
 
     p.cargo("generate-lockfile")
@@ -245,22 +243,20 @@ foo v0.0.1 ([CWD])
         )
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest Rust 1.60.0 compatible versions
 [ADDING] newer-and-older v1.5.0 (latest: v1.6.0)
-",
-        )
+
+"#]])
         .run();
     p.cargo("tree")
-        .with_stdout(
-            "\
-foo v0.0.1 ([CWD])
+        .with_stdout_data(str![[r#"
+foo v0.0.1 ([ROOT]/foo)
 ├── newer-and-older v1.5.0
 └── only-newer v1.6.0
-",
-        )
+
+"#]])
         .run();
 }
 
@@ -305,21 +301,19 @@ fn resolve_with_rustc() {
         )
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest compatible versions
-",
-        )
+
+"#]])
         .run();
     p.cargo("tree")
-        .with_stdout(
-            "\
-foo v0.0.1 ([CWD])
+        .with_stdout_data(str![[r#"
+foo v0.0.1 ([ROOT]/foo)
 ├── newer-and-older v1.6.0
 └── only-newer v1.6.0
-",
-        )
+
+"#]])
         .run();
 
     p.cargo("generate-lockfile")
@@ -329,22 +323,20 @@ foo v0.0.1 ([CWD])
         )
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest Rust [..] compatible versions
+[LOCKING] 3 packages to latest Rust 1.60.0 compatible versions
 [ADDING] newer-and-older v1.5.0 (latest: v1.6.0)
-",
-        )
+
+"#]])
         .run();
     p.cargo("tree")
-        .with_stdout(
-            "\
-foo v0.0.1 ([CWD])
+        .with_stdout_data(str![[r#"
+foo v0.0.1 ([ROOT]/foo)
 ├── newer-and-older v1.5.0
 └── only-newer v1.6.0
-",
-        )
+
+"#]])
         .run();
 }
 
@@ -387,21 +379,19 @@ fn resolve_with_backtracking() {
         )
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest compatible versions
-",
-        )
+
+"#]])
         .run();
     p.cargo("tree")
-        .with_stdout(
-            "\
-foo v0.0.1 ([CWD])
+        .with_stdout_data(str![[r#"
+foo v0.0.1 ([ROOT]/foo)
 └── no-rust-version v2.2.0
     └── has-rust-version v1.6.0
-",
-        )
+
+"#]])
         .run();
 
     // Ideally we'd pick `has-rust-version` 1.6.0 which requires backtracking
@@ -412,21 +402,19 @@ foo v0.0.1 ([CWD])
         )
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest Rust 1.60.0 compatible versions
-",
-        )
+
+"#]])
         .run();
     p.cargo("tree")
-        .with_stdout(
-            "\
-foo v0.0.1 ([CWD])
+        .with_stdout_data(str![[r#"
+foo v0.0.1 ([ROOT]/foo)
 └── no-rust-version v2.2.0
     └── has-rust-version v1.6.0
-",
-        )
+
+"#]])
         .run();
 }
 
@@ -494,21 +482,19 @@ fn resolve_with_multiple_rust_versions() {
         )
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 4 packages to latest compatible versions
-",
-        )
+
+"#]])
         .run();
     p.cargo("tree")
-        .with_stdout(
-            "\
-higher v0.0.1 ([CWD])
+        .with_stdout_data(str![[r#"
+higher v0.0.1 ([ROOT]/foo)
 ├── newer-and-older v1.6.0
 └── only-newer v1.6.0
-",
-        )
+
+"#]])
         .run();
 
     p.cargo("generate-lockfile")
@@ -518,22 +504,20 @@ higher v0.0.1 ([CWD])
         )
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 4 packages to latest Rust 1.50.0 compatible versions
 [ADDING] newer-and-older v1.5.0 (latest: v1.6.0)
-",
-        )
+
+"#]])
         .run();
     p.cargo("tree")
-        .with_stdout(
-            "\
-higher v0.0.1 ([CWD])
+        .with_stdout_data(str![[r#"
+higher v0.0.1 ([ROOT]/foo)
 ├── newer-and-older v1.5.0
 └── only-newer v1.6.0
-",
-        )
+
+"#]])
         .run();
 }
 
@@ -576,42 +560,38 @@ fn resolve_unstable_config_on_stable() {
             "CARGO_RESOLVER_SOMETHING_LIKE_PRECEDENCE",
             "something-like-rust-version",
         )
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [WARNING] ignoring `resolver` config table without `-Zmsrv-policy`
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest compatible versions
-",
-        )
+
+"#]])
         .run();
     p.cargo("tree")
-        .with_stdout(
-            "\
-foo v0.0.1 ([CWD])
+        .with_stdout_data(str![[r#"
+foo v0.0.1 ([ROOT]/foo)
 ├── newer-and-older v1.6.0
 └── only-newer v1.6.0
-",
-        )
+
+"#]])
         .run();
 
     p.cargo("generate-lockfile")
         .env("CARGO_RESOLVER_SOMETHING_LIKE_PRECEDENCE", "non-existent")
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [WARNING] ignoring `resolver` config table without `-Zmsrv-policy`
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest compatible versions
-",
-        )
+
+"#]])
         .run();
     p.cargo("tree")
-        .with_stdout(
-            "\
-foo v0.0.1 ([CWD])
+        .with_stdout_data(str![[r#"
+foo v0.0.1 ([ROOT]/foo)
 ├── newer-and-older v1.6.0
 └── only-newer v1.6.0
-",
-        )
+
+"#]])
         .run();
 }
 
@@ -655,47 +635,43 @@ fn resolve_edition2024() {
     p.cargo("generate-lockfile")
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["edition2024", "msrv-policy"])
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest Rust 1.60.0 compatible versions
 [ADDING] newer-and-older v1.5.0 (latest: v1.6.0)
-",
-        )
+
+"#]])
         .run();
     p.cargo("tree")
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["edition2024", "msrv-policy"])
-        .with_stdout(
-            "\
-foo v0.0.1 ([CWD])
+        .with_stdout_data(str![[r#"
+foo v0.0.1 ([ROOT]/foo)
 ├── newer-and-older v1.5.0
 └── only-newer v1.6.0
-",
-        )
+
+"#]])
         .run();
 
     // `--ignore-rust-version` has precedence over Edition2024
     p.cargo("generate-lockfile --ignore-rust-version")
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest compatible versions
-",
-        )
+
+"#]])
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .run();
     p.cargo("tree")
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["edition2024", "msrv-policy"])
-        .with_stdout(
-            "\
-foo v0.0.1 ([CWD])
+        .with_stdout_data(str![[r#"
+foo v0.0.1 ([ROOT]/foo)
 ├── newer-and-older v1.6.0
 └── only-newer v1.6.0
-",
-        )
+
+"#]])
         .run();
 
     // config has precedence over Edition2024
@@ -704,25 +680,23 @@ foo v0.0.1 ([CWD])
             "CARGO_RESOLVER_SOMETHING_LIKE_PRECEDENCE",
             "something-like-maximum",
         )
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest compatible versions
-",
-        )
+
+"#]])
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .run();
     p.cargo("tree")
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["edition2024", "msrv-policy"])
-        .with_stdout(
-            "\
-foo v0.0.1 ([CWD])
+        .with_stdout_data(str![[r#"
+foo v0.0.1 ([ROOT]/foo)
 ├── newer-and-older v1.6.0
 └── only-newer v1.6.0
-",
-        )
+
+"#]])
         .run();
 }
 
@@ -767,47 +741,43 @@ fn resolve_v3() {
     p.cargo("generate-lockfile")
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["edition2024", "msrv-policy"])
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest Rust 1.60.0 compatible versions
 [ADDING] newer-and-older v1.5.0 (latest: v1.6.0)
-",
-        )
+
+"#]])
         .run();
     p.cargo("tree")
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["edition2024", "msrv-policy"])
-        .with_stdout(
-            "\
-foo v0.0.1 ([CWD])
+        .with_stdout_data(str![[r#"
+foo v0.0.1 ([ROOT]/foo)
 ├── newer-and-older v1.5.0
 └── only-newer v1.6.0
-",
-        )
+
+"#]])
         .run();
 
     // `--ignore-rust-version` has precedence over v3
     p.cargo("generate-lockfile --ignore-rust-version")
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest compatible versions
-",
-        )
+
+"#]])
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .run();
     p.cargo("tree")
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["edition2024", "msrv-policy"])
-        .with_stdout(
-            "\
-foo v0.0.1 ([CWD])
+        .with_stdout_data(str![[r#"
+foo v0.0.1 ([ROOT]/foo)
 ├── newer-and-older v1.6.0
 └── only-newer v1.6.0
-",
-        )
+
+"#]])
         .run();
 
     // config has precedence over v3
@@ -816,40 +786,37 @@ foo v0.0.1 ([CWD])
             "CARGO_RESOLVER_SOMETHING_LIKE_PRECEDENCE",
             "something-like-maximum",
         )
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest compatible versions
-",
-        )
+
+"#]])
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .run();
     p.cargo("tree")
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["edition2024", "msrv-policy"])
-        .with_stdout(
-            "\
-foo v0.0.1 ([CWD])
+        .with_stdout_data(str![[r#"
+foo v0.0.1 ([ROOT]/foo)
 ├── newer-and-older v1.6.0
 └── only-newer v1.6.0
-",
-        )
+
+"#]])
         .run();
 
     // unstable
     p.cargo("generate-lockfile")
         .with_status(101)
-        .with_stderr(
-            "\
-[ERROR] failed to parse manifest at `[CWD]/Cargo.toml`
+        .with_stderr_data(str![[r#"
+[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
 
 Caused by:
   the cargo feature `edition2024` requires a nightly version of Cargo, but this is the `stable` channel
   See https://doc.rust-lang.org/book/appendix-07-nightly-rust.html for more information about Rust release channels.
   See https://doc.rust-lang.org/cargo/reference/unstable.html#edition-2024 for more information about using this feature.
-",
-        )
+
+"#]])
         .run();
 }
 
@@ -883,13 +850,12 @@ fn generate_lockfile_ignore_rust_version_is_unstable() {
 
     p.cargo("generate-lockfile --ignore-rust-version")
         .with_status(101)
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [ERROR] the `--ignore-rust-version` flag is unstable, and only available on the nightly channel of Cargo, but this is the `stable` channel
 See https://doc.rust-lang.org/book/appendix-07-nightly-rust.html for more information about Rust release channels.
 See https://github.com/rust-lang/cargo/issues/9930 for more information about the `--ignore-rust-version` flag.
-",
-        )
+
+"#]])
         .run();
 }
 
@@ -928,23 +894,21 @@ fn update_msrv_resolve() {
         )
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest Rust 1.60.0 compatible versions
 [ADDING] bar v1.5.0 (latest: v1.6.0)
-",
-        )
+
+"#]])
         .run();
     p.cargo("update --ignore-rust-version")
         .with_status(101)
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [ERROR] the `--ignore-rust-version` flag is unstable, and only available on the nightly channel of Cargo, but this is the `stable` channel
 See https://doc.rust-lang.org/book/appendix-07-nightly-rust.html for more information about Rust release channels.
 See https://github.com/rust-lang/cargo/issues/9930 for more information about the `--ignore-rust-version` flag.
-",
-        )
+
+"#]])
         .run();
     p.cargo("update --ignore-rust-version")
         .env(
@@ -953,13 +917,12 @@ See https://github.com/rust-lang/cargo/issues/9930 for more information about th
         )
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [UPDATING] bar v1.5.0 -> v1.6.0
-",
-        )
+
+"#]])
         .run();
 }
 
@@ -998,13 +961,12 @@ fn update_precise_overrides_msrv_resolver() {
         )
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest Rust 1.60.0 compatible versions
 [ADDING] bar v1.5.0 (latest: v1.6.0)
-",
-        )
+
+"#]])
         .run();
     p.cargo("update --precise 1.6.0 bar")
         .env(
@@ -1013,12 +975,11 @@ fn update_precise_overrides_msrv_resolver() {
         )
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [UPDATING] bar v1.5.0 -> v1.6.0
-",
-        )
+
+"#]])
         .run();
 }
 
@@ -1063,28 +1024,29 @@ fn check_msrv_resolve() {
         )
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
-        .with_stderr(
-            "\
+        .with_stderr_data(
+            str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
-[DOWNLOADED] [..]
-[DOWNLOADED] [..]
-[CHECKING] [..]
-[CHECKING] [..]
-[CHECKING] foo [..]
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
-",
+[DOWNLOADED] only-newer v1.6.0 (registry `dummy-registry`)
+[DOWNLOADED] newer-and-older v1.6.0 (registry `dummy-registry`)
+[CHECKING] only-newer v1.6.0
+[CHECKING] newer-and-older v1.6.0
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]]
+            .unordered(),
         )
         .run();
     p.cargo("tree")
-        .with_stdout(
-            "\
-foo v0.0.1 ([CWD])
+        .with_stdout_data(str![[r#"
+foo v0.0.1 ([ROOT]/foo)
 ├── newer-and-older v1.6.0
 └── only-newer v1.6.0
-",
-        )
+
+"#]])
         .run();
 
     std::fs::remove_file(p.root().join("Cargo.lock")).unwrap();
@@ -1095,27 +1057,25 @@ foo v0.0.1 ([CWD])
         )
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest Rust 1.60.0 compatible versions
 [ADDING] newer-and-older v1.5.0 (latest: v1.6.0)
 [DOWNLOADING] crates ...
-[DOWNLOADED] [..]
-[CHECKING] [..]
-[CHECKING] foo [..]
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
-",
-        )
+[DOWNLOADED] newer-and-older v1.5.0 (registry `dummy-registry`)
+[CHECKING] newer-and-older v1.5.0
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
     p.cargo("tree")
-        .with_stdout(
-            "\
-foo v0.0.1 ([CWD])
+        .with_stdout_data(str![[r#"
+foo v0.0.1 ([ROOT]/foo)
 ├── newer-and-older v1.5.0
 └── only-newer v1.6.0
-",
-        )
+
+"#]])
         .run();
 }
 
@@ -1142,22 +1102,21 @@ fn cargo_install_ignores_msrv_config() {
         )
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
-        .with_stderr(
-            "\
-[UPDATING] `[..]` index
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
-[DOWNLOADED] foo v0.0.1 (registry [..])
+[DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
 [INSTALLING] foo v0.0.1
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
-[DOWNLOADED] dep v1.1.0 (registry [..])
+[DOWNLOADED] dep v1.1.0 (registry `dummy-registry`)
 [COMPILING] dep v1.1.0
 [COMPILING] foo v0.0.1
-[FINISHED] `release` profile [optimized] target(s) in [..]
-[INSTALLING] [CWD]/home/.cargo/bin/foo[EXE]
+[FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
+[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
 [INSTALLED] package `foo v0.0.1` (executable `foo[EXE]`)
-[WARNING] be sure to add `[..]` to your PATH to be able to run the installed binaries
-",
-        )
+[WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
+
+"#]])
         .run();
 }

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -1,12 +1,7 @@
 //! Tests for the `cargo rustc` command.
 
-#![allow(deprecated)]
-
-use cargo_test_support::{basic_bin_manifest, basic_lib_manifest, basic_manifest, project};
-
-const CARGO_RUSTC_ERROR: &str =
-    "[ERROR] extra arguments to `rustc` can only be passed to one target, consider filtering
-the package by passing, e.g., `--lib` or `--bin NAME` to specify a single target";
+use cargo_test_support::prelude::*;
+use cargo_test_support::{basic_bin_manifest, basic_lib_manifest, basic_manifest, project, str};
 
 #[cargo_test]
 fn build_lib_for_foo() {
@@ -15,19 +10,12 @@ fn build_lib_for_foo() {
         .file("src/lib.rs", r#" "#)
         .build();
 
-    p.cargo("rustc --lib -v")
-        .with_stderr(
-            "\
-[COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib \
-        --emit=[..]link[..]-C debuginfo=2 [..]\
-        -C metadata=[..] \
-        --out-dir [..] \
-        -L dependency=[CWD]/target/debug/deps`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
-        .run();
+    p.cargo("rustc --lib -v").with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=2 [..]-C metadata=[..] [..]--out-dir [ROOT]/foo/target/debug/deps -L dependency=[ROOT]/foo/target/debug/deps`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]]).run();
 }
 
 #[cargo_test]
@@ -38,18 +26,12 @@ fn lib() {
         .build();
 
     p.cargo("rustc --lib -v -- -C debug-assertions=off")
-        .with_stderr(
-            "\
-[COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib \
-        --emit=[..]link[..]-C debuginfo=2 [..]\
-        -C debug-assertions=off[..]\
-        -C metadata=[..] \
-        --out-dir [..] \
-        -L dependency=[CWD]/target/debug/deps`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=2 [..]-C debug-assertions=off[..]-C metadata=[..] [..]--out-dir [ROOT]/foo/target/debug/deps -L dependency=[ROOT]/foo/target/debug/deps`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -61,26 +43,13 @@ fn build_main_and_allow_unstable_options() {
         .build();
 
     p.cargo("rustc -v --bin foo -- -C debug-assertions")
-        .with_stderr(format!(
-            "\
-[COMPILING] {name} v{version} ([CWD])
-[RUNNING] `rustc --crate-name {name} --edition=2015 src/lib.rs [..]--crate-type lib \
-        --emit=[..]link[..]-C debuginfo=2 [..]\
-        -C metadata=[..] \
-        --out-dir [..] \
-        -L dependency=[CWD]/target/debug/deps`
-[RUNNING] `rustc --crate-name {name} --edition=2015 src/main.rs [..]--crate-type bin \
-        --emit=[..]link[..]-C debuginfo=2 [..]\
-        -C debug-assertions[..]\
-        -C metadata=[..] \
-        --out-dir [..] \
-        -L dependency=[CWD]/target/debug/deps \
-        --extern {name}=[CWD]/target/debug/deps/lib{name}-[..].rlib`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-            name = "foo",
-            version = "0.0.1"
-        ))
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=2 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/deps -L dependency=[ROOT]/foo/target/debug/deps`
+[RUNNING] `rustc --crate-name foo --edition=2015 src/main.rs [..]--crate-type bin --emit=[..]link[..]-C debuginfo=2 [..]-C debug-assertions[..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/deps -L dependency=[ROOT]/foo/target/debug/deps --extern foo=[ROOT]/foo/target/debug/deps/libfoo-[HASH].rlib`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -93,7 +62,11 @@ fn fails_when_trying_to_build_main_and_lib_with_args() {
 
     p.cargo("rustc -v -- -C debug-assertions")
         .with_status(101)
-        .with_stderr(CARGO_RUSTC_ERROR)
+        .with_stderr_data(str![[r#"
+[ERROR] extra arguments to `rustc` can only be passed to one target, consider filtering
+the package by passing, e.g., `--lib` or `--bin NAME` to specify a single target
+
+"#]])
         .run();
 }
 
@@ -107,17 +80,13 @@ fn build_with_args_to_one_of_multiple_binaries() {
         .build();
 
     p.cargo("rustc -v --bin bar -- -C debug-assertions")
-        .with_stderr(
-            "\
-[COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]\
-        -C debuginfo=2 [..]-C metadata=[..] \
-        --out-dir [..]`
-[RUNNING] `rustc --crate-name bar --edition=2015 src/bin/bar.rs [..]--crate-type bin --emit=[..]link[..]\
-        -C debuginfo=2 [..]-C debug-assertions [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=2 [..]-C metadata=[..] --out-dir [..]`
+[RUNNING] `rustc --crate-name bar --edition=2015 src/bin/bar.rs [..]--crate-type bin --emit=[..]link[..]-C debuginfo=2 [..]-C debug-assertions [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -132,7 +101,11 @@ fn fails_with_args_to_all_binaries() {
 
     p.cargo("rustc -v -- -C debug-assertions")
         .with_status(101)
-        .with_stderr(CARGO_RUSTC_ERROR)
+        .with_stderr_data(str![[r#"
+[ERROR] extra arguments to `rustc` can only be passed to one target, consider filtering
+the package by passing, e.g., `--lib` or `--bin NAME` to specify a single target
+
+"#]])
         .run();
 }
 
@@ -147,10 +120,11 @@ fn fails_with_crate_type_to_multi_binaries() {
 
     p.cargo("rustc --crate-type lib")
         .with_status(101)
-        .with_stderr(
-            "[ERROR] crate types to rustc can only be passed to one target, consider filtering
-the package by passing, e.g., `--lib` or `--example` to specify a single target",
-        )
+        .with_stderr_data(str![[r#"
+[ERROR] crate types to rustc can only be passed to one target, consider filtering
+the package by passing, e.g., `--lib` or `--example` to specify a single target
+
+"#]])
         .run();
 }
 
@@ -181,10 +155,11 @@ fn fails_with_crate_type_to_multi_examples() {
 
     p.cargo("rustc -v --example ex1 --example ex2 --crate-type lib,cdylib")
         .with_status(101)
-        .with_stderr(
-            "[ERROR] crate types to rustc can only be passed to one target, consider filtering
-the package by passing, e.g., `--lib` or `--example` to specify a single target",
-        )
+        .with_stderr_data(str![[r#"
+[ERROR] crate types to rustc can only be passed to one target, consider filtering
+the package by passing, e.g., `--lib` or `--example` to specify a single target
+
+"#]])
         .run();
 }
 
@@ -194,10 +169,11 @@ fn fails_with_crate_type_to_binary() {
 
     p.cargo("rustc --crate-type lib")
         .with_status(101)
-        .with_stderr(
-            "[ERROR] crate types can only be specified for libraries and example libraries.
-Binaries, tests, and benchmarks are always the `bin` crate type",
-        )
+        .with_stderr_data(str![[r#"
+[ERROR] crate types can only be specified for libraries and example libraries.
+Binaries, tests, and benchmarks are always the `bin` crate type
+
+"#]])
         .run();
 }
 
@@ -206,13 +182,12 @@ fn build_with_crate_type_for_foo() {
     let p = project().file("src/lib.rs", "").build();
 
     p.cargo("rustc -v --crate-type cdylib")
-        .with_stderr(
-            "\
-[COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type cdylib [..]
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type cdylib [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -244,16 +219,15 @@ fn build_with_crate_type_for_foo_with_deps() {
         .build();
 
     p.cargo("rustc -v --crate-type cdylib")
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [LOCKING] 2 packages to latest compatible versions
-[COMPILING] a v0.1.0 ([CWD]/a)
-[RUNNING] `rustc --crate-name a --edition=2015 a/src/lib.rs [..]--crate-type lib [..]
-[COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type cdylib [..]
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+[COMPILING] a v0.1.0 ([ROOT]/foo/a)
+[RUNNING] `rustc --crate-name a --edition=2015 a/src/lib.rs [..]--crate-type lib [..]`
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type cdylib [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -262,13 +236,12 @@ fn build_with_crate_types_for_foo() {
     let p = project().file("src/lib.rs", "").build();
 
     p.cargo("rustc -v --crate-type lib,cdylib")
-        .with_stderr(
-            "\
-[COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib,cdylib [..]
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib,cdylib [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -294,14 +267,13 @@ fn build_with_crate_type_to_example() {
         .build();
 
     p.cargo("rustc -v --example ex --crate-type cdylib")
-        .with_stderr(
-            "\
-[COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib [..]
-[RUNNING] `rustc --crate-name ex --edition=2015 examples/ex.rs [..]--crate-type cdylib [..]
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib [..]`
+[RUNNING] `rustc --crate-name ex --edition=2015 examples/ex.rs [..]--crate-type cdylib [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -327,14 +299,13 @@ fn build_with_crate_types_to_example() {
         .build();
 
     p.cargo("rustc -v --example ex --crate-type lib,cdylib")
-        .with_stderr(
-            "\
-[COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib [..]
-[RUNNING] `rustc --crate-name ex --edition=2015 examples/ex.rs [..]--crate-type lib,cdylib [..]
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib [..]`
+[RUNNING] `rustc --crate-name ex --edition=2015 examples/ex.rs [..]--crate-type lib,cdylib [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -364,14 +335,13 @@ fn build_with_crate_types_to_one_of_multi_examples() {
         .build();
 
     p.cargo("rustc -v --example ex1 --crate-type lib,cdylib")
-        .with_stderr(
-            "\
-[COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib [..]
-[RUNNING] `rustc --crate-name ex1 --edition=2015 examples/ex1.rs [..]--crate-type lib,cdylib [..]
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib [..]`
+[RUNNING] `rustc --crate-name ex1 --edition=2015 examples/ex1.rs [..]--crate-type lib,cdylib [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -385,17 +355,13 @@ fn build_with_args_to_one_of_multiple_tests() {
         .build();
 
     p.cargo("rustc -v --test bar -- -C debug-assertions")
-        .with_stderr(
-            "\
-[COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]\
-        -C debuginfo=2 [..]-C metadata=[..] \
-        --out-dir [..]`
-[RUNNING] `rustc --crate-name bar --edition=2015 tests/bar.rs [..]--emit=[..]link[..]-C debuginfo=2 [..]\
-        -C debug-assertions [..]--test[..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=2 [..]-C metadata=[..] --out-dir [..]`
+[RUNNING] `rustc --crate-name bar --edition=2015 tests/bar.rs [..]--emit=[..]link[..]-C debuginfo=2 [..]-C debug-assertions --test[..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -424,16 +390,15 @@ fn build_foo_with_bar_dependency() {
         .build();
 
     foo.cargo("rustc -v -- -C debug-assertions")
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [LOCKING] 2 packages to latest compatible versions
-[COMPILING] bar v0.1.0 ([..])
-[RUNNING] `[..] -C debuginfo=2 [..]`
-[COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `[..] -C debuginfo=2 [..]-C debug-assertions [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+[COMPILING] bar v0.1.0 ([ROOT]/bar)
+[RUNNING] `rustc --crate-name bar [..] -C debuginfo=2[..]`
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..] -C debuginfo=2 [..]-C debug-assertions [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -462,17 +427,17 @@ fn build_only_bar_dependency() {
         .build();
 
     foo.cargo("rustc -v -p bar -- -C debug-assertions")
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [LOCKING] 2 packages to latest compatible versions
-[COMPILING] bar v0.1.0 ([..])
+[COMPILING] bar v0.1.0 ([ROOT]/bar)
 [RUNNING] `rustc --crate-name bar [..]--crate-type lib [..] -C debug-assertions [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
+#[allow(deprecated)]
 #[cargo_test]
 fn targets_selected_default() {
     let p = project().file("src/main.rs", "fn main() {}").build();
@@ -499,15 +464,15 @@ fn targets_selected_default() {
 fn targets_selected_all() {
     let p = project().file("src/main.rs", "fn main() {}").build();
     p.cargo("rustc -v --all-targets")
-        // bin
-        .with_stderr_contains(
-            "[RUNNING] `rustc --crate-name foo --edition=2015 src/main.rs [..]--crate-type bin \
-             --emit=[..]link[..]",
-        )
-        // unit test
-        .with_stderr_contains(
-            "[RUNNING] `rustc --crate-name foo --edition=2015 src/main.rs [..]--emit=[..]link[..]\
-             -C debuginfo=2 [..]--test [..]",
+        // bin and unit test
+        .with_stderr_data(
+            str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo --edition=2015 src/main.rs [..]--crate-type bin --emit=[..]link[..]`
+[RUNNING] `rustc --crate-name foo --edition=2015 src/main.rs [..]--emit[..]link[..] -C debuginfo=2 [..]--test [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]].unordered()
         )
         .run();
 }
@@ -562,11 +527,10 @@ fn fail_with_multiple_packages() {
 
     foo.cargo("rustc -v -p bar -p baz")
         .with_status(1)
-        .with_stderr_contains(
-            "\
-error: the argument '--package [<SPEC>]' cannot be used multiple times
-",
-        )
+        .with_stderr_data(str![[r#"
+[ERROR] the argument '--package [<SPEC>]' cannot be used multiple times
+...
+"#]])
         .run();
 }
 
@@ -586,7 +550,10 @@ fn fail_with_glob() {
 
     p.cargo("rustc -p '*z'")
         .with_status(101)
-        .with_stderr("[ERROR] Glob patterns on package selection are not supported.")
+        .with_stderr_data(str![[r#"
+[ERROR] Glob patterns on package selection are not supported.
+
+"#]])
         .run();
 }
 
@@ -622,6 +589,7 @@ fn rustc_with_other_profile() {
     p.cargo("rustc --profile test").run();
 }
 
+#[allow(deprecated)]
 #[cargo_test]
 fn rustc_fingerprint() {
     // Verify that the fingerprint includes the rustc args.
@@ -631,43 +599,39 @@ fn rustc_fingerprint() {
         .build();
 
     p.cargo("rustc -v -- -C debug-assertions")
-        .with_stderr(
-            "\
-[COMPILING] foo [..]
-[RUNNING] `rustc [..]-C debug-assertions [..]
-[FINISHED] [..]
-",
-        )
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.5.0 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]-C debug-assertions [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 
     p.cargo("rustc -v -- -C debug-assertions")
-        .with_stderr(
-            "\
-[FRESH] foo [..]
-[FINISHED] [..]
-",
-        )
+        .with_stderr_data(str![[r#"
+[FRESH] foo v0.5.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 
     p.cargo("rustc -v")
         .with_stderr_does_not_contain("-C debug-assertions")
-        .with_stderr(
-            "\
-[DIRTY] foo [..]: the profile configuration changed
-[COMPILING] foo [..]
-[RUNNING] `rustc [..]
-[FINISHED] [..]
-",
-        )
+        .with_stderr_data(str![[r#"
+[DIRTY] foo v0.5.0 ([ROOT]/foo): the profile configuration changed
+[COMPILING] foo v0.5.0 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 
     p.cargo("rustc -v")
-        .with_stderr(
-            "\
-[FRESH] foo [..]
-[FINISHED] [..]
-",
-        )
+        .with_stderr_data(str![[r#"
+[FRESH] foo v0.5.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -693,15 +657,16 @@ fn rustc_test_with_implicit_bin() {
         .build();
 
     p.cargo("rustc --test test1 -v -- --cfg foo")
-        .with_stderr_contains(
-            "\
-[RUNNING] `rustc --crate-name test1 --edition=2015 tests/test1.rs [..] --cfg foo [..]
-",
-        )
-        .with_stderr_contains(
-            "\
-[RUNNING] `rustc --crate-name foo --edition=2015 src/main.rs [..]
-",
+        .with_stderr_data(
+            str![[r#"
+[COMPILING] foo v0.5.0 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name test1 --edition=2015 tests/test1.rs [..] --cfg foo [..]`
+[RUNNING] `rustc --crate-name foo --edition=2015 src/main.rs [..]`
+...
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]]
+            .unordered(),
         )
         .run();
 }
@@ -715,15 +680,21 @@ fn rustc_with_print_cfg_single_target() {
 
     p.cargo("rustc -Z unstable-options --target x86_64-pc-windows-msvc --print cfg")
         .masquerade_as_nightly_cargo(&["print"])
-        .with_stdout_contains("debug_assertions")
-        .with_stdout_contains("target_arch=\"x86_64\"")
-        .with_stdout_contains("target_endian=\"little\"")
-        .with_stdout_contains("target_env=\"msvc\"")
-        .with_stdout_contains("target_family=\"windows\"")
-        .with_stdout_contains("target_os=\"windows\"")
-        .with_stdout_contains("target_pointer_width=\"64\"")
-        .with_stdout_contains("target_vendor=\"pc\"")
-        .with_stdout_contains("windows")
+        .with_stdout_data(
+            str![[r#"
+debug_assertions
+target_arch="x86_64"
+target_endian="little"
+target_env="msvc"
+target_family="windows"
+target_os="windows"
+target_pointer_width="64"
+target_vendor="pc"
+windows
+...
+"#]]
+            .unordered(),
+        )
         .run();
 }
 
@@ -736,21 +707,27 @@ fn rustc_with_print_cfg_multiple_targets() {
 
     p.cargo("rustc -Z unstable-options --target x86_64-pc-windows-msvc --target i686-unknown-linux-gnu --print cfg")
         .masquerade_as_nightly_cargo(&["print"])
-        .with_stdout_contains("debug_assertions")
-        .with_stdout_contains("target_arch=\"x86_64\"")
-        .with_stdout_contains("target_endian=\"little\"")
-        .with_stdout_contains("target_env=\"msvc\"")
-        .with_stdout_contains("target_family=\"windows\"")
-        .with_stdout_contains("target_os=\"windows\"")
-        .with_stdout_contains("target_pointer_width=\"64\"")
-        .with_stdout_contains("target_vendor=\"pc\"")
-        .with_stdout_contains("windows")
-        .with_stdout_contains("target_env=\"gnu\"")
-        .with_stdout_contains("target_family=\"unix\"")
-        .with_stdout_contains("target_pointer_width=\"32\"")
-        .with_stdout_contains("target_vendor=\"unknown\"")
-        .with_stdout_contains("target_os=\"linux\"")
-        .with_stdout_contains("unix")
+        .with_stdout_data(str![[r#"
+debug_assertions
+target_arch="x86"
+target_endian="little"
+target_env="gnu"
+target_family="unix"
+target_os="linux"
+target_pointer_width="32"
+target_vendor="unknown"
+unix
+debug_assertions
+target_arch="x86_64"
+target_endian="little"
+target_env="msvc"
+target_family="windows"
+target_os="windows"
+target_pointer_width="64"
+target_vendor="pc"
+windows
+...
+"#]].unordered())
         .run();
 }
 
@@ -764,16 +741,22 @@ fn rustc_with_print_cfg_rustflags_env_var() {
     p.cargo("rustc -Z unstable-options --target x86_64-pc-windows-msvc --print cfg")
         .masquerade_as_nightly_cargo(&["print"])
         .env("RUSTFLAGS", "-C target-feature=+crt-static")
-        .with_stdout_contains("debug_assertions")
-        .with_stdout_contains("target_arch=\"x86_64\"")
-        .with_stdout_contains("target_endian=\"little\"")
-        .with_stdout_contains("target_env=\"msvc\"")
-        .with_stdout_contains("target_family=\"windows\"")
-        .with_stdout_contains("target_feature=\"crt-static\"")
-        .with_stdout_contains("target_os=\"windows\"")
-        .with_stdout_contains("target_pointer_width=\"64\"")
-        .with_stdout_contains("target_vendor=\"pc\"")
-        .with_stdout_contains("windows")
+        .with_stdout_data(
+            str![[r#"
+debug_assertions
+target_arch="x86_64"
+target_endian="little"
+target_env="msvc"
+target_family="windows"
+target_feature="crt-static"
+target_os="windows"
+target_pointer_width="64"
+target_vendor="pc"
+windows
+...
+"#]]
+            .unordered(),
+        )
         .run();
 }
 
@@ -794,15 +777,21 @@ rustflags = ["-C", "target-feature=+crt-static"]
     p.cargo("rustc -Z unstable-options --target x86_64-pc-windows-msvc --print cfg")
         .masquerade_as_nightly_cargo(&["print"])
         .env("RUSTFLAGS", "-C target-feature=+crt-static")
-        .with_stdout_contains("debug_assertions")
-        .with_stdout_contains("target_arch=\"x86_64\"")
-        .with_stdout_contains("target_endian=\"little\"")
-        .with_stdout_contains("target_env=\"msvc\"")
-        .with_stdout_contains("target_family=\"windows\"")
-        .with_stdout_contains("target_feature=\"crt-static\"")
-        .with_stdout_contains("target_os=\"windows\"")
-        .with_stdout_contains("target_pointer_width=\"64\"")
-        .with_stdout_contains("target_vendor=\"pc\"")
-        .with_stdout_contains("windows")
+        .with_stdout_data(
+            str![[r#"
+debug_assertions
+target_arch="x86_64"
+target_endian="little"
+target_env="msvc"
+target_family="windows"
+target_feature="crt-static"
+target_os="windows"
+target_pointer_width="64"
+target_vendor="pc"
+windows
+...
+"#]]
+            .unordered(),
+        )
         .run();
 }

--- a/tests/testsuite/rustc_info_cache.rs
+++ b/tests/testsuite/rustc_info_cache.rs
@@ -1,7 +1,5 @@
 //! Tests for the cache file for the rustc version info.
 
-#![allow(deprecated)]
-
 use cargo_test_support::{basic_bin_manifest, paths::CargoPathExt};
 use cargo_test_support::{basic_manifest, project};
 use std::env;
@@ -10,6 +8,7 @@ const MISS: &str = "[..] rustc info cache miss[..]";
 const HIT: &str = "[..]rustc info cache hit[..]";
 const UPDATE: &str = "[..]updated rustc info cache[..]";
 
+#[allow(deprecated)]
 #[cargo_test]
 fn rustc_info_cache() {
     let p = project()
@@ -105,6 +104,7 @@ fn rustc_info_cache() {
         .run();
 }
 
+#[allow(deprecated)]
 #[cargo_test]
 fn rustc_info_cache_with_wrappers() {
     let wrapper_project = project()


### PR DESCRIPTION
### What does this PR try to resolve?

Part of https://github.com/rust-lang/cargo/issues/14039.

Migrate following to snapbox:

- `tests/testsuite/rust_version.rs`
- `tests/testsuite/rustc.rs`
- `tests/testsuite/rustc_info_cache.rs`