### PR TITLE
test: migrate fetch and list_availables to snapbox

### DIFF
--- a/tests/testsuite/fetch.rs
+++ b/tests/testsuite/fetch.rs
@@ -1,11 +1,9 @@
 //! Tests for the `cargo fetch` command.
 
-#![allow(deprecated)]
-
 use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
 use cargo_test_support::rustc_host;
-use cargo_test_support::{basic_manifest, cross_compile, project};
+use cargo_test_support::{basic_manifest, cross_compile, project, str};
 
 #[cargo_test]
 fn no_deps() {
@@ -14,7 +12,7 @@ fn no_deps() {
         .file("src/a.rs", "")
         .build();
 
-    p.cargo("fetch").with_stderr("").run();
+    p.cargo("fetch").with_stderr_data("").run();
 }
 
 #[cargo_test]
@@ -60,11 +58,16 @@ fn fetch_all_platform_dependencies_when_no_target_is_given() {
         .build();
 
     p.cargo("fetch")
-        .with_stderr_contains("[DOWNLOADED] d1 v1.2.3 [..]")
-        .with_stderr_contains("[DOWNLOADED] d2 v0.1.2 [..]")
+        .with_stderr_data(str![[r#"
+...
+[DOWNLOADED] d1 v1.2.3 (registry `dummy-registry`)
+[DOWNLOADED] d2 v0.1.2 (registry `dummy-registry`)
+...
+"#]])
         .run();
 }
 
+#[allow(deprecated)]
 #[cargo_test]
 fn fetch_platform_specific_dependencies() {
     if cross_compile::disabled() {
@@ -136,6 +139,9 @@ fn fetch_warning() {
         .file("src/lib.rs", "")
         .build();
     p.cargo("fetch")
-        .with_stderr("[WARNING] unused manifest key: package.misspelled")
+        .with_stderr_data(str![[r#"
+[WARNING] unused manifest key: package.misspelled
+
+"#]])
         .run();
 }

--- a/tests/testsuite/list_availables.rs
+++ b/tests/testsuite/list_availables.rs
@@ -1,8 +1,6 @@
 //! Tests for packages/target filter flags giving suggestions on which
 //! packages/targets are available.
 
-#![allow(deprecated)]
-
 use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 
@@ -28,9 +26,9 @@ fn list_availables_test(command: &str, targets: u8) {
     if targets & EXAMPLE != 0 {
         full_project
             .cargo(&format!("{} --example", command))
-            .with_stderr(
+            .with_stderr_data(
                 "\
-error: \"--example\" takes one argument.
+[ERROR] \"--example\" takes one argument.
 Available examples:
     a
     b
@@ -44,9 +42,9 @@ Available examples:
     if targets & BIN != 0 {
         full_project
             .cargo(&format!("{} --bin", command))
-            .with_stderr(
+            .with_stderr_data(
                 "\
-error: \"--bin\" takes one argument.
+[ERROR] \"--bin\" takes one argument.
 Available binaries:
     foo
 
@@ -59,9 +57,9 @@ Available binaries:
     if targets & BENCH != 0 {
         full_project
             .cargo(&format!("{} --bench", command))
-            .with_stderr(
+            .with_stderr_data(
                 "\
-error: \"--bench\" takes one argument.
+[ERROR] \"--bench\" takes one argument.
 Available bench targets:
     bench1
     bench2
@@ -75,9 +73,9 @@ Available bench targets:
     if targets & TEST != 0 {
         full_project
             .cargo(&format!("{} --test", command))
-            .with_stderr(
+            .with_stderr_data(
                 "\
-error: \"--test\" takes one argument.
+[ERROR] \"--test\" takes one argument.
 Available test targets:
     test1
     test2
@@ -91,7 +89,7 @@ Available test targets:
     if targets & PACKAGE != 0 {
         full_project
             .cargo(&format!("{} -p", command))
-            .with_stderr(
+            .with_stderr_data(
                 "\
 [ERROR] \"--package <SPEC>\" requires a SPEC format value, \
 which can be any package ID specifier in the dependency graph.
@@ -111,9 +109,9 @@ Possible packages/workspace members:
     if targets & EXAMPLE != 0 {
         empty_project
             .cargo(&format!("{} --example", command))
-            .with_stderr(
+            .with_stderr_data(
                 "\
-error: \"--example\" takes one argument.
+[ERROR] \"--example\" takes one argument.
 No examples available.
 
 ",
@@ -125,9 +123,9 @@ No examples available.
     if targets & BIN != 0 {
         empty_project
             .cargo(&format!("{} --bin", command))
-            .with_stderr(
+            .with_stderr_data(
                 "\
-error: \"--bin\" takes one argument.
+[ERROR] \"--bin\" takes one argument.
 No binaries available.
 
 ",
@@ -139,9 +137,9 @@ No binaries available.
     if targets & BENCH != 0 {
         empty_project
             .cargo(&format!("{} --bench", command))
-            .with_stderr(
+            .with_stderr_data(
                 "\
-error: \"--bench\" takes one argument.
+[ERROR] \"--bench\" takes one argument.
 No bench targets available.
 
 ",
@@ -153,9 +151,9 @@ No bench targets available.
     if targets & TEST != 0 {
         empty_project
             .cargo(&format!("{} --test", command))
-            .with_stderr(
+            .with_stderr_data(
                 "\
-error: \"--test\" takes one argument.
+[ERROR] \"--test\" takes one argument.
 No test targets available.
 
 ",
@@ -167,9 +165,9 @@ No test targets available.
     if targets & TARGET != 0 {
         empty_project
             .cargo(&format!("{} --target", command))
-            .with_stderr(
+            .with_stderr_data(
                 "\
-error: \"--target\" takes a target architecture as an argument.
+[ERROR] \"--target\" takes a target architecture as an argument.
 
 Run `[..]` to see possible targets.
 ",

--- a/tests/testsuite/list_availables.rs
+++ b/tests/testsuite/list_availables.rs
@@ -3,15 +3,10 @@
 
 use cargo_test_support::prelude::*;
 use cargo_test_support::project;
+use cargo_test_support::str;
+use snapbox::IntoData;
 
-const EXAMPLE: u8 = 1 << 0;
-const BIN: u8 = 1 << 1;
-const TEST: u8 = 1 << 2;
-const BENCH: u8 = 1 << 3;
-const PACKAGE: u8 = 1 << 4;
-const TARGET: u8 = 1 << 5;
-
-fn list_availables_test(command: &str, targets: u8) {
+fn list_availables_test(command: &str, expected: ExpectedSnapshots<impl IntoData>) {
     let full_project = project()
         .file("examples/a.rs", "fn main() { }")
         .file("examples/b.rs", "fn main() { }")
@@ -23,155 +18,148 @@ fn list_availables_test(command: &str, targets: u8) {
         .file("Cargo.lock", "") // for `cargo pkgid`
         .build();
 
-    if targets & EXAMPLE != 0 {
+    if let ExpectedSnapshots {
+        example: ProjectExpected {
+            full: Some(example),
+            ..
+        },
+        ..
+    } = expected
+    {
         full_project
             .cargo(&format!("{} --example", command))
-            .with_stderr_data(
-                "\
-[ERROR] \"--example\" takes one argument.
-Available examples:
-    a
-    b
-
-",
-            )
+            .with_stderr_data(example)
             .with_status(101)
             .run();
     }
 
-    if targets & BIN != 0 {
+    if let ExpectedSnapshots {
+        bin: ProjectExpected {
+            full: Some(bin), ..
+        },
+        ..
+    } = expected
+    {
         full_project
             .cargo(&format!("{} --bin", command))
-            .with_stderr_data(
-                "\
-[ERROR] \"--bin\" takes one argument.
-Available binaries:
-    foo
-
-",
-            )
+            .with_stderr_data(bin)
             .with_status(101)
             .run();
     }
 
-    if targets & BENCH != 0 {
+    if let ExpectedSnapshots {
+        bench: ProjectExpected {
+            full: Some(bench), ..
+        },
+        ..
+    } = expected
+    {
         full_project
             .cargo(&format!("{} --bench", command))
-            .with_stderr_data(
-                "\
-[ERROR] \"--bench\" takes one argument.
-Available bench targets:
-    bench1
-    bench2
-
-",
-            )
+            .with_stderr_data(bench)
             .with_status(101)
             .run();
     }
 
-    if targets & TEST != 0 {
+    if let ExpectedSnapshots {
+        test: ProjectExpected {
+            full: Some(test), ..
+        },
+        ..
+    } = expected
+    {
         full_project
             .cargo(&format!("{} --test", command))
-            .with_stderr_data(
-                "\
-[ERROR] \"--test\" takes one argument.
-Available test targets:
-    test1
-    test2
-
-",
-            )
+            .with_stderr_data(test)
             .with_status(101)
             .run();
     }
 
-    if targets & PACKAGE != 0 {
+    if let ExpectedSnapshots {
+        package: ProjectExpected {
+            full: Some(package),
+            ..
+        },
+        ..
+    } = expected
+    {
         full_project
             .cargo(&format!("{} -p", command))
-            .with_stderr_data(
-                "\
-[ERROR] \"--package <SPEC>\" requires a SPEC format value, \
-which can be any package ID specifier in the dependency graph.
-Run `cargo help pkgid` for more information about SPEC format.
-
-Possible packages/workspace members:
-    foo
-
-",
-            )
+            .with_stderr_data(package)
             .with_status(101)
             .run();
     }
 
     let empty_project = project().file("src/lib.rs", "").build();
 
-    if targets & EXAMPLE != 0 {
+    if let ExpectedSnapshots {
+        example: ProjectExpected {
+            empty: Some(example),
+            ..
+        },
+        ..
+    } = expected
+    {
         empty_project
             .cargo(&format!("{} --example", command))
-            .with_stderr_data(
-                "\
-[ERROR] \"--example\" takes one argument.
-No examples available.
-
-",
-            )
+            .with_stderr_data(example)
             .with_status(101)
             .run();
     }
 
-    if targets & BIN != 0 {
+    if let ExpectedSnapshots {
+        bin: ProjectExpected {
+            empty: Some(bin), ..
+        },
+        ..
+    } = expected
+    {
         empty_project
             .cargo(&format!("{} --bin", command))
-            .with_stderr_data(
-                "\
-[ERROR] \"--bin\" takes one argument.
-No binaries available.
-
-",
-            )
+            .with_stderr_data(bin)
             .with_status(101)
             .run();
     }
 
-    if targets & BENCH != 0 {
+    if let ExpectedSnapshots {
+        bench: ProjectExpected {
+            empty: Some(bench), ..
+        },
+        ..
+    } = expected
+    {
         empty_project
             .cargo(&format!("{} --bench", command))
-            .with_stderr_data(
-                "\
-[ERROR] \"--bench\" takes one argument.
-No bench targets available.
-
-",
-            )
+            .with_stderr_data(bench)
             .with_status(101)
             .run();
     }
 
-    if targets & TEST != 0 {
+    if let ExpectedSnapshots {
+        test: ProjectExpected {
+            empty: Some(test), ..
+        },
+        ..
+    } = expected
+    {
         empty_project
             .cargo(&format!("{} --test", command))
-            .with_stderr_data(
-                "\
-[ERROR] \"--test\" takes one argument.
-No test targets available.
-
-",
-            )
+            .with_stderr_data(test)
             .with_status(101)
             .run();
     }
 
-    if targets & TARGET != 0 {
+    if let ExpectedSnapshots {
+        target: ProjectExpected {
+            empty: Some(target),
+            ..
+        },
+        ..
+    } = expected
+    {
         empty_project
             .cargo(&format!("{} --target", command))
-            .with_stderr_data(
-                "\
-[ERROR] \"--target\" takes a target architecture as an argument.
-
-Run `[..]` to see possible targets.
-",
-            )
+            .with_stderr_data(target)
             .with_status(101)
             .run();
     }
@@ -179,70 +167,839 @@ Run `[..]` to see possible targets.
 
 #[cargo_test]
 fn build_list_availables() {
-    list_availables_test("build", EXAMPLE | BIN | TEST | BENCH | PACKAGE | TARGET);
+    list_availables_test(
+        "build",
+        SnapshotsBuilder::new()
+            .with_example(str![[r#"
+[ERROR] "--example" takes one argument.
+Available examples:
+    a
+    b
+
+
+"#]], str![[r#"
+[ERROR] "--example" takes one argument.
+No examples available.
+
+
+"#]])
+            .with_bin(str![[r#"
+[ERROR] "--bin" takes one argument.
+Available binaries:
+    foo
+
+
+"#]], str![[r#"
+[ERROR] "--bin" takes one argument.
+No binaries available.
+
+
+"#]])
+            .with_test(str![[r#"
+[ERROR] "--test" takes one argument.
+Available test targets:
+    test1
+    test2
+
+
+"#]], str![[r#"
+[ERROR] "--test" takes one argument.
+No test targets available.
+
+
+"#]])
+            .with_bench(str![[r#"
+[ERROR] "--bench" takes one argument.
+Available bench targets:
+    bench1
+    bench2
+
+
+"#]], str![[r#"
+[ERROR] "--bench" takes one argument.
+No bench targets available.
+
+
+"#]])
+            .with_package(str![[r#"
+[ERROR] "--package <SPEC>" requires a SPEC format value, which can be any package ID specifier in the dependency graph.
+Run `cargo help pkgid` for more information about SPEC format.
+
+Possible packages/workspace members:
+    foo
+
+
+"#]])
+            .with_target(str![[r#"
+[ERROR] "--target" takes a target architecture as an argument.
+
+Run `[..]` to see possible targets.
+
+"#]])
+            .build(),
+    );
 }
 
 #[cargo_test]
 fn check_list_availables() {
-    list_availables_test("check", EXAMPLE | BIN | TEST | BENCH | PACKAGE | TARGET);
+    list_availables_test(
+        "check",
+        SnapshotsBuilder::new()
+            .with_example(str![[r#"
+[ERROR] "--example" takes one argument.
+Available examples:
+    a
+    b
+
+
+"#]], str![[r#"
+[ERROR] "--example" takes one argument.
+No examples available.
+
+
+"#]])
+            .with_bin(str![[r#"
+[ERROR] "--bin" takes one argument.
+Available binaries:
+    foo
+
+
+"#]], str![[r#"
+[ERROR] "--bin" takes one argument.
+No binaries available.
+
+
+"#]])
+            .with_test(str![[r#"
+[ERROR] "--test" takes one argument.
+Available test targets:
+    test1
+    test2
+
+
+"#]], str![[r#"
+[ERROR] "--test" takes one argument.
+No test targets available.
+
+
+"#]])
+            .with_bench(str![[r#"
+[ERROR] "--bench" takes one argument.
+Available bench targets:
+    bench1
+    bench2
+
+
+"#]], str![[r#"
+[ERROR] "--bench" takes one argument.
+No bench targets available.
+
+
+"#]])
+            .with_package(str![[r#"
+[ERROR] "--package <SPEC>" requires a SPEC format value, which can be any package ID specifier in the dependency graph.
+Run `cargo help pkgid` for more information about SPEC format.
+
+Possible packages/workspace members:
+    foo
+
+
+"#]])
+            .with_target(str![[r#"
+[ERROR] "--target" takes a target architecture as an argument.
+
+Run `[..]` to see possible targets.
+
+"#]])
+            .build(),
+    );
 }
 
 #[cargo_test]
 fn doc_list_availables() {
-    list_availables_test("doc", BIN | PACKAGE | TARGET);
+    list_availables_test(
+        "doc",
+        SnapshotsBuilder::new()
+            .with_bin(str![[r#"
+[ERROR] "--bin" takes one argument.
+Available binaries:
+    foo
+
+
+"#]], str![[r#"
+[ERROR] "--bin" takes one argument.
+No binaries available.
+
+
+"#]])
+            .with_package(str![[r#"
+[ERROR] "--package <SPEC>" requires a SPEC format value, which can be any package ID specifier in the dependency graph.
+Run `cargo help pkgid` for more information about SPEC format.
+
+Possible packages/workspace members:
+    foo
+
+
+"#]])
+            .with_target(str![[r#"
+[ERROR] "--target" takes a target architecture as an argument.
+
+Run `[..]` to see possible targets.
+
+"#]])
+            .build(),
+    );
 }
 
 #[cargo_test]
 fn fix_list_availables() {
-    list_availables_test("fix", EXAMPLE | BIN | TEST | BENCH | PACKAGE | TARGET);
+    list_availables_test(
+        "fix",
+        SnapshotsBuilder::new()
+            .with_example(str![[r#"
+[ERROR] "--example" takes one argument.
+Available examples:
+    a
+    b
+
+
+"#]], str![[r#"
+[ERROR] "--example" takes one argument.
+No examples available.
+
+
+"#]])
+            .with_bin(str![[r#"
+[ERROR] "--bin" takes one argument.
+Available binaries:
+    foo
+
+
+"#]], str![[r#"
+[ERROR] "--bin" takes one argument.
+No binaries available.
+
+
+"#]])
+            .with_test(str![[r#"
+[ERROR] "--test" takes one argument.
+Available test targets:
+    test1
+    test2
+
+
+"#]], str![[r#"
+[ERROR] "--test" takes one argument.
+No test targets available.
+
+
+"#]])
+            .with_bench(str![[r#"
+[ERROR] "--bench" takes one argument.
+Available bench targets:
+    bench1
+    bench2
+
+
+"#]], str![[r#"
+[ERROR] "--bench" takes one argument.
+No bench targets available.
+
+
+"#]])
+            .with_package(str![[r#"
+[ERROR] "--package <SPEC>" requires a SPEC format value, which can be any package ID specifier in the dependency graph.
+Run `cargo help pkgid` for more information about SPEC format.
+
+Possible packages/workspace members:
+    foo
+
+
+"#]])
+            .with_target(str![[r#"
+[ERROR] "--target" takes a target architecture as an argument.
+
+Run `[..]` to see possible targets.
+
+"#]])
+            .build(),
+    );
 }
 
 #[cargo_test]
 fn run_list_availables() {
-    list_availables_test("run", EXAMPLE | BIN | PACKAGE | TARGET);
+    list_availables_test(
+        "run",
+        SnapshotsBuilder::new()
+            .with_example(str![[r#"
+[ERROR] "--example" takes one argument.
+Available examples:
+    a
+    b
+
+
+"#]], str![[r#"
+[ERROR] "--example" takes one argument.
+No examples available.
+
+
+"#]])
+            .with_bin(str![[r#"
+[ERROR] "--bin" takes one argument.
+Available binaries:
+    foo
+
+
+"#]], str![[r#"
+[ERROR] "--bin" takes one argument.
+No binaries available.
+
+
+"#]])
+            .with_package(str![[r#"
+[ERROR] "--package <SPEC>" requires a SPEC format value, which can be any package ID specifier in the dependency graph.
+Run `cargo help pkgid` for more information about SPEC format.
+
+Possible packages/workspace members:
+    foo
+
+
+"#]])
+            .with_target(str![[r#"
+[ERROR] "--target" takes a target architecture as an argument.
+
+Run `[..]` to see possible targets.
+
+"#]])
+            .build(),
+    );
 }
 
 #[cargo_test]
 fn test_list_availables() {
-    list_availables_test("test", EXAMPLE | BIN | TEST | BENCH | PACKAGE | TARGET);
+    list_availables_test(
+        "test",
+        SnapshotsBuilder::new()
+            .with_example(str![[r#"
+[ERROR] "--example" takes one argument.
+Available examples:
+    a
+    b
+
+
+"#]], str![[r#"
+[ERROR] "--example" takes one argument.
+No examples available.
+
+
+"#]])
+            .with_bin(str![[r#"
+[ERROR] "--bin" takes one argument.
+Available binaries:
+    foo
+
+
+"#]], str![[r#"
+[ERROR] "--bin" takes one argument.
+No binaries available.
+
+
+"#]])
+            .with_test(str![[r#"
+[ERROR] "--test" takes one argument.
+Available test targets:
+    test1
+    test2
+
+
+"#]], str![[r#"
+[ERROR] "--test" takes one argument.
+No test targets available.
+
+
+"#]])
+            .with_bench(str![[r#"
+[ERROR] "--bench" takes one argument.
+Available bench targets:
+    bench1
+    bench2
+
+
+"#]], str![[r#"
+[ERROR] "--bench" takes one argument.
+No bench targets available.
+
+
+"#]])
+            .with_package(str![[r#"
+[ERROR] "--package <SPEC>" requires a SPEC format value, which can be any package ID specifier in the dependency graph.
+Run `cargo help pkgid` for more information about SPEC format.
+
+Possible packages/workspace members:
+    foo
+
+
+"#]])
+            .with_target(str![[r#"
+[ERROR] "--target" takes a target architecture as an argument.
+
+Run `[..]` to see possible targets.
+
+"#]])
+            .build(),
+    );
 }
 
 #[cargo_test]
 fn bench_list_availables() {
-    list_availables_test("bench", EXAMPLE | BIN | TEST | BENCH | PACKAGE | TARGET);
+    list_availables_test(
+        "bench",
+        SnapshotsBuilder::new()
+            .with_example(str![[r#"
+[ERROR] "--example" takes one argument.
+Available examples:
+    a
+    b
+
+
+"#]], str![[r#"
+[ERROR] "--example" takes one argument.
+No examples available.
+
+
+"#]])
+            .with_bin(str![[r#"
+[ERROR] "--bin" takes one argument.
+Available binaries:
+    foo
+
+
+"#]], str![[r#"
+[ERROR] "--bin" takes one argument.
+No binaries available.
+
+
+"#]])
+            .with_test(str![[r#"
+[ERROR] "--test" takes one argument.
+Available test targets:
+    test1
+    test2
+
+
+"#]], str![[r#"
+[ERROR] "--test" takes one argument.
+No test targets available.
+
+
+"#]])
+            .with_bench(str![[r#"
+[ERROR] "--bench" takes one argument.
+Available bench targets:
+    bench1
+    bench2
+
+
+"#]], str![[r#"
+[ERROR] "--bench" takes one argument.
+No bench targets available.
+
+
+"#]])
+            .with_package(str![[r#"
+[ERROR] "--package <SPEC>" requires a SPEC format value, which can be any package ID specifier in the dependency graph.
+Run `cargo help pkgid` for more information about SPEC format.
+
+Possible packages/workspace members:
+    foo
+
+
+"#]])
+            .with_target(str![[r#"
+[ERROR] "--target" takes a target architecture as an argument.
+
+Run `[..]` to see possible targets.
+
+"#]])
+            .build(),
+    );
 }
 
 #[cargo_test]
 fn install_list_availables() {
-    list_availables_test("install", EXAMPLE | BIN | TARGET);
+    list_availables_test(
+        "install",
+        SnapshotsBuilder::new()
+            .with_example(
+                str![[r#"
+[ERROR] "--example" takes one argument.
+Available examples:
+    a
+    b
+
+
+"#]],
+                str![[r#"
+[ERROR] "--example" takes one argument.
+No examples available.
+
+
+"#]],
+            )
+            .with_bin(
+                str![[r#"
+[ERROR] "--bin" takes one argument.
+Available binaries:
+    foo
+
+
+"#]],
+                str![[r#"
+[ERROR] "--bin" takes one argument.
+No binaries available.
+
+
+"#]],
+            )
+            .with_target(str![[r#"
+[ERROR] "--target" takes a target architecture as an argument.
+
+Run `[..]` to see possible targets.
+
+"#]])
+            .build(),
+    );
 }
 
 #[cargo_test]
 fn rustdoc_list_availables() {
-    list_availables_test("rustdoc", EXAMPLE | BIN | TEST | BENCH | PACKAGE | TARGET);
+    list_availables_test(
+        "rustdoc",
+        SnapshotsBuilder::new()
+            .with_example(str![[r#"
+[ERROR] "--example" takes one argument.
+Available examples:
+    a
+    b
+
+
+"#]], str![[r#"
+[ERROR] "--example" takes one argument.
+No examples available.
+
+
+"#]])
+            .with_bin(str![[r#"
+[ERROR] "--bin" takes one argument.
+Available binaries:
+    foo
+
+
+"#]], str![[r#"
+[ERROR] "--bin" takes one argument.
+No binaries available.
+
+
+"#]])
+            .with_test(str![[r#"
+[ERROR] "--test" takes one argument.
+Available test targets:
+    test1
+    test2
+
+
+"#]], str![[r#"
+[ERROR] "--test" takes one argument.
+No test targets available.
+
+
+"#]])
+            .with_bench(str![[r#"
+[ERROR] "--bench" takes one argument.
+Available bench targets:
+    bench1
+    bench2
+
+
+"#]], str![[r#"
+[ERROR] "--bench" takes one argument.
+No bench targets available.
+
+
+"#]])
+            .with_package(str![[r#"
+[ERROR] "--package <SPEC>" requires a SPEC format value, which can be any package ID specifier in the dependency graph.
+Run `cargo help pkgid` for more information about SPEC format.
+
+Possible packages/workspace members:
+    foo
+
+
+"#]])
+            .with_target(str![[r#"
+[ERROR] "--target" takes a target architecture as an argument.
+
+Run `[..]` to see possible targets.
+
+"#]])
+            .build(),
+    );
 }
 
 #[cargo_test]
 fn rustc_list_availables() {
-    list_availables_test("rustc", EXAMPLE | BIN | TEST | BENCH | PACKAGE | TARGET);
+    list_availables_test(
+        "rustc",
+        SnapshotsBuilder::new()
+            .with_example(str![[r#"
+[ERROR] "--example" takes one argument.
+Available examples:
+    a
+    b
+
+
+"#]], str![[r#"
+[ERROR] "--example" takes one argument.
+No examples available.
+
+
+"#]])
+            .with_bin(str![[r#"
+[ERROR] "--bin" takes one argument.
+Available binaries:
+    foo
+
+
+"#]], str![[r#"
+[ERROR] "--bin" takes one argument.
+No binaries available.
+
+
+"#]])
+            .with_test(str![[r#"
+[ERROR] "--test" takes one argument.
+Available test targets:
+    test1
+    test2
+
+
+"#]], str![[r#"
+[ERROR] "--test" takes one argument.
+No test targets available.
+
+
+"#]])
+            .with_bench(str![[r#"
+[ERROR] "--bench" takes one argument.
+Available bench targets:
+    bench1
+    bench2
+
+
+"#]], str![[r#"
+[ERROR] "--bench" takes one argument.
+No bench targets available.
+
+
+"#]])
+            .with_package(str![[r#"
+[ERROR] "--package <SPEC>" requires a SPEC format value, which can be any package ID specifier in the dependency graph.
+Run `cargo help pkgid` for more information about SPEC format.
+
+Possible packages/workspace members:
+    foo
+
+
+"#]])
+            .with_target(str![[r#"
+[ERROR] "--target" takes a target architecture as an argument.
+
+Run `[..]` to see possible targets.
+
+"#]])
+            .build(),
+    );
 }
 
 #[cargo_test]
 fn pkgid_list_availables() {
-    list_availables_test("pkgid", PACKAGE);
+    list_availables_test(
+        "pkgid",
+        SnapshotsBuilder::new()
+            .with_package(str![[r#"
+[ERROR] "--package <SPEC>" requires a SPEC format value, which can be any package ID specifier in the dependency graph.
+Run `cargo help pkgid` for more information about SPEC format.
+
+Possible packages/workspace members:
+    foo
+
+
+"#]])
+            .build(),
+    );
 }
 
 #[cargo_test]
 fn tree_list_availables() {
-    list_availables_test("tree", PACKAGE | TARGET);
+    list_availables_test(
+        "tree",
+        SnapshotsBuilder::new()
+            .with_package(str![[r#"
+[ERROR] "--package <SPEC>" requires a SPEC format value, which can be any package ID specifier in the dependency graph.
+Run `cargo help pkgid` for more information about SPEC format.
+
+Possible packages/workspace members:
+    foo
+
+
+"#]])
+            .with_target(str![[r#"
+[ERROR] "--target" takes a target architecture as an argument.
+
+Run `[..]` to see possible targets.
+
+"#]])
+            .build(),
+    )
 }
 
 #[cargo_test]
 fn clean_list_availables() {
-    list_availables_test("clean", PACKAGE | TARGET);
+    list_availables_test(
+        "clean",
+        SnapshotsBuilder::new()
+            .with_package(str![[r#"
+[ERROR] "--package <SPEC>" requires a SPEC format value, which can be any package ID specifier in the dependency graph.
+Run `cargo help pkgid` for more information about SPEC format.
+
+Possible packages/workspace members:
+    foo
+
+
+"#]])
+            .with_target(str![[r#"
+[ERROR] "--target" takes a target architecture as an argument.
+
+Run `[..]` to see possible targets.
+
+"#]])
+            .build(),
+    );
 }
 
 #[cargo_test]
 fn update_list_availables() {
-    list_availables_test("update", PACKAGE);
+    list_availables_test(
+        "update",
+        SnapshotsBuilder::new()
+            .with_package(str![[r#"
+[ERROR] "--package <SPEC>" requires a SPEC format value, which can be any package ID specifier in the dependency graph.
+Run `cargo help pkgid` for more information about SPEC format.
+
+Possible packages/workspace members:
+    foo
+
+
+"#]])
+            .build(),
+    );
+}
+
+struct ExpectedSnapshots<T: IntoData> {
+    example: ProjectExpected<T>,
+    bin: ProjectExpected<T>,
+    test: ProjectExpected<T>,
+    bench: ProjectExpected<T>,
+    package: ProjectExpected<T>,
+    target: ProjectExpected<T>,
+}
+
+struct ProjectExpected<T: IntoData> {
+    full: Option<T>,
+    empty: Option<T>,
+}
+
+struct SnapshotsBuilder<T: IntoData> {
+    example: ProjectExpected<T>,
+    bin: ProjectExpected<T>,
+    test: ProjectExpected<T>,
+    bench: ProjectExpected<T>,
+    package: ProjectExpected<T>,
+    target: ProjectExpected<T>,
+}
+
+impl<T: IntoData> SnapshotsBuilder<T> {
+    pub fn new() -> Self {
+        Self {
+            example: ProjectExpected {
+                full: None,
+                empty: None,
+            },
+            bin: ProjectExpected {
+                full: None,
+                empty: None,
+            },
+            test: ProjectExpected {
+                full: None,
+                empty: None,
+            },
+            bench: ProjectExpected {
+                full: None,
+                empty: None,
+            },
+            package: ProjectExpected {
+                full: None,
+                empty: None,
+            },
+            target: ProjectExpected {
+                full: None,
+                empty: None,
+            },
+        }
+    }
+
+    fn with_example(mut self, full: T, empty: T) -> Self {
+        self.example.full = Some(full);
+        self.example.empty = Some(empty);
+        self
+    }
+
+    fn with_bin(mut self, full: T, empty: T) -> Self {
+        self.bin.full = Some(full);
+        self.bin.empty = Some(empty);
+        self
+    }
+
+    fn with_test(mut self, full: T, empty: T) -> Self {
+        self.test.full = Some(full);
+        self.test.empty = Some(empty);
+        self
+    }
+
+    fn with_bench(mut self, full: T, empty: T) -> Self {
+        self.bench.full = Some(full);
+        self.bench.empty = Some(empty);
+        self
+    }
+
+    fn with_package(mut self, full: T) -> Self {
+        self.package.full = Some(full);
+        self
+    }
+
+    fn with_target(mut self, empty: T) -> Self {
+        self.target.empty = Some(empty);
+        self
+    }
+
+    fn build(self) -> ExpectedSnapshots<T> {
+        ExpectedSnapshots {
+            example: self.example,
+            bin: self.bin,
+            test: self.test,
+            bench: self.bench,
+            package: self.package,
+            target: self.target,
+        }
+    }
 }


### PR DESCRIPTION
### What does this PR try to resolve?

Part of https://github.com/rust-lang/cargo/issues/14039.

Migrate following to snapbox:

- `tests/testsuite/fetch.rs`
- `tests/testsuite/list_availables.rs`
