### PR TITLE
fix(test): Redact elapsed time in the minutes time frame 

### DIFF
--- a/crates/cargo-test-support/src/compare.rs
+++ b/crates/cargo-test-support/src/compare.rs
@@ -161,19 +161,19 @@ fn add_regex_redactions(subs: &mut snapbox::Redactions) {
     // For e2e tests
     subs.insert(
         "[ELAPSED]",
-        regex!(r"\[FINISHED\].*in (?<redacted>[0-9]+(\.[0-9]+))s"),
+        regex!(r"\[FINISHED\].*in (?<redacted>[0-9]+(\.[0-9]+)?(m [0-9]+)?)s"),
     )
     .unwrap();
     // for UI tests
     subs.insert(
         "[ELAPSED]",
-        regex!(r"Finished.*in (?<redacted>[0-9]+(\.[0-9]+))s"),
+        regex!(r"Finished.*in (?<redacted>[0-9]+(\.[0-9]+)?(m [0-9]+)?)s"),
     )
     .unwrap();
     // output from libtest
     subs.insert(
         "[ELAPSED]",
-        regex!(r"; finished in (?<redacted>[0-9]+(\.[0-9]+))s"),
+        regex!(r"; finished in (?<redacted>[0-9]+(\.[0-9]+)?(m [0-9]+)?)s"),
     )
     .unwrap();
     subs.insert(
@@ -976,7 +976,7 @@ B", false,
         );
         assert_data_eq!(
             subs.redact("[FINISHED] `release` profile [optimized] target(s) in 1m 05s"),
-            str!["[FINISHED] `release` profile [optimized] target(s) in 1m 05s"].raw()
+            str!["[FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s"].raw()
         );
     }
 }

--- a/crates/cargo-test-support/src/compare.rs
+++ b/crates/cargo-test-support/src/compare.rs
@@ -832,6 +832,10 @@ impl fmt::Debug for WildStr<'_> {
 
 #[cfg(test)]
 mod test {
+    use snapbox::assert_data_eq;
+    use snapbox::prelude::*;
+    use snapbox::str;
+
     use super::*;
 
     #[test]
@@ -958,6 +962,21 @@ B", false,
             "\
 [DIRTY-MSVC] a",
             false,
+        );
+    }
+
+    #[test]
+    fn redact_elapsed_time() {
+        let mut subs = snapbox::Redactions::new();
+        add_regex_redactions(&mut subs);
+
+        assert_data_eq!(
+            subs.redact("[FINISHED] `release` profile [optimized] target(s) in 5.5s"),
+            str!["[FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s"].raw()
+        );
+        assert_data_eq!(
+            subs.redact("[FINISHED] `release` profile [optimized] target(s) in 1m 05s"),
+            str!["[FINISHED] `release` profile [optimized] target(s) in 1m 05s"].raw()
         );
     }
 }

--- a/crates/cargo-test-support/src/compare.rs
+++ b/crates/cargo-test-support/src/compare.rs
@@ -822,129 +822,134 @@ impl fmt::Debug for WildStr<'_> {
     }
 }
 
-#[test]
-fn wild_str_cmp() {
-    for (a, b) in &[
-        ("a b", "a b"),
-        ("a[..]b", "a b"),
-        ("a[..]", "a b"),
-        ("[..]", "a b"),
-        ("[..]b", "a b"),
-    ] {
-        assert_eq!(WildStr::new(a), WildStr::new(b));
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn wild_str_cmp() {
+        for (a, b) in &[
+            ("a b", "a b"),
+            ("a[..]b", "a b"),
+            ("a[..]", "a b"),
+            ("[..]", "a b"),
+            ("[..]b", "a b"),
+        ] {
+            assert_eq!(WildStr::new(a), WildStr::new(b));
+        }
+        for (a, b) in &[("[..]b", "c"), ("b", "c"), ("b", "cb")] {
+            assert_ne!(WildStr::new(a), WildStr::new(b));
+        }
     }
-    for (a, b) in &[("[..]b", "c"), ("b", "c"), ("b", "cb")] {
-        assert_ne!(WildStr::new(a), WildStr::new(b));
-    }
-}
 
-#[test]
-fn dirty_msvc() {
-    let case = |expected: &str, wild: &str, msvc: bool| {
-        assert_eq!(expected, &replace_dirty_msvc_impl(wild, msvc));
-    };
+    #[test]
+    fn dirty_msvc() {
+        let case = |expected: &str, wild: &str, msvc: bool| {
+            assert_eq!(expected, &replace_dirty_msvc_impl(wild, msvc));
+        };
 
-    // no replacements
-    case("aa", "aa", false);
-    case("aa", "aa", true);
+        // no replacements
+        case("aa", "aa", false);
+        case("aa", "aa", true);
 
-    // with replacements
-    case(
-        "\
+        // with replacements
+        case(
+            "\
 [DIRTY] a",
-        "\
+            "\
 [DIRTY-MSVC] a",
-        true,
-    );
-    case(
-        "",
-        "\
+            true,
+        );
+        case(
+            "",
+            "\
 [DIRTY-MSVC] a",
-        false,
-    );
-    case(
-        "\
+            false,
+        );
+        case(
+            "\
 [DIRTY] a
 [COMPILING] a",
-        "\
+            "\
 [DIRTY-MSVC] a
 [COMPILING] a",
-        true,
-    );
-    case(
-        "\
+            true,
+        );
+        case(
+            "\
 [COMPILING] a",
-        "\
+            "\
 [DIRTY-MSVC] a
 [COMPILING] a",
-        false,
-    );
+            false,
+        );
 
-    // test trailing newline behavior
-    case(
-        "\
+        // test trailing newline behavior
+        case(
+            "\
 A
 B
 ", "\
 A
 B
 ", true,
-    );
+        );
 
-    case(
-        "\
+        case(
+            "\
 A
 B
 ", "\
 A
 B
 ", false,
-    );
+        );
 
-    case(
-        "\
+        case(
+            "\
 A
 B", "\
 A
 B", true,
-    );
+        );
 
-    case(
-        "\
+        case(
+            "\
 A
 B", "\
 A
 B", false,
-    );
+        );
 
-    case(
-        "\
+        case(
+            "\
 [DIRTY] a
 ",
-        "\
+            "\
 [DIRTY-MSVC] a
 ",
-        true,
-    );
-    case(
-        "\n",
-        "\
+            true,
+        );
+        case(
+            "\n",
+            "\
 [DIRTY-MSVC] a
 ",
-        false,
-    );
+            false,
+        );
 
-    case(
-        "\
+        case(
+            "\
 [DIRTY] a",
-        "\
+            "\
 [DIRTY-MSVC] a",
-        true,
-    );
-    case(
-        "",
-        "\
+            true,
+        );
+        case(
+            "",
+            "\
 [DIRTY-MSVC] a",
-        false,
-    );
+            false,
+        );
+    }
 }


### PR DESCRIPTION
### What does this PR try to resolve?

This came up in #14231
```
---- expected: tests/testsuite/lto.rs:611:27
++++ actual:   stderr
   1    1 | [FRESH] registry-shared v0.0.1
   2    2 | [FRESH] registry v0.0.1
   3    3 | [COMPILING] bar v0.0.0 ([ROOT]/foo/bar)
   4    4 | [RUNNING] `rustc --crate-name bar [..]-C lto [..]--test [..]`
   5    5 | [RUNNING] `rustc --crate-name b [..]-C lto [..]--test [..]`
   6      - [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
   7    6 | [RUNNING] `[ROOT]/foo/target/release/deps/bar-[HASH][EXE]`
   8    7 | [RUNNING] `[ROOT]/foo/target/release/deps/b-[HASH][EXE]`
   9    8 | [DOCTEST] bar
  10    9 | [RUNNING] `rustdoc --edition=2015 --crate-type cdylib --crate-type rlib --crate-name bar --test [..]-C lto [..]
       10 + [FINISHED] `release` profile [optimized] target(s) in 1m 00s

Update with SNAPSHOTS=overwrite
```

### How should we test and review this PR?

### Additional information

