### PR TITLE
perf(source): Don't `du` on every git source load

### DIFF
--- a/src/cargo/core/global_cache_tracker.rs
+++ b/src/cargo/core/global_cache_tracker.rs
@@ -1800,7 +1800,7 @@ pub fn is_silent_error(e: &anyhow::Error) -> bool {
 
 /// Returns the disk usage for a git checkout directory.
 #[tracing::instrument]
-pub fn du_git_checkout(path: &Path) -> CargoResult<u64> {
+fn du_git_checkout(path: &Path) -> CargoResult<u64> {
     // !.git is used because clones typically use hardlinks for the git
     // contents. TODO: Verify behavior on Windows.
     // TODO: Or even better, switch to worktrees, and remove this.


### PR DESCRIPTION
### What does this PR try to resolve?

When profiling Zed (#14238), a major factor in their no-op run times is git patches and git dependencies.  The slowest operation for each git source is running `du`.  This is extraneous for a couple of reasons
- GC isn't stable, slowing people down for a feature they aren't using
- Size tracking was expected to be lazy, only reading sizes when the GC is configured for size, while this was eager
- Git checkouts are immutable but we check on every load
- This optimized for "while filesystem caches are warm" from a checkout operation when checkout operations are rare compared to all of the other commands run on a working directory.

This removes the `du`, relying on the lazy loading that happens in `update_null_sizes`.

For Zed, this removed about 40ms total from the runtime.  While by itself, this is below the threshold of being noticed,
- It adds up if any editor integrations are calling `cargo metadata` a lot
- Over time, small gains like this will add up

### How should we test and review this PR?


### Additional information

cc @ehuss 