### PR TITLE
Revert "fix: Ensure dep/feature activates the dependency on 2024"

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -324,7 +324,7 @@ fn resolve_toml(
             });
         resolved_toml.package = Some(resolved_package);
 
-        resolved_toml.features = resolve_features(original_toml.features.as_ref(), edition)?;
+        resolved_toml.features = resolve_features(original_toml.features.as_ref())?;
 
         resolved_toml.lib = targets::resolve_lib(
             original_toml.lib.as_ref(),
@@ -693,33 +693,10 @@ fn default_readme_from_package_root(package_root: &Path) -> Option<String> {
 #[tracing::instrument(skip_all)]
 fn resolve_features(
     original_features: Option<&BTreeMap<manifest::FeatureName, Vec<String>>>,
-    edition: Edition,
 ) -> CargoResult<Option<BTreeMap<manifest::FeatureName, Vec<String>>>> {
-    let Some(mut resolved_features) = original_features.cloned() else {
+    let Some(resolved_features) = original_features.cloned() else {
         return Ok(None);
     };
-
-    if Edition::Edition2024 <= edition {
-        for activations in resolved_features.values_mut() {
-            let mut deps = Vec::new();
-            for feature_value in activations.iter() {
-                let feature_value = FeatureValue::new(InternedString::new(feature_value));
-                let FeatureValue::DepFeature {
-                    dep_name,
-                    dep_feature: _,
-                    weak: false,
-                } = feature_value
-                else {
-                    continue;
-                };
-                let dep = FeatureValue::Dep { dep_name }.to_string();
-                if !activations.contains(&dep) {
-                    deps.push(dep);
-                }
-            }
-            activations.extend(deps);
-        }
-    }
 
     Ok(Some(resolved_features))
 }

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -1889,27 +1889,17 @@ fn strong_dep_feature_edition2024() {
 
     p.cargo("metadata")
         .masquerade_as_nightly_cargo(&["edition2024"])
-        .with_stdout_data(
-            str![[r#"
-{
-  "metadata": null,
-  "packages": [
-    {
-      "features": {
-        "optional_dep": [
-          "optional_dep/foo",
-          "dep:optional_dep"
-        ]
-      },
-      "name": "foo",
-      "...": "{...}"
-    }
-  ],
-  "...": "{...}"
-}
-"#]]
-            .json(),
-        )
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] feature `optional_dep` includes `optional_dep/foo`, but `optional_dep` is not a dependency
+ --> Cargo.toml:9:32
+  |
+9 |                 optional_dep = ["optional_dep/foo"]
+  |                                ^^^^^^^^^^^^^^^^^^^^
+  |
+[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
+
+"#]])
         .run();
 }
 


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes #14283 by re-opening #14016 so we don't block people testing other Edition 2024 changes.


### How should we test and review this PR?

This reverts commit 99fae9187ac0bae12a03585083169e34dc7a197d.

I initially held off on reverting in case we quickly had a clear direction to go.  Since we're still doing some investigation, I decided to move forward with this.

### Additional information

