### PR TITLE
Add a JSON output mode to `cargo package`.

### DIFF
--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -10,7 +10,7 @@ pub use self::cargo_fetch::{fetch, FetchOptions};
 pub use self::cargo_install::{install, install_list};
 pub use self::cargo_new::{init, new, NewOptions, NewProjectKind, VersionControl};
 pub use self::cargo_output_metadata::{output_metadata, ExportInfo, OutputMetadataOptions};
-pub use self::cargo_package::{check_yanked, package, package_one, PackageOpts};
+pub use self::cargo_package::{check_yanked, package, package_one, ListMode, PackageOpts};
 pub use self::cargo_pkgid::pkgid;
 pub use self::cargo_read_manifest::read_package;
 pub use self::cargo_run::run;

--- a/src/cargo/ops/registry/publish.rs
+++ b/src/cargo/ops/registry/publish.rs
@@ -27,6 +27,7 @@ use crate::core::PackageIdSpecQuery;
 use crate::core::SourceId;
 use crate::core::Workspace;
 use crate::ops;
+use crate::ops::ListMode;
 use crate::ops::PackageOpts;
 use crate::ops::Packages;
 use crate::sources::source::QueryKind;
@@ -149,7 +150,7 @@ pub fn publish(ws: &Workspace<'_>, opts: &PublishOpts<'_>) -> CargoResult<()> {
         &PackageOpts {
             gctx: opts.gctx,
             verify: opts.verify,
-            list: false,
+            list: ListMode::Disabled,
             check_metadata: true,
             allow_dirty: opts.allow_dirty,
             to_package: Packages::Default,

--- a/src/doc/man/cargo-package.md
+++ b/src/doc/man/cargo-package.md
@@ -82,6 +82,10 @@ There is no guarantee that the source code in the tarball matches the VCS inform
 Print files included in a package without making one.
 {{/option}}
 
+{{#option "`-l=json`" "`--list=json`" }}
+Output the files included in a package in JSON form, without actually building the package.
+{{/option}}
+
 {{#option "`--no-verify`" }}
 Don't verify the contents by building them.
 {{/option}}

--- a/src/doc/man/generated_txt/cargo-package.txt
+++ b/src/doc/man/generated_txt/cargo-package.txt
@@ -76,6 +76,10 @@ OPTIONS
        -l, --list
            Print files included in a package without making one.
 
+       -l=json, --list=json
+           Output the files included in a package in JSON form, without
+           actually building the package.
+
        --no-verify
            Don’t verify the contents by building them.
 

--- a/src/doc/src/commands/cargo-package.md
+++ b/src/doc/src/commands/cargo-package.md
@@ -78,6 +78,11 @@ There is no guarantee that the source code in the tarball matches the VCS inform
 <dd class="option-desc">Print files included in a package without making one.</dd>
 
 
+<dt class="option-term" id="option-cargo-package--l=json"><a class="option-anchor" href="#option-cargo-package--l=json"></a><code>-l=json</code></dt>
+<dt class="option-term" id="option-cargo-package---list=json"><a class="option-anchor" href="#option-cargo-package---list=json"></a><code>--list=json</code></dt>
+<dd class="option-desc">Output the files included in a package in JSON form, without actually building the package.</dd>
+
+
 <dt class="option-term" id="option-cargo-package---no-verify"><a class="option-anchor" href="#option-cargo-package---no-verify"></a><code>--no-verify</code></dt>
 <dd class="option-desc">Don’t verify the contents by building them.</dd>
 

--- a/src/etc/man/cargo-package.1
+++ b/src/etc/man/cargo-package.1
@@ -103,6 +103,12 @@ There is no guarantee that the source code in the tarball matches the VCS inform
 Print files included in a package without making one.
 .RE
 .sp
+\fB\-l=json\fR, 
+\fB\-\-list=json\fR
+.RS 4
+Output the files included in a package in JSON form, without actually building the package.
+.RE
+.sp
 \fB\-\-no\-verify\fR
 .RS 4
 Don\[cq]t verify the contents by building them.

--- a/tests/testsuite/cargo_package/help/stdout.term.svg
+++ b/tests/testsuite/cargo_package/help/stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="852px" height="740px" xmlns="http://www.w3.org/2000/svg">
+<svg width="852px" height="758px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -29,75 +29,77 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan bold">-l</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--list</tspan><tspan>                Print files included in a package without making one</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan bold">-l</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--list</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;MODE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Print files included in a package without making one [possible values:</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-verify</tspan><tspan>           Don't verify the contents by building them</tspan>
+    <tspan x="10px" y="136px"><tspan>                            basic, json]</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-metadata</tspan><tspan>         Ignore warnings about a lack of human-usable metadata</tspan>
+    <tspan x="10px" y="154px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-verify</tspan><tspan>           Don't verify the contents by building them</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-cyan bold">--allow-dirty</tspan><tspan>         Allow dirty working directories to be packaged</tspan>
+    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-metadata</tspan><tspan>         Ignore warnings about a lack of human-usable metadata</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>          Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-cyan bold">--allow-dirty</tspan><tspan>         Allow dirty working directories to be packaged</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>               Do not print cargo log messages</tspan>
+    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>          Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>        Coloring: auto, always, never</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>               Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>        Coloring: auto, always, never</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details</tspan>
+    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                Print help</tspan>
+    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details</tspan>
 </tspan>
-    <tspan x="10px" y="298px">
+    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                Print help</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan class="fg-green bold">Package Selection:</tspan>
+    <tspan x="10px" y="316px">
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package(s) to assemble</tspan>
+    <tspan x="10px" y="334px"><tspan class="fg-green bold">Package Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--workspace</tspan><tspan>         Assemble all packages in the workspace</tspan>
+    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package(s) to assemble</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--exclude</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>    Don't assemble specified packages</tspan>
+    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--workspace</tspan><tspan>         Assemble all packages in the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="388px">
+    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--exclude</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>    Don't assemble specified packages</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan class="fg-green bold">Feature Selection:</tspan>
+    <tspan x="10px" y="406px">
 </tspan>
-    <tspan x="10px" y="424px"><tspan>  </tspan><tspan class="fg-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
+    <tspan x="10px" y="424px"><tspan class="fg-green bold">Feature Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
+    <tspan x="10px" y="442px"><tspan>  </tspan><tspan class="fg-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
+    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
 </tspan>
-    <tspan x="10px" y="478px">
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan class="fg-green bold">Compilation Options:</tspan>
+    <tspan x="10px" y="496px">
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Build for the target triple</tspan>
+    <tspan x="10px" y="514px"><tspan class="fg-green bold">Compilation Options:</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
+    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Build for the target triple</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>  </tspan><tspan class="fg-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
+    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
+    <tspan x="10px" y="568px"><tspan>  </tspan><tspan class="fg-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
 </tspan>
-    <tspan x="10px" y="586px">
+    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="604px">
 </tspan>
-    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="622px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="676px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="694px">
+    <tspan x="10px" y="694px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help package</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="712px">
 </tspan>
-    <tspan x="10px" y="730px">
+    <tspan x="10px" y="730px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help package</tspan><tspan class="bold">` for more detailed information.</tspan>
+</tspan>
+    <tspan x="10px" y="748px">
 </tspan>
   </text>
 


### PR DESCRIPTION
In multi-crate workspaces, it can be ambiguous where files are sourced from when building packages. This extends the existing `--list` command line flag to optionally emit JSON when called as `-l=json` or `--list=json`. Existing behaviour is unaffected.

The JSON format is slightly different to that proposed in #11666: it exposes the distinction within `cargo::ops::cargo_package` itself around whether an archive file is generated or sourced from the disk. A new crate created with `cargo new --lib foo` generates this output:

```json
{
  ".cargo_vcs_info.json": {
    "Generated": {
      "VcsInfo": {
        "git": {
          "sha1": "af0bf5917934ec4684cd23763f90c16242d7c5ce"
        },
        "path_in_vcs": ""
      }
    }
  },
  ".gitignore": {
    "OnDisk": "/tmp/foo/.gitignore"
  },
  "Cargo.toml": {
    "Generated": "Manifest"
  },
  "Cargo.toml.orig": {
    "OnDisk": "/tmp/foo/Cargo.toml"
  },
  "src/lib.rs": {
    "OnDisk": "/tmp/foo/src/lib.rs"
  }
}
```

I'm open minded as to whether the `VcsInfo` should actually be included, but it feels like there's little harm in doing so.

Fixes #11666, and is at least extremely relevant to #13953.

<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
