### PR TITLE
chore(ci): bump CI tools

### DIFF
--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install mdbook
       run: |
         mkdir mdbook
-        curl -Lf https://github.com/rust-lang/mdBook/releases/download/v0.4.37/mdbook-v0.4.37-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
+        curl -Lf https://github.com/rust-lang/mdBook/releases/download/v0.4.40/mdbook-v0.4.40-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
         echo `pwd`/mdbook >> $GITHUB_PATH
     - name: Deploy docs
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -260,7 +260,7 @@ jobs:
     - name: Install mdbook
       run: |
         mkdir mdbook
-        curl -Lf https://github.com/rust-lang/mdBook/releases/download/v0.4.37/mdbook-v0.4.37-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
+        curl -Lf https://github.com/rust-lang/mdBook/releases/download/v0.4.40/mdbook-v0.4.40-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
         echo `pwd`/mdbook >> $GITHUB_PATH
     - run: cd src/doc && mdbook build --dest-dir ../../target/doc
     - name: Run linkchecker.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Install cargo-semver-checks
         run: |
           mkdir installed-bins
-          curl -Lf https://github.com/obi1kenobi/cargo-semver-checks/releases/download/v0.31.0/cargo-semver-checks-x86_64-unknown-linux-gnu.tar.gz \
+          curl -Lf https://github.com/obi1kenobi/cargo-semver-checks/releases/download/v0.32.0/cargo-semver-checks-x86_64-unknown-linux-gnu.tar.gz \
             | tar -xz --directory=./installed-bins
           echo `pwd`/installed-bins >> $GITHUB_PATH
       - run: ci/validate-version-bump.sh

--- a/src/doc/book.toml
+++ b/src/doc/book.toml
@@ -3,7 +3,7 @@ title = "The Cargo Book"
 author = "Alex Crichton, Steve Klabnik and Carol Nichols, with contributions from the Rust community"
 
 [output.html]
-curly-quotes = true # Enable smart-punctuation feature for more than quotes.
+smart-punctuation = true # Enable smart-punctuation feature for more than quotes.
 git-repository-url = "https://github.com/rust-lang/cargo/tree/master/src/doc/src"
 edit-url-template = "https://github.com/rust-lang/cargo/edit/master/src/doc/{path}"
 search.use-boolean-and = true


### PR DESCRIPTION
### What does this PR try to resolve?

* Bump cargo-semver-checks to 0.32.0, which supports rustdoc JSON format v30
* Bump mdbook to 0.4.40, and change `curly-quotes` to `smart-punctuation`

### How should we test and review this PR?

Wait for CI green.

### Additional information

<!-- homu-ignore:start -->

<img width="360" alt="image" src="https://github.com/user-attachments/assets/119900f4-d744-4cc9-8a00-a951c1908584">

<!-- homu-ignore:end -->
