### PR TITLE
docs: clarify `target.'cfg(...)'`  doesnt respect cfg from build script

### DIFF
--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -1173,9 +1173,9 @@ rustflags = ["…", "…"]
 ```
 
 `cfg` values come from those built-in to the compiler (run `rustc --print=cfg`
-to view), values set by [build scripts], and extra `--cfg` flags passed to
-`rustc` (such as those defined in `RUSTFLAGS`). Do not try to match on
-`debug_assertions` or Cargo features like `feature="foo"`.
+to view) and extra `--cfg` flags passed to `rustc` (such as those defined in
+`RUSTFLAGS`). Do not try to match on `debug_assertions`, `test`, Cargo features
+like `feature="foo"`, or values set by [build scripts].
 
 If using a target spec JSON file, the [`<triple>`] value is the filename stem.
 For example `--target foo/bar.json` would match `[target.bar]`.


### PR DESCRIPTION


<!-- homu-ignore:start -->

### What does this PR try to resolve?

This was a doc mistake, see https://github.com/rust-lang/cargo/issues/14306

### How should we test and review this PR?

Read the doc.

### Additional information

<!-- homu-ignore:end -->
