### PR TITLE
test: Fix some test based on rustc version

### DIFF
--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -6419,7 +6419,6 @@ fn pipelining_big_graph() {
         .with_stderr_data(
             str![[r#"
 [LOCKING] 61 packages to latest compatible versions
-[COMPILING] b30 v0.5.0 ([ROOT]/foo/b30)
 [COMPILING] a30 v0.5.0 ([ROOT]/foo/a30)
 [ERROR] don't actually build me
 ...

--- a/tests/testsuite/lints/implicit_features.rs
+++ b/tests/testsuite/lints/implicit_features.rs
@@ -127,7 +127,7 @@ unused_optional_dependency = "allow"
         .masquerade_as_nightly_cargo(&["cargo-lints", "edition2024"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest Rust 1.81.0-nightly compatible versions
+[LOCKING] 2 packages to latest Rust [..] compatible versions
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 


### PR DESCRIPTION
### What does this PR try to resolve?

Some test ouput specifies the latest rustc version and will failed when the rustc version get updated

### How should we test and review this PR?

### Additional information

