### PR TITLE
fix(test): Move 'cargo_home' from 'install' to 'paths' 

### DIFF
--- a/crates/cargo-test-support/src/install.rs
+++ b/crates/cargo-test-support/src/install.rs
@@ -1,14 +1,13 @@
-use crate::paths;
 use std::env::consts::EXE_SUFFIX;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 /// Used by `cargo install` tests to assert an executable binary
 /// has been installed. Example usage:
 /// ```no_run
 /// use cargo_test_support::install::assert_has_installed_exe;
-/// use cargo_test_support::install::cargo_home;
+/// use cargo_test_support::paths;
 ///
-/// assert_has_installed_exe(cargo_home(), "foo");
+/// assert_has_installed_exe(paths::cargo_home(), "foo");
 /// ```
 #[track_caller]
 pub fn assert_has_installed_exe<P: AsRef<Path>>(path: P, name: &'static str) {
@@ -22,10 +21,6 @@ pub fn assert_has_not_installed_exe<P: AsRef<Path>>(path: P, name: &'static str)
 
 fn check_has_installed_exe<P: AsRef<Path>>(path: P, name: &'static str) -> bool {
     path.as_ref().join("bin").join(exe(name)).is_file()
-}
-
-pub fn cargo_home() -> PathBuf {
-    paths::home().join(".cargo")
 }
 
 pub fn exe(name: &str) -> String {

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1308,7 +1308,7 @@ pub trait TestEnvCommandExt: Sized {
         self = self
             .current_dir(&paths::root())
             .env("HOME", paths::home())
-            .env("CARGO_HOME", paths::home().join(".cargo"))
+            .env("CARGO_HOME", paths::cargo_home())
             .env("__CARGO_TEST_ROOT", paths::global_root())
             // Force Cargo to think it's on the stable channel for all tests, this
             // should hopefully not surprise us as we add cargo features over time and

--- a/crates/cargo-test-support/src/paths.rs
+++ b/crates/cargo-test-support/src/paths.rs
@@ -110,6 +110,10 @@ pub fn home() -> PathBuf {
     path
 }
 
+pub fn cargo_home() -> PathBuf {
+    home().join(".cargo")
+}
+
 pub trait CargoPathExt {
     fn to_url(&self) -> url::Url;
 

--- a/crates/cargo-test-support/src/registry.rs
+++ b/crates/cargo-test-support/src/registry.rs
@@ -279,7 +279,7 @@ impl RegistryBuilder {
     /// Initializes the registry.
     #[must_use]
     pub fn build(self) -> TestRegistry {
-        let config_path = paths::home().join(".cargo/config.toml");
+        let config_path = paths::cargo_home().join("config.toml");
         t!(fs::create_dir_all(config_path.parent().unwrap()));
         let prefix = if let Some(alternative) = &self.alternative {
             format!("{alternative}-")
@@ -391,7 +391,7 @@ impl RegistryBuilder {
         }
 
         if self.configure_token {
-            let credentials = paths::home().join(".cargo/credentials.toml");
+            let credentials = paths::cargo_home().join("credentials.toml");
             match &registry.token {
                 Token::Plaintext(token) => {
                     if let Some(alternative) = &self.alternative {
@@ -1195,7 +1195,7 @@ impl Package {
     /// Creates a new package builder.
     /// Call `publish()` to finalize and build the package.
     pub fn new(name: &str, vers: &str) -> Package {
-        let config = paths::home().join(".cargo/config.toml");
+        let config = paths::cargo_home().join("config.toml");
         if !config.exists() {
             init();
         }

--- a/tests/testsuite/binary_name.rs
+++ b/tests/testsuite/binary_name.rs
@@ -2,7 +2,7 @@
 
 use cargo_test_support::install::assert_has_installed_exe;
 use cargo_test_support::install::assert_has_not_installed_exe;
-use cargo_test_support::install::cargo_home;
+use cargo_test_support::paths;
 use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::str;
@@ -221,7 +221,7 @@ Hello, crabs!
         .masquerade_as_nightly_cargo(&["different-binary-name"])
         .run();
 
-    assert_has_installed_exe(cargo_home(), "007bar");
+    assert_has_installed_exe(paths::cargo_home(), "007bar");
 
     p.cargo("uninstall")
         .with_stderr_data(str![[r#"
@@ -231,7 +231,7 @@ Hello, crabs!
         .masquerade_as_nightly_cargo(&["different-binary-name"])
         .run();
 
-    assert_has_not_installed_exe(cargo_home(), "007bar");
+    assert_has_not_installed_exe(paths::cargo_home(), "007bar");
 }
 
 #[cargo_test]

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -6,7 +6,7 @@ use std::io;
 use std::thread;
 
 use cargo_test_support::compare::assert_e2e;
-use cargo_test_support::install::cargo_home;
+use cargo_test_support::paths::cargo_home;
 use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
 use cargo_test_support::str;

--- a/tests/testsuite/concurrent.rs
+++ b/tests/testsuite/concurrent.rs
@@ -9,7 +9,8 @@ use std::{env, str};
 
 use cargo_test_support::cargo_process;
 use cargo_test_support::git;
-use cargo_test_support::install::{assert_has_installed_exe, cargo_home};
+use cargo_test_support::install::assert_has_installed_exe;
+use cargo_test_support::paths;
 use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
 use cargo_test_support::str;
@@ -46,8 +47,8 @@ fn multiple_installs() {
     execs().run_output(&a);
     execs().run_output(&b);
 
-    assert_has_installed_exe(cargo_home(), "foo");
-    assert_has_installed_exe(cargo_home(), "bar");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "bar");
 }
 
 #[cargo_test]
@@ -75,8 +76,8 @@ fn concurrent_installs() {
     execs().run_output(&a);
     execs().run_output(&b);
 
-    assert_has_installed_exe(cargo_home(), "foo");
-    assert_has_installed_exe(cargo_home(), "bar");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "bar");
 }
 
 #[cargo_test]
@@ -104,7 +105,7 @@ fn one_install_should_be_bad() {
     execs().run_output(&a);
     execs().run_output(&b);
 
-    assert_has_installed_exe(cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
 }
 
 #[cargo_test]

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -3,7 +3,7 @@
 use std::fs::File;
 
 use cargo_test_support::cross_compile::{self, alternate};
-use cargo_test_support::install::cargo_home;
+use cargo_test_support::paths;
 use cargo_test_support::prelude::*;
 use cargo_test_support::publish::validate_crate_contents;
 use cargo_test_support::registry::{Dependency, Package};
@@ -2208,8 +2208,8 @@ fn minimal_download() {
         .build();
 
     let clear = || {
-        cargo_home().join("registry/cache").rm_rf();
-        cargo_home().join("registry/src").rm_rf();
+        paths::cargo_home().join("registry/cache").rm_rf();
+        paths::cargo_home().join("registry/src").rm_rf();
         p.build_dir().rm_rf();
     };
 

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -18,9 +18,7 @@ use cargo_test_support::{
 };
 use cargo_util::{ProcessBuilder, ProcessError};
 
-use cargo_test_support::install::{
-    assert_has_installed_exe, assert_has_not_installed_exe, cargo_home, exe,
-};
+use cargo_test_support::install::{assert_has_installed_exe, assert_has_not_installed_exe, exe};
 use cargo_test_support::paths;
 
 fn pkg(name: &str, vers: &str) {
@@ -49,7 +47,7 @@ fn simple() {
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]]).run();
-    assert_has_installed_exe(cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
 
     cargo_process("uninstall foo")
         .with_stderr_data(str![[r#"
@@ -57,7 +55,7 @@ fn simple() {
 
 "#]])
         .run();
-    assert_has_not_installed_exe(cargo_home(), "foo");
+    assert_has_not_installed_exe(paths::cargo_home(), "foo");
 }
 
 #[cargo_test]
@@ -78,7 +76,7 @@ fn install_the_same_version_twice() {
 
 "#]])
         .run();
-    assert_has_installed_exe(cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
 }
 
 #[cargo_test]
@@ -182,7 +180,7 @@ fn simple_with_message_format() {
             "#,
         )
         .run();
-    assert_has_installed_exe(cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
 }
 
 #[cargo_test]
@@ -205,7 +203,7 @@ fn with_index() {
 
 "#]])
         .run();
-    assert_has_installed_exe(cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
 
     cargo_process("uninstall foo")
         .with_stderr_data(str![[r#"
@@ -213,7 +211,7 @@ fn with_index() {
 
 "#]])
         .run();
-    assert_has_not_installed_exe(cargo_home(), "foo");
+    assert_has_not_installed_exe(paths::cargo_home(), "foo");
 }
 
 #[cargo_test]
@@ -246,8 +244,8 @@ fn multiple_pkgs() {
 
 "#]])
         .run();
-    assert_has_installed_exe(cargo_home(), "foo");
-    assert_has_installed_exe(cargo_home(), "bar");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "bar");
 
     cargo_process("uninstall foo bar")
         .with_stderr_data(str![[r#"
@@ -258,8 +256,8 @@ fn multiple_pkgs() {
 "#]])
         .run();
 
-    assert_has_not_installed_exe(cargo_home(), "foo");
-    assert_has_not_installed_exe(cargo_home(), "bar");
+    assert_has_not_installed_exe(paths::cargo_home(), "foo");
+    assert_has_not_installed_exe(paths::cargo_home(), "bar");
 }
 
 fn path() -> Vec<PathBuf> {
@@ -276,7 +274,7 @@ fn multiple_pkgs_path_set() {
 
     // add CARGO_HOME/bin to path
     let mut path = path();
-    path.push(cargo_home().join("bin"));
+    path.push(paths::cargo_home().join("bin"));
     let new_path = env::join_paths(path).unwrap();
     cargo_process("install foo bar baz")
         .env("PATH", new_path)
@@ -303,8 +301,8 @@ fn multiple_pkgs_path_set() {
 
 "#]])
         .run();
-    assert_has_installed_exe(cargo_home(), "foo");
-    assert_has_installed_exe(cargo_home(), "bar");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "bar");
 
     cargo_process("uninstall foo bar")
         .with_stderr_data(str![[r#"
@@ -315,8 +313,8 @@ fn multiple_pkgs_path_set() {
 "#]])
         .run();
 
-    assert_has_not_installed_exe(cargo_home(), "foo");
-    assert_has_not_installed_exe(cargo_home(), "bar");
+    assert_has_not_installed_exe(paths::cargo_home(), "foo");
+    assert_has_not_installed_exe(paths::cargo_home(), "bar");
 }
 
 #[cargo_test]
@@ -339,7 +337,7 @@ fn pick_max_version() {
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]]).run();
-    assert_has_installed_exe(cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
 }
 
 #[cargo_test]
@@ -353,7 +351,7 @@ fn installs_beta_version_by_explicit_name_from_git() {
         .arg(p.url().to_string())
         .arg("foo")
         .run();
-    assert_has_installed_exe(cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
 }
 
 #[cargo_test]
@@ -439,7 +437,7 @@ fn install_location_precedence() {
     let t1 = root.join("t1");
     let t2 = root.join("t2");
     let t3 = root.join("t3");
-    let t4 = cargo_home();
+    let t4 = paths::cargo_home();
 
     fs::create_dir(root.join(".cargo")).unwrap();
     fs::write(
@@ -489,7 +487,7 @@ fn install_path() {
     let p = project().file("src/main.rs", "fn main() {}").build();
 
     cargo_process("install --path").arg(p.root()).run();
-    assert_has_installed_exe(cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
     // path-style installs force a reinstall
     p.cargo("install --path .").with_stderr_data(str![[r#"
 [INSTALLING] foo v0.0.1 ([ROOT]/foo)
@@ -680,7 +678,7 @@ fn multiple_binaries_in_selected_package_installs_all() {
         .arg("bar")
         .run();
 
-    let cargo_home = cargo_home();
+    let cargo_home = paths::cargo_home();
     assert_has_installed_exe(&cargo_home, "bin1");
     assert_has_installed_exe(&cargo_home, "bin2");
 }
@@ -700,7 +698,7 @@ fn multiple_binaries_in_selected_package_with_bin_option_installs_only_one() {
         .arg("bar")
         .run();
 
-    let cargo_home = cargo_home();
+    let cargo_home = paths::cargo_home();
     assert_has_installed_exe(&cargo_home, "bin1");
     assert_has_not_installed_exe(&cargo_home, "bin2");
 }
@@ -718,14 +716,14 @@ fn multiple_crates_select() {
         .arg(p.url().to_string())
         .arg("foo")
         .run();
-    assert_has_installed_exe(cargo_home(), "foo");
-    assert_has_not_installed_exe(cargo_home(), "bar");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
+    assert_has_not_installed_exe(paths::cargo_home(), "bar");
 
     cargo_process("install --git")
         .arg(p.url().to_string())
         .arg("bar")
         .run();
-    assert_has_installed_exe(cargo_home(), "bar");
+    assert_has_installed_exe(paths::cargo_home(), "bar");
 }
 
 #[cargo_test]
@@ -774,7 +772,7 @@ fn multiple_crates_auto_binaries() {
         .build();
 
     cargo_process("install --path").arg(p.root()).run();
-    assert_has_installed_exe(cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
 }
 
 #[cargo_test]
@@ -809,7 +807,7 @@ fn multiple_crates_auto_examples() {
         .arg(p.root())
         .arg("--example=foo")
         .run();
-    assert_has_installed_exe(cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
 }
 
 #[cargo_test]
@@ -873,7 +871,7 @@ fn examples() {
         .arg(p.root())
         .arg("--example=foo")
         .run();
-    assert_has_installed_exe(cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
 }
 
 #[cargo_test]
@@ -1031,8 +1029,8 @@ fn git_repo() {
 
 "#]])
         .run();
-    assert_has_installed_exe(cargo_home(), "foo");
-    assert_has_installed_exe(cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
 }
 
 #[cargo_test]
@@ -1087,7 +1085,7 @@ foo v0.0.1:
 
 "#]])
         .run();
-    let mut worldfile_path = cargo_home();
+    let mut worldfile_path = paths::cargo_home();
     worldfile_path.push(".crates.toml");
     let mut worldfile = OpenOptions::new()
         .write(true)
@@ -1147,8 +1145,8 @@ fn uninstall_piecemeal() {
         .build();
 
     cargo_process("install --path").arg(p.root()).run();
-    assert_has_installed_exe(cargo_home(), "foo");
-    assert_has_installed_exe(cargo_home(), "bar");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "bar");
 
     cargo_process("uninstall foo --bin=bar")
         .with_stderr_data(str![[r#"
@@ -1157,8 +1155,8 @@ fn uninstall_piecemeal() {
 "#]])
         .run();
 
-    assert_has_installed_exe(cargo_home(), "foo");
-    assert_has_not_installed_exe(cargo_home(), "bar");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
+    assert_has_not_installed_exe(paths::cargo_home(), "bar");
 
     cargo_process("uninstall foo --bin=foo")
         .with_stderr_data(str![[r#"
@@ -1166,7 +1164,7 @@ fn uninstall_piecemeal() {
 
 "#]])
         .run();
-    assert_has_not_installed_exe(cargo_home(), "foo");
+    assert_has_not_installed_exe(paths::cargo_home(), "foo");
 
     cargo_process("uninstall foo")
         .with_status(101)
@@ -1206,7 +1204,7 @@ fn installs_from_cwd_by_default() {
 [WARNING] Using `cargo install` to install the binaries from the package in current working directory is deprecated, use `cargo install --path .` instead. Use `cargo build` if you want to simply build the package.
 ...
 "#]]).run();
-    assert_has_installed_exe(cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
 }
 
 #[cargo_test]
@@ -1232,7 +1230,7 @@ fn installs_from_cwd_with_2018_warnings() {
 
 "#]])
         .run();
-    assert_has_not_installed_exe(cargo_home(), "foo");
+    assert_has_not_installed_exe(paths::cargo_home(), "foo");
 }
 
 #[cargo_test]
@@ -1247,7 +1245,7 @@ fn uninstall_cwd() {
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]]).run();
-    assert_has_installed_exe(cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
 
     p.cargo("uninstall")
         .with_stdout_data("")
@@ -1256,7 +1254,7 @@ fn uninstall_cwd() {
 
 "#]])
         .run();
-    assert_has_not_installed_exe(cargo_home(), "foo");
+    assert_has_not_installed_exe(paths::cargo_home(), "foo");
 }
 
 #[cargo_test]
@@ -1306,7 +1304,7 @@ fn do_not_rebuilds_on_local_install() {
 
     assert!(p.build_dir().exists());
     assert!(p.release_bin("foo").exists());
-    assert_has_installed_exe(cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
 }
 
 #[cargo_test]
@@ -1393,7 +1391,7 @@ fn readonly_dir() {
     fs::set_permissions(dir, perms).unwrap();
 
     cargo_process("install foo").cwd(dir).run();
-    assert_has_installed_exe(cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
 }
 
 #[cargo_test]
@@ -1590,7 +1588,7 @@ fn install_target_native() {
     cargo_process("install foo --target")
         .arg(cargo_test_support::rustc_host())
         .run();
-    assert_has_installed_exe(cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
 }
 
 #[cargo_test]
@@ -1604,7 +1602,7 @@ fn install_target_foreign() {
     cargo_process("install foo --target")
         .arg(cross_compile::alternate())
         .run();
-    assert_has_installed_exe(cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
 }
 
 #[cargo_test]
@@ -1768,8 +1766,8 @@ fn uninstall_multiple_and_some_pkg_does_not_exist() {
 "#]])
         .run();
 
-    assert_has_not_installed_exe(cargo_home(), "foo");
-    assert_has_not_installed_exe(cargo_home(), "bar");
+    assert_has_not_installed_exe(paths::cargo_home(), "foo");
+    assert_has_not_installed_exe(paths::cargo_home(), "bar");
 }
 
 #[cargo_test]
@@ -2010,7 +2008,7 @@ fn install_ignores_local_cargo_config() {
         .build();
 
     p.cargo("install bar").run();
-    assert_has_installed_exe(cargo_home(), "bar");
+    assert_has_installed_exe(paths::cargo_home(), "bar");
 }
 
 #[cargo_test]
@@ -2031,14 +2029,14 @@ fn install_ignores_unstable_table_in_local_cargo_config() {
     p.cargo("install bar")
         .masquerade_as_nightly_cargo(&["build-std"])
         .run();
-    assert_has_installed_exe(cargo_home(), "bar");
+    assert_has_installed_exe(paths::cargo_home(), "bar");
 }
 
 #[cargo_test]
 fn install_global_cargo_config() {
     pkg("bar", "0.0.1");
 
-    let config = cargo_home().join("config.toml");
+    let config = paths::cargo_home().join("config.toml");
     let mut toml = fs::read_to_string(&config).unwrap_or_default();
 
     toml.push_str(
@@ -2271,7 +2269,7 @@ workspace: [ROOT]/foo/Cargo.toml
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]]).run();
-    assert_has_installed_exe(cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
 }
 
 #[cargo_test]
@@ -2376,7 +2374,7 @@ fn no_auto_fix_note() {
 
 "#]])
         .run();
-    assert_has_installed_exe(cargo_home(), "auto_fix");
+    assert_has_installed_exe(paths::cargo_home(), "auto_fix");
 
     cargo_process("uninstall auto_fix")
         .with_stderr_data(str![[r#"
@@ -2384,7 +2382,7 @@ fn no_auto_fix_note() {
 
 "#]])
         .run();
-    assert_has_not_installed_exe(cargo_home(), "auto_fix");
+    assert_has_not_installed_exe(paths::cargo_home(), "auto_fix");
 }
 
 #[cargo_test]
@@ -2447,7 +2445,7 @@ fn sparse_install() {
 
 "#]])
         .run();
-    assert_has_installed_exe(cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
     let assert_v1 = |expected| {
         let v1 = fs::read_to_string(paths::home().join(".cargo/.crates.toml")).unwrap();
         assert_e2e().eq(&v1, expected);
@@ -2458,7 +2456,7 @@ fn sparse_install() {
 
 "#]]);
     cargo_process("install bar").run();
-    assert_has_installed_exe(cargo_home(), "bar");
+    assert_has_installed_exe(paths::cargo_home(), "bar");
     assert_v1(str![[r#"
 [v1]
 "bar 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = ["bar[EXE]"]
@@ -2472,7 +2470,7 @@ fn sparse_install() {
 
 "#]])
         .run();
-    assert_has_not_installed_exe(cargo_home(), "bar");
+    assert_has_not_installed_exe(paths::cargo_home(), "bar");
     assert_v1(str![[r#"
 [v1]
 "foo 0.0.1 (sparse+http://127.0.0.1:[..]/index/)" = ["foo[EXE]"]
@@ -2484,7 +2482,7 @@ fn sparse_install() {
 
 "#]])
         .run();
-    assert_has_not_installed_exe(cargo_home(), "foo");
+    assert_has_not_installed_exe(paths::cargo_home(), "foo");
     assert_v1(str![[r#"
 [v1]
 
@@ -2523,7 +2521,7 @@ fn self_referential() {
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]]).run();
-    assert_has_installed_exe(cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
 }
 
 #[cargo_test]
@@ -2568,7 +2566,7 @@ fn ambiguous_registry_vs_local_package() {
 
 "#]])
         .run();
-    assert_has_installed_exe(cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
 }
 
 #[cargo_test]
@@ -2614,10 +2612,12 @@ fn install_incompat_msrv() {
 
 fn assert_tracker_noexistence(key: &str) {
     let v1_data: toml::Value =
-        toml::from_str(&fs::read_to_string(cargo_home().join(".crates.toml")).unwrap()).unwrap();
-    let v2_data: serde_json::Value =
-        serde_json::from_str(&fs::read_to_string(cargo_home().join(".crates2.json")).unwrap())
+        toml::from_str(&fs::read_to_string(paths::cargo_home().join(".crates.toml")).unwrap())
             .unwrap();
+    let v2_data: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(paths::cargo_home().join(".crates2.json")).unwrap(),
+    )
+    .unwrap();
 
     assert!(v1_data["v1"].get(key).is_none());
     assert!(v2_data["installs"][key].is_null());
@@ -2666,9 +2666,9 @@ fn uninstall_running_binary() {
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]]).run();
-    assert_has_installed_exe(cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
 
-    let foo_bin = cargo_home().join("bin").join(exe("foo"));
+    let foo_bin = paths::cargo_home().join("bin").join(exe("foo"));
     let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = l.local_addr().unwrap().to_string();
     let t = thread::spawn(move || {
@@ -2716,7 +2716,7 @@ fn uninstall_running_binary() {
         t.join().unwrap();
     };
 
-    assert_has_not_installed_exe(cargo_home(), "foo");
+    assert_has_not_installed_exe(paths::cargo_home(), "foo");
     assert_tracker_noexistence(key);
 
     cargo_process("install foo").with_stderr_data(str![[r#"

--- a/tests/testsuite/install_upgrade.rs
+++ b/tests/testsuite/install_upgrade.rs
@@ -7,7 +7,8 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use cargo::core::PackageId;
-use cargo_test_support::install::{cargo_home, exe};
+use cargo_test_support::install::exe;
+use cargo_test_support::paths;
 use cargo_test_support::prelude::*;
 use cargo_test_support::registry::{self, Package};
 use cargo_test_support::{
@@ -30,11 +31,11 @@ fn pkg(name: &str, vers: &str) {
 }
 
 fn v1_path() -> PathBuf {
-    cargo_home().join(".crates.toml")
+    paths::cargo_home().join(".crates.toml")
 }
 
 fn v2_path() -> PathBuf {
-    cargo_home().join(".crates2.json")
+    paths::cargo_home().join(".crates2.json")
 }
 
 fn load_crates1() -> toml::Value {
@@ -46,7 +47,7 @@ fn load_crates2() -> serde_json::Value {
 }
 
 fn installed_exe(name: &str) -> PathBuf {
-    cargo_home().join("bin").join(exe(name))
+    paths::cargo_home().join("bin").join(exe(name))
 }
 
 /// Helper for executing binaries installed by cargo.
@@ -531,7 +532,7 @@ fn forwards_compatible() {
     pkg("bar", "1.0.0");
     cargo_process("install foo").run();
     let key = "foo 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)";
-    let v2 = cargo_home().join(".crates2.json");
+    let v2 = paths::cargo_home().join(".crates2.json");
     let mut data = load_crates2();
     data["newfield"] = serde_json::Value::Bool(true);
     data["installs"][key]["moreinfo"] = serde_json::Value::String("shazam".to_string());

--- a/tests/testsuite/jobserver.rs
+++ b/tests/testsuite/jobserver.rs
@@ -8,7 +8,7 @@ use std::thread;
 use cargo_test_support::basic_bin_manifest;
 use cargo_test_support::cargo_exe;
 use cargo_test_support::install::assert_has_installed_exe;
-use cargo_test_support::install::cargo_home;
+use cargo_test_support::paths;
 use cargo_test_support::prelude::*;
 use cargo_test_support::{project, rustc_host, str};
 use cargo_util::is_ci;
@@ -105,7 +105,7 @@ all:
         .build();
 
     p.cargo("install --path .").run();
-    assert_has_installed_exe(cargo_home(), name);
+    assert_has_installed_exe(paths::cargo_home(), name);
 
     p.process(make).env("CARGO", cargo_exe()).arg("-j2").run();
 }
@@ -138,9 +138,9 @@ fn runner_inherits_jobserver() {
 
     // Add .cargo/bin to PATH
     let mut path: Vec<_> = env::split_paths(&env::var_os("PATH").unwrap_or_default()).collect();
-    path.push(cargo_home().join("bin"));
+    path.push(paths::cargo_home().join("bin"));
     let path = &env::join_paths(path).unwrap();
-    assert_has_installed_exe(cargo_home(), runner);
+    assert_has_installed_exe(paths::cargo_home(), runner);
 
     let host = rustc_host();
     let config_value = &format!("target.{host}.runner = \"{runner}\"");

--- a/tests/testsuite/member_discovery.rs
+++ b/tests/testsuite/member_discovery.rs
@@ -2,7 +2,7 @@
 
 use cargo::core::{Shell, Workspace};
 use cargo::util::context::GlobalContext;
-use cargo_test_support::install::cargo_home;
+use cargo_test_support::paths;
 use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::registry;
@@ -35,8 +35,8 @@ fn bad_file_member_exclusion() {
     registry::init();
     let gctx = GlobalContext::new(
         Shell::from_write(Box::new(Vec::new())),
-        cargo_home(),
-        cargo_home(),
+        paths::cargo_home(),
+        paths::cargo_home(),
     );
     let ws = Workspace::new(&p.root().join("Cargo.toml"), &gctx).unwrap();
     assert_eq!(ws.members().count(), 1);

--- a/tests/testsuite/member_errors.rs
+++ b/tests/testsuite/member_errors.rs
@@ -4,7 +4,7 @@ use cargo::core::resolver::ResolveError;
 use cargo::core::{compiler::CompileMode, Shell, Workspace};
 use cargo::ops::{self, CompileOptions};
 use cargo::util::{context::GlobalContext, errors::ManifestError};
-use cargo_test_support::install::cargo_home;
+use cargo_test_support::paths;
 use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::registry;
@@ -151,8 +151,8 @@ fn member_manifest_version_error() {
     registry::init();
     let gctx = GlobalContext::new(
         Shell::from_write(Box::new(Vec::new())),
-        cargo_home(),
-        cargo_home(),
+        paths::cargo_home(),
+        paths::cargo_home(),
     );
     let ws = Workspace::new(&p.root().join("Cargo.toml"), &gctx).unwrap();
     let compile_options = CompileOptions::new(&gctx, CompileMode::Build).unwrap();

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -1,7 +1,6 @@
 //! Tests for the `cargo metadata` command.
 
-use cargo_test_support::install::cargo_home;
-use cargo_test_support::paths::CargoPathExt;
+use cargo_test_support::paths;
 use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
 use cargo_test_support::{
@@ -3640,8 +3639,8 @@ fn filter_platform() {
     // We're going to be checking that we don't download excessively,
     // so we need to ensure that downloads will happen.
     let clear = || {
-        cargo_home().join("registry/cache").rm_rf();
-        cargo_home().join("registry/src").rm_rf();
+        paths::cargo_home().join("registry/cache").rm_rf();
+        paths::cargo_home().join("registry/src").rm_rf();
         p.build_dir().rm_rf();
     };
 

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -14,7 +14,7 @@ use cargo_test_support::registry::{
     self, registry_path, Dependency, Package, RegistryBuilder, Response, TestRegistry,
 };
 use cargo_test_support::{basic_manifest, project, str};
-use cargo_test_support::{git, install::cargo_home, t};
+use cargo_test_support::{git, t};
 use cargo_util::paths::remove_dir_all;
 
 fn setup_http() -> TestRegistry {
@@ -3105,7 +3105,7 @@ fn package_lock_inside_package_is_overwritten() {
 
     let id = SourceId::for_registry(registry.index_url()).unwrap();
     let hash = cargo::util::hex::short_hash(&id);
-    let ok = cargo_home()
+    let ok = paths::cargo_home()
         .join("registry")
         .join("src")
         .join(format!("-{}", hash))
@@ -3144,7 +3144,7 @@ fn package_lock_as_a_symlink_inside_package_is_overwritten() {
 
     let id = SourceId::for_registry(registry.index_url()).unwrap();
     let hash = cargo::util::hex::short_hash(&id);
-    let pkg_root = cargo_home()
+    let pkg_root = paths::cargo_home()
         .join("registry")
         .join("src")
         .join(format!("-{}", hash))
@@ -3872,7 +3872,7 @@ or use environment variable CARGO_REGISTRIES_ALTERNATIVE_TOKEN
 
     // Test the output with the default.
     cargo_util::paths::append(
-        &cargo_home().join("config.toml"),
+        &paths::cargo_home().join("config.toml"),
         br#"
             [registry]
             default = "alternative"

--- a/tests/testsuite/required_features.rs
+++ b/tests/testsuite/required_features.rs
@@ -1,9 +1,8 @@
 //! Tests for targets with `required-features`.
 
-use cargo_test_support::install::{
-    assert_has_installed_exe, assert_has_not_installed_exe, cargo_home,
-};
+use cargo_test_support::install::{assert_has_installed_exe, assert_has_not_installed_exe};
 use cargo_test_support::is_nightly;
+use cargo_test_support::paths;
 use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::str;
@@ -742,7 +741,7 @@ fn install_default_features() {
         .build();
 
     p.cargo("install --path .").run();
-    assert_has_installed_exe(cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
     p.cargo("uninstall foo").run();
 
     p.cargo("install --path . --no-default-features")
@@ -756,10 +755,10 @@ Consider enabling some of the needed features by passing, e.g., `--features="a"`
 
 "#]])
         .run();
-    assert_has_not_installed_exe(cargo_home(), "foo");
+    assert_has_not_installed_exe(paths::cargo_home(), "foo");
 
     p.cargo("install --path . --bin=foo").run();
-    assert_has_installed_exe(cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
     p.cargo("uninstall foo").run();
 
     p.cargo("install --path . --bin=foo --no-default-features")
@@ -775,10 +774,10 @@ Caused by:
 
 "#]])
         .run();
-    assert_has_not_installed_exe(cargo_home(), "foo");
+    assert_has_not_installed_exe(paths::cargo_home(), "foo");
 
     p.cargo("install --path . --example=foo").run();
-    assert_has_installed_exe(cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
     p.cargo("uninstall foo").run();
 
     p.cargo("install --path . --example=foo --no-default-features")
@@ -794,7 +793,7 @@ Caused by:
 
 "#]])
         .run();
-    assert_has_not_installed_exe(cargo_home(), "foo");
+    assert_has_not_installed_exe(paths::cargo_home(), "foo");
 }
 
 #[cargo_test]
@@ -821,7 +820,7 @@ fn install_arg_features() {
         .build();
 
     p.cargo("install --features a").run();
-    assert_has_installed_exe(cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
     p.cargo("uninstall foo").run();
 }
 
@@ -871,32 +870,32 @@ fn install_multiple_required_features() {
         .build();
 
     p.cargo("install --path .").run();
-    assert_has_not_installed_exe(cargo_home(), "foo_1");
-    assert_has_installed_exe(cargo_home(), "foo_2");
-    assert_has_not_installed_exe(cargo_home(), "foo_3");
-    assert_has_not_installed_exe(cargo_home(), "foo_4");
+    assert_has_not_installed_exe(paths::cargo_home(), "foo_1");
+    assert_has_installed_exe(paths::cargo_home(), "foo_2");
+    assert_has_not_installed_exe(paths::cargo_home(), "foo_3");
+    assert_has_not_installed_exe(paths::cargo_home(), "foo_4");
     p.cargo("uninstall foo").run();
 
     p.cargo("install --path . --bins --examples").run();
-    assert_has_not_installed_exe(cargo_home(), "foo_1");
-    assert_has_installed_exe(cargo_home(), "foo_2");
-    assert_has_not_installed_exe(cargo_home(), "foo_3");
-    assert_has_installed_exe(cargo_home(), "foo_4");
+    assert_has_not_installed_exe(paths::cargo_home(), "foo_1");
+    assert_has_installed_exe(paths::cargo_home(), "foo_2");
+    assert_has_not_installed_exe(paths::cargo_home(), "foo_3");
+    assert_has_installed_exe(paths::cargo_home(), "foo_4");
     p.cargo("uninstall foo").run();
 
     p.cargo("install --path . --features c").run();
-    assert_has_installed_exe(cargo_home(), "foo_1");
-    assert_has_installed_exe(cargo_home(), "foo_2");
-    assert_has_not_installed_exe(cargo_home(), "foo_3");
-    assert_has_not_installed_exe(cargo_home(), "foo_4");
+    assert_has_installed_exe(paths::cargo_home(), "foo_1");
+    assert_has_installed_exe(paths::cargo_home(), "foo_2");
+    assert_has_not_installed_exe(paths::cargo_home(), "foo_3");
+    assert_has_not_installed_exe(paths::cargo_home(), "foo_4");
     p.cargo("uninstall foo").run();
 
     p.cargo("install --path . --features c --bins --examples")
         .run();
-    assert_has_installed_exe(cargo_home(), "foo_1");
-    assert_has_installed_exe(cargo_home(), "foo_2");
-    assert_has_installed_exe(cargo_home(), "foo_3");
-    assert_has_installed_exe(cargo_home(), "foo_4");
+    assert_has_installed_exe(paths::cargo_home(), "foo_1");
+    assert_has_installed_exe(paths::cargo_home(), "foo_2");
+    assert_has_installed_exe(paths::cargo_home(), "foo_3");
+    assert_has_installed_exe(paths::cargo_home(), "foo_4");
     p.cargo("uninstall foo").run();
 
     p.cargo("install --path . --no-default-features")
@@ -954,10 +953,10 @@ Consider enabling some of the needed features by passing, e.g., `--features="b c
 
 "#]])
         .run();
-    assert_has_not_installed_exe(cargo_home(), "foo_1");
-    assert_has_not_installed_exe(cargo_home(), "foo_2");
-    assert_has_not_installed_exe(cargo_home(), "foo_3");
-    assert_has_not_installed_exe(cargo_home(), "foo_4");
+    assert_has_not_installed_exe(paths::cargo_home(), "foo_1");
+    assert_has_not_installed_exe(paths::cargo_home(), "foo_2");
+    assert_has_not_installed_exe(paths::cargo_home(), "foo_3");
+    assert_has_not_installed_exe(paths::cargo_home(), "foo_4");
 }
 
 #[cargo_test]
@@ -1075,7 +1074,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured; 0 filtered out; fini
 
     // install
     p.cargo("install").run();
-    assert_has_installed_exe(cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
     p.cargo("uninstall foo").run();
 }
 
@@ -1261,10 +1260,10 @@ Consider enabling some of the needed features by passing, e.g., `--features="bar
 
 "#]])
         .run();
-    assert_has_not_installed_exe(cargo_home(), "foo");
+    assert_has_not_installed_exe(paths::cargo_home(), "foo");
 
     p.cargo("install --features bar/a").run();
-    assert_has_installed_exe(cargo_home(), "foo");
+    assert_has_installed_exe(paths::cargo_home(), "foo");
     p.cargo("uninstall foo").run();
 }
 


### PR DESCRIPTION
### What does this PR try to resolve?

This is used outside of `cargo install` contexts and this makes it more
discoverable for those use cases.  That I found places that weren't using `cargo_home` but could helps illustrate the point.

### How should we test and review this PR?

### Additional information


