### PR TITLE
Use `Rc` instead of `Arc` for storing rustflags

### DIFF
--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -20,8 +20,8 @@ use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::collections::hash_map::{Entry, HashMap};
 use std::path::{Path, PathBuf};
+use std::rc::Rc;
 use std::str::{self, FromStr};
-use std::sync::Arc;
 
 /// Information about the platform target gleaned from querying rustc.
 ///
@@ -51,9 +51,9 @@ pub struct TargetInfo {
     /// target libraries.
     pub sysroot_target_libdir: PathBuf,
     /// Extra flags to pass to `rustc`, see [`extra_args`].
-    pub rustflags: Arc<[String]>,
+    pub rustflags: Rc<[String]>,
     /// Extra flags to pass to `rustdoc`, see [`extra_args`].
-    pub rustdocflags: Arc<[String]>,
+    pub rustdocflags: Rc<[String]>,
     /// Whether or not rustc (stably) supports the `--check-cfg` flag.
     ///
     /// Can be removed once the minimum supported rustc version of Cargo is

--- a/src/cargo/core/compiler/unit.rs
+++ b/src/cargo/core/compiler/unit.rs
@@ -14,7 +14,6 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 use std::rc::Rc;
-use std::sync::Arc;
 
 use super::BuildOutput;
 
@@ -72,7 +71,7 @@ pub struct UnitInner {
     ///
     /// [`BuildContext::extra_args_for`]: crate::core::compiler::build_context::BuildContext::extra_args_for
     /// [`TargetInfo.rustflags`]: crate::core::compiler::build_context::TargetInfo::rustflags
-    pub rustflags: Arc<[String]>,
+    pub rustflags: Rc<[String]>,
     /// Extra compiler flags to pass to `rustdoc` for a given unit.
     ///
     /// Although it depends on the caller, in the current Cargo implementation,
@@ -83,7 +82,7 @@ pub struct UnitInner {
     ///
     /// [`BuildContext::extra_args_for`]: crate::core::compiler::build_context::BuildContext::extra_args_for
     /// [`TargetInfo.rustdocflags`]: crate::core::compiler::build_context::TargetInfo::rustdocflags
-    pub rustdocflags: Arc<[String]>,
+    pub rustdocflags: Rc<[String]>,
     /// Build script override for the given library name.
     ///
     /// Any package with a `links` value for the given library name will skip
@@ -232,8 +231,8 @@ impl UnitInterner {
         kind: CompileKind,
         mode: CompileMode,
         features: Vec<InternedString>,
-        rustflags: Arc<[String]>,
-        rustdocflags: Arc<[String]>,
+        rustflags: Rc<[String]>,
+        rustdocflags: Rc<[String]>,
         links_overrides: Rc<BTreeMap<String, BuildOutput>>,
         is_std: bool,
         dep_hash: u64,


### PR DESCRIPTION
# What does this PR try to resolve?

There's no reason that these reference counted pointers (which I introduced in #13900) need to be atomic, so let's use non-atomic pointers.

# Additional information

First noticed by @weihanglo [here](https://github.com/rust-lang/cargo/pull/14205#discussion_r1678347073).

r? @weihanglo 