### PR TITLE
Improved error message when `update --breaking` invalid spec.

### DIFF
--- a/src/cargo/ops/cargo_update.rs
+++ b/src/cargo/ops/cargo_update.rs
@@ -14,6 +14,7 @@ use crate::util::toml_mut::manifest::LocalManifest;
 use crate::util::toml_mut::upgrade::upgrade_requirement;
 use crate::util::{style, OptVersionReq};
 use crate::util::{CargoResult, VersionExt};
+use anyhow::Context as _;
 use itertools::Itertools;
 use semver::{Op, Version, VersionReq};
 use std::cmp::Ordering;
@@ -224,7 +225,10 @@ pub fn upgrade_manifests(
 
     let to_update = to_update
         .iter()
-        .map(|s| PackageIdSpec::parse(s))
+        .map(|spec| {
+            PackageIdSpec::parse(spec)
+                .with_context(|| format!("invalid package ID specification: `{spec}`"))
+        })
         .collect::<Result<Vec<_>, _>>()?;
 
     // Updates often require a lot of modifications to the registry, so ensure

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -2263,7 +2263,10 @@ fn update_breaking_spec_version() {
         .masquerade_as_nightly_cargo(&["update-breaking"])
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] expected a version like "1.32"
+[ERROR] invalid package ID specification: `incompatible@foo`
+
+Caused by:
+  expected a version like "1.32"
 
 "#]])
         .run();


### PR DESCRIPTION
Improves an error message when trying to do `cargo update --breaking clap@foo`:

```
- [ERROR] expected a version like "1.32"
+ [ERROR] invalid package ID specification: `clap@foo`
+ Caused by:
+   expected a version like "1.32"
```

Related to #12425. Fixes an item [here](https://github.com/rust-lang/cargo/issues/12425#issuecomment-2186198258), as noted [here](https://github.com/rust-lang/cargo/pull/14049#discussion_r1656929921).

<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
