### PR TITLE
feat(test): Add cargo_test to test-support prelude

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,7 +279,6 @@ dependencies = [
  "cargo-credential-macos-keychain",
  "cargo-credential-wincred",
  "cargo-platform 0.1.8",
- "cargo-test-macro",
  "cargo-test-support",
  "cargo-util",
  "cargo-util-schemas",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -237,7 +237,6 @@ features = [
 
 [dev-dependencies]
 annotate-snippets = { workspace = true, features = ["testing-colors"] }
-cargo-test-macro.workspace = true
 cargo-test-support.workspace = true
 gix = { workspace = true, features = ["revision"] }
 same-file.workspace = true

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -73,6 +73,7 @@ pub mod registry;
 pub mod tools;
 
 pub mod prelude {
+    pub use crate::cargo_test;
     pub use crate::ArgLine;
     pub use crate::CargoCommand;
     pub use crate::ChannelChanger;

--- a/src/doc/contrib/src/tests/writing.md
+++ b/src/doc/contrib/src/tests/writing.md
@@ -30,6 +30,8 @@ stdout and stderr output against the expected output.
 
 Generally, a functional test will be placed in `tests/testsuite/<command>.rs` and will look roughly like:
 ```rust,ignore
+use cargo_test_support::prelude::*;
+
 #[cargo_test]
 fn <description>() {
     let p = project()

--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -21,7 +21,7 @@
 #![allow(clippy::disallowed_methods)]
 
 use cargo_test_support::prelude::*;
-use cargo_test_support::*;
+use cargo_test_support::{basic_manifest, paths, project, rustc_host, str, Execs};
 use std::env;
 use std::path::Path;
 

--- a/tests/testsuite/advanced_env.rs
+++ b/tests/testsuite/advanced_env.rs
@@ -1,5 +1,6 @@
 //! -Zadvanced-env tests
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::{paths, project, registry::Package};
 
 #[cargo_test]

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -1,12 +1,13 @@
 //! Tests for alternative registries.
 
+use std::fs;
+
 use cargo_test_support::compare::assert_e2e;
 use cargo_test_support::prelude::*;
 use cargo_test_support::publish::validate_alt_upload;
 use cargo_test_support::registry::{self, Package, RegistryBuilder};
 use cargo_test_support::str;
 use cargo_test_support::{basic_manifest, paths, project};
-use std::fs;
 
 #[cargo_test]
 fn depend_on_alt_registry() {

--- a/tests/testsuite/artifact_dir.rs
+++ b/tests/testsuite/artifact_dir.rs
@@ -1,12 +1,13 @@
 //! Tests for --artifact-dir flag.
 
+use std::env;
+use std::fs;
+use std::path::Path;
+
 use cargo_test_support::prelude::*;
 use cargo_test_support::sleep_ms;
 use cargo_test_support::str;
 use cargo_test_support::{basic_manifest, project};
-use std::env;
-use std::fs;
-use std::path::Path;
 
 #[cargo_test]
 fn binary_with_debug() {

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -1,5 +1,10 @@
 //! Tests for the `cargo build` command.
 
+use std::env;
+use std::fs;
+use std::io::Read;
+use std::process::Stdio;
+
 use cargo::{
     core::compiler::CompileMode,
     core::{Shell, Workspace},
@@ -17,10 +22,6 @@ use cargo_test_support::{
     tools, Execs, ProjectBuilder,
 };
 use cargo_util::paths::dylib_path_envvar;
-use std::env;
-use std::fs;
-use std::io::Read;
-use std::process::Stdio;
 
 #[cargo_test]
 fn cargo_compile_simple() {

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -1,5 +1,10 @@
 //! Tests for build.rs scripts.
 
+use std::env;
+use std::fs;
+use std::io;
+use std::thread;
+
 use cargo_test_support::compare::assert_e2e;
 use cargo_test_support::install::cargo_home;
 use cargo_test_support::paths::CargoPathExt;
@@ -12,10 +17,6 @@ use cargo_test_support::{
 };
 use cargo_test_support::{rustc_host, sleep_ms, slow_cpu_multiplier, symlink_supported};
 use cargo_util::paths::{self, remove_dir_all};
-use std::env;
-use std::fs;
-use std::io;
-use std::thread;
 
 #[cargo_test]
 fn custom_build_script_failed() {

--- a/tests/testsuite/build_script_env.rs
+++ b/tests/testsuite/build_script_env.rs
@@ -1,6 +1,7 @@
 //! Tests for build.rs rerun-if-env-changed and rustc-env
 
 use cargo_test_support::basic_manifest;
+use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::sleep_ms;
 use cargo_test_support::str;

--- a/tests/testsuite/build_script_extra_link_arg.rs
+++ b/tests/testsuite/build_script_extra_link_arg.rs
@@ -4,6 +4,7 @@
 // because MSVC link.exe just gives a warning on unknown flags (how helpful!),
 // and other linkers will return an error.
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
 use cargo_test_support::str;
 use cargo_test_support::{basic_bin_manifest, basic_lib_manifest, basic_manifest, project};

--- a/tests/testsuite/cache_lock.rs
+++ b/tests/testsuite/cache_lock.rs
@@ -1,10 +1,13 @@
 //! Tests for `CacheLock`.
 
-use crate::config::GlobalContextBuilder;
+use std::thread::JoinHandle;
+
 use cargo::util::cache_lock::{CacheLockMode, CacheLocker};
 use cargo_test_support::paths::{self, CargoPathExt};
+use cargo_test_support::prelude::*;
 use cargo_test_support::{retry, thread_wait_timeout, threaded_timeout};
-use std::thread::JoinHandle;
+
+use crate::config::GlobalContextBuilder;
 
 /// Helper to verify that it is OK to acquire the given lock (it shouldn't block).
 fn verify_lock_is_ok(mode: CacheLockMode) {

--- a/tests/testsuite/cache_messages.rs
+++ b/tests/testsuite/cache_messages.rs
@@ -1,9 +1,11 @@
 //! Tests for caching compiler diagnostics.
 
-use super::messages::raw_rustc_output;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::tools;
 use cargo_test_support::{basic_manifest, is_coarse_mtime, project, registry::Package, sleep_ms};
+
+use super::messages::raw_rustc_output;
 
 fn as_str(bytes: &[u8]) -> &str {
     std::str::from_utf8(bytes).expect("valid utf-8")

--- a/tests/testsuite/cargo_alias_config.rs
+++ b/tests/testsuite/cargo_alias_config.rs
@@ -2,6 +2,7 @@
 
 use std::env;
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::tools::echo_subcommand;
 use cargo_test_support::{basic_bin_manifest, project};

--- a/tests/testsuite/cargo_bench/no_keep_going/mod.rs
+++ b/tests/testsuite/cargo_bench/no_keep_going/mod.rs
@@ -1,5 +1,6 @@
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -9,6 +9,7 @@ use std::str;
 
 use cargo_test_support::basic_manifest;
 use cargo_test_support::paths::CargoPathExt;
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
 use cargo_test_support::str;
 use cargo_test_support::tools::echo_subcommand;

--- a/tests/testsuite/cargo_env_config.rs
+++ b/tests/testsuite/cargo_env_config.rs
@@ -1,6 +1,7 @@
 //! Tests for `[env]` config.
 
 use cargo_test_support::basic_manifest;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::{basic_bin_manifest, project};
 

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -1,5 +1,6 @@
 //! Tests for `cargo-features` definitions.
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
 use cargo_test_support::str;
 use cargo_test_support::{project, registry};

--- a/tests/testsuite/cargo_init/inherit_workspace_package_table/mod.rs
+++ b/tests/testsuite/cargo_init/inherit_workspace_package_table/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_init/reserved_name/mod.rs
+++ b/tests/testsuite/cargo_init/reserved_name/mod.rs
@@ -1,8 +1,9 @@
+use std::fs;
+
 use cargo_test_support::file;
 use cargo_test_support::paths;
 use cargo_test_support::prelude::*;
 use cargo_test_support::str;
-use std::fs;
 
 #[cargo_test]
 fn case() {

--- a/tests/testsuite/cargo_new/add_members_to_non_workspace/mod.rs
+++ b/tests/testsuite/cargo_new/add_members_to_non_workspace/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_new/add_members_to_workspace_format_previous_items/mod.rs
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_format_previous_items/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_new/add_members_to_workspace_format_sorted/mod.rs
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_format_sorted/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_new/add_members_to_workspace_with_absolute_package_path/mod.rs
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_with_absolute_package_path/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_new/add_members_to_workspace_with_empty_members/mod.rs
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_with_empty_members/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_new/add_members_to_workspace_with_exclude_list/mod.rs
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_with_exclude_list/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_new/add_members_to_workspace_with_members_glob/mod.rs
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_with_members_glob/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_new/add_members_to_workspace_without_members/mod.rs
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_without_members/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_new/empty_name/mod.rs
+++ b/tests/testsuite/cargo_new/empty_name/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_new/inherit_workspace_lints/mod.rs
+++ b/tests/testsuite/cargo_new/inherit_workspace_lints/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table/mod.rs
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table_with_edition/mod.rs
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table_with_edition/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table_with_registry/mod.rs
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table_with_registry/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table_without_version/mod.rs
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table_without_version/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_new/not_inherit_workspace_package_table_if_not_members/mod.rs
+++ b/tests/testsuite/cargo_new/not_inherit_workspace_package_table_if_not_members/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/avoid_empty_tables/mod.rs
+++ b/tests/testsuite/cargo_remove/avoid_empty_tables/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/build/mod.rs
+++ b/tests/testsuite/cargo_remove/build/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/dev/mod.rs
+++ b/tests/testsuite/cargo_remove/dev/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/dry_run/mod.rs
+++ b/tests/testsuite/cargo_remove/dry_run/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/gc_keep_used_patch/mod.rs
+++ b/tests/testsuite/cargo_remove/gc_keep_used_patch/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/gc_patch/mod.rs
+++ b/tests/testsuite/cargo_remove/gc_patch/mod.rs
@@ -3,6 +3,7 @@ use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
 use cargo_test_support::git;
+use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;

--- a/tests/testsuite/cargo_remove/gc_profile/mod.rs
+++ b/tests/testsuite/cargo_remove/gc_profile/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/gc_replace/mod.rs
+++ b/tests/testsuite/cargo_remove/gc_replace/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/invalid_arg/mod.rs
+++ b/tests/testsuite/cargo_remove/invalid_arg/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/invalid_dep/mod.rs
+++ b/tests/testsuite/cargo_remove/invalid_dep/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/invalid_package/mod.rs
+++ b/tests/testsuite/cargo_remove/invalid_package/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/invalid_package_multiple/mod.rs
+++ b/tests/testsuite/cargo_remove/invalid_package_multiple/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/invalid_section/mod.rs
+++ b/tests/testsuite/cargo_remove/invalid_section/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/invalid_section_dep/mod.rs
+++ b/tests/testsuite/cargo_remove/invalid_section_dep/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/invalid_target/mod.rs
+++ b/tests/testsuite/cargo_remove/invalid_target/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/invalid_target_dep/mod.rs
+++ b/tests/testsuite/cargo_remove/invalid_target_dep/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/multiple_deps/mod.rs
+++ b/tests/testsuite/cargo_remove/multiple_deps/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/multiple_dev/mod.rs
+++ b/tests/testsuite/cargo_remove/multiple_dev/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/no_arg/mod.rs
+++ b/tests/testsuite/cargo_remove/no_arg/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/offline/mod.rs
+++ b/tests/testsuite/cargo_remove/offline/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/optional_dep_feature/mod.rs
+++ b/tests/testsuite/cargo_remove/optional_dep_feature/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/optional_dep_feature_formatting/mod.rs
+++ b/tests/testsuite/cargo_remove/optional_dep_feature_formatting/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/optional_feature/mod.rs
+++ b/tests/testsuite/cargo_remove/optional_feature/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/package/mod.rs
+++ b/tests/testsuite/cargo_remove/package/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/remove_basic/mod.rs
+++ b/tests/testsuite/cargo_remove/remove_basic/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/skip_gc_glob_profile/mod.rs
+++ b/tests/testsuite/cargo_remove/skip_gc_glob_profile/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/target/mod.rs
+++ b/tests/testsuite/cargo_remove/target/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/target_build/mod.rs
+++ b/tests/testsuite/cargo_remove/target_build/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/target_dev/mod.rs
+++ b/tests/testsuite/cargo_remove/target_dev/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/update_lock_file/mod.rs
+++ b/tests/testsuite/cargo_remove/update_lock_file/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/workspace/mod.rs
+++ b/tests/testsuite/cargo_remove/workspace/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/workspace_non_virtual/mod.rs
+++ b/tests/testsuite/cargo_remove/workspace_non_virtual/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_remove/workspace_preserved/mod.rs
+++ b/tests/testsuite/cargo_remove/workspace_preserved/mod.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cargo_targets.rs
+++ b/tests/testsuite/cargo_targets.rs
@@ -1,5 +1,6 @@
 //! Tests specifically related to target handling (lib, bins, examples, tests, benches).
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::str;
 

--- a/tests/testsuite/cargo_test/no_keep_going/mod.rs
+++ b/tests/testsuite/cargo_test/no_keep_going/mod.rs
@@ -1,5 +1,6 @@
 use cargo_test_support::current_dir;
 use cargo_test_support::file;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::CargoCommand;
 use cargo_test_support::Project;

--- a/tests/testsuite/cfg.rs
+++ b/tests/testsuite/cfg.rs
@@ -1,5 +1,6 @@
 //! Tests for cfg() expressions.
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
 use cargo_test_support::rustc_host;
 use cargo_test_support::{basic_manifest, project, str};

--- a/tests/testsuite/concurrent.rs
+++ b/tests/testsuite/concurrent.rs
@@ -10,6 +10,7 @@ use std::{env, str};
 use cargo_test_support::cargo_process;
 use cargo_test_support::git;
 use cargo_test_support::install::{assert_has_installed_exe, cargo_home};
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
 use cargo_test_support::str;
 use cargo_test_support::{basic_manifest, execs, project, slow_cpu_multiplier};

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -1,5 +1,12 @@
 //! Tests for config settings.
 
+use std::borrow::Borrow;
+use std::collections::{BTreeMap, HashMap};
+use std::fs;
+use std::io;
+use std::os;
+use std::path::{Path, PathBuf};
+
 use cargo::core::features::{GitFeatures, GitoxideFeatures};
 use cargo::core::{PackageIdSpec, Shell};
 use cargo::util::context::{
@@ -14,12 +21,6 @@ use cargo_util_schemas::manifest::TomlTrimPaths;
 use cargo_util_schemas::manifest::TomlTrimPathsValue;
 use cargo_util_schemas::manifest::{self as cargo_toml, TomlDebugInfo, VecStringOrBool as VSOB};
 use serde::Deserialize;
-use std::borrow::Borrow;
-use std::collections::{BTreeMap, HashMap};
-use std::fs;
-use std::io;
-use std::os;
-use std::path::{Path, PathBuf};
 
 /// Helper for constructing a `GlobalContext` object.
 pub struct GlobalContextBuilder {

--- a/tests/testsuite/config_cli.rs
+++ b/tests/testsuite/config_cli.rs
@@ -1,13 +1,16 @@
 //! Tests for the --config CLI option.
 
-use super::config::{
-    assert_error, read_output, write_config_at, write_config_toml, GlobalContextBuilder,
-};
+use std::{collections::HashMap, fs};
+
 use cargo::util::context::Definition;
 use cargo_test_support::compare::assert_e2e;
 use cargo_test_support::paths;
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
-use std::{collections::HashMap, fs};
+
+use super::config::{
+    assert_error, read_output, write_config_at, write_config_toml, GlobalContextBuilder,
+};
 
 #[cargo_test]
 fn basic() {

--- a/tests/testsuite/config_include.rs
+++ b/tests/testsuite/config_include.rs
@@ -1,8 +1,10 @@
 //! Tests for `include` config field.
 
-use super::config::{assert_error, write_config_at, write_config_toml, GlobalContextBuilder};
+use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::str;
+
+use super::config::{assert_error, write_config_at, write_config_toml, GlobalContextBuilder};
 
 #[cargo_test]
 fn gated() {

--- a/tests/testsuite/corrupt_git.rs
+++ b/tests/testsuite/corrupt_git.rs
@@ -1,10 +1,12 @@
 //! Tests for corrupt git repos.
 
-use cargo_test_support::paths;
-use cargo_test_support::{basic_manifest, git, project};
-use cargo_util::paths as cargopaths;
 use std::fs;
 use std::path::{Path, PathBuf};
+
+use cargo_test_support::paths;
+use cargo_test_support::prelude::*;
+use cargo_test_support::{basic_manifest, git, project};
+use cargo_util::paths as cargopaths;
 
 #[cargo_test]
 fn deleting_database_files() {

--- a/tests/testsuite/credential_process.rs
+++ b/tests/testsuite/credential_process.rs
@@ -1,5 +1,6 @@
 //! Tests for credential-process.
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::{Package, TestRegistry};
 use cargo_test_support::{basic_manifest, cargo_process, paths, project, registry, str, Project};
 

--- a/tests/testsuite/cross_publish.rs
+++ b/tests/testsuite/cross_publish.rs
@@ -2,6 +2,7 @@
 
 use std::fs::File;
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::{cross_compile, project, publish, registry, str};
 
 #[cargo_test]

--- a/tests/testsuite/custom_target.rs
+++ b/tests/testsuite/custom_target.rs
@@ -1,7 +1,9 @@
 //! Tests for custom json target specifications.
 
-use cargo_test_support::{basic_manifest, project, str};
 use std::fs;
+
+use cargo_test_support::prelude::*;
+use cargo_test_support::{basic_manifest, project, str};
 
 const MINIMAL_LIB: &str = r#"
 #![allow(internal_features)]

--- a/tests/testsuite/death.rs
+++ b/tests/testsuite/death.rs
@@ -1,11 +1,13 @@
 //! Tests for ctrl-C handling.
 
-use cargo_test_support::{project, slow_cpu_multiplier};
 use std::fs;
 use std::io::{self, Read};
 use std::net::TcpListener;
 use std::process::{Child, Stdio};
 use std::thread;
+
+use cargo_test_support::prelude::*;
+use cargo_test_support::{project, slow_cpu_multiplier};
 
 #[cargo_test]
 fn ctrl_c_kills_everyone() {

--- a/tests/testsuite/dep_info.rs
+++ b/tests/testsuite/dep_info.rs
@@ -1,17 +1,19 @@
 //! Tests for dep-info files. This includes the dep-info file Cargo creates in
 //! the output directory, and the ones stored in the fingerprint.
 
+use std::fs;
+use std::path::Path;
+use std::str;
+
 use cargo_test_support::compare::assert_e2e;
 use cargo_test_support::paths::{self, CargoPathExt};
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
 use cargo_test_support::str;
 use cargo_test_support::{
     basic_bin_manifest, basic_manifest, main_file, project, rustc_host, Project,
 };
 use filetime::FileTime;
-use std::fs;
-use std::path::Path;
-use std::str;
 
 // Helper for testing dep-info files in the fingerprint dir.
 #[track_caller]

--- a/tests/testsuite/diagnostics.rs
+++ b/tests/testsuite/diagnostics.rs
@@ -1,3 +1,4 @@
+use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::str;
 

--- a/tests/testsuite/direct_minimal_versions.rs
+++ b/tests/testsuite/direct_minimal_versions.rs
@@ -2,6 +2,7 @@
 //!
 //! Note: Some tests are located in the resolver-tests package.
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::registry::Package;
 use cargo_test_support::str;

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -4,14 +4,14 @@ use std::collections::HashMap;
 use std::fs;
 use std::str;
 
-use serde::Serialize;
-
 use cargo_test_support::cargo_process;
 use cargo_test_support::git;
 use cargo_test_support::paths;
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::{cksum, Package};
 use cargo_test_support::str;
 use cargo_test_support::{basic_manifest, project, t, ProjectBuilder};
+use serde::Serialize;
 
 fn setup() {
     let root = paths::root();

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1,5 +1,8 @@
 //! Tests for the `cargo doc` command.
 
+use std::fs;
+use std::str;
+
 use cargo::core::compiler::RustDocFingerprint;
 use cargo_test_support::paths::CargoPathExt;
 use cargo_test_support::prelude::*;
@@ -7,8 +10,6 @@ use cargo_test_support::registry::Package;
 use cargo_test_support::str;
 use cargo_test_support::{basic_lib_manifest, basic_manifest, git, project};
 use cargo_test_support::{rustc_host, symlink_supported, tools};
-use std::fs;
-use std::str;
 
 #[cargo_test]
 fn simple() {

--- a/tests/testsuite/edition.rs
+++ b/tests/testsuite/edition.rs
@@ -1,6 +1,7 @@
 //! Tests for edition setting.
 
 use cargo::core::Edition;
+use cargo_test_support::prelude::*;
 use cargo_test_support::{basic_lib_manifest, project, str};
 
 #[cargo_test]

--- a/tests/testsuite/error.rs
+++ b/tests/testsuite/error.rs
@@ -1,6 +1,7 @@
 //! General error tests that don't belong anywhere else.
 
 use cargo_test_support::cargo_process;
+use cargo_test_support::prelude::*;
 
 #[cargo_test]
 fn internal_error() {

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -1,5 +1,7 @@
 //! Tests for the new feature resolver.
 
+use std::fs::File;
+
 use cargo_test_support::cross_compile::{self, alternate};
 use cargo_test_support::install::cargo_home;
 use cargo_test_support::paths::CargoPathExt;
@@ -8,7 +10,6 @@ use cargo_test_support::publish::validate_crate_contents;
 use cargo_test_support::registry::{Dependency, Package};
 use cargo_test_support::str;
 use cargo_test_support::{basic_manifest, cargo_process, project, rustc_host, Project};
-use std::fs::File;
 
 /// Switches Cargo.toml to use `resolver = "2"`.
 pub fn switch_to_resolver_2(p: &Project) {

--- a/tests/testsuite/features_namespaced.rs
+++ b/tests/testsuite/features_namespaced.rs
@@ -1,10 +1,11 @@
 //! Tests for namespaced features.
 
-use super::features2::switch_to_resolver_2;
 use cargo_test_support::prelude::*;
 use cargo_test_support::registry::{Dependency, Package, RegistryBuilder};
 use cargo_test_support::str;
 use cargo_test_support::{project, publish};
+
+use super::features2::switch_to_resolver_2;
 
 #[cargo_test]
 fn dependency_with_crate_syntax() {

--- a/tests/testsuite/fetch.rs
+++ b/tests/testsuite/fetch.rs
@@ -2,6 +2,7 @@
 
 #![allow(deprecated)]
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
 use cargo_test_support::rustc_host;
 use cargo_test_support::{basic_manifest, cross_compile, project};

--- a/tests/testsuite/fix_n_times.rs
+++ b/tests/testsuite/fix_n_times.rs
@@ -14,10 +14,11 @@
 //! The [`expect_fix_runs_rustc_n_times`] function handles setting everything
 //! up, and verifying the results.
 
-use cargo_test_support::{basic_manifest, paths, project, str, tools, Execs};
-use snapbox::IntoData;
 use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
+
+use cargo_test_support::prelude::*;
+use cargo_test_support::{basic_manifest, paths, project, str, tools, Execs};
 
 /// The action that the `rustc` shim should take in the current sequence of
 /// events.

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -1,7 +1,5 @@
 //! Tests for fingerprinting (rebuild detection).
 
-use filetime::FileTime;
-use snapbox::IntoData;
 use std::fs::{self, OpenOptions};
 use std::io;
 use std::io::prelude::*;
@@ -11,13 +9,16 @@ use std::process::Stdio;
 use std::thread;
 use std::time::SystemTime;
 
-use super::death;
 use cargo_test_support::paths::{self, CargoPathExt};
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
 use cargo_test_support::{
     basic_lib_manifest, basic_manifest, is_coarse_mtime, project, rustc_host, rustc_host_env,
     sleep_ms, str,
 };
+use filetime::FileTime;
+
+use super::death;
 
 #[cargo_test]
 fn modifying_and_moving() {

--- a/tests/testsuite/future_incompat_report.rs
+++ b/tests/testsuite/future_incompat_report.rs
@@ -7,9 +7,11 @@
 //! So we pick some random lint that will likely always be the same
 //! over time.
 
-use super::config::write_config_toml;
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
 use cargo_test_support::{basic_manifest, project, str, Project};
+
+use super::config::write_config_toml;
 
 // An arbitrary lint (unused_variables) that triggers a lint.
 // We use a special flag to force it to generate a report.

--- a/tests/testsuite/generate_lockfile.rs
+++ b/tests/testsuite/generate_lockfile.rs
@@ -1,9 +1,10 @@
 //! Tests for the `cargo generate-lockfile` command.
 
+use std::fs;
+
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::{Package, RegistryBuilder};
 use cargo_test_support::{basic_manifest, paths, project, str, ProjectBuilder};
-use snapbox::IntoData;
-use std::fs;
 
 #[cargo_test]
 fn adding_and_removing_packages() {

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -12,6 +12,7 @@ use std::thread;
 use cargo_test_support::git::cargo_uses_gitoxide;
 use cargo_test_support::paths::{self, CargoPathExt};
 use cargo_test_support::prelude::IntoData;
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
 use cargo_test_support::{basic_lib_manifest, basic_manifest, git, main_file, path2url, project};
 use cargo_test_support::{sleep_ms, str, t, Project};

--- a/tests/testsuite/git_auth.rs
+++ b/tests/testsuite/git_auth.rs
@@ -11,6 +11,7 @@ use std::thread::{self, JoinHandle};
 use cargo_test_support::basic_manifest;
 use cargo_test_support::git::cargo_uses_gitoxide;
 use cargo_test_support::paths;
+use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 
 fn setup_failed_auth_test() -> (SocketAddr, JoinHandle<()>, Arc<AtomicUsize>) {

--- a/tests/testsuite/git_gc.rs
+++ b/tests/testsuite/git_gc.rs
@@ -7,9 +7,9 @@ use std::path::PathBuf;
 use cargo_test_support::git;
 use cargo_test_support::git::cargo_uses_gitoxide;
 use cargo_test_support::paths;
+use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::registry::Package;
-
 use url::Url;
 
 pub fn find_index() -> PathBuf {

--- a/tests/testsuite/git_shallow.rs
+++ b/tests/testsuite/git_shallow.rs
@@ -1,6 +1,8 @@
-use crate::git_gc::find_index;
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
 use cargo_test_support::{basic_manifest, git, paths, project};
+
+use crate::git_gc::find_index;
 
 enum RepoMode {
     Shallow,

--- a/tests/testsuite/global_cache_tracker.rs
+++ b/tests/testsuite/global_cache_tracker.rs
@@ -8,18 +8,6 @@
 
 #![allow(deprecated)]
 
-use super::config::GlobalContextBuilder;
-use cargo::core::global_cache_tracker::{self, DeferredGlobalLastUse, GlobalCacheTracker};
-use cargo::util::cache_lock::CacheLockMode;
-use cargo::util::interning::InternedString;
-use cargo::GlobalContext;
-use cargo_test_support::paths::{self, CargoPathExt};
-use cargo_test_support::registry::{Package, RegistryBuilder};
-use cargo_test_support::{
-    basic_manifest, cargo_process, execs, git, process, project, retry, sleep_ms,
-    thread_wait_timeout, Execs, Project,
-};
-use itertools::Itertools;
 use std::env;
 use std::fmt::Write;
 use std::path::Path;
@@ -27,6 +15,21 @@ use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::OnceLock;
 use std::time::{Duration, SystemTime};
+
+use cargo::core::global_cache_tracker::{self, DeferredGlobalLastUse, GlobalCacheTracker};
+use cargo::util::cache_lock::CacheLockMode;
+use cargo::util::interning::InternedString;
+use cargo::GlobalContext;
+use cargo_test_support::paths::{self, CargoPathExt};
+use cargo_test_support::prelude::*;
+use cargo_test_support::registry::{Package, RegistryBuilder};
+use cargo_test_support::{
+    basic_manifest, cargo_process, execs, git, process, project, retry, sleep_ms,
+    thread_wait_timeout, Execs, Project,
+};
+use itertools::Itertools;
+
+use super::config::GlobalContextBuilder;
 
 /// Helper to create a simple `foo` project which depends on a registry
 /// dependency called `bar`.

--- a/tests/testsuite/help.rs
+++ b/tests/testsuite/help.rs
@@ -1,11 +1,13 @@
 //! Tests for cargo's help output.
 
-use cargo_test_support::registry::Package;
-use cargo_test_support::str;
-use cargo_test_support::{basic_manifest, cargo_exe, cargo_process, paths, process, project};
 use std::fs;
 use std::path::Path;
 use std::str::from_utf8;
+
+use cargo_test_support::prelude::*;
+use cargo_test_support::registry::Package;
+use cargo_test_support::str;
+use cargo_test_support::{basic_manifest, cargo_exe, cargo_process, paths, process, project};
 
 #[cargo_test]
 fn help() {

--- a/tests/testsuite/https.rs
+++ b/tests/testsuite/https.rs
@@ -4,6 +4,7 @@
 //! or CARGO_PUBLIC_NETWORK_TESTS.
 
 use cargo_test_support::containers::Container;
+use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::str;
 

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -1,8 +1,10 @@
 //! Tests for the `cargo install` command.
 
+use std::env;
 use std::fs::{self, OpenOptions};
 use std::io::prelude::*;
 use std::path::Path;
+use std::path::PathBuf;
 use std::thread;
 
 use cargo_test_support::compare::assert_e2e;
@@ -20,8 +22,6 @@ use cargo_test_support::install::{
     assert_has_installed_exe, assert_has_not_installed_exe, cargo_home, exe,
 };
 use cargo_test_support::paths::{self, CargoPathExt};
-use std::env;
-use std::path::PathBuf;
 
 fn pkg(name: &str, vers: &str) {
     Package::new(name, vers)

--- a/tests/testsuite/install_upgrade.rs
+++ b/tests/testsuite/install_upgrade.rs
@@ -1,14 +1,15 @@
 //! Tests for `cargo install` where it upgrades a package if it is out-of-date.
 
-use cargo::core::PackageId;
 use std::collections::BTreeSet;
 use std::env;
 use std::fs;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use cargo::core::PackageId;
 use cargo_test_support::install::{cargo_home, exe};
 use cargo_test_support::paths::CargoPathExt;
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::{self, Package};
 use cargo_test_support::{
     basic_manifest, cargo_process, cross_compile, execs, git, process, project, str, Execs,

--- a/tests/testsuite/jobserver.rs
+++ b/tests/testsuite/jobserver.rs
@@ -1,6 +1,5 @@
 //! Tests for the jobserver protocol.
 
-use cargo_util::is_ci;
 use std::env;
 use std::net::TcpListener;
 use std::process::Command;
@@ -10,7 +9,9 @@ use cargo_test_support::basic_bin_manifest;
 use cargo_test_support::cargo_exe;
 use cargo_test_support::install::assert_has_installed_exe;
 use cargo_test_support::install::cargo_home;
+use cargo_test_support::prelude::*;
 use cargo_test_support::{project, rustc_host, str};
+use cargo_util::is_ci;
 
 const EXE_CONTENT: &str = r#"
 use std::env;

--- a/tests/testsuite/lints/implicit_features.rs
+++ b/tests/testsuite/lints/implicit_features.rs
@@ -1,3 +1,4 @@
+use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::registry::Package;
 use cargo_test_support::str;

--- a/tests/testsuite/lints/mod.rs
+++ b/tests/testsuite/lints/mod.rs
@@ -1,3 +1,4 @@
+use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::registry::Package;
 use cargo_test_support::str;

--- a/tests/testsuite/lints/unknown_lints.rs
+++ b/tests/testsuite/lints/unknown_lints.rs
@@ -1,3 +1,4 @@
+use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::str;
 

--- a/tests/testsuite/lints/unused_optional_dependencies.rs
+++ b/tests/testsuite/lints/unused_optional_dependencies.rs
@@ -1,3 +1,4 @@
+use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::registry::Package;
 use cargo_test_support::str;

--- a/tests/testsuite/lints_table.rs
+++ b/tests/testsuite/lints_table.rs
@@ -1,5 +1,6 @@
 //! Tests for `[lints]`
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::registry::Package;
 use cargo_test_support::str;

--- a/tests/testsuite/list_availables.rs
+++ b/tests/testsuite/list_availables.rs
@@ -3,6 +3,7 @@
 
 #![allow(deprecated)]
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 
 const EXAMPLE: u8 = 1 << 0;

--- a/tests/testsuite/local_registry.rs
+++ b/tests/testsuite/local_registry.rs
@@ -1,10 +1,11 @@
 //! Tests for local-registry sources.
 
+use std::fs;
+
 use cargo_test_support::paths::{self, CargoPathExt};
 use cargo_test_support::prelude::*;
 use cargo_test_support::registry::{registry_path, Package};
 use cargo_test_support::{basic_manifest, project, str, t};
-use std::fs;
 
 fn setup() {
     let root = paths::root();

--- a/tests/testsuite/lockfile_compat.rs
+++ b/tests/testsuite/lockfile_compat.rs
@@ -2,6 +2,7 @@
 
 use cargo_test_support::compare::assert_e2e;
 use cargo_test_support::git;
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
 use cargo_test_support::str;
 use cargo_test_support::{basic_lib_manifest, basic_manifest, project};

--- a/tests/testsuite/login.rs
+++ b/tests/testsuite/login.rs
@@ -1,12 +1,14 @@
 //! Tests for the `cargo login` command.
 
+use std::fs;
+use std::path::PathBuf;
+
 use cargo_test_support::cargo_process;
 use cargo_test_support::paths::{self, CargoPathExt};
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::{self, RegistryBuilder};
 use cargo_test_support::str;
 use cargo_test_support::t;
-use std::fs;
-use std::path::PathBuf;
 
 const TOKEN: &str = "test-token";
 const TOKEN2: &str = "test-token2";

--- a/tests/testsuite/logout.rs
+++ b/tests/testsuite/logout.rs
@@ -2,6 +2,7 @@
 
 use super::login::check_token;
 use cargo_test_support::paths::{self, CargoPathExt};
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::TestRegistry;
 use cargo_test_support::{cargo_process, registry, str};
 

--- a/tests/testsuite/lto.rs
+++ b/tests/testsuite/lto.rs
@@ -1,8 +1,9 @@
+use std::process::Output;
+
 use cargo::core::compiler::Lto;
 use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
 use cargo_test_support::{basic_manifest, project, str, Project};
-use std::process::Output;
 
 #[cargo_test]
 fn with_deps() {

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -2,9 +2,6 @@
 #![allow(clippy::print_stderr)]
 #![allow(clippy::print_stdout)]
 
-#[macro_use]
-extern crate cargo_test_macro;
-
 mod advanced_env;
 mod alt_registry;
 mod artifact_dep;
@@ -185,6 +182,8 @@ mod warn_on_failure;
 mod weak_dep_features;
 mod workspaces;
 mod yank;
+
+use cargo_test_support::prelude::*;
 
 #[cargo_test]
 fn aaa_trigger_cross_compile_disabled_check() {

--- a/tests/testsuite/member_discovery.rs
+++ b/tests/testsuite/member_discovery.rs
@@ -2,8 +2,8 @@
 
 use cargo::core::{Shell, Workspace};
 use cargo::util::context::GlobalContext;
-
 use cargo_test_support::install::cargo_home;
+use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::registry;
 

--- a/tests/testsuite/member_errors.rs
+++ b/tests/testsuite/member_errors.rs
@@ -4,8 +4,8 @@ use cargo::core::resolver::ResolveError;
 use cargo::core::{compiler::CompileMode, Shell, Workspace};
 use cargo::ops::{self, CompileOptions};
 use cargo::util::{context::GlobalContext, errors::ManifestError};
-
 use cargo_test_support::install::cargo_home;
+use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::registry;
 use cargo_test_support::str;

--- a/tests/testsuite/message_format.rs
+++ b/tests/testsuite/message_format.rs
@@ -1,5 +1,6 @@
 //! Tests for --message-format flag.
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::{basic_lib_manifest, basic_manifest, project, str};
 
 #[cargo_test]

--- a/tests/testsuite/messages.rs
+++ b/tests/testsuite/messages.rs
@@ -4,6 +4,7 @@
 
 #![allow(deprecated)]
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::{process, project, Project};
 use cargo_util::ProcessError;
 

--- a/tests/testsuite/metabuild.rs
+++ b/tests/testsuite/metabuild.rs
@@ -1,12 +1,12 @@
 //! Tests for the metabuild feature (declarative build scripts).
 
+use std::str;
+
 use cargo_test_support::prelude::*;
 use cargo_test_support::{
     basic_lib_manifest, basic_manifest, is_coarse_mtime, project, registry::Package, rustc_host,
     str, Project,
 };
-
-use std::str;
 
 #[cargo_test]
 fn metabuild_gated() {

--- a/tests/testsuite/minimal_versions.rs
+++ b/tests/testsuite/minimal_versions.rs
@@ -2,6 +2,7 @@
 //!
 //! Note: Some tests are located in the resolver-tests package.
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::registry::Package;
 use cargo_test_support::str;

--- a/tests/testsuite/net_config.rs
+++ b/tests/testsuite/net_config.rs
@@ -1,5 +1,6 @@
 //! Tests for network configuration.
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::str;
 

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -1,10 +1,12 @@
 //! Tests for the `cargo new` command.
 
-use cargo_test_support::cargo_process;
-use cargo_test_support::paths;
-use cargo_test_support::str;
 use std::env;
 use std::fs::{self, File};
+
+use cargo_test_support::cargo_process;
+use cargo_test_support::paths;
+use cargo_test_support::prelude::*;
+use cargo_test_support::str;
 
 fn create_default_gitconfig() {
     // This helps on Windows where libgit2 is very aggressive in attempting to

--- a/tests/testsuite/offline.rs
+++ b/tests/testsuite/offline.rs
@@ -1,11 +1,13 @@
 //! Tests for --offline flag.
 
+use std::fs;
+
+use cargo_test_support::prelude::*;
 use cargo_test_support::{
     basic_manifest, git, main_file, project,
     registry::{Package, RegistryBuilder},
     str, Execs,
 };
-use std::fs;
 
 #[allow(deprecated)]
 #[cargo_test]

--- a/tests/testsuite/old_cargos.rs
+++ b/tests/testsuite/old_cargos.rs
@@ -12,13 +12,15 @@
 
 #![allow(deprecated)]
 
+use std::fs;
+
 use cargo::CargoResult;
 use cargo_test_support::paths::CargoPathExt;
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::{self, Dependency, Package};
 use cargo_test_support::{cargo_exe, execs, paths, process, project, rustc_host};
 use cargo_util::{ProcessBuilder, ProcessError};
 use semver::Version;
-use std::fs;
 
 fn tc_process(cmd: &str, toolchain: &str) -> ProcessBuilder {
     let mut p = if toolchain == "this" {

--- a/tests/testsuite/owner.rs
+++ b/tests/testsuite/owner.rs
@@ -3,6 +3,7 @@
 use std::fs;
 
 use cargo_test_support::paths::CargoPathExt;
+use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::registry::{self, api_path};
 use cargo_test_support::str;

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1,5 +1,8 @@
 //! Tests for the `cargo package` command.
 
+use std::fs::{self, read_to_string, File};
+use std::path::Path;
+
 use cargo_test_support::paths::CargoPathExt;
 use cargo_test_support::prelude::*;
 use cargo_test_support::publish::validate_crate_contents;
@@ -9,8 +12,6 @@ use cargo_test_support::{
     symlink_supported, t, ProjectBuilder,
 };
 use flate2::read::GzDecoder;
-use std::fs::{self, read_to_string, File};
-use std::path::Path;
 use tar::Archive;
 
 #[cargo_test]

--- a/tests/testsuite/package_features.rs
+++ b/tests/testsuite/package_features.rs
@@ -1,10 +1,12 @@
 //! Tests for feature selection on the command-line.
 
-use super::features2::switch_to_resolver_2;
+use std::fmt::Write;
+
 use cargo_test_support::prelude::*;
 use cargo_test_support::registry::{Dependency, Package};
 use cargo_test_support::{basic_manifest, project, str};
-use std::fmt::Write;
+
+use super::features2::switch_to_resolver_2;
 
 #[cargo_test]
 fn virtual_no_default_features() {

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -1,11 +1,12 @@
 //! Tests for `[patch]` table source replacement.
 
+use std::fs;
+
 use cargo_test_support::git;
 use cargo_test_support::paths;
 use cargo_test_support::prelude::*;
 use cargo_test_support::registry::{self, Package};
 use cargo_test_support::{basic_manifest, project, str};
-use std::fs;
 
 #[cargo_test]
 fn replace() {

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -1,11 +1,13 @@
 //! Tests for `path` dependencies.
 
+use std::fs;
+
 use cargo_test_support::paths::{self, CargoPathExt};
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
 use cargo_test_support::str;
 use cargo_test_support::{basic_lib_manifest, basic_manifest, main_file, project};
 use cargo_test_support::{sleep_ms, t};
-use std::fs;
 
 #[cargo_test]
 // I have no idea why this is failing spuriously on Windows;

--- a/tests/testsuite/paths.rs
+++ b/tests/testsuite/paths.rs
@@ -1,5 +1,6 @@
 //! Tests for `paths` overrides.
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
 use cargo_test_support::str;
 use cargo_test_support::{basic_manifest, project};

--- a/tests/testsuite/precise_pre_release.rs
+++ b/tests/testsuite/precise_pre_release.rs
@@ -1,5 +1,6 @@
 //! Tests for selecting pre-release versions with `update --precise`.
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::{project, str};
 
 #[cargo_test]

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -4,6 +4,7 @@ use cargo_test_support::basic_manifest;
 use cargo_test_support::compare::assert_e2e;
 use cargo_test_support::git;
 use cargo_test_support::paths;
+use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::registry::Package;
 use cargo_test_support::str;

--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -1,9 +1,10 @@
 //! Tests for profiles.
 
+use std::env;
+
 use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
 use cargo_test_support::{project, rustc_host, str};
-use std::env;
 
 #[cargo_test]
 fn profile_overrides() {

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -1,11 +1,13 @@
 //! Tests for the `cargo publish` command.
 
-use cargo_test_support::git::{self, repo};
-use cargo_test_support::paths;
-use cargo_test_support::registry::{self, Package, RegistryBuilder, Response};
-use cargo_test_support::{basic_manifest, project, publish, str};
 use std::fs;
 use std::sync::{Arc, Mutex};
+
+use cargo_test_support::git::{self, repo};
+use cargo_test_support::paths;
+use cargo_test_support::prelude::*;
+use cargo_test_support::registry::{self, Package, RegistryBuilder, Response};
+use cargo_test_support::{basic_manifest, project, publish, str};
 
 const CLEAN_FOO_JSON: &str = r#"
     {

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -1,5 +1,11 @@
 //! Tests for normal registry dependencies.
 
+use std::fmt::Write;
+use std::fs::{self, File};
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::Mutex;
+
 use cargo::core::SourceId;
 use cargo_test_support::cargo_process;
 use cargo_test_support::paths::{self, CargoPathExt};
@@ -10,11 +16,6 @@ use cargo_test_support::registry::{
 use cargo_test_support::{basic_manifest, project, str};
 use cargo_test_support::{git, install::cargo_home, t};
 use cargo_util::paths::remove_dir_all;
-use std::fmt::Write;
-use std::fs::{self, File};
-use std::path::Path;
-use std::sync::Arc;
-use std::sync::Mutex;
 
 fn setup_http() -> TestRegistry {
     RegistryBuilder::new().http_index().build()

--- a/tests/testsuite/registry_auth.rs
+++ b/tests/testsuite/registry_auth.rs
@@ -1,6 +1,7 @@
 //! Tests for registry authentication.
 
 use cargo_test_support::compare::assert_e2e;
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::{Package, RegistryBuilder, Token};
 use cargo_test_support::str;
 use cargo_test_support::{project, Execs, Project};

--- a/tests/testsuite/registry_overlay.rs
+++ b/tests/testsuite/registry_overlay.rs
@@ -1,5 +1,6 @@
 //! Tests for local-registry sources.
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::registry::{Package, RegistryBuilder, TestRegistry};
 

--- a/tests/testsuite/rename_deps.rs
+++ b/tests/testsuite/rename_deps.rs
@@ -2,6 +2,7 @@
 
 use cargo_test_support::git;
 use cargo_test_support::paths;
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::{self, Package};
 use cargo_test_support::{basic_manifest, project, str};
 

--- a/tests/testsuite/replace.rs
+++ b/tests/testsuite/replace.rs
@@ -2,6 +2,7 @@
 
 use cargo_test_support::git;
 use cargo_test_support::paths;
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
 use cargo_test_support::{basic_manifest, project, str};
 

--- a/tests/testsuite/required_features.rs
+++ b/tests/testsuite/required_features.rs
@@ -5,6 +5,7 @@ use cargo_test_support::install::{
 };
 use cargo_test_support::is_nightly;
 use cargo_test_support::paths::CargoPathExt;
+use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::str;
 

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -1,5 +1,6 @@
 //! Tests for the `cargo run` command.
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::{
     basic_bin_manifest, basic_lib_manifest, basic_manifest, project, str, Project,
 };

--- a/tests/testsuite/rustc_info_cache.rs
+++ b/tests/testsuite/rustc_info_cache.rs
@@ -1,8 +1,10 @@
 //! Tests for the cache file for the rustc version info.
 
+use std::env;
+
+use cargo_test_support::prelude::*;
 use cargo_test_support::{basic_bin_manifest, paths::CargoPathExt};
 use cargo_test_support::{basic_manifest, project};
-use std::env;
 
 const MISS: &str = "[..] rustc info cache miss[..]";
 const HIT: &str = "[..]rustc info cache hit[..]";

--- a/tests/testsuite/rustdoc.rs
+++ b/tests/testsuite/rustdoc.rs
@@ -1,5 +1,6 @@
 //! Tests for the `cargo rustdoc` command.
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::{basic_manifest, cross_compile, project};
 

--- a/tests/testsuite/rustdoc_extern_html.rs
+++ b/tests/testsuite/rustdoc_extern_html.rs
@@ -1,5 +1,6 @@
 //! Tests for the -Zrustdoc-map feature.
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::{self, Package};
 use cargo_test_support::{paths, project, str, Project};
 

--- a/tests/testsuite/rustdocflags.rs
+++ b/tests/testsuite/rustdocflags.rs
@@ -1,5 +1,6 @@
 //! Tests for setting custom rustdoc flags.
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::rustc_host;
 use cargo_test_support::rustc_host_env;

--- a/tests/testsuite/rustflags.rs
+++ b/tests/testsuite/rustflags.rs
@@ -1,8 +1,10 @@
 //! Tests for setting custom rustc flags.
 
+use std::fs;
+
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
 use cargo_test_support::{basic_manifest, paths, project, project_in_home, rustc_host, str};
-use std::fs;
 
 #[cargo_test]
 fn env_rustflags_normal_source() {

--- a/tests/testsuite/rustup.rs
+++ b/tests/testsuite/rustup.rs
@@ -1,12 +1,14 @@
 //! Tests for Cargo's behavior under Rustup.
 
-use cargo_test_support::paths::{home, root, CargoPathExt};
-use cargo_test_support::{cargo_process, process, project, str};
 use std::env;
 use std::env::consts::EXE_EXTENSION;
 use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
+
+use cargo_test_support::paths::{home, root, CargoPathExt};
+use cargo_test_support::prelude::*;
+use cargo_test_support::{cargo_process, process, project, str};
 
 /// Helper to generate an executable.
 fn make_exe(dest: &Path, name: &str, contents: &str, env: &[(&str, PathBuf)]) -> PathBuf {

--- a/tests/testsuite/search.rs
+++ b/tests/testsuite/search.rs
@@ -1,11 +1,13 @@
 //! Tests for the `cargo search` command.
 
+use std::collections::HashSet;
+
 use cargo::util::cache_lock::CacheLockMode;
 use cargo_test_support::cargo_process;
 use cargo_test_support::paths;
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::{RegistryBuilder, Response};
 use cargo_test_support::str;
-use std::collections::HashSet;
 
 const SEARCH_API_RESPONSE: &[u8] = br#"
 {

--- a/tests/testsuite/shell_quoting.rs
+++ b/tests/testsuite/shell_quoting.rs
@@ -2,6 +2,7 @@
 //! in the output, their arguments are quoted properly
 //! so that the command can be run in a terminal.
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::str;
 

--- a/tests/testsuite/source_replacement.rs
+++ b/tests/testsuite/source_replacement.rs
@@ -2,6 +2,7 @@
 
 use std::fs;
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::{Package, RegistryBuilder, TestRegistry};
 use cargo_test_support::{cargo_process, paths, project, str, t};
 

--- a/tests/testsuite/ssh.rs
+++ b/tests/testsuite/ssh.rs
@@ -5,12 +5,14 @@
 //!
 //! NOTE: The container tests almost certainly won't work on Windows.
 
-use cargo_test_support::containers::{Container, ContainerHandle, MkFile};
-use cargo_test_support::git::cargo_uses_gitoxide;
-use cargo_test_support::{paths, process, project, str, Project};
 use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
+
+use cargo_test_support::containers::{Container, ContainerHandle, MkFile};
+use cargo_test_support::git::cargo_uses_gitoxide;
+use cargo_test_support::prelude::*;
+use cargo_test_support::{paths, process, project, str, Project};
 
 fn ssh_repo_url(container: &ContainerHandle, name: &str) -> String {
     let port = container.port_mappings[&22];

--- a/tests/testsuite/standard_lib.rs
+++ b/tests/testsuite/standard_lib.rs
@@ -4,10 +4,12 @@
 //! rebuild the real one. There is a separate integration test `build-std`
 //! which builds the real thing, but that should be avoided if possible.
 
+use std::path::{Path, PathBuf};
+
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::{Dependency, Package};
 use cargo_test_support::ProjectBuilder;
 use cargo_test_support::{paths, project, rustc_host, str, Execs};
-use std::path::{Path, PathBuf};
 
 struct Setup {
     rustc_wrapper: PathBuf,

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo test` command.
 
+use std::fs;
+
 use cargo_test_support::paths::CargoPathExt;
 use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
@@ -9,7 +11,6 @@ use cargo_test_support::{
 use cargo_test_support::{cross_compile, paths};
 use cargo_test_support::{rustc_host, rustc_host_env, sleep_ms};
 use cargo_util::paths::dylib_path_envvar;
-use std::fs;
 
 #[cargo_test]
 fn cargo_test_simple() {

--- a/tests/testsuite/timings.rs
+++ b/tests/testsuite/timings.rs
@@ -1,5 +1,6 @@
 //! Tests for --timings.
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::registry::Package;
 use cargo_test_support::str;

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -1,5 +1,6 @@
 //! Tests for configuration values that point to programs.
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::{basic_lib_manifest, project, rustc_host, rustc_host_env, str};
 
 #[cargo_test]

--- a/tests/testsuite/tree.rs
+++ b/tests/testsuite/tree.rs
@@ -1,10 +1,12 @@
 //! Tests for the `cargo tree` command.
 
-use super::features2::switch_to_resolver_2;
 use cargo_test_support::cross_compile::{self, alternate};
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::{Dependency, Package};
 use cargo_test_support::str;
 use cargo_test_support::{basic_manifest, git, project, rustc_host, Project};
+
+use super::features2::switch_to_resolver_2;
 
 fn make_simple_proj() -> Project {
     Package::new("c", "1.0.0").publish();

--- a/tests/testsuite/tree_graph_features.rs
+++ b/tests/testsuite/tree_graph_features.rs
@@ -1,5 +1,6 @@
 //! Tests for the `cargo tree` command with -e features option.
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::registry::{Dependency, Package};
 use cargo_test_support::str;

--- a/tests/testsuite/verify_project.rs
+++ b/tests/testsuite/verify_project.rs
@@ -1,5 +1,6 @@
 //! Tests for the `cargo verify-project` command.
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::{basic_bin_manifest, main_file, project, str};
 
 #[cargo_test]

--- a/tests/testsuite/version.rs
+++ b/tests/testsuite/version.rs
@@ -1,5 +1,6 @@
 //! Tests for displaying the cargo version.
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::{cargo_process, project};
 
 #[cargo_test]

--- a/tests/testsuite/warn_on_failure.rs
+++ b/tests/testsuite/warn_on_failure.rs
@@ -1,5 +1,6 @@
 //! Tests for whether or not warnings are displayed for build scripts.
 
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
 use cargo_test_support::{project, str, Project};
 

--- a/tests/testsuite/weak_dep_features.rs
+++ b/tests/testsuite/weak_dep_features.rs
@@ -1,11 +1,14 @@
 //! Tests for weak-dep-features.
 
-use super::features2::switch_to_resolver_2;
+use std::fmt::Write;
+
 use cargo_test_support::paths::CargoPathExt;
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::{Dependency, Package, RegistryBuilder};
 use cargo_test_support::str;
 use cargo_test_support::{project, publish};
-use std::fmt::Write;
+
+use super::features2::switch_to_resolver_2;
 
 // Helper to create lib.rs files that check features.
 fn require(enabled_features: &[&str], disabled_features: &[&str]) -> String {

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -1,10 +1,12 @@
 //! Tests for workspaces.
 
+use std::env;
+use std::fs;
+
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
 use cargo_test_support::str;
 use cargo_test_support::{basic_lib_manifest, basic_manifest, git, project, sleep_ms};
-use std::env;
-use std::fs;
 
 #[cargo_test]
 fn simple_explicit() {

--- a/tests/testsuite/yank.rs
+++ b/tests/testsuite/yank.rs
@@ -3,6 +3,7 @@
 use std::fs;
 
 use cargo_test_support::paths::CargoPathExt;
+use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::registry;
 use cargo_test_support::str;


### PR DESCRIPTION
### What does this PR try to resolve?

With where we are at with #14039, I was revisiting our test writing documentation.  I was wanting to put more emphasis on rustdoc and found it would be helpful to talk about the concepts if a prelude was used instead of `extern crate`.

### How should we test and review this PR?

Yes, this included some `use` clean ups in tangentially-related commit but its already painful enough
walking through every test file, I didn't want to do it twice.

### Additional information

