### PR TITLE
test: migrate generate_lockfile and glob_targets to snapbox

### DIFF
--- a/tests/testsuite/generate_lockfile.rs
+++ b/tests/testsuite/generate_lockfile.rs
@@ -215,6 +215,7 @@ fn duplicate_entries_in_lockfile() {
             name = "b"
             authors = []
             version = "0.0.1"
+            edition = "2015"
 
             [dependencies]
             common = {path="common"}

--- a/tests/testsuite/generate_lockfile.rs
+++ b/tests/testsuite/generate_lockfile.rs
@@ -1,9 +1,8 @@
 //! Tests for the `cargo generate-lockfile` command.
 
-#![allow(deprecated)]
-
 use cargo_test_support::registry::{Package, RegistryBuilder};
-use cargo_test_support::{basic_manifest, paths, project, ProjectBuilder};
+use cargo_test_support::{basic_manifest, paths, project, str, ProjectBuilder};
+use snapbox::IntoData;
 use std::fs;
 
 #[cargo_test]
@@ -61,15 +60,35 @@ fn adding_and_removing_packages() {
 #[cargo_test]
 fn no_index_update_sparse() {
     let _registry = RegistryBuilder::new().http_index().build();
-    no_index_update();
+    no_index_update(
+        str![[r#"
+[UPDATING] `dummy-registry` index
+[LOCKING] 2 packages to latest compatible versions
+
+"#]],
+        str![[r#"
+[LOCKING] 2 packages to latest compatible versions
+
+"#]],
+    );
 }
 
 #[cargo_test]
 fn no_index_update_git() {
-    no_index_update();
+    no_index_update(
+        str![[r#"
+[UPDATING] `dummy-registry` index
+[LOCKING] 2 packages to latest compatible versions
+
+"#]],
+        str![[r#"
+[LOCKING] 2 packages to latest compatible versions
+
+"#]],
+    );
 }
 
-fn no_index_update() {
+fn no_index_update(expected: impl IntoData, expected_unstable_option: impl IntoData) {
     Package::new("serde", "1.0.0").publish();
 
     let p = project()
@@ -89,22 +108,13 @@ fn no_index_update() {
         .build();
 
     p.cargo("generate-lockfile")
-        .with_stderr(
-            "\
-[UPDATING] `[..]` index
-[LOCKING] 2 packages to latest compatible versions
-",
-        )
+        .with_stderr_data(expected)
         .run();
 
     p.cargo("generate-lockfile -Zno-index-update")
         .masquerade_as_nightly_cargo(&["no-index-update"])
-        .with_stdout("")
-        .with_stderr(
-            "\
-[LOCKING] 2 packages to latest compatible versions
-",
-        )
+        .with_stdout_data("")
+        .with_stderr_data(expected_unstable_option)
         .run();
 }
 
@@ -172,13 +182,13 @@ fn cargo_update_generate_lockfile() {
 
     let lockfile = p.root().join("Cargo.lock");
     assert!(!lockfile.is_file());
-    p.cargo("update").with_stderr("").run();
+    p.cargo("update").with_stderr_data("").run();
     assert!(lockfile.is_file());
 
     fs::remove_file(p.root().join("Cargo.lock")).unwrap();
 
     assert!(!lockfile.is_file());
-    p.cargo("update").with_stderr("").run();
+    p.cargo("update").with_stderr_data("").run();
     assert!(lockfile.is_file());
 }
 
@@ -233,11 +243,10 @@ fn duplicate_entries_in_lockfile() {
     // should fail due to a duplicate package `common` in the lock file
     b.cargo("build")
         .with_status(101)
-        .with_stderr_contains(
-            "[..]package collision in the lockfile: packages common [..] and \
-             common [..] are different, but only one can be written to \
-             lockfile unambiguously",
-        )
+        .with_stderr_data(str![[r#"
+[ERROR] package collision in the lockfile: packages common v0.0.1 ([ROOT]/a/common) and common v0.0.1 ([ROOT]/b/common) are different, but only one can be written to lockfile unambiguously
+
+"#]])
         .run();
 }
 
@@ -260,19 +269,17 @@ fn generate_lockfile_holds_lock_and_offline() {
         .build();
 
     p.cargo("generate-lockfile")
-        .with_stderr(
-            "\
-[UPDATING] `[..]` index
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
-",
-        )
+
+"#]])
         .run();
 
     p.cargo("generate-lockfile --offline")
-        .with_stderr_contains(
-            "\
+        .with_stderr_data(str![[r#"
 [LOCKING] 2 packages to latest compatible versions
-",
-        )
+
+"#]])
         .run();
 }

--- a/tests/testsuite/glob_targets.rs
+++ b/tests/testsuite/glob_targets.rs
@@ -1,20 +1,18 @@
 //! Tests for target filter flags with glob patterns.
 
-#![allow(deprecated)]
-
-use cargo_test_support::{project, Project};
+use cargo_test_support::prelude::*;
+use cargo_test_support::{project, str, Project};
 
 #[cargo_test]
 fn build_example() {
     full_project()
         .cargo("build -v --example 'ex*1'")
-        .with_stderr(
-            "\
-[COMPILING] foo v0.0.1 ([CWD])
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name example1 [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -22,13 +20,12 @@ fn build_example() {
 fn build_bin() {
     full_project()
         .cargo("build -v --bin 'bi*1'")
-        .with_stderr(
-            "\
-[COMPILING] foo v0.0.1 ([CWD])
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name bin1 [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -36,19 +33,17 @@ fn build_bin() {
 fn build_bench() {
     full_project()
         .cargo("build -v --bench 'be*1'")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name bench1 [..]`")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name bin2 [..]`")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name bin1 [..]`")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name foo [..]`")
-        .with_stderr(
-            "\
-[COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc --crate-name [..]`
-[RUNNING] `rustc --crate-name [..]`
-[RUNNING] `rustc --crate-name [..]`
-[RUNNING] `rustc --crate-name [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
+        .with_stderr_data(
+            str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]`
+[RUNNING] `rustc --crate-name bench1 [..]`
+[RUNNING] `rustc --crate-name bin2 [..]`
+[RUNNING] `rustc --crate-name bin1 [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]]
+            .unordered(),
         )
         .run();
 }
@@ -57,19 +52,17 @@ fn build_bench() {
 fn build_test() {
     full_project()
         .cargo("build -v --test 'te*1'")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name test1 [..]`")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name bin2 [..]`")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name bin1 [..]`")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name foo [..]`")
-        .with_stderr(
-            "\
-[COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc --crate-name [..]`
-[RUNNING] `rustc --crate-name [..]`
-[RUNNING] `rustc --crate-name [..]`
-[RUNNING] `rustc --crate-name [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
+        .with_stderr_data(
+            str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name bin1 [..]`
+[RUNNING] `rustc --crate-name foo [..]`
+[RUNNING] `rustc --crate-name bin2 [..]`
+[RUNNING] `rustc --crate-name test1 [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]]
+            .unordered(),
         )
         .run();
 }
@@ -78,13 +71,12 @@ fn build_test() {
 fn check_example() {
     full_project()
         .cargo("check -v --example 'ex*1'")
-        .with_stderr(
-            "\
-[CHECKING] foo v0.0.1 ([CWD])
+        .with_stderr_data(str![[r#"
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name example1 [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -92,13 +84,12 @@ fn check_example() {
 fn check_bin() {
     full_project()
         .cargo("check -v --bin 'bi*1'")
-        .with_stderr(
-            "\
-[CHECKING] foo v0.0.1 ([CWD])
+        .with_stderr_data(str![[r#"
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name bin1 [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -106,13 +97,12 @@ fn check_bin() {
 fn check_bench() {
     full_project()
         .cargo("check -v --bench 'be*1'")
-        .with_stderr(
-            "\
-[CHECKING] foo v0.0.1 ([CWD])
+        .with_stderr_data(str![[r#"
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name bench1 [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -120,13 +110,12 @@ fn check_bench() {
 fn check_test() {
     full_project()
         .cargo("check -v --test 'te*1'")
-        .with_stderr(
-            "\
-[CHECKING] foo v0.0.1 ([CWD])
+        .with_stderr_data(str![[r#"
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name test1 [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -134,14 +123,13 @@ fn check_test() {
 fn doc_bin() {
     full_project()
         .cargo("doc -v --bin 'bi*1'")
-        .with_stderr(
-            "\
-[DOCUMENTING] foo v0.0.1 ([CWD])
+        .with_stderr_data(str![[r#"
+[DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustdoc --edition=2015 --crate-type bin --crate-name bin1 [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-[GENERATED] [CWD]/target/doc/bin1/index.html
-",
-        )
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[GENERATED] [ROOT]/foo/target/doc/bin1/index.html
+
+"#]])
         .run();
 }
 
@@ -149,14 +137,13 @@ fn doc_bin() {
 fn fix_example() {
     full_project()
         .cargo("fix -v --example 'ex*1' --allow-no-vcs")
-        .with_stderr(
-            "\
-[CHECKING] foo v0.0.1 ([CWD])
+        .with_stderr_data(str![[r#"
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..] rustc --crate-name example1 [..]`
 [FIXING] examples/example1.rs
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -164,14 +151,13 @@ fn fix_example() {
 fn fix_bin() {
     full_project()
         .cargo("fix -v --bin 'bi*1' --allow-no-vcs")
-        .with_stderr(
-            "\
-[CHECKING] foo v0.0.1 ([CWD])
+        .with_stderr_data(str![[r#"
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..] rustc --crate-name bin1 [..]`
 [FIXING] src/bin/bin1.rs
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -179,14 +165,13 @@ fn fix_bin() {
 fn fix_bench() {
     full_project()
         .cargo("fix -v --bench 'be*1' --allow-no-vcs")
-        .with_stderr(
-            "\
-[CHECKING] foo v0.0.1 ([CWD])
+        .with_stderr_data(str![[r#"
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..] rustc --crate-name bench1 [..]`
 [FIXING] benches/bench1.rs
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -194,14 +179,13 @@ fn fix_bench() {
 fn fix_test() {
     full_project()
         .cargo("fix -v --test 'te*1' --allow-no-vcs")
-        .with_stderr(
-            "\
-[CHECKING] foo v0.0.1 ([CWD])
+        .with_stderr_data(str![[r#"
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..] rustc --crate-name test1 [..]`
 [FIXING] tests/test1.rs
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -210,12 +194,18 @@ fn run_example_and_bin() {
     let p = full_project();
     p.cargo("run -v --bin 'bi*1'")
         .with_status(101)
-        .with_stderr("[ERROR] `cargo run` does not support glob patterns on target selection")
+        .with_stderr_data(str![[r#"
+[ERROR] `cargo run` does not support glob patterns on target selection
+
+"#]])
         .run();
 
     p.cargo("run -v --example 'ex*1'")
         .with_status(101)
-        .with_stderr("[ERROR] `cargo run` does not support glob patterns on target selection")
+        .with_stderr_data(str![[r#"
+[ERROR] `cargo run` does not support glob patterns on target selection
+
+"#]])
         .run();
 }
 
@@ -223,14 +213,13 @@ fn run_example_and_bin() {
 fn test_example() {
     full_project()
         .cargo("test -v --example 'ex*1'")
-        .with_stderr(
-            "\
-[COMPILING] foo v0.0.1 ([CWD])
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name example1 [..]`
-[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] [..]example1[..]
-",
-        )
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[RUNNING] `[ROOT]/foo/target/debug/examples/example1-[HASH][EXE]`
+
+"#]])
         .run();
 }
 
@@ -238,14 +227,13 @@ fn test_example() {
 fn test_bin() {
     full_project()
         .cargo("test -v --bin 'bi*1'")
-        .with_stderr(
-            "\
-[COMPILING] foo v0.0.1 ([CWD])
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name bin1 [..]`
-[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] [..]bin1[..]
-",
-        )
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[RUNNING] `[ROOT]/foo/target/debug/deps/bin1-[HASH][EXE]`
+
+"#]])
         .run();
 }
 
@@ -253,20 +241,18 @@ fn test_bin() {
 fn test_bench() {
     full_project()
         .cargo("test -v --bench 'be*1'")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name bench1 [..]`")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name bin2 [..]`")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name bin1 [..]`")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name foo [..]`")
-        .with_stderr(
-            "\
-[COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc --crate-name [..]`
-[RUNNING] `rustc --crate-name [..]`
-[RUNNING] `rustc --crate-name [..]`
-[RUNNING] `rustc --crate-name [..]`
-[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] [..]bench1[..]
-",
+        .with_stderr_data(
+            str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name bin2 [..]`
+[RUNNING] `rustc --crate-name foo [..]`
+[RUNNING] `rustc --crate-name bench1 [..]`
+[RUNNING] `rustc --crate-name bin1 [..]`
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[RUNNING] `[ROOT]/foo/target/debug/deps/bench1-[HASH][EXE]`
+
+"#]]
+            .unordered(),
         )
         .run();
 }
@@ -275,20 +261,18 @@ fn test_bench() {
 fn test_test() {
     full_project()
         .cargo("test -v --test 'te*1'")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name test1 [..]`")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name bin2 [..]`")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name bin1 [..]`")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name foo [..]`")
-        .with_stderr(
-            "\
-[COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc --crate-name [..]`
-[RUNNING] `rustc --crate-name [..]`
-[RUNNING] `rustc --crate-name [..]`
-[RUNNING] `rustc --crate-name [..]`
-[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] [..]test1[..]
-",
+        .with_stderr_data(
+            str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name test1 [..]`
+[RUNNING] `rustc --crate-name bin1 [..]`
+[RUNNING] `rustc --crate-name foo [..]`
+[RUNNING] `rustc --crate-name bin2 [..]`
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[RUNNING] `[ROOT]/foo/target/debug/deps/test1-[HASH][EXE]`
+
+"#]]
+            .unordered(),
         )
         .run();
 }
@@ -297,14 +281,13 @@ fn test_test() {
 fn bench_example() {
     full_project()
         .cargo("bench -v --example 'ex*1'")
-        .with_stderr(
-            "\
-[COMPILING] foo v0.0.1 ([CWD])
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name example1 [..]`
-[FINISHED] `bench` profile [optimized] target(s) in [..]
-[RUNNING] `[..]example1[..] --bench`
-",
-        )
+[FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
+[RUNNING] `[ROOT]/foo/target/release/examples/example1-[HASH][EXE] --bench`
+
+"#]])
         .run();
 }
 
@@ -312,14 +295,13 @@ fn bench_example() {
 fn bench_bin() {
     full_project()
         .cargo("bench -v --bin 'bi*1'")
-        .with_stderr(
-            "\
-[COMPILING] foo v0.0.1 ([CWD])
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name bin1 [..]`
-[FINISHED] `bench` profile [optimized] target(s) in [..]
-[RUNNING] `[..]bin1[..] --bench`
-",
-        )
+[FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
+[RUNNING] `[ROOT]/foo/target/release/deps/bin1-[HASH][EXE] --bench`
+
+"#]])
         .run();
 }
 
@@ -327,20 +309,18 @@ fn bench_bin() {
 fn bench_bench() {
     full_project()
         .cargo("bench -v --bench 'be*1'")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name bench1 [..]`")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name bin2 [..]`")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name bin1 [..]`")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name foo [..]`")
-        .with_stderr(
-            "\
-[COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc --crate-name [..]`
-[RUNNING] `rustc --crate-name [..]`
-[RUNNING] `rustc --crate-name [..]`
-[RUNNING] `rustc --crate-name [..]`
-[FINISHED] `bench` profile [optimized] target(s) in [..]
-[RUNNING] `[..]bench1[..] --bench`
-",
+        .with_stderr_data(
+            str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name bin1 [..]`
+[RUNNING] `rustc --crate-name bin2 [..]`
+[RUNNING] `rustc --crate-name foo [..]`
+[RUNNING] `rustc --crate-name bench1 [..]`
+[FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
+[RUNNING] `[ROOT]/foo/target/release/deps/bench1-[HASH][EXE] --bench`
+
+"#]]
+            .unordered(),
         )
         .run();
 }
@@ -349,20 +329,18 @@ fn bench_bench() {
 fn bench_test() {
     full_project()
         .cargo("bench -v --test 'te*1'")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name test1 [..]`")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name bin2 [..]`")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name bin1 [..]`")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name foo [..]`")
-        .with_stderr(
-            "\
-[COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc --crate-name [..]`
-[RUNNING] `rustc --crate-name [..]`
-[RUNNING] `rustc --crate-name [..]`
-[RUNNING] `rustc --crate-name [..]`
-[FINISHED] `bench` profile [optimized] target(s) in [..]
-[RUNNING] `[..]test1[..] --bench`
-",
+        .with_stderr_data(
+            str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name bin2 [..]`
+[RUNNING] `rustc --crate-name foo [..]`
+[RUNNING] `rustc --crate-name test1 [..]`
+[RUNNING] `rustc --crate-name bin1 [..]`
+[FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
+[RUNNING] `[ROOT]/foo/target/release/deps/test1-[HASH][EXE] --bench`
+
+"#]]
+            .unordered(),
         )
         .run();
 }
@@ -371,16 +349,15 @@ fn bench_test() {
 fn install_example() {
     full_project()
         .cargo("install --path . --example 'ex*1'")
-        .with_stderr(
-            "\
-[INSTALLING] foo v0.0.1 ([CWD])
-[COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] `release` profile [optimized] target(s) in [..]
-[INSTALLING] [..]/home/.cargo/bin/example1[EXE]
-[INSTALLED] package `foo v0.0.1 ([CWD])` (executable `example1[EXE]`)
-[WARNING] be sure to add [..]
-",
-        )
+        .with_stderr_data(str![[r#"
+[INSTALLING] foo v0.0.1 ([ROOT]/foo)
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
+[INSTALLING] [ROOT]/home/.cargo/bin/example1[EXE]
+[INSTALLED] package `foo v0.0.1 ([ROOT]/foo)` (executable `example1[EXE]`)
+[WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
+
+"#]])
         .run();
 }
 
@@ -388,16 +365,15 @@ fn install_example() {
 fn install_bin() {
     full_project()
         .cargo("install --path . --bin 'bi*1'")
-        .with_stderr(
-            "\
-[INSTALLING] foo v0.0.1 ([CWD])
-[COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] `release` profile [optimized] target(s) in [..]
-[INSTALLING] [..]/home/.cargo/bin/bin1[EXE]
-[INSTALLED] package `foo v0.0.1 ([CWD])` (executable `bin1[EXE]`)
-[WARNING] be sure to add [..]
-",
-        )
+        .with_stderr_data(str![[r#"
+[INSTALLING] foo v0.0.1 ([ROOT]/foo)
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
+[INSTALLING] [ROOT]/home/.cargo/bin/bin1[EXE]
+[INSTALLED] package `foo v0.0.1 ([ROOT]/foo)` (executable `bin1[EXE]`)
+[WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
+
+"#]])
         .run();
 }
 
@@ -405,14 +381,13 @@ fn install_bin() {
 fn rustdoc_example() {
     full_project()
         .cargo("rustdoc -v --example 'ex*1'")
-        .with_stderr(
-            "\
-[DOCUMENTING] foo v0.0.1 ([CWD])
+        .with_stderr_data(str![[r#"
+[DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustdoc --edition=2015 --crate-type bin --crate-name example1 [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-[GENERATED] [CWD]/target/doc/example1/index.html
-",
-        )
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[GENERATED] [ROOT]/foo/target/doc/example1/index.html
+
+"#]])
         .run();
 }
 
@@ -420,14 +395,13 @@ fn rustdoc_example() {
 fn rustdoc_bin() {
     full_project()
         .cargo("rustdoc -v --bin 'bi*1'")
-        .with_stderr(
-            "\
-[DOCUMENTING] foo v0.0.1 ([CWD])
+        .with_stderr_data(str![[r#"
+[DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustdoc --edition=2015 --crate-type bin --crate-name bin1 [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-[GENERATED] [CWD]/target/doc/bin1/index.html
-",
-        )
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[GENERATED] [ROOT]/foo/target/doc/bin1/index.html
+
+"#]])
         .run();
 }
 
@@ -435,14 +409,13 @@ fn rustdoc_bin() {
 fn rustdoc_bench() {
     full_project()
         .cargo("rustdoc -v --bench 'be*1'")
-        .with_stderr(
-            "\
-[DOCUMENTING] foo v0.0.1 ([CWD])
+        .with_stderr_data(str![[r#"
+[DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustdoc --edition=2015 --crate-type bin --crate-name bench1 [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-[GENERATED] [CWD]/target/doc/bench1/index.html
-",
-        )
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[GENERATED] [ROOT]/foo/target/doc/bench1/index.html
+
+"#]])
         .run();
 }
 
@@ -450,14 +423,13 @@ fn rustdoc_bench() {
 fn rustdoc_test() {
     full_project()
         .cargo("rustdoc -v --test 'te*1'")
-        .with_stderr(
-            "\
-[DOCUMENTING] foo v0.0.1 ([CWD])
+        .with_stderr_data(str![[r#"
+[DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustdoc --edition=2015 --crate-type bin --crate-name test1 [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-[GENERATED] [CWD]/target/doc/test1/index.html
-",
-        )
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[GENERATED] [ROOT]/foo/target/doc/test1/index.html
+
+"#]])
         .run();
 }
 
@@ -465,13 +437,12 @@ fn rustdoc_test() {
 fn rustc_example() {
     full_project()
         .cargo("rustc -v --example 'ex*1'")
-        .with_stderr(
-            "\
-[COMPILING] foo v0.0.1 ([CWD])
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name example1 [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -479,13 +450,12 @@ fn rustc_example() {
 fn rustc_bin() {
     full_project()
         .cargo("rustc -v --bin 'bi*1'")
-        .with_stderr(
-            "\
-[COMPILING] foo v0.0.1 ([CWD])
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name bin1 [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -493,19 +463,17 @@ fn rustc_bin() {
 fn rustc_bench() {
     full_project()
         .cargo("rustc -v --bench 'be*1'")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name bench1 [..]`")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name bin2 [..]`")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name bin1 [..]`")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name foo [..]`")
-        .with_stderr(
-            "\
-[COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc --crate-name [..]`
-[RUNNING] `rustc --crate-name [..]`
-[RUNNING] `rustc --crate-name [..]`
-[RUNNING] `rustc --crate-name [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
+        .with_stderr_data(
+            str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name bin1 [..]`
+[RUNNING] `rustc --crate-name bench1 [..]`
+[RUNNING] `rustc --crate-name bin2 [..]`
+[RUNNING] `rustc --crate-name foo [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]]
+            .unordered(),
         )
         .run();
 }
@@ -514,19 +482,17 @@ fn rustc_bench() {
 fn rustc_test() {
     full_project()
         .cargo("rustc -v --test 'te*1'")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name test1 [..]`")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name bin2 [..]`")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name bin1 [..]`")
-        .with_stderr_contains("[RUNNING] `rustc --crate-name foo [..]`")
-        .with_stderr(
-            "\
-[COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc --crate-name [..]`
-[RUNNING] `rustc --crate-name [..]`
-[RUNNING] `rustc --crate-name [..]`
-[RUNNING] `rustc --crate-name [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
+        .with_stderr_data(
+            str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name bin1 [..]`
+[RUNNING] `rustc --crate-name bin2 [..]`
+[RUNNING] `rustc --crate-name foo [..]`
+[RUNNING] `rustc --crate-name test1 [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]]
+            .unordered(),
         )
         .run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?

Part of https://github.com/rust-lang/cargo/issues/14039.

Migrate following to snapbox:

- `tests/testsuite/generate_lockfile.rs`
- `tests/testsuite/glob_targets.rs`