### PR TITLE
Change tests to support `rustc` wording changes

### DIFF
--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -819,7 +819,7 @@ fn short_message_format() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
-src/lib.rs:1:27: error[E0308]: mismatched types
+src/lib.rs:1:27: error[E0308]: mismatched types[..]
 [ERROR] could not compile `foo` (lib) due to 1 previous error
 
 "#]])


### PR DESCRIPTION
With rust-lang/rust#126818 the output of rustc for resolution errors is going to change in such a way that some existing cargo tests will fail. Change them to support both the current and future output, so that those PRs can land in `rustc`. Follow up to #14135. Noticed in https://github.com/rust-lang-ci/rust/actions/runs/10192263962/job/28194880547#step:25:7529 when trying to land rust-lang/rust#126818.

<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
