### PR TITLE
Add rustdocflags to Unit's Debug impl

### DIFF
--- a/src/cargo/core/compiler/unit.rs
+++ b/src/cargo/core/compiler/unit.rs
@@ -175,6 +175,7 @@ impl fmt::Debug for Unit {
             .field("mode", &self.mode)
             .field("features", &self.features)
             .field("rustflags", &self.rustflags)
+            .field("rustdocflags", &self.rustdocflags)
             .field("artifact", &self.artifact.is_true())
             .field(
                 "artifact_target_for_features",


### PR DESCRIPTION
### What does this PR try to resolve?

Not adding this was an oversight in #13900, `rustflags` was added but not `rustdocflags`.

Sorry about not getting this right the first time.

### How should we test and review this PR?

Read the code and compare to the original PR where the matching line was added for rustflags.

r? @weihanglo 