### PR TITLE
test(progress): Resolve flakiness

### DIFF
--- a/tests/testsuite/progress.rs
+++ b/tests/testsuite/progress.rs
@@ -114,12 +114,9 @@ fn always_shows_progress() {
     p.cargo("check")
         .with_stderr_data(
             str![[r#"
-[DOWNLOADING] 1 crate                                                                              
-[DOWNLOADING] 2 crates                                                                             
-[DOWNLOADING] 3 crates                                                                             
+[DOWNLOADING] [..] crate                                                                              
 [DOWNLOADED] 3 crates ([..]KB) in [..]s
-[BUILDING] [..] 0/4: [..]
-[BUILDING] [..] 3/4: foo                                             
+[BUILDING] [..] [..]/4: [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 ...
 "#]]


### PR DESCRIPTION
This is a follow up to #14181 which broke CI in #14221

```
---- progress::always_shows_progress stdout ----
running `/Users/runner/work/cargo/cargo/target/debug/cargo check`
thread 'progress::always_shows_progress' panicked at tests/testsuite/progress.rs:128:10:

---- expected: tests/testsuite/progress.rs:116:13
++++ actual:   stderr
   1    1 | [DOWNLOADING] 1 crate                                                                              
   2    2 | [DOWNLOADING] 2 crates                                                                             
   3    3 | [DOWNLOADING] 3 crates                                                                             
   4    4 | [DOWNLOADED] 3 crates ([..]KB) in [..]s
   5      - [BUILDING] [..] 0/4: [..]
   6    5 | [BUILDING] [..] 3/4: foo                                             
   7    6 | [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
   8    7 | ...∅

Update with SNAPSHOTS=overwrite
```

<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
