### PR TITLE
Don't downgrade on prerelease `VersionReq` when update with --breaking.

### DIFF
--- a/src/cargo/util/toml_mut/upgrade.rs
+++ b/src/cargo/util/toml_mut/upgrade.rs
@@ -217,5 +217,10 @@ mod test {
             assert_req_bump("1.1.1", "=1.0.0", "=1.1.1");
             assert_req_bump("2.0.0", "=1.0.0", "=2.0.0");
         }
+
+        #[test]
+        fn caret_prerelease() {
+            assert_req_bump("1.7.0", "2.0.0-beta.21", "1.7.0");
+        }
     }
 }

--- a/src/cargo/util/toml_mut/upgrade.rs
+++ b/src/cargo/util/toml_mut/upgrade.rs
@@ -15,12 +15,16 @@ pub(crate) fn upgrade_requirement(
         // Empty matches everything, no-change.
         Ok(None)
     } else {
-        let comparators: CargoResult<Vec<_>> = raw_req
+        let comparators: Vec<_> = raw_req
             .comparators
             .into_iter()
+            // Don't downgrade if pre-release was used, see https://github.com/rust-lang/cargo/issues/14178 and https://github.com/rust-lang/cargo/issues/13290.
+            .filter(|p| p.pre.is_empty() || matches_greater(p, version))
             .map(|p| set_comparator(p, version))
-            .collect();
-        let comparators = comparators?;
+            .collect::<CargoResult<_>>()?;
+        if comparators.is_empty() {
+            return Ok(None);
+        }
         let new_req = semver::VersionReq { comparators };
         let mut new_req_text = new_req.to_string();
         if new_req_text.starts_with('^') && !req.starts_with('^') {
@@ -72,6 +76,33 @@ fn set_comparator(
             Err(unsupported_version_req(user_pred))
         }
     }
+}
+
+// See https://github.com/dtolnay/semver/blob/69efd3cc770ead273a06ad1788477b3092996d29/src/eval.rs#L64-L88
+fn matches_greater(cmp: &semver::Comparator, ver: &semver::Version) -> bool {
+    if ver.major != cmp.major {
+        return ver.major > cmp.major;
+    }
+
+    match cmp.minor {
+        None => return false,
+        Some(minor) => {
+            if ver.minor != minor {
+                return ver.minor > minor;
+            }
+        }
+    }
+
+    match cmp.patch {
+        None => return false,
+        Some(patch) => {
+            if ver.patch != patch {
+                return ver.patch > patch;
+            }
+        }
+    }
+
+    ver.pre > cmp.pre
 }
 
 fn assign_partial_req(
@@ -219,8 +250,15 @@ mod test {
         }
 
         #[test]
-        fn caret_prerelease() {
-            assert_req_bump("1.7.0", "2.0.0-beta.21", "1.7.0");
+        fn greater_prerelease() {
+            assert_req_bump("1.7.0", "2.0.0-beta.21", None);
+            assert_req_bump("1.7.0", "=2.0.0-beta.21", None);
+            assert_req_bump("1.7.0", "~2.0.0-beta.21", None);
+            assert_req_bump("2.0.0-beta.20", "2.0.0-beta.21", None);
+            assert_req_bump("2.0.0-beta.21", "2.0.0-beta.21", None);
+            assert_req_bump("2.0.0-beta.22", "2.0.0-beta.21", "2.0.0-beta.22");
+            assert_req_bump("2.0.0", "2.0.0-beta.21", "2.0.0");
+            assert_req_bump("3.0.0", "2.0.0-beta.21", "3.0.0");
         }
     }
 }

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -2651,9 +2651,6 @@ fn update_breaking_pre_release_downgrade() {
         .masquerade_as_nightly_cargo(&["update-breaking"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[UPGRADING] bar ^2.0.0-beta.21 -> ^1.7.0
-[LOCKING] 1 package to latest compatible version
-[DOWNGRADING] bar v2.0.0-beta.21 -> v1.7.0
 
 "#]])
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?
Do nothing with prerelease when update with `--breaking`. 

Fixes https://github.com/rust-lang/cargo/issues/14178

### How should we test and review this PR?

Previous commit add a test, next commit to fix and update.

### Additional information

