### PR TITLE
chore: bump cargo-test-support to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,7 @@ version = "0.3.0"
 
 [[package]]
 name = "cargo-test-support"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ cargo-credential-macos-keychain = { version = "0.4.7", path = "credential/cargo-
 cargo-credential-wincred = { version = "0.4.7", path = "credential/cargo-credential-wincred" }
 cargo-platform = { path = "crates/cargo-platform", version = "0.1.5" }
 cargo-test-macro = { version = "0.3.0", path = "crates/cargo-test-macro" }
-cargo-test-support = { version = "0.3.0", path = "crates/cargo-test-support" }
+cargo-test-support = { version = "0.4.0", path = "crates/cargo-test-support" }
 cargo-util = { version = "0.2.14", path = "crates/cargo-util" }
 cargo-util-schemas = { version = "0.5.0", path = "crates/cargo-util-schemas" }
 cargo_metadata = "0.18.1"

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-test-support"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version = "1.79"  # MSRV:1
 license.workspace = true


### PR DESCRIPTION
### What does this PR try to resolve?

These PRs have contributed to major changes:

* https://github.com/rust-lang/cargo/pull/14266
* https://github.com/rust-lang/cargo/pull/14269
* https://github.com/rust-lang/cargo/pull/14270


### How should we test and review this PR?


### Additional information

Error log:

```
    Checking cargo-test-support v0.3.0 -> v0.3.1 (minor change)
     Checked [   0.079s] 66 checks; 63 passed, 3 failed, 6 unnecessary

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.31.0/src/lints/function_missing.ron

Failed in:
  function cargo_test_support::install::cargo_home, previously in file /projects/cargo/target/semver-checks/git-a2b58c3dad4d554ba01ed6c45c41ff85390560f2/e5a046bb78236b6c7eddf006d3a5ac7b4a5593aa/crates/cargo-test-support/src/install.rs:27
  function cargo_test_support::path2url, previously in file /projects/cargo/target/semver-checks/git-a2b58c3dad4d554ba01ed6c45c41ff85390560f2/e5a046bb78236b6c7eddf006d3a5ac7b4a5593aa/crates/cargo-test-support/src/lib.rs:1187

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.31.0/src/lints/struct_missing.ron

Failed in:
  struct cargo_test_support::RawOutput, previously in file /projects/cargo/target/semver-checks/git-a2b58c3dad4d554ba01ed6c45c41ff85390560f2/e5a046bb78236b6c7eddf006d3a5ac7b4a5593aa/crates/cargo-test-support/src/lib.rs:524

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.31.0/src/lints/trait_missing.ron

Failed in:
  trait cargo_test_support::TestEnv, previously in file /projects/cargo/target/semver-checks/git-a2b58c3dad4d554ba01ed6c45c41ff85390560f2/e5a046bb78236b6c7eddf006d3a5ac7b4a5593aa/crates/cargo-test-support/src/lib.rs:1272
  trait cargo_test_support::prelude::TestEnv, previously in file /projects/cargo/target/semver-checks/git-a2b58c3dad4d554ba01ed6c45c41ff85390560f2/e5a046bb78236b6c7eddf006d3a5ac7b4a5593aa/crates/cargo-test-support/src/lib.rs:1272
  trait cargo_test_support::ChannelChanger, previously in file /projects/cargo/target/semver-checks/git-a2b58c3dad4d554ba01ed6c45c41ff85390560f2/e5a046bb78236b6c7eddf006d3a5ac7b4a5593aa/crates/cargo-test-support/src/lib.rs:1252
  trait cargo_test_support::prelude::ChannelChanger, previously in file /projects/cargo/target/semver-checks/git-a2b58c3dad4d554ba01ed6c45c41ff85390560f2/e5a046bb78236b6c7eddf006d3a5ac7b4a5593aa/crates/cargo-test-support/src/lib.rs:1252
  trait cargo_test_support::CargoCommand, previously in file /projects/cargo/target/semver-checks/git-a2b58c3dad4d554ba01ed6c45c41ff85390560f2/e5a046bb78236b6c7eddf006d3a5ac7b4a5593aa/crates/cargo-test-support/src/lib.rs:1388
  trait cargo_test_support::prelude::CargoCommand, previously in file /projects/cargo/target/semver-checks/git-a2b58c3dad4d554ba01ed6c45c41ff85390560f2/e5a046bb78236b6c7eddf006d3a5ac7b4a5593aa/crates/cargo-test-support/src/lib.rs:1388
  trait cargo_test_support::ArgLine, previously in file /projects/cargo/target/semver-checks/git-a2b58c3dad4d554ba01ed6c45c41ff85390560f2/e5a046bb78236b6c7eddf006d3a5ac7b4a5593aa/crates/cargo-test-support/src/lib.rs:1402
  trait cargo_test_support::prelude::ArgLine, previously in file /projects/cargo/target/semver-checks/git-a2b58c3dad4d554ba01ed6c45c41ff85390560f2/e5a046bb78236b6c7eddf006d3a5ac7b4a5593aa/crates/cargo-test-support/src/lib.rs:1402
     Summary semver requires new major version: 3 major and 0 minor checks failed
```