### PR TITLE
dont call wrap in a no-op source_id::with*

### DIFF
--- a/src/cargo/core/source_id.rs
+++ b/src/cargo/core/source_id.rs
@@ -468,34 +468,51 @@ impl SourceId {
 
     /// Creates a new `SourceId` from this source with the given `precise`.
     pub fn with_git_precise(self, fragment: Option<String>) -> SourceId {
-        SourceId::wrap(SourceIdInner {
-            precise: fragment.map(|f| Precise::GitUrlFragment(f)),
-            ..(*self.inner).clone()
-        })
+        let precise = fragment.map(|f| Precise::GitUrlFragment(f));
+        if self.inner.precise == precise {
+            self
+        } else {
+            SourceId::wrap(SourceIdInner {
+                precise,
+                ..(*self.inner).clone()
+            })
+        }
     }
 
     /// Creates a new `SourceId` from this source without a `precise`.
     pub fn without_precise(self) -> SourceId {
-        SourceId::wrap(SourceIdInner {
-            precise: None,
-            ..(*self.inner).clone()
-        })
+        if self.inner.precise.is_none() {
+            self
+        } else {
+            SourceId::wrap(SourceIdInner {
+                precise: None,
+                ..(*self.inner).clone()
+            })
+        }
     }
 
     /// Creates a new `SourceId` from this source without a `precise`.
     pub fn with_locked_precise(self) -> SourceId {
-        SourceId::wrap(SourceIdInner {
-            precise: Some(Precise::Locked),
-            ..(*self.inner).clone()
-        })
+        if self.inner.precise == Some(Precise::Locked) {
+            self
+        } else {
+            SourceId::wrap(SourceIdInner {
+                precise: Some(Precise::Locked),
+                ..(*self.inner).clone()
+            })
+        }
     }
 
     /// Creates a new `SourceId` from this source with the `precise` from some other `SourceId`.
     pub fn with_precise_from(self, v: Self) -> SourceId {
-        SourceId::wrap(SourceIdInner {
-            precise: v.inner.precise.clone(),
-            ..(*self.inner).clone()
-        })
+        if self.inner.precise == v.inner.precise {
+            self
+        } else {
+            SourceId::wrap(SourceIdInner {
+                precise: v.inner.precise.clone(),
+                ..(*self.inner).clone()
+            })
+        }
     }
 
     /// When updating a lock file on a version using `cargo update --precise`

--- a/src/cargo/core/source_id.rs
+++ b/src/cargo/core/source_id.rs
@@ -468,48 +468,30 @@ impl SourceId {
 
     /// Creates a new `SourceId` from this source with the given `precise`.
     pub fn with_git_precise(self, fragment: Option<String>) -> SourceId {
-        let precise = fragment.map(|f| Precise::GitUrlFragment(f));
-        if self.inner.precise == precise {
-            self
-        } else {
-            SourceId::wrap(SourceIdInner {
-                precise,
-                ..(*self.inner).clone()
-            })
-        }
+        self.with_precise(&fragment.map(|f| Precise::GitUrlFragment(f)))
     }
 
     /// Creates a new `SourceId` from this source without a `precise`.
     pub fn without_precise(self) -> SourceId {
-        if self.inner.precise.is_none() {
-            self
-        } else {
-            SourceId::wrap(SourceIdInner {
-                precise: None,
-                ..(*self.inner).clone()
-            })
-        }
+        self.with_precise(&None)
     }
 
     /// Creates a new `SourceId` from this source without a `precise`.
     pub fn with_locked_precise(self) -> SourceId {
-        if self.inner.precise == Some(Precise::Locked) {
-            self
-        } else {
-            SourceId::wrap(SourceIdInner {
-                precise: Some(Precise::Locked),
-                ..(*self.inner).clone()
-            })
-        }
+        self.with_precise(&Some(Precise::Locked))
     }
 
     /// Creates a new `SourceId` from this source with the `precise` from some other `SourceId`.
     pub fn with_precise_from(self, v: Self) -> SourceId {
-        if self.inner.precise == v.inner.precise {
+        self.with_precise(&v.inner.precise)
+    }
+
+    fn with_precise(self, precise: &Option<Precise>) -> SourceId {
+        if &self.inner.precise == precise {
             self
         } else {
             SourceId::wrap(SourceIdInner {
-                precise: v.inner.precise.clone(),
+                precise: precise.clone(),
                 ..(*self.inner).clone()
             })
         }


### PR DESCRIPTION
### What does this PR try to resolve?

When running resolution in parallel (which my pubgrub tests do but cargo does not) there can be a lot of contention on the lock for constructing new `source_id`. When investigating much of this is due to `without_precise` in `encodable_package_id` in `check_duplicate_pkgs_in_lockfile`. There are many ways to solve this, the simplest seems to be to return `self` if the requested modification made no difference.

### How should we test and review this PR?

All tests still pass and it's an internal re-factor.

In addition running all crates on crates.io through cargoes resolver in parallel on 190 cores went from >20k sec cpu time to ~10k. 

### Additional information

