### PR TITLE
Check build target supports std when building with -Zbuild-std=std

### DIFF
--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -72,6 +72,17 @@ pub fn resolve_std<'gctx>(
             .warn("-Zbuild-std does not currently fully support --build-plan")?;
     }
 
+    // check that targets support building std
+    if crates.contains(&"std".to_string()) {
+        let unsupported_targets = target_data.get_unsupported_std_targets();
+        if !unsupported_targets.is_empty() {
+            anyhow::bail!(
+                "building std is not supported on the following targets: {}",
+                unsupported_targets.join(", ")
+            )
+        }
+    }
+
     let src_path = detect_sysroot_src_path(target_data)?;
     let std_ws_manifest_path = src_path.join("Cargo.toml");
     let gctx = ws.gctx();

--- a/tests/testsuite/standard_lib.rs
+++ b/tests/testsuite/standard_lib.rs
@@ -324,6 +324,32 @@ fn check_core() {
 }
 
 #[cargo_test(build_std_mock)]
+fn test_std_on_unsupported_target() {
+    let setup = setup();
+
+    let p = project()
+        .file(
+            "src/main.rs",
+            r#"
+        fn main() {
+            println!("hello");
+        }
+        "#,
+        )
+        .build();
+
+    p.cargo("build")
+        .arg("--target=aarch64-unknown-none")
+        .arg("--target=x86_64-unknown-none")
+        .build_std(&setup)
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] building std is not supported on the following targets: [..]
+"#]])
+        .run();
+}
+
+#[cargo_test(build_std_mock)]
 fn depend_same_as_std() {
     let setup = setup();
 


### PR DESCRIPTION
**What does this PR try to resolve?**

Ensures that Cargo first verifies whether a given target supports building the standard library when the `-Zbuild-std=std` option is passed to Cargo ([see issue here](https://github.com/rust-lang/wg-cargo-std-aware/issues/87)). This information can be obtained by querying `rustc --print=target-spec-json`. The target spec "metadata" contains an `Option<bool>` determining whether the target supports building std.

In the case this value is `false`, cargo will stop the build. This avoids the numerous "use of unstable library" errors, giving a cleaner, and simpler, "building std is not supported on this target".

**How should we test and review this PR?**

It can be manually tested by running `cargo build --target <target> -Zbuild-std=std`. If a target who's target-spec marks std as false is passed, cargo will exit. This works with multiple `--target`'s, and if any of them don't support std, cargo will exit.

**Additional Information**

This change relies on two things:
* The target-spec metadata in rustc needs to be filled out. Currently, most fields are None, which is treated as OK with this change. Meaning this can be merged before the rustc changes.
* The new test case added with this change will fail without at least `aarch64-unknown-none` having it's target-spec metadata completed.
* Some targets have std support marked as "?". If this state is properly represented in the target-spec in the future, it needs to be determined whether this is allowed, so the build can continue, or whether it fails.
