### PR TITLE
test: Migrate some json tests to snapbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2170,7 +2170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -3216,9 +3216,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "snapbox"
-version = "0.6.10"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40e14d10e4c2b4331ac24c33baa5a03e1fbca81c045b285b53b2a612d28569fb"
+checksum = "042fb2fd44b9f8b1fa5a3b410473982e06abf644f7a8d761cfe4b454a7781191"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ sha1 = "0.10.6"
 sha2 = "0.10.8"
 shell-escape = "0.1.5"
 supports-hyperlinks = "3.0.0"
-snapbox = { version = "0.6.9", features = ["diff", "dir", "term-svg", "regex", "json"] }
+snapbox = { version = "0.6.14", features = ["diff", "dir", "term-svg", "regex", "json"] }
 tar = { version = "0.4.40", default-features = false }
 tempfile = "3.10.1"
 thiserror = "1.0.59"

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -876,7 +876,9 @@ impl Execs {
     /// - The order of arrays is ignored.
     /// - Strings support patterns described in [`compare`].
     /// - Use `"{...}"` to match any object.
-    #[deprecated(note = "replaced with `Execs::with_stdout_data(expected.json_lines())`")]
+    #[deprecated(
+        note = "replaced with `Execs::with_stdout_data(expected.is_json().against_jsonlines())`"
+    )]
     pub fn with_json(&mut self, expected: &str) -> &mut Self {
         self.expect_json = Some(expected.to_string());
         self

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -989,7 +989,7 @@ fn alt_reg_metadata() {
   "workspace_root": "[ROOT]/foo"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 
@@ -1353,7 +1353,7 @@ fn alt_reg_metadata() {
   "workspace_root": "[ROOT]/foo"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -1615,7 +1615,7 @@ fn unknown_registry() {
   "workspace_root": "[ROOT]/foo"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }

--- a/tests/testsuite/bad_manifest_path.rs
+++ b/tests/testsuite/bad_manifest_path.rs
@@ -331,10 +331,14 @@ fn verify_project_dir_containing_cargo_toml() {
         .with_status(1)
         .with_stdout_data(
             str![[r#"
-{"invalid":"the manifest-path must be a path to a Cargo.toml file"}
-
+[
+  {
+    "invalid": "the manifest-path must be a path to a Cargo.toml file"
+  }
+]
 "#]]
-            .is_jsonlines(),
+            .is_json()
+            .against_jsonlines(),
         )
         .run();
 }
@@ -351,10 +355,14 @@ fn verify_project_dir_plus_file() {
         .with_status(1)
         .with_stdout_data(
             str![[r#"
-{"invalid":"the manifest-path must be a path to a Cargo.toml file"}
-
+[
+  {
+    "invalid": "the manifest-path must be a path to a Cargo.toml file"
+  }
+]
 "#]]
-            .is_jsonlines(),
+            .is_json()
+            .against_jsonlines(),
         )
         .run();
 }
@@ -371,10 +379,14 @@ fn verify_project_dir_plus_path() {
         .with_status(1)
         .with_stdout_data(
             str![[r#"
-{"invalid":"the manifest-path must be a path to a Cargo.toml file"}
-
+[
+  {
+    "invalid": "the manifest-path must be a path to a Cargo.toml file"
+  }
+]
 "#]]
-            .is_jsonlines(),
+            .is_json()
+            .against_jsonlines(),
         )
         .run();
 }
@@ -387,10 +399,14 @@ fn verify_project_dir_to_nonexistent_cargo_toml() {
         .with_status(1)
         .with_stdout_data(
             str![[r#"
-{"invalid":"manifest path `foo/bar/baz/Cargo.toml` does not exist"}
-
+[
+  {
+    "invalid": "manifest path `foo/bar/baz/Cargo.toml` does not exist"
+  }
+]
 "#]]
-            .is_jsonlines(),
+            .is_json()
+            .against_jsonlines(),
         )
         .run();
 }

--- a/tests/testsuite/bad_manifest_path.rs
+++ b/tests/testsuite/bad_manifest_path.rs
@@ -334,7 +334,7 @@ fn verify_project_dir_containing_cargo_toml() {
 {"invalid":"the manifest-path must be a path to a Cargo.toml file"}
 
 "#]]
-            .json_lines(),
+            .is_jsonlines(),
         )
         .run();
 }
@@ -354,7 +354,7 @@ fn verify_project_dir_plus_file() {
 {"invalid":"the manifest-path must be a path to a Cargo.toml file"}
 
 "#]]
-            .json_lines(),
+            .is_jsonlines(),
         )
         .run();
 }
@@ -374,7 +374,7 @@ fn verify_project_dir_plus_path() {
 {"invalid":"the manifest-path must be a path to a Cargo.toml file"}
 
 "#]]
-            .json_lines(),
+            .is_jsonlines(),
         )
         .run();
 }
@@ -390,7 +390,7 @@ fn verify_project_dir_to_nonexistent_cargo_toml() {
 {"invalid":"manifest path `foo/bar/baz/Cargo.toml` does not exist"}
 
 "#]]
-            .json_lines(),
+            .is_jsonlines(),
         )
         .run();
 }

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -2112,11 +2112,39 @@ fn json_artifact_includes_executable_for_benchmark() {
     p.cargo("bench --no-run --message-format=json")
         .with_stdout_data(
             str![[r#"
-{"executable":"[ROOT]/foo/target/release/deps/benchmark-[HASH][EXE]","features":[],"filenames":"{...}","fresh":false,"manifest_path":"[ROOT]/foo/Cargo.toml","package_id":"path+[ROOTURL]/foo#0.0.1","profile":"{...}","reason":"compiler-artifact","target":{"crate_types":["bin"],"doc":false,"doctest":false,"edition":"2015","kind":["bench"],"name":"benchmark","src_path":"[ROOT]/foo/benches/benchmark.rs","test":false}}
-{"reason":"build-finished","success":true}
-
+[
+  {
+    "executable": "[..]",
+    "features": [],
+    "filenames": "{...}",
+    "fresh": false,
+    "manifest_path": "[ROOT]/foo/Cargo.toml",
+    "package_id": "path+[ROOTURL]/foo#0.0.1",
+    "profile": "{...}",
+    "reason": "compiler-artifact",
+    "target": {
+      "crate_types": [
+        "bin"
+      ],
+      "doc": false,
+      "doctest": false,
+      "edition": "2015",
+      "kind": [
+        "bench"
+      ],
+      "name": "benchmark",
+      "src_path": "[ROOT]/foo/benches/benchmark.rs",
+      "test": false
+    }
+  },
+  {
+    "reason": "build-finished",
+    "success": true
+  }
+]
 "#]]
-            .is_jsonlines(),
+            .is_json()
+            .against_jsonlines(),
         )
         .run();
 }

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -2116,7 +2116,7 @@ fn json_artifact_includes_executable_for_benchmark() {
 {"reason":"build-finished","success":true}
 
 "#]]
-            .json_lines(),
+            .is_jsonlines(),
         )
         .run();
 }

--- a/tests/testsuite/binary_name.rs
+++ b/tests/testsuite/binary_name.rs
@@ -319,6 +319,6 @@ fn check_msg_format_json() {
 {"executable":"[ROOT]/foo/target/debug/007bar[EXE]","features":[],"filenames":"{...}","fresh":false,"manifest_path":"[ROOT]/foo/Cargo.toml","package_id":"path+[ROOTURL]/foo#0.0.1","profile":"{...}","reason":"compiler-artifact","target":"{...}"}
 {"reason":"build-finished","success":true}
 
-"#]].json_lines())
+"#]].is_jsonlines())
         .run();
 }

--- a/tests/testsuite/binary_name.rs
+++ b/tests/testsuite/binary_name.rs
@@ -315,10 +315,28 @@ fn check_msg_format_json() {
     // Run cargo build.
     p.cargo("build --message-format=json")
         .masquerade_as_nightly_cargo(&["different-binary-name"])
-        .with_stdout_data(str![[r#"
-{"executable":"[ROOT]/foo/target/debug/007bar[EXE]","features":[],"filenames":"{...}","fresh":false,"manifest_path":"[ROOT]/foo/Cargo.toml","package_id":"path+[ROOTURL]/foo#0.0.1","profile":"{...}","reason":"compiler-artifact","target":"{...}"}
-{"reason":"build-finished","success":true}
-
-"#]].is_jsonlines())
+        .with_stdout_data(
+            str![[r#"
+[
+  {
+    "executable": "[ROOT]/foo/target/debug/007bar[EXE]",
+    "features": [],
+    "filenames": "{...}",
+    "fresh": false,
+    "manifest_path": "[ROOT]/foo/Cargo.toml",
+    "package_id": "path+[ROOTURL]/foo#0.0.1",
+    "profile": "{...}",
+    "reason": "compiler-artifact",
+    "target": "{...}"
+  },
+  {
+    "reason": "build-finished",
+    "success": true
+  }
+]
+"#]]
+            .is_json()
+            .against_jsonlines(),
+        )
         .run();
 }

--- a/tests/testsuite/build_plan.rs
+++ b/tests/testsuite/build_plan.rs
@@ -39,7 +39,7 @@ fn cargo_build_plan_simple() {
   ]
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
     assert!(!p.bin("foo").is_file());
@@ -126,7 +126,7 @@ fn cargo_build_plan_single_dep() {
   ]
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -213,7 +213,7 @@ fn cargo_build_plan_build_script() {
   ]
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }

--- a/tests/testsuite/cargo_config/mod.rs
+++ b/tests/testsuite/cargo_config/mod.rs
@@ -217,7 +217,7 @@ fn get_json() {
 }
 
 "#
-            .json(),
+            .is_json(),
         )
         .with_stderr_data(str![[r#"
 [NOTE] The following environment variables may affect the loaded values.
@@ -270,7 +270,7 @@ CARGO_HOME=[ROOT]/home/.cargo
 }
   
 "#
-            .json(),
+            .is_json(),
         )
         .with_stderr_data(str![[r#"
 [NOTE] The following environment variables may affect the loaded values.

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1879,24 +1879,29 @@ fn doc_message_format() {
 
     p.cargo("doc --message-format=json")
         .with_status(101)
-        .with_json_contains_unordered(
-            r#"
-            {
-                "message": {
-                    "$message_type": "diagnostic",
-                    "children": "{...}",
-                    "code": "{...}",
-                    "level": "error",
-                    "message": "{...}",
-                    "rendered": "{...}",
-                    "spans": "{...}"
-                },
-                "package_id": "path+file:///[..]/foo#0.0.1",
-                "manifest_path": "[..]",
-                "reason": "compiler-message",
-                "target": "{...}"
-            }
-            "#,
+        .with_stdout_data(
+            str![[r##"
+[
+  {
+    "manifest_path": "[ROOT]/foo/Cargo.toml",
+    "message": {
+      "$message_type": "diagnostic",
+      "children": "{...}",
+      "code": "{...}",
+      "level": "error",
+      "message": "{...}",
+      "rendered": "{...}",
+      "spans": "{...}"
+    },
+    "package_id": "path+[ROOTURL]/foo#0.0.1",
+    "reason": "compiler-message",
+    "target": "{...}"
+  },
+  "{...}"
+]
+"##]]
+            .is_json()
+            .against_jsonlines(),
         )
         .run();
 }
@@ -1911,76 +1916,95 @@ fn doc_json_artifacts() {
         .build();
 
     p.cargo("doc --message-format=json")
-        .with_json_contains_unordered(
-            r#"
-{
-    "reason": "compiler-artifact",
-    "package_id": "path+file:///[..]/foo#0.0.1",
-    "manifest_path": "[ROOT]/foo/Cargo.toml",
-    "target":
-    {
-        "kind": ["lib"],
-        "crate_types": ["lib"],
-        "name": "foo",
-        "src_path": "[ROOT]/foo/src/lib.rs",
-        "edition": "2015",
-        "doc": true,
-        "doctest": true,
-        "test": true
-    },
-    "profile": "{...}",
-    "features": [],
-    "filenames": ["[ROOT]/foo/target/debug/deps/libfoo-[..].rmeta"],
+        .with_stdout_data(
+            str![[r#"
+[
+  {
     "executable": null,
-    "fresh": false
-}
-
-{
-    "reason": "compiler-artifact",
-    "package_id": "path+file:///[..]/foo#0.0.1",
-    "manifest_path": "[ROOT]/foo/Cargo.toml",
-    "target":
-    {
-        "kind": ["lib"],
-        "crate_types": ["lib"],
-        "name": "foo",
-        "src_path": "[ROOT]/foo/src/lib.rs",
-        "edition": "2015",
-        "doc": true,
-        "doctest": true,
-        "test": true
-    },
-    "profile": "{...}",
     "features": [],
-    "filenames": ["[ROOT]/foo/target/doc/foo/index.html"],
-    "executable": null,
-    "fresh": false
-}
-
-{
-    "reason": "compiler-artifact",
-    "package_id": "path+file:///[..]/foo#0.0.1",
+    "filenames": [
+      "[ROOT]/foo/target/debug/deps/libfoo-[HASH].rmeta"
+    ],
+    "fresh": false,
     "manifest_path": "[ROOT]/foo/Cargo.toml",
-    "target":
-    {
-        "kind": ["bin"],
-        "crate_types": ["bin"],
-        "name": "somebin",
-        "src_path": "[ROOT]/foo/src/bin/somebin.rs",
-        "edition": "2015",
-        "doc": true,
-        "doctest": false,
-        "test": true
-    },
+    "package_id": "path+[ROOTURL]/foo#0.0.1",
     "profile": "{...}",
-    "features": [],
-    "filenames": ["[ROOT]/foo/target/doc/somebin/index.html"],
+    "reason": "compiler-artifact",
+    "target": {
+      "crate_types": [
+        "lib"
+      ],
+      "doc": true,
+      "doctest": true,
+      "edition": "2015",
+      "kind": [
+        "lib"
+      ],
+      "name": "foo",
+      "src_path": "[ROOT]/foo/src/lib.rs",
+      "test": true
+    }
+  },
+  {
     "executable": null,
-    "fresh": false
-}
-
-{"reason":"build-finished","success":true}
-"#,
+    "features": [],
+    "filenames": [
+      "[ROOT]/foo/target/doc/foo/index.html"
+    ],
+    "fresh": false,
+    "manifest_path": "[ROOT]/foo/Cargo.toml",
+    "package_id": "path+[ROOTURL]/foo#0.0.1",
+    "profile": "{...}",
+    "reason": "compiler-artifact",
+    "target": {
+      "crate_types": [
+        "lib"
+      ],
+      "doc": true,
+      "doctest": true,
+      "edition": "2015",
+      "kind": [
+        "lib"
+      ],
+      "name": "foo",
+      "src_path": "[ROOT]/foo/src/lib.rs",
+      "test": true
+    }
+  },
+  {
+    "executable": null,
+    "features": [],
+    "filenames": [
+      "[ROOT]/foo/target/doc/somebin/index.html"
+    ],
+    "fresh": false,
+    "manifest_path": "[ROOT]/foo/Cargo.toml",
+    "package_id": "path+[ROOTURL]/foo#0.0.1",
+    "profile": "{...}",
+    "reason": "compiler-artifact",
+    "target": {
+      "crate_types": [
+        "bin"
+      ],
+      "doc": true,
+      "doctest": false,
+      "edition": "2015",
+      "kind": [
+        "bin"
+      ],
+      "name": "somebin",
+      "src_path": "[ROOT]/foo/src/bin/somebin.rs",
+      "test": true
+    }
+  },
+  {
+    "reason": "build-finished",
+    "success": true
+  }
+]
+"#]]
+            .is_json()
+            .against_jsonlines(),
         )
         .run();
 }

--- a/tests/testsuite/features_namespaced.rs
+++ b/tests/testsuite/features_namespaced.rs
@@ -640,7 +640,7 @@ fn json_exposed() {
 }
 
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -3656,7 +3656,7 @@ fn metadata_master_consistency() {
 
     let bar_source = "git+[ROOTURL]/bar?branch=master";
     p.cargo("metadata")
-        .with_stdout_data(&metadata(&bar_source).json())
+        .with_stdout_data(&metadata(&bar_source).is_json())
         .run();
 
     // Conversely, remove branch="master" from Cargo.toml, but use a new Cargo.lock that has ?branch=master.
@@ -3702,7 +3702,7 @@ fn metadata_master_consistency() {
     // No ?branch=master!
     let bar_source = "git+[ROOTURL]/bar";
     p.cargo("metadata")
-        .with_stdout_data(&metadata(&bar_source).json())
+        .with_stdout_data(&metadata(&bar_source).is_json())
         .run();
 }
 

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -106,7 +106,6 @@ fn url() {
         .run();
 }
 
-#[allow(deprecated)]
 #[cargo_test]
 fn simple_with_message_format() {
     pkg("foo", "0.0.1");
@@ -124,60 +123,65 @@ fn simple_with_message_format() {
 [WARNING] be sure to add `[..]` to your PATH to be able to run the installed binaries
 
 "#]])
-        .with_json(
-            r#"
-            {
-                "reason": "compiler-artifact",
-                "package_id": "registry+https://[..]#foo@0.0.1",
-                "manifest_path": "[..]",
-                "target": {
-                    "kind": [
-                        "lib"
-                    ],
-                    "crate_types": [
-                        "lib"
-                    ],
-                    "name": "foo",
-                    "src_path": "[..]/foo-0.0.1/src/lib.rs",
-                    "edition": "2015",
-                    "doc": true,
-                    "doctest": true,
-                    "test": true
-                },
-                "profile": "{...}",
-                "features": [],
-                "filenames": "{...}",
-                "executable": null,
-                "fresh": false
-            }
-
-            {
-                "reason": "compiler-artifact",
-                "package_id": "registry+https://[..]#foo@0.0.1",
-                "manifest_path": "[..]",
-                "target": {
-                    "kind": [
-                        "bin"
-                    ],
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "name": "foo",
-                    "src_path": "[..]/foo-0.0.1/src/main.rs",
-                    "edition": "2015",
-                    "doc": true,
-                    "doctest": false,
-                    "test": true
-                },
-                "profile": "{...}",
-                "features": [],
-                "filenames": "{...}",
-                "executable": "[..]",
-                "fresh": false
-            }
-
-            {"reason":"build-finished","success":true}
-            "#,
+        .with_stdout_data(
+            str![[r#"
+[
+  {
+    "executable": null,
+    "features": [],
+    "filenames": "{...}",
+    "fresh": false,
+    "manifest_path": "[ROOT]/home/.cargo/registry/src/-[HASH]/foo-0.0.1/Cargo.toml",
+    "package_id": "registry+https://github.com/rust-lang/crates.io-index#foo@0.0.1",
+    "profile": "{...}",
+    "reason": "compiler-artifact",
+    "target": {
+      "crate_types": [
+        "lib"
+      ],
+      "doc": true,
+      "doctest": true,
+      "edition": "2015",
+      "kind": [
+        "lib"
+      ],
+      "name": "foo",
+      "src_path": "[ROOT]/home/.cargo/registry/src/-[HASH]/foo-0.0.1/src/lib.rs",
+      "test": true
+    }
+  },
+  {
+    "executable": "[..]",
+    "features": [],
+    "filenames": "{...}",
+    "fresh": false,
+    "manifest_path": "[ROOT]/home/.cargo/registry/src/-[HASH]/foo-0.0.1/Cargo.toml",
+    "package_id": "registry+https://github.com/rust-lang/crates.io-index#foo@0.0.1",
+    "profile": "{...}",
+    "reason": "compiler-artifact",
+    "target": {
+      "crate_types": [
+        "bin"
+      ],
+      "doc": true,
+      "doctest": false,
+      "edition": "2015",
+      "kind": [
+        "bin"
+      ],
+      "name": "foo",
+      "src_path": "[ROOT]/home/.cargo/registry/src/-[HASH]/foo-0.0.1/src/main.rs",
+      "test": true
+    }
+  },
+  {
+    "reason": "build-finished",
+    "success": true
+  }
+]
+"#]]
+            .is_json()
+            .against_jsonlines(),
         )
         .run();
     assert_has_installed_exe(paths::cargo_home(), "foo");

--- a/tests/testsuite/locate_project.rs
+++ b/tests/testsuite/locate_project.rs
@@ -15,7 +15,7 @@ fn simple() {
   "root": "[ROOT]/foo/Cargo.toml"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -38,7 +38,7 @@ fn message_format() {
   "root": "[ROOT]/foo/Cargo.toml"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 
@@ -84,7 +84,7 @@ fn workspace() {
   "root": "[ROOT]/foo/Cargo.toml"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 
@@ -96,7 +96,7 @@ fn workspace() {
   "root": "[ROOT]/foo/inner/Cargo.toml"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 
@@ -107,7 +107,7 @@ fn workspace() {
   "root": "[ROOT]/foo/Cargo.toml"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 
@@ -119,7 +119,7 @@ fn workspace() {
   "root": "[ROOT]/foo/Cargo.toml"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }

--- a/tests/testsuite/metabuild.rs
+++ b/tests/testsuite/metabuild.rs
@@ -586,7 +586,7 @@ fn metabuild_build_plan() {
   ]
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -87,7 +87,7 @@ fn cargo_metadata_simple() {
   "workspace_root": "[ROOT]/foo"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -200,7 +200,7 @@ crate-type = ["lib", "staticlib"]
   "workspace_root": "[ROOT]/foo"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -303,7 +303,7 @@ optional_feat = []
   "workspace_root": "[ROOT]/foo"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -622,7 +622,7 @@ fn cargo_metadata_with_deps_and_version() {
   "workspace_root": "[ROOT]/foo"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -729,7 +729,7 @@ name = "ex"
   "workspace_root": "[ROOT]/foo"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -838,7 +838,7 @@ crate-type = ["rlib", "dylib"]
   "workspace_root": "[ROOT]/foo"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -1000,7 +1000,7 @@ fn workspace_metadata() {
   "workspace_root": "[ROOT]/foo"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -1224,7 +1224,7 @@ fn workspace_metadata_with_dependencies_no_deps() {
   "workspace_root": "[ROOT]/foo"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -1860,7 +1860,7 @@ fn workspace_metadata_with_dependencies_and_resolve() {
   "workspace_root": "[ROOT]/foo"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -2094,7 +2094,7 @@ fn cargo_metadata_no_deps_path_to_cargo_toml_relative() {
   "workspace_root": "[ROOT]/foo"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -2170,7 +2170,7 @@ fn cargo_metadata_no_deps_path_to_cargo_toml_absolute() {
   "workspace_root": "[ROOT]/foo"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -2279,7 +2279,7 @@ fn cargo_metadata_no_deps_cwd() {
   "workspace_root": "[ROOT]/foo"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -2419,7 +2419,7 @@ fn package_metadata() {
   "workspace_root": "[ROOT]/foo"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -2513,7 +2513,7 @@ fn package_publish() {
   "workspace_root": "[ROOT]/foo"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -2610,7 +2610,7 @@ fn cargo_metadata_path_to_cargo_toml_project() {
   "workspace_root": "[ROOT]/foo/target/package/bar-0.5.0"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -2702,7 +2702,7 @@ fn package_edition_2018() {
   "workspace_root": "[ROOT]/foo"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -2854,7 +2854,7 @@ fn target_edition_2018() {
   "workspace_root": "[ROOT]/foo"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -3094,7 +3094,7 @@ fn rename_dependency() {
   "workspace_root": "[ROOT]/foo"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -3199,7 +3199,7 @@ fn metadata_links() {
   "workspace_root": "[ROOT]/foo"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run()
 }
@@ -3306,7 +3306,7 @@ fn deps_with_bin_only() {
   "workspace_root": "[ROOT]/foo"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -4149,7 +4149,7 @@ fn dep_kinds() {
   "workspace_root": "[ROOT]/foo"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -4268,7 +4268,7 @@ fn dep_kinds_workspace() {
   "workspace_root": "[ROOT]/foo"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -4536,7 +4536,7 @@ fn workspace_metadata_with_dependencies_no_deps_artifact() {
   "workspace_root": "[ROOT]/foo"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -4819,7 +4819,7 @@ fn versionless_packages() {
   "workspace_root": "[ROOT]/foo"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -4929,7 +4929,7 @@ local-time = 1979-05-27
   "workspace_root": "[ROOT]/foo"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }

--- a/tests/testsuite/open_namespaces.rs
+++ b/tests/testsuite/open_namespaces.rs
@@ -98,7 +98,7 @@ fn implicit_lib_within_namespace() {
   "version": "0.0.1"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .with_stderr_data("")
         .run()
@@ -167,7 +167,7 @@ fn implicit_bin_within_namespace() {
   "version": "0.0.1"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .with_stderr_data("")
         .run()
@@ -254,7 +254,7 @@ fn explicit_bin_within_namespace() {
   "version": "0.0.1"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .with_stderr_data("")
         .run()
@@ -322,7 +322,7 @@ fn main() {}
   "version": "0.0.0"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .with_stderr_data("")
         .run();

--- a/tests/testsuite/pkgid.rs
+++ b/tests/testsuite/pkgid.rs
@@ -306,66 +306,47 @@ fn pkgid_json_message_metadata_consistency() {
     let pkgid = pkgid.trim();
     assert_e2e().eq(pkgid, str!["path+[ROOTURL]/foo#0.5.0"]);
 
-    #[allow(deprecated)]
     p.cargo("check --message-format=json")
-        .with_json(
-            &r#"
-{
-  "reason": "compiler-artifact",
-  "package_id": "$PKGID",
-  "manifest_path": "[..]",
-  "target": "{...}",
-  "profile": "{...}",
-  "features": [],
-  "filenames": "{...}",
-  "executable": null,
-  "fresh": false
-}
-
-{
-  "reason": "build-script-executed",
-  "package_id": "$PKGID",
-  "linked_libs": [],
-  "linked_paths": [],
-  "cfgs": [],
-  "env": [],
-  "out_dir": "[..]"
-}
-
-{
-  "manifest_path": "[..]",
-  "message": "{...}",
-  "package_id": "$PKGID",
-  "reason": "compiler-message",
-  "target": "{...}"
-}
-
-{
-  "reason": "compiler-message",
-  "package_id": "$PKGID",
-  "manifest_path": "[..]",
-  "target": "{...}",
-  "message": "{...}"
-}
-
-{
-  "reason": "compiler-artifact",
-  "package_id": "$PKGID",
-  "manifest_path": "[..]",
-  "target": "{...}",
-  "profile": "{...}",
-  "features": [],
-  "filenames": "{...}",
-  "executable": null,
-  "fresh": false
-}
-
-{
-  "reason": "build-finished",
-  "success": true
-}
-            "#
-            .replace("$PKGID", pkgid),
+        .with_stdout_data(
+            str![[r#"
+[
+  {
+    "manifest_path": "[ROOT]/foo/Cargo.toml",
+    "package_id": "path+[ROOTURL]/foo#0.5.0",
+    "reason": "compiler-artifact",
+    "...": "{...}"
+  },
+  {
+    "package_id": "path+[ROOTURL]/foo#0.5.0",
+    "reason": "build-script-executed",
+    "...": "{...}"
+  },
+  {
+    "manifest_path": "[ROOT]/foo/Cargo.toml",
+    "package_id": "path+[ROOTURL]/foo#0.5.0",
+    "reason": "compiler-message",
+    "...": "{...}"
+  },
+  {
+    "manifest_path": "[ROOT]/foo/Cargo.toml",
+    "package_id": "path+[ROOTURL]/foo#0.5.0",
+    "reason": "compiler-message",
+    "...": "{...}"
+  },
+  {
+    "manifest_path": "[ROOT]/foo/Cargo.toml",
+    "package_id": "path+[ROOTURL]/foo#0.5.0",
+    "reason": "compiler-artifact",
+    "...": "{...}"
+  },
+  {
+    "reason": "build-finished",
+    "success": true
+  }
+]
+"#]]
+            .is_json()
+            .against_jsonlines(),
         )
         .run();
 

--- a/tests/testsuite/pkgid.rs
+++ b/tests/testsuite/pkgid.rs
@@ -426,7 +426,7 @@ fn pkgid_json_message_metadata_consistency() {
   "workspace_root": "[ROOT]/foo"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run()
 }

--- a/tests/testsuite/read_manifest.rs
+++ b/tests/testsuite/read_manifest.rs
@@ -37,7 +37,7 @@ fn cargo_read_manifest_path_to_cargo_toml_relative() {
   "...": "{...}"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -59,7 +59,7 @@ fn cargo_read_manifest_path_to_cargo_toml_absolute() {
   "...": "{...}"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -114,7 +114,7 @@ fn cargo_read_manifest_cwd() {
   "...": "{...}"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -138,7 +138,7 @@ fn cargo_read_manifest_with_specified_readme() {
   "...": "{...}"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -163,7 +163,7 @@ fn cargo_read_manifest_default_readme() {
   "...": "{...}"
 }
 "#]]
-        .json(),
+        .is_json(),
     );
 
     assert_output(
@@ -174,7 +174,7 @@ fn cargo_read_manifest_default_readme() {
   "...": "{...}"
 }
 "#]]
-        .json(),
+        .is_json(),
     );
 
     assert_output(
@@ -185,7 +185,7 @@ fn cargo_read_manifest_default_readme() {
   "...": "{...}"
 }
 "#]]
-        .json(),
+        .is_json(),
     );
 }
 
@@ -208,7 +208,7 @@ fn cargo_read_manifest_suppress_default_readme() {
   "...": "{...}"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }
@@ -230,7 +230,7 @@ fn cargo_read_manifest_defaults_readme_if_true() {
   "...": "{...}"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -1115,7 +1115,7 @@ fn cmd_metadata_with_embedded() {
   "workspace_root": "[ROOT]/foo"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to `2021`
@@ -1177,7 +1177,7 @@ fn cmd_read_manifest_with_embedded() {
   "version": "0.0.0"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to `2021`
@@ -1258,7 +1258,7 @@ fn cmd_verify_project_with_embedded() {
   "success": "true"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to `2021`

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -4428,31 +4428,41 @@ fn json_artifact_includes_executable_for_library_tests() {
         .build();
 
     p.cargo("test --lib -v --no-run --message-format=json")
-        .with_json(
-            r#"
-                {
-                    "executable": "[..]/foo/target/debug/deps/foo-[..][EXE]",
-                    "features": [],
-                    "filenames": "{...}",
-                    "fresh": false,
-                    "package_id": "path+file:///[..]/foo#0.0.1",
-                    "manifest_path": "[..]",
-                    "profile": "{...}",
-                    "reason": "compiler-artifact",
-                    "target": {
-                        "crate_types": [ "lib" ],
-                        "kind": [ "lib" ],
-                        "doc": true,
-                        "doctest": true,
-                        "edition": "2015",
-                        "name": "foo",
-                        "src_path": "[..]/foo/src/lib.rs",
-                        "test": true
-                    }
-                }
-
-                {"reason": "build-finished", "success": true}
-            "#,
+        .with_stdout_data(
+            str![[r#"
+[
+  {
+    "executable": "[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]",
+    "features": [],
+    "filenames": "{...}",
+    "fresh": false,
+    "manifest_path": "[ROOT]/foo/Cargo.toml",
+    "package_id": "path+[ROOTURL]/foo#0.0.1",
+    "profile": "{...}",
+    "reason": "compiler-artifact",
+    "target": {
+      "crate_types": [
+        "lib"
+      ],
+      "doc": true,
+      "doctest": true,
+      "edition": "2015",
+      "kind": [
+        "lib"
+      ],
+      "name": "foo",
+      "src_path": "[ROOT]/foo/src/lib.rs",
+      "test": true
+    }
+  },
+  {
+    "reason": "build-finished",
+    "success": true
+  }
+]
+"#]]
+            .is_json()
+            .against_jsonlines(),
         )
         .run();
 }
@@ -4468,31 +4478,41 @@ fn json_artifact_includes_executable_for_integration_tests() {
         .build();
 
     p.cargo("test -v --no-run --message-format=json --test integration_test")
-        .with_json(
-            r#"
-                {
-                    "executable": "[..]/foo/target/debug/deps/integration_test-[..][EXE]",
-                    "features": [],
-                    "filenames": "{...}",
-                    "fresh": false,
-                    "package_id": "path+file:///[..]/foo#0.0.1",
-                    "manifest_path": "[..]",
-                    "profile": "{...}",
-                    "reason": "compiler-artifact",
-                    "target": {
-                        "crate_types": [ "bin" ],
-                        "kind": [ "test" ],
-                        "doc": false,
-                        "doctest": false,
-                        "edition": "2015",
-                        "name": "integration_test",
-                        "src_path": "[..]/foo/tests/integration_test.rs",
-                        "test": true
-                    }
-                }
-
-                {"reason": "build-finished", "success": true}
-            "#,
+        .with_stdout_data(
+            str![[r#"
+[
+  {
+    "executable": "[ROOT]/foo/target/debug/deps/integration_test-[HASH][EXE]",
+    "features": [],
+    "filenames": "{...}",
+    "fresh": false,
+    "manifest_path": "[ROOT]/foo/Cargo.toml",
+    "package_id": "path+[ROOTURL]/foo#0.0.1",
+    "profile": "{...}",
+    "reason": "compiler-artifact",
+    "target": {
+      "crate_types": [
+        "bin"
+      ],
+      "doc": false,
+      "doctest": false,
+      "edition": "2015",
+      "kind": [
+        "test"
+      ],
+      "name": "integration_test",
+      "src_path": "[ROOT]/foo/tests/integration_test.rs",
+      "test": true
+    }
+  },
+  {
+    "reason": "build-finished",
+    "success": true
+  }
+]
+"#]]
+            .is_json()
+            .against_jsonlines(),
         )
         .run();
 }

--- a/tests/testsuite/unit_graph.rs
+++ b/tests/testsuite/unit_graph.rs
@@ -230,7 +230,7 @@ fn simple() {
   "version": 1
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 }

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -838,7 +838,7 @@ fn update_precise_first_run() {
   "workspace_root": "[ROOT]/foo"
 }
 "#]]
-            .json(),
+            .is_json(),
         )
         .run();
 


### PR DESCRIPTION
### What does this PR try to resolve?

This builds on assert-rs/snapbox#348 and is part of #14039.

Note: this also updates existing `.is_jsonlines()` usage to `.is_json().against_jsonlines()`.

### How should we test and review this PR?


### Additional information

