### PR TITLE
fix: rename to `rustdoc::broken_intra_doc_links`

### DIFF
--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1812,7 +1812,7 @@ fn doc_private_ws() {
 }
 
 const BAD_INTRA_LINK_LIB: &str = r#"
-#![deny(broken_intra_doc_links)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 /// [bad_link]
 pub fn foo() {}


### PR DESCRIPTION
Found in <https://github.com/rust-lang/cargo/pull/14209#issuecomment-2216340197>.