### PR TITLE
Add workflow to publish Cargo automatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+# Publish Cargo to crates.io whenever a new tag is pushed. Tags are pushed by
+# the Rust release process (https://github.com/rust-lang/promote-release),
+# which will cause this workflow to run.
+
+name: Release
+on:
+  push:
+    tags:
+      - "**"
+
+# Prevent multiple releases from starting at the same time.
+concurrency:
+  group: release
+
+jobs:
+  crates-io:
+    name: Publish on crates.io
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    # Gain access to the crates.io publishing token.
+    environment:
+      name: release
+
+    steps:
+      - name: Checkout the source code
+        uses: actions/checkout@v4
+
+      - name: Publish Cargo to crates.io
+        run: ./publish.py
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/publish.py
+++ b/publish.py
@@ -15,6 +15,9 @@ import urllib.request
 from urllib.error import HTTPError
 
 
+# Whenever you add a new crate to this list that does NOT start with "cargo-"
+# you must reach out to the infra team to add the crate to the list of crates
+# allowed to be published from the "cargo CI" crates.io token.
 TO_PUBLISH = [
     'credential/cargo-credential',
     'credential/cargo-credential-libsecret',


### PR DESCRIPTION
One of the last manual pieces of the Rust release process is publishing Cargo, and as it happens after the release itself it is often forgotten (I am often guilty of that). This PR aims to fully automate that.

Nowadays tagging Cargo happens automatically, as the release process creates and pushes a signed tag for the release. So the only piece remaining is automatically executing the `publish.py` script. This PR adds a workflow triggered by the tag push to run `publish.py` with a [rust-lang-owner](https://crates.io/users/rust-lang-owner) scoped token.

The secret is stored in the [`release` environment](https://github.com/rust-lang/cargo/settings/environments/3357627654/edit), which can only be used during tag pushes.

cc @Mark-Simulacrum 