### PR TITLE
refactor: move get_source_id out of registry

### DIFF
--- a/src/cargo/ops/registry/login.rs
+++ b/src/cargo/ops/registry/login.rs
@@ -26,8 +26,15 @@ pub fn registry_login(
 ) -> CargoResult<()> {
     let source_ids = get_source_id(gctx, reg_or_index)?;
 
-    let login_url = match registry(gctx, token_from_cmdline.clone(), reg_or_index, false, None) {
-        Ok((registry, _)) => Some(format!("{}/me", registry.host())),
+    let login_url = match registry(
+        gctx,
+        &source_ids,
+        token_from_cmdline.clone(),
+        reg_or_index,
+        false,
+        None,
+    ) {
+        Ok(registry) => Some(format!("{}/me", registry.host())),
         Err(e) if e.is::<AuthorizationError>() => e
             .downcast::<AuthorizationError>()
             .unwrap()

--- a/src/cargo/ops/registry/mod.rs
+++ b/src/cargo/ops/registry/mod.rs
@@ -107,6 +107,8 @@ impl RegistryCredentialConfig {
 
 /// Returns the `Registry` and `Source` based on command-line and config settings.
 ///
+/// * `source_ids`: The source IDs for the registry. It contains the original source ID and
+///   the replacement source ID.
 /// * `token_from_cmdline`: The token from the command-line. If not set, uses the token
 ///   from the config.
 /// * `index`: The index URL from the command-line.
@@ -116,13 +118,12 @@ impl RegistryCredentialConfig {
 /// * `token_required`: If `true`, the token will be set.
 fn registry(
     gctx: &GlobalContext,
+    source_ids: &RegistrySourceIds,
     token_from_cmdline: Option<Secret<&str>>,
     reg_or_index: Option<&RegistryOrIndex>,
     force_update: bool,
     token_required: Option<Operation<'_>>,
-) -> CargoResult<(Registry, RegistrySourceIds)> {
-    let source_ids = get_source_id(gctx, reg_or_index)?;
-
+) -> CargoResult<Registry> {
     let is_index = reg_or_index.map(|v| v.is_index()).unwrap_or_default();
     if is_index && token_required.is_some() && token_from_cmdline.is_none() {
         bail!("command-line argument --index requires --token to be specified");
@@ -165,9 +166,11 @@ fn registry(
         None
     };
     let handle = http_handle(gctx)?;
-    Ok((
-        Registry::new_handle(api_host, token, handle, cfg.auth_required),
-        source_ids,
+    Ok(Registry::new_handle(
+        api_host,
+        token,
+        handle,
+        cfg.auth_required,
     ))
 }
 

--- a/src/cargo/ops/registry/owner.rs
+++ b/src/cargo/ops/registry/owner.rs
@@ -35,9 +35,10 @@ pub fn modify_owners(gctx: &GlobalContext, opts: &OwnersOptions) -> CargoResult<
     };
 
     let operation = Operation::Owners { name: &name };
-
-    let (mut registry, _) = super::registry(
+    let source_ids = super::get_source_id(gctx, opts.reg_or_index.as_ref())?;
+    let mut registry = super::registry(
         gctx,
+        &source_ids,
         opts.token.as_ref().map(Secret::as_deref),
         opts.reg_or_index.as_ref(),
         true,

--- a/src/cargo/ops/registry/search.rs
+++ b/src/cargo/ops/registry/search.rs
@@ -20,8 +20,9 @@ pub fn search(
     reg_or_index: Option<RegistryOrIndex>,
     limit: u32,
 ) -> CargoResult<()> {
-    let (mut registry, source_ids) =
-        super::registry(gctx, None, reg_or_index.as_ref(), false, None)?;
+    let source_ids = super::get_source_id(gctx, reg_or_index.as_ref())?;
+    let mut registry =
+        super::registry(gctx, &source_ids, None, reg_or_index.as_ref(), false, None)?;
     let (crates, total_crates) = registry.search(query, limit).with_context(|| {
         format!(
             "failed to retrieve search results from the registry at {}",

--- a/src/cargo/ops/registry/yank.rs
+++ b/src/cargo/ops/registry/yank.rs
@@ -46,9 +46,10 @@ pub fn yank(
             vers: &version,
         }
     };
-
-    let (mut registry, _) = super::registry(
+    let source_ids = super::get_source_id(gctx, reg_or_index.as_ref())?;
+    let mut registry = super::registry(
         gctx,
+        &source_ids,
         token.as_ref().map(Secret::as_deref),
         reg_or_index.as_ref(),
         true,


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

This PR tries to do some refactorings to make sure we can use the registry API in https://github.com/rust-lang/cargo/pull/14141.

The code splits from [`7261982` (#14141)](https://github.com/rust-lang/cargo/pull/14141/commits/7261982a94531b978ee5be95415f3e2122d9285b) and [`3c17779` (#14141)](https://github.com/rust-lang/cargo/pull/14141/commits/3c177798b79782fc979d51145437eec23073bd31).

Because `cargo-information` has its own logic to obtain the RegistrySourceIds, we need to pass the source_ids into the registry function instead of calling it within the registry function.

Also, I refactored the function get_source_id to ensure we can reuse some common functions from it. This will help us avoid code duplication in https://github.com/rust-lang/cargo/pull/14141.

Original proposed in https://github.com/rust-lang/cargo/pull/14141#discussion_r1669278421 and https://github.com/rust-lang/cargo/pull/14141#discussion_r1669279924.

### How should we test and review this PR?

Just refactoring, so the old tests are enough.

### Additional information

r? @epage 

<!-- homu-ignore:end -->
