### PR TITLE
docs(test): Expand documentation of cargo-test-support

### DIFF
--- a/crates/cargo-test-macro/src/lib.rs
+++ b/crates/cargo-test-macro/src/lib.rs
@@ -14,6 +14,49 @@ use std::path::Path;
 use std::process::Command;
 use std::sync::Once;
 
+/// Replacement for `#[test]`
+///
+/// The `#[cargo_test]` attribute extends `#[test]` with some setup before starting the test.
+/// It will create a filesystem "sandbox" under the "cargo integration test" directory for each test, such as `/path/to/cargo/target/tmp/cit/t123/`.
+/// The sandbox will contain a `home` directory that will be used instead of your normal home directory.
+///
+/// The `#[cargo_test]` attribute takes several options that will affect how the test is generated.
+/// They are listed in parentheses separated with commas, such as:
+///
+/// ```rust,ignore
+/// #[cargo_test(nightly, reason = "-Zfoo is unstable")]
+/// ```
+///
+/// The options it supports are:
+///
+/// * `>=1.64` --- This indicates that the test will only run with the given version of `rustc` or newer.
+///   This can be used when a new `rustc` feature has been stabilized that the test depends on.
+///   If this is specified, a `reason` is required to explain why it is being checked.
+/// * `nightly` --- This will cause the test to be ignored if not running on the nightly toolchain.
+///   This is useful for tests that use unstable options in `rustc` or `rustdoc`.
+///   These tests are run in Cargo's CI, but are disabled in rust-lang/rust's CI due to the difficulty of updating both repos simultaneously.
+///   A `reason` field is required to explain why it is nightly-only.
+/// * `requires_<cmd>` --- This indicates a command that is required to be installed to be run.
+///   For example, `requires_rustfmt` means the test will only run if the executable `rustfmt` is installed.
+///   These tests are *always* run on CI.
+///   This is mainly used to avoid requiring contributors from having every dependency installed.
+/// * `build_std_real` --- This is a "real" `-Zbuild-std` test (in the `build_std` integration test).
+///   This only runs on nightly, and only if the environment variable `CARGO_RUN_BUILD_STD_TESTS` is set (these tests on run on Linux).
+/// * `build_std_mock` --- This is a "mock" `-Zbuild-std` test (which uses a mock standard library).
+///   This only runs on nightly, and is disabled for windows-gnu.
+/// * `public_network_test` --- This tests contacts the public internet.
+///   These tests are disabled unless the `CARGO_PUBLIC_NETWORK_TESTS` environment variable is set.
+///   Use of this should be *extremely rare*, please avoid using it if possible.
+///   The hosts it contacts should have a relatively high confidence that they are reliable and stable (such as github.com), especially in CI.
+///   The tests should be carefully considered for developer security and privacy as well.
+/// * `container_test` --- This indicates that it is a test that uses Docker.
+///   These tests are disabled unless the `CARGO_CONTAINER_TESTS` environment variable is set.
+///   This requires that you have Docker installed.
+///   The SSH tests also assume that you have OpenSSH installed.
+///   These should work on Linux, macOS, and Windows where possible.
+///   Unfortunately these tests are not run in CI for macOS or Windows (no Docker on macOS, and Windows does not support Linux images).
+///   See [`crates/cargo-test-support/src/containers.rs`](https://github.com/rust-lang/cargo/blob/master/crates/cargo-test-support/src/containers.rs) for more on writing these tests.
+/// * `ignore_windows="reason"` --- Indicates that the test should be ignored on windows for the given reason.
 #[proc_macro_attribute]
 pub fn cargo_test(attr: TokenStream, item: TokenStream) -> TokenStream {
     // Ideally these options would be embedded in the test itself. However, I

--- a/crates/cargo-test-macro/src/lib.rs
+++ b/crates/cargo-test-macro/src/lib.rs
@@ -55,7 +55,7 @@ use std::sync::Once;
 ///   The SSH tests also assume that you have OpenSSH installed.
 ///   These should work on Linux, macOS, and Windows where possible.
 ///   Unfortunately these tests are not run in CI for macOS or Windows (no Docker on macOS, and Windows does not support Linux images).
-///   See [`crates/cargo-test-support/src/containers.rs`](https://github.com/rust-lang/cargo/blob/master/crates/cargo-test-support/src/containers.rs) for more on writing these tests.
+///   See [`cargo-test-support::containers`](https://doc.rust-lang.org/nightly/nightly-rustc/cargo_test_support/containers) for more on writing these tests.
 /// * `ignore_windows="reason"` --- Indicates that the test should be ignored on windows for the given reason.
 #[proc_macro_attribute]
 pub fn cargo_test(attr: TokenStream, item: TokenStream) -> TokenStream {

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -8,9 +8,6 @@ homepage.workspace = true
 repository.workspace = true
 description = "Testing framework for Cargo's testsuite."
 
-[lib]
-doctest = false
-
 [dependencies]
 anstream.workspace = true
 anstyle.workspace = true

--- a/crates/cargo-test-support/src/compare.rs
+++ b/crates/cargo-test-support/src/compare.rs
@@ -1,6 +1,11 @@
 //! Routines for comparing and diffing output.
 //!
-//! # Patterns
+//! # Deprecated comparisons
+//!
+//! Cargo's tests are in transition from internal-only pattern and normalization routines used in
+//! asserts like [`crate::Execs::with_stdout`] to [`assert_e2e`] and [`assert_ui`].
+//!
+//! ## Patterns
 //!
 //! Many of these functions support special markup to assist with comparing
 //! text that may vary or is otherwise uninteresting for the test at hand. The
@@ -22,7 +27,7 @@
 //!   can use this to avoid duplicating the `with_stderr` call like:
 //!   `if cfg!(target_env = "msvc") {e.with_stderr("...[DIRTY]...");} else {e.with_stderr("...");}`.
 //!
-//! # Normalization
+//! ## Normalization
 //!
 //! In addition to the patterns described above, the strings are normalized
 //! in such a way to avoid unwanted differences. The normalizations are:
@@ -86,6 +91,19 @@ macro_rules! regex {
 ///   Other heuristics are applied to try to ensure Windows-style paths aren't
 ///   a problem.
 /// - Carriage returns are removed, which can help when running on Windows.
+///
+/// # Example
+///
+/// ```no_run
+/// # use cargo_test_support::compare::assert_e2e;
+/// # use cargo_test_support::file;
+/// # let p = cargo_test_support::project().build();
+/// # let stdout = "";
+/// assert_e2e().eq(stdout, file!["stderr.term.svg"]);
+/// ```
+/// ```console
+/// $ SNAPSHOTS=overwrite cargo test
+/// ```
 pub fn assert_ui() -> snapbox::Assert {
     let mut subs = snapbox::Redactions::new();
     subs.extend(MIN_LITERAL_REDACTIONS.into_iter().cloned())
@@ -129,6 +147,18 @@ pub fn assert_ui() -> snapbox::Assert {
 ///   Other heuristics are applied to try to ensure Windows-style paths aren't
 ///   a problem.
 /// - Carriage returns are removed, which can help when running on Windows.
+///
+/// # Example
+///
+/// ```no_run
+/// # use cargo_test_support::compare::assert_e2e;
+/// # use cargo_test_support::str;
+/// # let p = cargo_test_support::project().build();
+/// assert_e2e().eq(p.read_lockfile(), str![]);
+/// ```
+/// ```console
+/// $ SNAPSHOTS=overwrite cargo test
+/// ```
 pub fn assert_e2e() -> snapbox::Assert {
     let mut subs = snapbox::Redactions::new();
     subs.extend(MIN_LITERAL_REDACTIONS.into_iter().cloned())

--- a/crates/cargo-test-support/src/git.rs
+++ b/crates/cargo-test-support/src/git.rs
@@ -1,42 +1,42 @@
-/*
-# Git Testing Support
-
-## Creating a git dependency
-`git::new()` is an easy way to create a new git repository containing a
-project that you can then use as a dependency. It will automatically add all
-the files you specify in the project and commit them to the repository.
-Example:
-
-```
-let git_project = git::new("dep1", |project| {
-    project
-        .file("Cargo.toml", &basic_manifest("dep1", "1.0.0"))
-        .file("src/lib.rs", r#"pub fn f() { println!("hi!"); } "#)
-});
-
-// Use the `url()` method to get the file url to the new repository.
-let p = project()
-    .file("Cargo.toml", &format!(r#"
-        [package]
-        name = "a"
-        version = "1.0.0"
-
-        [dependencies]
-        dep1 = {{ git = '{}' }}
-    "#, git_project.url()))
-    .file("src/lib.rs", "extern crate dep1;")
-    .build();
-```
-
-## Manually creating repositories
-`git::repo()` can be used to create a `RepoBuilder` which provides a way of
-adding files to a blank repository and committing them.
-
-If you want to then manipulate the repository (such as adding new files or
-tags), you can use `git2::Repository::open()` to open the repository and then
-use some of the helper functions in this file to interact with the repository.
-
-*/
+//! # Git Testing Support
+//!
+//! ## Creating a git dependency
+//! `git::new()` is an easy way to create a new git repository containing a
+//! project that you can then use as a dependency. It will automatically add all
+//! the files you specify in the project and commit them to the repository.
+//! Example:
+//!
+//! ```no_run
+//! # use cargo_test_support::project;
+//! # use cargo_test_support::basic_manifest;
+//! # use cargo_test_support::git;
+//! let git_project = git::new("dep1", |project| {
+//!     project
+//!         .file("Cargo.toml", &basic_manifest("dep1", "1.0.0"))
+//!         .file("src/lib.rs", r#"pub fn f() { println!("hi!"); } "#)
+//! });
+//!
+//! // Use the `url()` method to get the file url to the new repository.
+//! let p = project()
+//!     .file("Cargo.toml", &format!(r#"
+//!         [package]
+//!         name = "a"
+//!         version = "1.0.0"
+//!
+//!         [dependencies]
+//!         dep1 = {{ git = '{}' }}
+//!     "#, git_project.url()))
+//!     .file("src/lib.rs", "extern crate dep1;")
+//!     .build();
+//! ```
+//!
+//! ## Manually creating repositories
+//! `git::repo()` can be used to create a `RepoBuilder` which provides a way of
+//! adding files to a blank repository and committing them.
+//!
+//! If you want to then manipulate the repository (such as adding new files or
+//! tags), you can use `git2::Repository::open()` to open the repository and then
+//! use some of the helper functions in this file to interact with the repository.
 
 use crate::{paths::CargoPathExt, project, Project, ProjectBuilder, SymlinkBuilder};
 use std::fs;

--- a/crates/cargo-test-support/src/git.rs
+++ b/crates/cargo-test-support/src/git.rs
@@ -1,10 +1,11 @@
 //! # Git Testing Support
 //!
 //! ## Creating a git dependency
-//! `git::new()` is an easy way to create a new git repository containing a
+//! [`new()`] is an easy way to create a new git repository containing a
 //! project that you can then use as a dependency. It will automatically add all
 //! the files you specify in the project and commit them to the repository.
-//! Example:
+//!
+//! ### Example:
 //!
 //! ```no_run
 //! # use cargo_test_support::project;
@@ -31,7 +32,8 @@
 //! ```
 //!
 //! ## Manually creating repositories
-//! `git::repo()` can be used to create a `RepoBuilder` which provides a way of
+//!
+//! [`repo()`] can be used to create a [`RepoBuilder`] which provides a way of
 //! adding files to a blank repository and committing them.
 //!
 //! If you want to then manipulate the repository (such as adding new files or
@@ -44,17 +46,21 @@ use std::path::{Path, PathBuf};
 use std::sync::Once;
 use url::Url;
 
+/// Manually construct a [`Repository`]
+///
+/// See also [`new`], [`repo`]
 #[must_use]
 pub struct RepoBuilder {
     repo: git2::Repository,
     files: Vec<PathBuf>,
 }
 
+/// See [`new`]
 pub struct Repository(git2::Repository);
 
-/// Create a `RepoBuilder` to build a new git repository.
+/// Create a [`RepoBuilder`] to build a new git repository.
 ///
-/// Call `build()` to finalize and create the repository.
+/// Call [`RepoBuilder::build()`] to finalize and create the repository.
 pub fn repo(p: &Path) -> RepoBuilder {
     RepoBuilder::init(p)
 }
@@ -130,7 +136,7 @@ impl Repository {
     }
 }
 
-/// Initialize a new repository at the given path.
+/// *(`git2`)* Initialize a new repository at the given path.
 pub fn init(path: &Path) -> git2::Repository {
     default_search_path();
     let repo = t!(git2::Repository::init(path));
@@ -158,7 +164,7 @@ fn default_repo_cfg(repo: &git2::Repository) {
     t!(cfg.set_str("user.name", "Foo Bar"));
 }
 
-/// Create a new git repository with a project.
+/// Create a new [`Project`] in a git [`Repository`]
 pub fn new<F>(name: &str, callback: F) -> Project
 where
     F: FnOnce(ProjectBuilder) -> ProjectBuilder,
@@ -166,8 +172,7 @@ where
     new_repo(name, callback).0
 }
 
-/// Create a new git repository with a project.
-/// Returns both the Project and the git Repository.
+/// Create a new [`Project`] with access to the [`Repository`]
 pub fn new_repo<F>(name: &str, callback: F) -> (Project, git2::Repository)
 where
     F: FnOnce(ProjectBuilder) -> ProjectBuilder,
@@ -182,14 +187,14 @@ where
     (git_project, repo)
 }
 
-/// Add all files in the working directory to the git index.
+/// *(`git2`)* Add all files in the working directory to the git index
 pub fn add(repo: &git2::Repository) {
     let mut index = t!(repo.index());
     t!(index.add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None));
     t!(index.write());
 }
 
-/// Add a git submodule to the repository.
+/// *(`git2`)* Add a git submodule to the repository
 pub fn add_submodule<'a>(
     repo: &'a git2::Repository,
     url: &str,
@@ -207,7 +212,7 @@ pub fn add_submodule<'a>(
     s
 }
 
-/// Commit changes to the git repository.
+/// *(`git2`)* Commit changes to the git repository
 pub fn commit(repo: &git2::Repository) -> git2::Oid {
     let tree_id = t!(t!(repo.index()).write_tree());
     let sig = t!(repo.signature());
@@ -226,7 +231,7 @@ pub fn commit(repo: &git2::Repository) -> git2::Oid {
     ))
 }
 
-/// Create a new tag in the git repository.
+/// *(`git2`)* Create a new tag in the git repository
 pub fn tag(repo: &git2::Repository, name: &str) {
     let head = repo.head().unwrap().target().unwrap();
     t!(repo.tag(

--- a/crates/cargo-test-support/src/install.rs
+++ b/crates/cargo-test-support/src/install.rs
@@ -1,3 +1,5 @@
+//! Helpers for testing `cargo install`
+
 use std::env::consts::EXE_SUFFIX;
 use std::path::Path;
 
@@ -23,6 +25,7 @@ fn check_has_installed_exe<P: AsRef<Path>>(path: P, name: &'static str) -> bool 
     path.as_ref().join("bin").join(exe(name)).is_file()
 }
 
+/// `$name$EXE`
 pub fn exe(name: &str) -> String {
     format!("{}{}", name, EXE_SUFFIX)
 }

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -540,10 +540,24 @@ pub fn project_in_home(name: &str) -> ProjectBuilder {
 
 // === Helpers ===
 
-pub fn main_file(println: &str, deps: &[&str]) -> String {
+/// Generate a `main.rs` printing the specified text
+///
+/// ```rust
+/// # use cargo_test_support::main_file;
+/// # mod dep {
+/// #     fn bar() -> &'static str {
+/// #         "world"
+/// #     }
+/// # }
+/// main_file(
+///     r#""hello {}", dep::bar()"#,
+///     &[]
+/// );
+/// ```
+pub fn main_file(println: &str, externed_deps: &[&str]) -> String {
     let mut buf = String::new();
 
-    for dep in deps.iter() {
+    for dep in externed_deps.iter() {
         buf.push_str(&format!("extern crate {};\n", dep));
     }
 

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -63,6 +63,14 @@ use url::Url;
 
 use self::paths::CargoPathExt;
 
+/// Unwrap a `Result` with a useful panic message
+///
+/// # Example
+///
+/// ```rust
+/// use cargo_test_support::t;
+/// t!(std::fs::read_to_string("Cargo.toml"));
+/// ```
 #[macro_export]
 macro_rules! t {
     ($e:expr) => {

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -604,7 +604,10 @@ impl Execs {
         self.process_builder = Some(p);
         self
     }
+}
 
+/// # Configure assertions
+impl Execs {
     /// Verifies that stdout is equal to the given lines.
     /// See [`compare`] for supported patterns.
     #[deprecated(note = "replaced with `Execs::with_stdout_data(expected)`")]
@@ -834,7 +837,10 @@ impl Execs {
         }
         self
     }
+}
 
+/// # Configure the process
+impl Execs {
     /// Forward subordinate process stdout/stderr to the terminal.
     /// Useful for printf debugging of the tests.
     /// CAUTION: CI will fail if you leave this in your test!
@@ -888,20 +894,6 @@ impl Execs {
         self
     }
 
-    pub fn exec_with_output(&mut self) -> Result<Output> {
-        self.ran = true;
-        // TODO avoid unwrap
-        let p = (&self.process_builder).clone().unwrap();
-        p.exec_with_output()
-    }
-
-    pub fn build_command(&mut self) -> Command {
-        self.ran = true;
-        // TODO avoid unwrap
-        let p = (&self.process_builder).clone().unwrap();
-        p.build_command()
-    }
-
     /// Enables nightly features for testing
     ///
     /// The list of reasons should be why nightly cargo is needed. If it is
@@ -949,6 +941,23 @@ impl Execs {
             return self.enable_split_debuginfo_packed();
         }
         self
+    }
+}
+
+/// # Run and verify the process
+impl Execs {
+    pub fn exec_with_output(&mut self) -> Result<Output> {
+        self.ran = true;
+        // TODO avoid unwrap
+        let p = (&self.process_builder).clone().unwrap();
+        p.exec_with_output()
+    }
+
+    pub fn build_command(&mut self) -> Command {
+        self.ran = true;
+        // TODO avoid unwrap
+        let p = (&self.process_builder).clone().unwrap();
+        p.build_command()
     }
 
     #[track_caller]

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1478,9 +1478,10 @@ pub fn cargo_process(arg_line: &str) -> Execs {
     execs().with_process_builder(p)
 }
 
-pub fn git_process(s: &str) -> ProcessBuilder {
+/// Run `git $arg_line`, see [`ProcessBuilder`]
+pub fn git_process(arg_line: &str) -> ProcessBuilder {
     let mut p = process("git");
-    p.arg_line(s);
+    p.arg_line(arg_line);
     p
 }
 

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1300,8 +1300,13 @@ pub fn is_nightly() -> bool {
         && (vv.contains("-nightly") || vv.contains("-dev"))
 }
 
-pub fn process<T: AsRef<OsStr>>(t: T) -> ProcessBuilder {
-    _process(t.as_ref())
+/// Run `$bin` in the test's environment, see [`ProcessBuilder`]
+///
+/// For more on the test environment, see
+/// - [`paths::root`]
+/// - [`TestEnvCommandExt`]
+pub fn process<T: AsRef<OsStr>>(bin: T) -> ProcessBuilder {
+    _process(bin.as_ref())
 }
 
 fn _process(t: &OsStr) -> ProcessBuilder {

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -566,10 +566,12 @@ pub fn cargo_exe() -> PathBuf {
 /// does not have access to the raw `ExitStatus` because `ProcessError` needs
 /// to be serializable (for the Rustc cache), and `ExitStatus` does not
 /// provide a constructor.
-pub struct RawOutput {
-    pub code: Option<i32>,
-    pub stdout: Vec<u8>,
-    pub stderr: Vec<u8>,
+struct RawOutput {
+    #[allow(dead_code)]
+    code: Option<i32>,
+    stdout: Vec<u8>,
+    #[allow(dead_code)]
+    stderr: Vec<u8>,
 }
 
 #[must_use]

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -574,6 +574,12 @@ struct RawOutput {
     stderr: Vec<u8>,
 }
 
+/// Run and verify a [`ProcessBuilder`]
+///
+/// Construct with
+/// - [`execs`]
+/// - [`cargo_process`]
+/// - [`Project`] methods
 #[must_use]
 #[derive(Clone)]
 pub struct Execs {
@@ -1166,6 +1172,7 @@ impl Drop for Execs {
     }
 }
 
+/// Run and verify a process, see [`Execs`]
 pub fn execs() -> Execs {
     Execs {
         ran: false,

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -524,17 +524,17 @@ impl Project {
     }
 }
 
-// Generates a project layout
+/// Generates a project layout, see [`ProjectBuilder`]
 pub fn project() -> ProjectBuilder {
     ProjectBuilder::new(paths::root().join("foo"))
 }
 
-// Generates a project layout in given directory
+/// Generates a project layout in given directory, see [`ProjectBuilder`]
 pub fn project_in(dir: &str) -> ProjectBuilder {
     ProjectBuilder::new(paths::root().join(dir).join("foo"))
 }
 
-// Generates a project layout inside our fake home dir
+/// Generates a project layout inside our fake home dir, see [`ProjectBuilder`]
 pub fn project_in_home(name: &str) -> ProjectBuilder {
     ProjectBuilder::new(paths::home().join(name))
 }

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -2,7 +2,16 @@
 //!
 //! See <https://rust-lang.github.io/cargo/contrib/> for a guide on writing tests.
 //!
-//! WARNING: You might not want to use this outside of Cargo.
+//! There are two places you can find API documentation
+//!
+//! - <https://docs.rs/cargo-test-support>:
+//!   targeted at external tool developers testing cargo-related code
+//!   - Released with every rustc release
+//! - <https://doc.rust-lang.org/nightly/nightly-rustc/cargo_test_support>:
+//!   targeted at cargo contributors
+//!   - Updated on each update of the `cargo` submodule in `rust-lang/rust`
+//!
+//! **WARNING:** You might not want to use this outside of Cargo.
 //!
 //! * This is designed for testing Cargo itself. Use at your own risk.
 //! * No guarantee on any stability across versions.

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1198,6 +1198,7 @@ pub fn execs() -> Execs {
     }
 }
 
+/// Generate a basic `Cargo.toml`
 pub fn basic_manifest(name: &str, version: &str) -> String {
     format!(
         r#"
@@ -1211,6 +1212,7 @@ pub fn basic_manifest(name: &str, version: &str) -> String {
     )
 }
 
+/// Generate a `Cargo.toml` with the specified `bin.name`
 pub fn basic_bin_manifest(name: &str) -> String {
     format!(
         r#"
@@ -1229,6 +1231,7 @@ pub fn basic_bin_manifest(name: &str) -> String {
     )
 }
 
+/// Generate a `Cargo.toml` with the specified `lib.name`
 pub fn basic_lib_manifest(name: &str) -> String {
     format!(
         r#"

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -554,6 +554,7 @@ pub fn main_file(println: &str, deps: &[&str]) -> String {
     buf
 }
 
+/// Path to the cargo binary
 pub fn cargo_exe() -> PathBuf {
     snapbox::cmd::cargo_bin("cargo")
 }

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1469,11 +1469,12 @@ impl ArgLineCommandExt for snapbox::cmd::Command {
     }
 }
 
-pub fn cargo_process(s: &str) -> Execs {
+/// Run `cargo $arg_line`, see [`Execs`]
+pub fn cargo_process(arg_line: &str) -> Execs {
     let cargo = cargo_exe();
     let mut p = process(&cargo);
     p.env("CARGO", cargo);
-    p.arg_line(s);
+    p.arg_line(arg_line);
     execs().with_process_builder(p)
 }
 

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -233,7 +233,13 @@ pub struct Project {
 
 /// Create a project to run tests against
 ///
-/// The project can be constructed programmatically or from the filesystem with [`Project::from_template`]
+/// - Creates a [`basic_manifest`] if one isn't supplied
+///
+/// To get started, see:
+/// - [`project`]
+/// - [`project_in`]
+/// - [`project_in_home`]
+/// - [`Project::from_template`]
 #[must_use]
 pub struct ProjectBuilder {
     root: Project,
@@ -257,6 +263,7 @@ impl ProjectBuilder {
         self.root.target_debug_dir()
     }
 
+    /// Create project in `root`
     pub fn new(root: PathBuf) -> ProjectBuilder {
         ProjectBuilder {
             root: Project { root },
@@ -266,6 +273,7 @@ impl ProjectBuilder {
         }
     }
 
+    /// Create project, relative to [`paths::root`]
     pub fn at<P: AsRef<Path>>(mut self, path: P) -> Self {
         self.root = Project {
             root: paths::root().join(path),

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -86,6 +86,7 @@ pub use snapbox::file;
 pub use snapbox::str;
 pub use snapbox::utils::current_dir;
 
+/// `panic!`, reporting the specified error , see also [`t!`]
 #[track_caller]
 pub fn panic_error(what: &str, err: impl Into<anyhow::Error>) -> ! {
     let err = err.into();

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -16,6 +16,30 @@
 //! * This is designed for testing Cargo itself. Use at your own risk.
 //! * No guarantee on any stability across versions.
 //! * No feature request would be accepted unless proved useful for testing Cargo.
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use cargo_test_support::prelude::*;
+//! use cargo_test_support::str;
+//! use cargo_test_support::project;
+//!
+//! #[cargo_test]
+//! fn some_test() {
+//!     let p = project()
+//!         .file("src/main.rs", r#"fn main() { println!("hi!"); }"#)
+//!         .build();
+//!
+//!     p.cargo("run --bin foo")
+//!         .with_stderr_data(str![[r#"
+//! [COMPILING] foo [..]
+//! [FINISHED] [..]
+//! [RUNNING] `target/debug/foo`
+//! "#]])
+//!         .with_stdout_data(str![["hi!"]])
+//!         .run();
+//! }
+//! ```
 
 #![allow(clippy::disallowed_methods)]
 #![allow(clippy::print_stderr)]

--- a/crates/cargo-test-support/src/registry.rs
+++ b/crates/cargo-test-support/src/registry.rs
@@ -1,3 +1,46 @@
+//! Interact with the [`TestRegistry`]
+//!
+//! # Example
+//!
+//! ```no_run
+//! use cargo_test_support::registry::Package;
+//! use cargo_test_support::project;
+//!
+//! // Publish package "a" depending on "b".
+//! Package::new("a", "1.0.0")
+//!     .dep("b", "1.0.0")
+//!     .file("src/lib.rs", r#"
+//!         extern crate b;
+//!         pub fn f() -> i32 { b::f() * 2 }
+//!     "#)
+//!     .publish();
+//!
+//! // Publish package "b".
+//! Package::new("b", "1.0.0")
+//!     .file("src/lib.rs", r#"
+//!         pub fn f() -> i32 { 12 }
+//!     "#)
+//!     .publish();
+//!
+//! // Create a project that uses package "a".
+//! let p = project()
+//!     .file("Cargo.toml", r#"
+//!         [package]
+//!         name = "foo"
+//!         version = "0.0.1"
+//!
+//!         [dependencies]
+//!         a = "1.0"
+//!     "#)
+//!     .file("src/main.rs", r#"
+//!         extern crate a;
+//!         fn main() { println!("{}", a::f()); }
+//!     "#)
+//!     .build();
+//!
+//! p.cargo("run").with_stdout("24").run();
+//! ```
+
 use crate::git::repo;
 use crate::paths;
 use crate::publish::{create_index_line, write_to_index};
@@ -20,39 +63,64 @@ use time::format_description::well_known::Rfc3339;
 use time::{Duration, OffsetDateTime};
 use url::Url;
 
-/// Gets the path to the local index pretending to be crates.io. This is a Git repo
+/// Path to the local index for psuedo-crates.io.
+///
+/// This is a Git repo
 /// initialized with a `config.json` file pointing to `dl_path` for downloads
 /// and `api_path` for uploads.
+///
+/// ex: `$CARGO_TARGET_TMPDIR/cit/t0/registry`
 pub fn registry_path() -> PathBuf {
     generate_path("registry")
 }
-/// Gets the path for local web API uploads. Cargo will place the contents of a web API
+
+/// Path to the local web API uploads
+///
+/// Cargo will place the contents of a web API
 /// request here. For example, `api/v1/crates/new` is the result of publishing a crate.
+///
+/// ex: `$CARGO_TARGET_TMPDIR/cit/t0/api`
 pub fn api_path() -> PathBuf {
     generate_path("api")
 }
-/// Gets the path where crates can be downloaded using the web API endpoint. Crates
+
+/// Path to download `.crate` files using the web API endpoint.
+///
+/// Crates
 /// should be organized as `{name}/{version}/download` to match the web API
 /// endpoint. This is rarely used and must be manually set up.
-fn dl_path() -> PathBuf {
+///
+/// ex: `$CARGO_TARGET_TMPDIR/cit/t0/dl`
+pub fn dl_path() -> PathBuf {
     generate_path("dl")
 }
-/// Gets the alternative-registry version of `registry_path`.
-fn alt_registry_path() -> PathBuf {
+
+/// Path to the alternative-registry version of [`registry_path`]
+///
+/// ex: `$CARGO_TARGET_TMPDIR/cit/t0/alternative-registry`
+pub fn alt_registry_path() -> PathBuf {
     generate_path("alternative-registry")
 }
-/// Gets the alternative-registry version of `registry_url`.
+
+/// URL to the alternative-registry version of `registry_url`
 fn alt_registry_url() -> Url {
     generate_url("alternative-registry")
 }
-/// Gets the alternative-registry version of `dl_path`.
+
+/// Path to the alternative-registry version of [`dl_path`]
+///
+/// ex: `$CARGO_TARGET_TMPDIR/cit/t0/alternative-dl`
 pub fn alt_dl_path() -> PathBuf {
     generate_path("alternative-dl")
 }
-/// Gets the alternative-registry version of `api_path`.
+
+/// Path to the alternative-registry version of [`api_path`]
+///
+/// ex: `$CARGO_TARGET_TMPDIR/cit/t0/alternative-api`
 pub fn alt_api_path() -> PathBuf {
     generate_path("alternative-api")
 }
+
 fn generate_path(name: &str) -> PathBuf {
     paths::root().join(name)
 }
@@ -60,6 +128,7 @@ fn generate_url(name: &str) -> Url {
     Url::from_file_path(generate_path(name)).ok().unwrap()
 }
 
+/// Auth-token for publishing, see [`RegistryBuilder::token`]
 #[derive(Clone)]
 pub enum Token {
     Plaintext(String),
@@ -68,6 +137,7 @@ pub enum Token {
 
 impl Token {
     /// This is a valid PASETO secret key.
+    ///
     /// This one is already publicly available as part of the text of the RFC so is safe to use for tests.
     pub fn rfc_key() -> Token {
         Token::Keys(
@@ -80,7 +150,9 @@ impl Token {
 
 type RequestCallback = Box<dyn Send + Fn(&Request, &HttpServer) -> Response>;
 
-/// A builder for initializing registries.
+/// Prepare a local [`TestRegistry`] fixture
+///
+/// See also [`init`] and [`alt_init`]
 pub struct RegistryBuilder {
     /// If set, configures an alternate registry with the given name.
     alternative: Option<String>,
@@ -108,6 +180,9 @@ pub struct RegistryBuilder {
     credential_provider: Option<String>,
 }
 
+/// A local registry fixture
+///
+/// Most tests won't need to call this directly but instead interact with [`Package`]
 pub struct TestRegistry {
     server: Option<HttpServerHandle>,
     index_url: Url,
@@ -459,71 +534,31 @@ impl RegistryBuilder {
     }
 }
 
-/// A builder for creating a new package in a registry.
+/// Published package builder for [`TestRegistry`]
 ///
 /// This uses "source replacement" using an automatically generated
 /// `.cargo/config` file to ensure that dependencies will use these packages
 /// instead of contacting crates.io. See `source-replacement.md` for more
 /// details on how source replacement works.
 ///
-/// Call `publish` to finalize and create the package.
+/// Call [`Package::publish`] to finalize and create the package.
 ///
 /// If no files are specified, an empty `lib.rs` file is automatically created.
 ///
 /// The `Cargo.toml` file is automatically generated based on the methods
-/// called on `Package` (for example, calling `dep()` will add to the
+/// called on `Package` (for example, calling [`Package::dep()`] will add to the
 /// `[dependencies]` automatically). You may also specify a `Cargo.toml` file
 /// to override the generated one.
 ///
 /// This supports different registry types:
 /// - Regular source replacement that replaces `crates.io` (the default).
 /// - A "local registry" which is a subset for vendoring (see
-///   `Package::local`).
+///   [`Package::local`]).
 /// - An "alternative registry" which requires specifying the registry name
-///   (see `Package::alternative`).
+///   (see [`Package::alternative`]).
 ///
 /// This does not support "directory sources". See `directory.rs` for
 /// `VendorPackage` which implements directory sources.
-///
-/// # Example
-/// ```no_run
-/// use cargo_test_support::registry::Package;
-/// use cargo_test_support::project;
-///
-/// // Publish package "a" depending on "b".
-/// Package::new("a", "1.0.0")
-///     .dep("b", "1.0.0")
-///     .file("src/lib.rs", r#"
-///         extern crate b;
-///         pub fn f() -> i32 { b::f() * 2 }
-///     "#)
-///     .publish();
-///
-/// // Publish package "b".
-/// Package::new("b", "1.0.0")
-///     .file("src/lib.rs", r#"
-///         pub fn f() -> i32 { 12 }
-///     "#)
-///     .publish();
-///
-/// // Create a project that uses package "a".
-/// let p = project()
-///     .file("Cargo.toml", r#"
-///         [package]
-///         name = "foo"
-///         version = "0.0.1"
-///
-///         [dependencies]
-///         a = "1.0"
-///     "#)
-///     .file("src/main.rs", r#"
-///         extern crate a;
-///         fn main() { println!("{}", a::f()); }
-///     "#)
-///     .build();
-///
-/// p.cargo("run").with_stdout("24").run();
-/// ```
 #[must_use]
 pub struct Package {
     name: String,
@@ -544,6 +579,7 @@ pub struct Package {
 
 pub(crate) type FeatureMap = BTreeMap<String, Vec<String>>;
 
+/// Published package dependency builder, see [`Package::add_dep`]
 #[derive(Clone)]
 pub struct Dependency {
     name: String,
@@ -582,14 +618,18 @@ struct PackageFile {
 
 const DEFAULT_MODE: u32 = 0o644;
 
-/// Initializes the on-disk registry and sets up the config so that crates.io
-/// is replaced with the one on disk.
+/// Setup a local psuedo-crates.io [`TestRegistry`]
+///
+/// This is implicitly called by [`Package::new`].
+///
+/// When calling `cargo publish`, see instead [`crate::publish`].
 pub fn init() -> TestRegistry {
     RegistryBuilder::new().build()
 }
 
-/// Variant of `init` that initializes the "alternative" registry and crates.io
-/// replacement.
+/// Setup a local "alternative" [`TestRegistry`]
+///
+/// When calling `cargo publish`, see instead [`crate::publish`].
 pub fn alt_init() -> TestRegistry {
     init();
     RegistryBuilder::new().alternative().build()
@@ -1234,6 +1274,8 @@ impl Package {
     /// See `src/doc/src/reference/registries.md` for more details on
     /// alternative registries. See `alt_registry.rs` for the tests that use
     /// this.
+    ///
+    /// **Requires:** [`alt_init`]
     pub fn alternative(&mut self, alternative: bool) -> &mut Package {
         self.alternative = alternative;
         self
@@ -1666,6 +1708,7 @@ impl Package {
     }
 }
 
+/// Generate a checksum
 pub fn cksum(s: &[u8]) -> String {
     Sha256::new().update(s).finish_hex()
 }

--- a/src/doc/contrib/src/tests/writing.md
+++ b/src/doc/contrib/src/tests/writing.md
@@ -30,6 +30,8 @@ stdout and stderr output against the expected output.
 Generally, a functional test will be placed in `tests/testsuite/<command>.rs` and will look roughly like:
 ```rust,ignore
 use cargo_test_support::prelude::*;
+use cargo_test_support::str;
+use cargo_test_support::project;
 
 #[cargo_test]
 fn <description>() {
@@ -38,16 +40,13 @@ fn <description>() {
         .build();
 
     p.cargo("run --bin foo")
-        .with_stderr(
-            "\
-    [COMPILING] foo [..]
-    [FINISHED] [..]
-    [RUNNING] `target/debug/foo`
-    ",
-        )
-        .with_stdout("hi!")
+        .with_stderr_data(str![[r#"
+[COMPILING] foo [..]
+[FINISHED] [..]
+[RUNNING] `target/debug/foo`
+"#]])
+        .with_stdout_data(str![["hi!"]])
         .run();
-    }
 }
 ```
 

--- a/src/doc/contrib/src/tests/writing.md
+++ b/src/doc/contrib/src/tests/writing.md
@@ -50,7 +50,9 @@ fn <description>() {
 }
 ```
 
-The [`#[cargo_test]` attribute](#cargo_test-attribute) is used in place of `#[test]` to inject some setup code.
+The [`#[cargo_test]` attribute][cargo_test attribute] is used in place of
+`#[test]` to inject some setup code and declare requirements for running the
+test.
 
 [`ProjectBuilder`] via `project()`:
 - Each project is in a separate directory in the sandbox
@@ -61,50 +63,6 @@ The [`#[cargo_test]` attribute](#cargo_test-attribute) is used in place of `#[te
 - This executes the command and evaluates different assertions
   - See [`support::compare`] for an explanation of the string pattern matching.
     Patterns are used to make it easier to match against the expected output.
-
-#### `#[cargo_test]` attribute
-
-The `#[cargo_test]` attribute injects code which does some setup before starting the test.
-It will create a filesystem "sandbox" under the "cargo integration test" directory for each test, such as `/path/to/cargo/target/tmp/cit/t123/`.
-The sandbox will contain a `home` directory that will be used instead of your normal home directory.
-
-The `#[cargo_test]` attribute takes several options that will affect how the test is generated.
-They are listed in parentheses separated with commas, such as:
-
-```rust,ignore
-#[cargo_test(nightly, reason = "-Zfoo is unstable")]
-```
-
-The options it supports are:
-
-* `nightly` --- This will cause the test to be ignored if not running on the nightly toolchain.
-  This is useful for tests that use unstable options in `rustc` or `rustdoc`.
-  These tests are run in Cargo's CI, but are disabled in rust-lang/rust's CI due to the difficulty of updating both repos simultaneously.
-  A `reason` field is required to explain why it is nightly-only.
-* `build_std_real` --- This is a "real" `-Zbuild-std` test (in the `build_std` integration test).
-  This only runs on nightly, and only if the environment variable `CARGO_RUN_BUILD_STD_TESTS` is set (these tests on run on Linux).
-* `build_std_mock` --- This is a "mock" `-Zbuild-std` test (which uses a mock standard library).
-  This only runs on nightly, and is disabled for windows-gnu.
-* `requires_` --- This indicates a command that is required to be installed to be run.
-  For example, `requires_rustfmt` means the test will only run if the executable `rustfmt` is installed.
-  These tests are *always* run on CI.
-  This is mainly used to avoid requiring contributors from having every dependency installed.
-* `>=1.64` --- This indicates that the test will only run with the given version of `rustc` or newer.
-  This can be used when a new `rustc` feature has been stabilized that the test depends on.
-  If this is specified, a `reason` is required to explain why it is being checked.
-* `public_network_test` --- This tests contacts the public internet.
-  These tests are disabled unless the `CARGO_PUBLIC_NETWORK_TESTS` environment variable is set.
-  Use of this should be *extremely rare*, please avoid using it if possible.
-  The hosts it contacts should have a relatively high confidence that they are reliable and stable (such as github.com), especially in CI.
-  The tests should be carefully considered for developer security and privacy as well.
-* `container_test` --- This indicates that it is a test that uses Docker.
-  These tests are disabled unless the `CARGO_CONTAINER_TESTS` environment variable is set.
-  This requires that you have Docker installed.
-  The SSH tests also assume that you have OpenSSH installed.
-  These should work on Linux, macOS, and Windows where possible.
-  Unfortunately these tests are not run in CI for macOS or Windows (no Docker on macOS, and Windows does not support Linux images).
-  See [`crates/cargo-test-support/src/containers.rs`](https://github.com/rust-lang/cargo/blob/master/crates/cargo-test-support/src/containers.rs) for more on writing these tests.
-* `ignore_windows="reason"` --- Indicates that the test should be ignored on windows for the given reason.
 
 #### Testing Nightly Features
 
@@ -328,6 +286,7 @@ environment. The general process is:
         2. Set a breakpoint, for example: `b generate_root_units`
         3. Run with arguments: `r check`
 
+[cargo_test attribute]: https://doc.rust-lang.org/nightly/nightly-rustc/cargo_test_macro/attr.cargo_test.html
 [`testsuite`]: https://github.com/rust-lang/cargo/tree/master/tests/testsuite/
 [`ProjectBuilder`]: https://github.com/rust-lang/cargo/blob/d847468768446168b596f721844193afaaf9d3f2/crates/cargo-test-support/src/lib.rs#L196-L202
 [`Execs`]: https://github.com/rust-lang/cargo/blob/d847468768446168b596f721844193afaaf9d3f2/crates/cargo-test-support/src/lib.rs#L531-L550

--- a/src/doc/contrib/src/tests/writing.md
+++ b/src/doc/contrib/src/tests/writing.md
@@ -12,9 +12,8 @@ and verify its behavior, located in the [`testsuite`] directory.  The
 There are two styles of tests that can roughly be categorized as
 - functional tests
   - The fixture is programmatically defined
-  - The assertions are regular string comparisons
+  - The assertions may be in-source snapshots, hard-coded strings, or programmatically generated
   - Easier to share in an issue as a code block is completely self-contained
-  - More resilient to insignificant changes though ui tests are easy to update when a change does occur
 - ui tests
   - The fixture is file-based
   - The assertions use file-backed snapshots that can be updated with an env variable


### PR DESCRIPTION
### What does this PR try to resolve?

In wanting to document #14039, I felt it would be good to put that documentation in `cargo-test-support`.  To do so, I wanted a baseline of existing documentation for it to build on top of.

I was tempted to move more of "Writing tests" contrib documentation here, as its more about using `cargo-test-support` but I decided to hold off for now as most of that was long-form documentation and this is mostly focused on reference documentation.

### How should we test and review this PR?


### Additional information

