### PR TITLE
Add a `--dry-run` flag to the `install` command

### DIFF
--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -69,6 +69,7 @@ pub fn cli() -> Command {
         )
         .arg(opt("root", "Directory to install packages into").value_name("DIR"))
         .arg(flag("force", "Force overwriting existing crates or binaries").short('f'))
+        .arg_dry_run("Perform all checks without installing (unstable)")
         .arg(flag("no-track", "Do not save tracking information"))
         .arg(flag(
             "list",
@@ -200,7 +201,9 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
 
     compile_opts.build_config.requested_profile =
         args.get_profile_name("release", ProfileChecking::Custom)?;
-
+    if args.dry_run() {
+        gctx.cli_unstable().fail_if_stable_opt("--dry-run", 11123)?;
+    }
     if args.flag("list") {
         ops::install_list(root, gctx)?;
     } else {
@@ -213,6 +216,7 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
             &compile_opts,
             args.flag("force"),
             args.flag("no-track"),
+            args.dry_run(),
         )?;
     }
     Ok(())

--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -31,6 +31,8 @@ pub struct BuildConfig {
     pub build_plan: bool,
     /// Output the unit graph to stdout instead of actually compiling.
     pub unit_graph: bool,
+    /// `true` to avoid really compiling.
+    pub dry_run: bool,
     /// An optional override of the rustc process for primary units
     pub primary_unit_rustc: Option<ProcessBuilder>,
     /// A thread used by `cargo fix` to receive messages on a socket regarding
@@ -112,6 +114,7 @@ impl BuildConfig {
             force_rebuild: false,
             build_plan: false,
             unit_graph: false,
+            dry_run: false,
             primary_unit_rustc: None,
             rustfix_diagnostic_server: Rc::new(RefCell::new(None)),
             export_dir: None,

--- a/src/cargo/ops/cargo_compile/mod.rs
+++ b/src/cargo/ops/cargo_compile/mod.rs
@@ -156,7 +156,11 @@ pub fn compile_ws<'a>(
     }
     crate::core::gc::auto_gc(bcx.gctx);
     let build_runner = BuildRunner::new(&bcx)?;
-    build_runner.compile(exec)
+    if options.build_config.dry_run {
+        build_runner.dry_run()
+    } else {
+        build_runner.compile(exec)
+    }
 }
 
 /// Executes `rustc --print <VALUE>`.

--- a/src/doc/man/cargo-install.md
+++ b/src/doc/man/cargo-install.md
@@ -121,6 +121,10 @@ Filesystem path to local crate to install from.
 List all installed packages and their versions.
 {{/option}}
 
+{{#option "`-n`" "`--dry-run`" }}
+(unstable) Perform all checks without installing.
+{{/option}}
+
 {{#option "`-f`" "`--force`" }}
 Force overwriting existing crates or binaries. This can be used if a package
 has installed a binary with the same name as another package. This is also

--- a/src/doc/man/generated_txt/cargo-install.txt
+++ b/src/doc/man/generated_txt/cargo-install.txt
@@ -120,6 +120,9 @@ OPTIONS
        --list
            List all installed packages and their versions.
 
+       -n, --dry-run
+           (unstable) Perform all checks without installing.
+
        -f, --force
            Force overwriting existing crates or binaries. This can be used if a
            package has installed a binary with the same name as another

--- a/src/doc/src/commands/cargo-install.md
+++ b/src/doc/src/commands/cargo-install.md
@@ -124,6 +124,11 @@ treated as a caret requirement like Cargo dependencies are.</dd>
 <dd class="option-desc">List all installed packages and their versions.</dd>
 
 
+<dt class="option-term" id="option-cargo-install--n"><a class="option-anchor" href="#option-cargo-install--n"></a><code>-n</code></dt>
+<dt class="option-term" id="option-cargo-install---dry-run"><a class="option-anchor" href="#option-cargo-install---dry-run"></a><code>--dry-run</code></dt>
+<dd class="option-desc">(unstable) Perform all checks without installing.</dd>
+
+
 <dt class="option-term" id="option-cargo-install--f"><a class="option-anchor" href="#option-cargo-install--f"></a><code>-f</code></dt>
 <dt class="option-term" id="option-cargo-install---force"><a class="option-anchor" href="#option-cargo-install---force"></a><code>--force</code></dt>
 <dd class="option-desc">Force overwriting existing crates or binaries. This can be used if a package

--- a/src/etc/man/cargo-install.1
+++ b/src/etc/man/cargo-install.1
@@ -151,6 +151,12 @@ Filesystem path to local crate to install from.
 List all installed packages and their versions.
 .RE
 .sp
+\fB\-n\fR, 
+\fB\-\-dry\-run\fR
+.RS 4
+(unstable) Perform all checks without installing.
+.RE
+.sp
 \fB\-f\fR, 
 \fB\-\-force\fR
 .RS 4

--- a/tests/testsuite/cargo_install/help/stdout.term.svg
+++ b/tests/testsuite/cargo_install/help/stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="844px" height="1046px" xmlns="http://www.w3.org/2000/svg">
+<svg width="844px" height="1064px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -55,83 +55,85 @@
 </tspan>
     <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-cyan bold">-f</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--force</tspan><tspan>                 Force overwriting existing crates or binaries</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-track</tspan><tspan>              Do not save tracking information</tspan>
+    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-cyan bold">-n</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--dry-run</tspan><tspan>               Perform all checks without installing (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--list</tspan><tspan>                  List all installed packages and their versions</tspan>
+    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-track</tspan><tspan>              Do not save tracking information</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--message-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>  Error format</tspan>
+    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--list</tspan><tspan>                  List all installed packages and their versions</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--debug</tspan><tspan>                 Build in debug mode (with the 'dev' profile) instead of release mode</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--message-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>  Error format</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>            Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--debug</tspan><tspan>                 Build in debug mode (with the 'dev' profile) instead of release mode</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                 Do not print cargo log messages</tspan>
+    <tspan x="10px" y="442px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>            Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>          Coloring: auto, always, never</tspan>
+    <tspan x="10px" y="460px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                 Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE&gt;</tspan><tspan>    Override a configuration value</tspan>
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>          Coloring: auto, always, never</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                   Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE&gt;</tspan><tspan>    Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>                              details</tspan>
+    <tspan x="10px" y="514px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                   Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                  Print help</tspan>
+    <tspan x="10px" y="532px"><tspan>                              details</tspan>
 </tspan>
-    <tspan x="10px" y="550px">
+    <tspan x="10px" y="550px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                  Print help</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="568px">
 </tspan>
-    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-cyan bold">--ignore-rust-version</tspan><tspan>  Ignore `rust-version` specification in packages</tspan>
+    <tspan x="10px" y="586px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>               Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-cyan bold">--ignore-rust-version</tspan><tspan>  Ignore `rust-version` specification in packages</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>              Run without accessing the network</tspan>
+    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>               Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>               Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>              Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="658px">
+    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>               Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan class="fg-green bold">Target Selection:</tspan>
+    <tspan x="10px" y="676px">
 </tspan>
-    <tspan x="10px" y="694px"><tspan>      </tspan><tspan class="fg-cyan bold">--bin</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>      Install only the specified binary</tspan>
+    <tspan x="10px" y="694px"><tspan class="fg-green bold">Target Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-cyan bold">--bins</tspan><tspan>              Install all binaries</tspan>
+    <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-cyan bold">--bin</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>      Install only the specified binary</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Install only the specified example</tspan>
+    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-cyan bold">--bins</tspan><tspan>              Install all binaries</tspan>
 </tspan>
-    <tspan x="10px" y="748px"><tspan>      </tspan><tspan class="fg-cyan bold">--examples</tspan><tspan>          Install all examples</tspan>
+    <tspan x="10px" y="748px"><tspan>      </tspan><tspan class="fg-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Install only the specified example</tspan>
 </tspan>
-    <tspan x="10px" y="766px">
+    <tspan x="10px" y="766px"><tspan>      </tspan><tspan class="fg-cyan bold">--examples</tspan><tspan>          Install all examples</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan class="fg-green bold">Feature Selection:</tspan>
+    <tspan x="10px" y="784px">
 </tspan>
-    <tspan x="10px" y="802px"><tspan>  </tspan><tspan class="fg-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
+    <tspan x="10px" y="802px"><tspan class="fg-green bold">Feature Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="820px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
+    <tspan x="10px" y="820px"><tspan>  </tspan><tspan class="fg-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
 </tspan>
-    <tspan x="10px" y="838px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
+    <tspan x="10px" y="838px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
 </tspan>
-    <tspan x="10px" y="856px">
+    <tspan x="10px" y="856px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
 </tspan>
-    <tspan x="10px" y="874px"><tspan class="fg-green bold">Compilation Options:</tspan>
+    <tspan x="10px" y="874px">
 </tspan>
-    <tspan x="10px" y="892px"><tspan>  </tspan><tspan class="fg-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
+    <tspan x="10px" y="892px"><tspan class="fg-green bold">Compilation Options:</tspan>
 </tspan>
-    <tspan x="10px" y="910px"><tspan>      </tspan><tspan class="fg-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
+    <tspan x="10px" y="910px"><tspan>  </tspan><tspan class="fg-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
 </tspan>
-    <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Install artifacts with the specified profile</tspan>
+    <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
 </tspan>
-    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Build for the target triple</tspan>
+    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Install artifacts with the specified profile</tspan>
 </tspan>
-    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
+    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Build for the target triple</tspan>
 </tspan>
-    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
+    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
 </tspan>
-    <tspan x="10px" y="1000px">
+    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
 </tspan>
-    <tspan x="10px" y="1018px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help install</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="1018px">
 </tspan>
-    <tspan x="10px" y="1036px">
+    <tspan x="10px" y="1036px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help install</tspan><tspan class="bold">` for more detailed information.</tspan>
+</tspan>
+    <tspan x="10px" y="1054px">
 </tspan>
   </text>
 

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -2734,3 +2734,162 @@ fn uninstall_running_binary() {
 
 "#]]).run();
 }
+
+#[cargo_test]
+fn dry_run() {
+    pkg("foo", "0.0.1");
+
+    cargo_process("install foo")
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
+[INSTALLING] foo v0.0.1
+[COMPILING] foo v0.0.1
+[FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
+[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
+[INSTALLED] package `foo v0.0.1` (executable `foo[EXE]`)
+[WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
+
+"#]])
+        .run();
+    assert_has_installed_exe(paths::cargo_home(), "foo");
+}
+
+#[cargo_test]
+fn dry_run_incompatible_package() {
+    Package::new("some-package-from-the-distant-future", "0.0.1")
+        .rust_version("1.2345.0")
+        .file("src/main.rs", "fn main() {}")
+        .publish();
+
+    cargo_process("install some-package-from-the-distant-future")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
+[ERROR] cannot install package `some-package-from-the-distant-future 0.0.1`, it requires rustc 1.2345.0 or newer, while the currently active rustc version is [..]
+
+"#]])
+        .run();
+    assert_has_not_installed_exe(paths::cargo_home(), "some-package-from-the-distant-future");
+}
+
+#[cargo_test]
+fn dry_run_incompatible_package_dependecy() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
+
+                [dependencies]
+                some-package-from-the-distant-future = { path = "a" }
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file(
+            "a/Cargo.toml",
+            r#"
+                [package]
+                name = "some-package-from-the-distant-future"
+                version = "0.1.0"
+                authors = []
+                rust-version = "1.2345.0"
+            "#,
+        )
+        .file("a/src/lib.rs", "")
+        .build();
+
+    cargo_process("install --path")
+        .arg(p.root())
+        .arg("foo")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[INSTALLING] foo v0.1.0 ([ROOT]/foo)
+[LOCKING] 1 package to latest compatible version
+[ERROR] failed to compile `foo v0.1.0 ([ROOT]/foo)`, intermediate artifacts can be found at `[ROOT]/foo/target`.
+To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
+
+Caused by:
+  rustc [..] is not supported by the following package:
+    some-package-from-the-distant-future@0.1.0 requires rustc 1.2345.0
+
+"#]])
+        .run();
+    assert_has_not_installed_exe(paths::cargo_home(), "foo");
+}
+
+#[cargo_test]
+fn dry_run_upgrade() {
+    pkg("foo", "0.0.1");
+    cargo_process("install foo").run();
+    assert_has_installed_exe(paths::cargo_home(), "foo");
+
+    pkg("foo", "0.0.2");
+    cargo_process("install foo")
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] foo v0.0.2 (registry `dummy-registry`)
+[INSTALLING] foo v0.0.2
+[COMPILING] foo v0.0.2
+[FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
+[REPLACING] [ROOT]/home/.cargo/bin/foo[EXE]
+[REPLACED] package `foo v0.0.1` with `foo v0.0.2` (executable `foo[EXE]`)
+[WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
+
+"#]])
+        .run();
+    assert_has_installed_exe(paths::cargo_home(), "foo");
+}
+
+#[cargo_test]
+fn dry_run_remove_orphan() {
+    Package::new("bar", "1.0.0")
+        .file("src/bin/client.rs", "fn main() {}")
+        .file("src/bin/server.rs", "fn main() {}")
+        .publish();
+
+    cargo_process("install bar")
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
+[INSTALLING] bar v1.0.0
+[COMPILING] bar v1.0.0
+[FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
+[INSTALLING] [ROOT]/home/.cargo/bin/client[EXE]
+[INSTALLING] [ROOT]/home/.cargo/bin/server[EXE]
+[INSTALLED] package `bar v1.0.0` (executables `client[EXE]`, `server[EXE]`)
+[WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
+
+"#]])
+        .run();
+    assert_has_installed_exe(paths::cargo_home(), "client");
+    assert_has_installed_exe(paths::cargo_home(), "server");
+
+    Package::new("bar", "2.0.0")
+        .file("src/bin/client.rs", "fn main() {}")
+        .publish();
+
+    cargo_process("install bar")
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v2.0.0 (registry `dummy-registry`)
+[INSTALLING] bar v2.0.0
+[COMPILING] bar v2.0.0
+[FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
+[REPLACING] [ROOT]/home/.cargo/bin/client[EXE]
+[REMOVING] executable `[ROOT]/home/.cargo/bin/server[EXE]` from previous version bar v1.0.0
+[REPLACED] package `bar v1.0.0` with `bar v2.0.0` (executable `client[EXE]`)
+[WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
+
+"#]])
+        .run();
+    assert_has_installed_exe(paths::cargo_home(), "client");
+    assert_has_not_installed_exe(paths::cargo_home(), "server");
+}


### PR DESCRIPTION
### What does this PR try to resolve?

This PR add the `--dry-run` flag to the `cargo install` command (see #11123).
I've tried to do the bare minimal for this flag to work without changing anything in the output.

In my opinion, the `--dry-run` flag should mimic as close as possible the behavior of the normal command to avoid missing potential issue in the normal execution. ~~Currently we're missing information about where the binary will be installed.~~

Unlike #13598 this PR:
- Include as much of the compilation process as possible without actually compiling
- use the information provided by `BuildContext` instead of `InstallablePackage::new`
- in the same way as `unit_graph`, it add a `dry_run` to the `CompileOptions` and return a `Compilation::new` from the function `compile_ws` without actually compiling.
- keeps the output the same rather than adding  status messages indicating which very broad actions would be performed
- ~~remove some warning not relevant in the case of  a `--dry-run`~~

Like #13598, the version check and crate downloads still occur.

### How should we test and review this PR?

The first commit include a unit tests to ensure that no binary is actually installed after the dry run.
There is also a snapshot test that show the diff output of the `--help` flag.

### Additional information

Tests and documentation done in #13598, may be cherry picked into this PR if needed.
