### PR TITLE
Fix warnings building tests on Windows

### DIFF
--- a/tests/testsuite/open_namespaces.rs
+++ b/tests/testsuite/open_namespaces.rs
@@ -1,6 +1,5 @@
 use cargo_test_support::prelude::*;
 use cargo_test_support::project;
-use cargo_test_support::registry::RegistryBuilder;
 use cargo_test_support::str;
 
 #[cargo_test]
@@ -331,6 +330,7 @@ fn main() {}
 #[cargo_test]
 #[cfg(unix)] // until we get proper packaging support
 fn publish_namespaced() {
+    use cargo_test_support::registry::RegistryBuilder;
     let registry = RegistryBuilder::new().http_api().http_index().build();
 
     let p = project()

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -1,7 +1,6 @@
 //! Tests for `-Ztrim-paths`.
 
 use cargo_test_support::basic_manifest;
-use cargo_test_support::compare::assert_e2e;
 use cargo_test_support::git;
 use cargo_test_support::paths;
 use cargo_test_support::prelude::*;
@@ -681,6 +680,7 @@ fn custom_build_env_var_trim_paths() {
 #[cfg(unix)]
 #[cargo_test(requires_lldb, nightly, reason = "-Zremap-path-scope is unstable")]
 fn lldb_works_after_trimmed() {
+    use cargo_test_support::compare::assert_e2e;
     use cargo_util::is_ci;
 
     if !is_ci() {


### PR DESCRIPTION
This fixes a few warnings when building cargo's testsuite on Windows due to some imports only being used inside some `cfg` elided tests.
