### PR TITLE
fix(overrides): Don't warn on duplicate packages from using '..'

### DIFF
--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -78,6 +78,7 @@ use crate::util::cache_lock::CacheLockMode;
 use crate::util::errors::CargoResult;
 use crate::util::CanonicalUrl;
 use anyhow::Context as _;
+use cargo_util::paths;
 use std::collections::{HashMap, HashSet};
 use tracing::{debug, trace};
 
@@ -454,7 +455,7 @@ pub fn add_overrides<'a>(
         // The path listed next to the string is the config file in which the
         // key was located, so we want to pop off the `.cargo/config` component
         // to get the directory containing the `.cargo` folder.
-        (def.root(gctx).join(s), def)
+        (paths::normalize_path(&def.root(gctx).join(s)), def)
     });
 
     for (path, definition) in paths {

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -964,9 +964,8 @@ fn override_and_depend() {
         .cwd("b")
         .with_stderr_data(str![[r#"
 [LOCKING] 3 packages to latest compatible versions
-[WARNING] skipping duplicate package `a2` found at `[ROOT]/foo/[..]`
-[CHECKING] a2 v0.5.0 ([ROOT]/foo/[..])
-[CHECKING] a1 v0.5.0 ([ROOT]/foo/[..])
+[CHECKING] a2 v0.5.0 ([ROOT]/foo/a)
+[CHECKING] a1 v0.5.0 ([ROOT]/foo/a)
 [CHECKING] b v0.5.0 ([ROOT]/foo/b)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -987,10 +986,10 @@ fn missing_path_dependency() {
     p.cargo("check")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to update path override `[ROOT]/foo/../whoa-this-does-not-exist` (defined in `[ROOT]/foo/.cargo/config.toml`)
+[ERROR] failed to update path override `[ROOT]/whoa-this-does-not-exist` (defined in `[ROOT]/foo/.cargo/config.toml`)
 
 Caused by:
-  failed to read directory `[ROOT]/foo/../whoa-this-does-not-exist`
+  failed to read directory `[ROOT]/whoa-this-does-not-exist`
 
 Caused by:
   [NOT_FOUND]


### PR DESCRIPTION
### What does this PR try to resolve?

As part of #10752, I was changing the "duplicate package" warning to be like:
```
[WARNING] skipping duplicate package `a2 v0.5.0 ([ROOT]/foo/b/../a)`:
  [ROOT]/foo/b/../a/a2/Cargo.toml
in favor of [ROOT]/foo/a/a2/Cargo.toml
```
and it showed that we were considering two paths to the same package to be duplicates.

This suppresses that warning.

### How should we test and review this PR?



### Additional information

