### PR TITLE
Add more profiling traces

### DIFF
--- a/src/cargo/core/global_cache_tracker.rs
+++ b/src/cargo/core/global_cache_tracker.rs
@@ -1799,6 +1799,7 @@ pub fn is_silent_error(e: &anyhow::Error) -> bool {
 }
 
 /// Returns the disk usage for a git checkout directory.
+#[tracing::instrument]
 pub fn du_git_checkout(path: &Path) -> CargoResult<u64> {
     // !.git is used because clones typically use hardlinks for the git
     // contents. TODO: Verify behavior on Windows.

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -336,6 +336,7 @@ impl<'gctx> PackageRegistry<'gctx> {
     /// The return value is a `Vec` of patches that should *not* be locked.
     /// This happens when the patch is locked, but the patch has been updated
     /// so the locked value is no longer correct.
+    #[tracing::instrument(skip(self, patch_deps))]
     pub fn patch(
         &mut self,
         url: &Url,
@@ -784,6 +785,7 @@ impl<'gctx> Registry for PackageRegistry<'gctx> {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     fn block_until_ready(&mut self) -> CargoResult<()> {
         if cfg!(debug_assertions) {
             // Force borrow to catch invalid borrows, regardless of which source is used and how it

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -723,6 +723,7 @@ impl<'gctx> Workspace<'gctx> {
     /// verifies that those are all valid packages to point to. Otherwise, this
     /// will transitively follow all `path` dependencies looking for members of
     /// the workspace.
+    #[tracing::instrument(skip_all)]
     fn find_members(&mut self) -> CargoResult<()> {
         let Some(workspace_config) = self.load_workspace_config()? else {
             debug!("find_members - only me as a member");
@@ -886,6 +887,7 @@ impl<'gctx> Workspace<'gctx> {
     /// 1. A workspace only has one root.
     /// 2. All workspace members agree on this one root as the root.
     /// 3. The current crate is a member of this workspace.
+    #[tracing::instrument(skip_all)]
     fn validate(&mut self) -> CargoResult<()> {
         // The rest of the checks require a VirtualManifest or multiple members.
         if self.root_manifest.is_none() {
@@ -954,6 +956,7 @@ impl<'gctx> Workspace<'gctx> {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     fn validate_members(&mut self) -> CargoResult<()> {
         for member in self.members.clone() {
             let root = self.find_root(&member)?;
@@ -1812,6 +1815,7 @@ impl WorkspaceRootConfig {
         self.members.is_some()
     }
 
+    #[tracing::instrument(skip_all)]
     fn members_paths(&self, globs: &[String]) -> CargoResult<Vec<PathBuf>> {
         let mut expanded_list = Vec::new();
 

--- a/src/cargo/ops/cargo_read_manifest.rs
+++ b/src/cargo/ops/cargo_read_manifest.rs
@@ -34,6 +34,7 @@ pub fn read_package(
     Ok(Package::new(manifest, path))
 }
 
+#[tracing::instrument(skip(source_id, gctx))]
 pub fn read_packages(
     path: &Path,
     source_id: SourceId,

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -164,6 +164,7 @@ impl GitRemote {
 
 impl GitDatabase {
     /// Checkouts to a revision at `dest`ination from this database.
+    #[tracing::instrument(skip(self, gctx))]
     pub fn copy_to(
         &self,
         rev: git2::Oid,


### PR DESCRIPTION
### What does this PR try to resolve?

Someone suggested I look at
[zed](https://github.com/zed-industries/zed).
It has some interesting performance characteristics compared to projects I looked at before:
- A lot of workspace members
- git dependencies
- patching with git dependencies

This adds traces that help provide more context for those scenarios when looking at them.

![image](https://github.com/rust-lang/cargo/assets/60961/4bee9a61-e019-477c-af67-6d8a1b1398e9)

### How should we test and review this PR?

### Additional information

Some of these areas might be of interest for
optimizing:
- On every invocation, we do a git2 `copy_to` call for each git checkout
- On every invocation, we do a `du` on each git checkout
- It'd be great to avoid parsing every manifest in a git checkout but we need to do a full parse to make sure we find all packages (see https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/Redundant.20code.20in.20.60GitSouce.60.3F)
- Its suspicious how much time we spend in the "poison" step of resolving when its a no-op