### PR TITLE
introduce no-path-check for install command

### DIFF
--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -620,6 +620,7 @@ pub fn install(
     opts: &ops::CompileOptions,
     force: bool,
     no_track: bool,
+    no_path_check: bool,
 ) -> CargoResult<()> {
     let root = resolve_root(root, gctx)?;
     let dst = root.join("bin").into_path_unlocked();
@@ -739,7 +740,12 @@ pub fn install(
         (!succeeded.is_empty(), !failed.is_empty())
     };
 
-    if installed_anything {
+    let skip_path_check = match gctx.get_env_os("CARGO_INSTALL_NO_PATH_CHECK") {
+        Some(v) => Some(v == "1"),
+        None => Some(no_path_check),
+    };
+
+    if installed_anything && !skip_path_check.is_some_and(|f| f) {
         // Print a warning that if this directory isn't in PATH that they won't be
         // able to run these commands.
         let path = gctx.get_env_os("PATH").unwrap_or_default();

--- a/src/cargo/util/context/mod.rs
+++ b/src/cargo/util/context/mod.rs
@@ -224,6 +224,7 @@ pub struct GlobalContext {
     future_incompat_config: LazyCell<CargoFutureIncompatConfig>,
     net_config: LazyCell<CargoNetConfig>,
     build_config: LazyCell<CargoBuildConfig>,
+    install_config: LazyCell<CargoInstallConfig>,
     target_cfgs: LazyCell<Vec<(String, TargetCfgConfig)>>,
     doc_extern_map: LazyCell<RustdocExternMap>,
     progress_config: ProgressConfig,
@@ -318,6 +319,7 @@ impl GlobalContext {
             future_incompat_config: LazyCell::new(),
             net_config: LazyCell::new(),
             build_config: LazyCell::new(),
+            install_config: LazyCell::new(),
             target_cfgs: LazyCell::new(),
             doc_extern_map: LazyCell::new(),
             progress_config: ProgressConfig::default(),
@@ -1824,6 +1826,11 @@ impl GlobalContext {
             .try_borrow_with(|| self.get::<CargoBuildConfig>("build"))
     }
 
+    pub fn install_config(&self) -> CargoResult<&CargoInstallConfig> {
+        self.install_config
+            .try_borrow_with(|| self.get::<CargoInstallConfig>("install"))
+    }
+
     pub fn progress_config(&self) -> &ProgressConfig {
         &self.progress_config
     }
@@ -2615,6 +2622,12 @@ pub struct CargoBuildConfig {
     // deprecated alias for artifact-dir
     pub out_dir: Option<ConfigRelativePath>,
     pub artifact_dir: Option<ConfigRelativePath>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct CargoInstallConfig {
+    pub no_path_check: Option<bool>,
 }
 
 /// Configuration for `build.target`.

--- a/src/doc/man/cargo-install.md
+++ b/src/doc/man/cargo-install.md
@@ -128,6 +128,12 @@ useful if something has changed on the system that you want to rebuild with,
 such as a newer version of `rustc`.
 {{/option}}
 
+{{#option "`--no-path-check`" }}
+By default, Cargo will check if installed programs are available in the
+configured `PATH` and generate a warning if this is not the case. This flag
+tells Cargo not to perform any path checks.
+{{/option}}
+
 {{#option "`--no-track`" }}
 By default, Cargo keeps track of the installed packages with a metadata file
 stored in the installation root directory. This flag tells Cargo not to use or

--- a/src/doc/src/commands/cargo-install.md
+++ b/src/doc/src/commands/cargo-install.md
@@ -132,6 +132,12 @@ useful if something has changed on the system that you want to rebuild with,
 such as a newer version of <code>rustc</code>.</dd>
 
 
+<dt class="option-term" id="option-cargo-install---no-path-check"><a class="option-anchor" href="#option-cargo-install---no-path-check"></a><code>--no-path-check</code></dt>
+<dd class="option-desc">By default, Cargo will check if installed programs are available in the
+configured <code>PATH</code> and generate a warning if this is not the case. This flag
+tells Cargo not to perform any path checks.</dd>
+
+
 <dt class="option-term" id="option-cargo-install---no-track"><a class="option-anchor" href="#option-cargo-install---no-track"></a><code>--no-track</code></dt>
 <dd class="option-desc">By default, Cargo keeps track of the installed packages with a metadata file
 stored in the installation root directory. This flag tells Cargo not to use or

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -757,6 +757,20 @@ string that includes Cargo's version.
 
 The `[install]` table defines defaults for the [`cargo install`] command.
 
+#### `install.no-path-check`
+* Type: boolean
+* Default: false
+* Environment: `CARGO_INSTALL_NO_PATH_CHECK`
+
+If this is `true`, then Cargo will not perform any checks if an installed
+command is not available on the configured `PATH`.
+
+Setting this to `true` can be helpful when the install root is configured
+to an interim location (e.g. cross-compiling) and an installer wishes to
+suppress any path checks warnings not relevant for their use case.
+
+Can be overridden with the `--no-path-check` command-line option.
+
 #### `install.root`
 * Type: string (path)
 * Default: Cargo's home directory

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -110,6 +110,7 @@ In summary, the supported environment variables are:
 * `CARGO_HTTP_LOW_SPEED_LIMIT` --- The HTTP low-speed limit, see [`http.low-speed-limit`].
 * `CARGO_HTTP_MULTIPLEXING` --- Whether HTTP/2 multiplexing is used, see [`http.multiplexing`].
 * `CARGO_HTTP_USER_AGENT` --- The HTTP user-agent header, see [`http.user-agent`].
+* `CARGO_INSTALL_NO_PATH_CHECK` --- Disables any path checks when using [`cargo install`], see [`install.no-path-check`].
 * `CARGO_INSTALL_ROOT` --- The default directory for [`cargo install`], see [`install.root`].
 * `CARGO_NET_RETRY` --- Number of times to retry network errors, see [`net.retry`].
 * `CARGO_NET_GIT_FETCH_WITH_CLI` --- Enables the use of the `git` executable to fetch, see [`net.git-fetch-with-cli`].
@@ -176,6 +177,7 @@ In summary, the supported environment variables are:
 [`http.low-speed-limit`]: config.md#httplow-speed-limit
 [`http.multiplexing`]: config.md#httpmultiplexing
 [`http.user-agent`]: config.md#httpuser-agent
+[`install.no-path-check`]: config.md#installno-path-check
 [`install.root`]: config.md#installroot
 [`net.retry`]: config.md#netretry
 [`net.git-fetch-with-cli`]: config.md#netgit-fetch-with-cli

--- a/src/etc/cargo.bashcomp.sh
+++ b/src/etc/cargo.bashcomp.sh
@@ -64,7 +64,7 @@ _cargo()
 	local opt__generate_lockfile="$opt_common $opt_mani $opt_lock"
 	local opt__help="$opt_help"
 	local opt__init="$opt_common $opt_lock --bin --lib --name --vcs --edition --registry"
-	local opt__install="$opt_common $opt_feat $opt_parallel $opt_lock $opt_force --bin --bins --branch --debug --example --examples --git --list --path --rev --root --tag --version --registry --target --profile --no-track --ignore-rust-version"
+	local opt__install="$opt_common $opt_feat $opt_parallel $opt_lock $opt_force --bin --bins --branch --debug --example --examples --git --list --path --rev --root --tag --version --registry --target --profile --no-path-check --no-track --ignore-rust-version"
 	local opt__locate_project="$opt_common $opt_mani $opt_lock --message-format --workspace"
 	local opt__login="$opt_common $opt_lock --registry"
 	local opt__metadata="$opt_common $opt_feat $opt_mani $opt_lock --format-version=1 --no-deps --filter-platform"


### PR DESCRIPTION
### What does this PR try to resolve?

Provides the option to allow a user to trigger an install request that will not generate a warning if an installed program is not available in the `PATH`. This can be helpful when the install root is configured to an interim location (e.g. cross-compiling) and there is a desire to suppress any path checks warnings not relevant for the install case.

For example, using a Buildroot configuration that uses a cargo-based package can have [logs](http://autobuild.buildroot.org/results/252/252399ad2719ad9e6ba18dea31601cbaaecadf14/build-end.log) that 

```
>>> tealdeer 1.6.1 Installing to target
cd /home/autobuild/autobuild/instance-15/output-1/build/tealdeer-1.6.1/ && ...
  Installing tealdeer v1.6.1 (/home/autobuild/autobuild/instance-15/output-1/build/tealdeer-1.6.1)
    Finished release [optimized] target(s) in 2.35s
  Installing /home/autobuild/autobuild/instance-15/output-1/target/usr/bin/tldr
   Installed package `tealdeer v1.6.1 (/home/autobuild/autobuild/instance-15/output-1/build/tealdeer-1.6.1)` (executable `tldr`)
warning: be sure to add `/home/autobuild/autobuild/instance-15/output-1/target/usr/bin` to your PATH to be able to run the installed binaries
```

The warning message ("warning: be sure to add...") is not desired in a cross-compiling scenario.

### How should we test and review this PR?

At this time, only manually testing using the following scenarios have been performed:

```
cargo install --no-path-check
cargo install --config install.no-path-check=true
CARGO_INSTALL_NO_PATH_CHECK=true cargo install
```

Sanity checking via unit tests should be possible (which can be added later if this change set is something desired).

### Additional information

- Has yet to be discussed/accepted for consideration.
- First time touching Rust. 😅