### PR TITLE
refactor(toml): Rename 'resolved' to 'normalized'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util-schemas"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ cargo-platform = { path = "crates/cargo-platform", version = "0.1.5" }
 cargo-test-macro = { version = "0.3.0", path = "crates/cargo-test-macro" }
 cargo-test-support = { version = "0.4.0", path = "crates/cargo-test-support" }
 cargo-util = { version = "0.2.14", path = "crates/cargo-util" }
-cargo-util-schemas = { version = "0.5.0", path = "crates/cargo-util-schemas" }
+cargo-util-schemas = { version = "0.6.0", path = "crates/cargo-util-schemas" }
 cargo_metadata = "0.18.1"
 clap = "4.5.11"
 color-print = "0.3.6"

--- a/crates/cargo-util-schemas/Cargo.toml
+++ b/crates/cargo-util-schemas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-util-schemas"
-version = "0.5.1"
+version = "0.6.0"
 rust-version = "1.80"  # MSRV:1
 edition.workspace = true
 license.workspace = true

--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -106,8 +106,8 @@ impl TomlManifest {
         self.features.as_ref()
     }
 
-    pub fn resolved_lints(&self) -> Result<Option<&TomlLints>, UnresolvedError> {
-        self.lints.as_ref().map(|l| l.resolved()).transpose()
+    pub fn normalized_lints(&self) -> Result<Option<&TomlLints>, UnresolvedError> {
+        self.lints.as_ref().map(|l| l.normalized()).transpose()
     }
 }
 
@@ -237,23 +237,26 @@ impl TomlPackage {
         }
     }
 
-    pub fn resolved_edition(&self) -> Result<Option<&String>, UnresolvedError> {
-        self.edition.as_ref().map(|v| v.resolved()).transpose()
+    pub fn normalized_edition(&self) -> Result<Option<&String>, UnresolvedError> {
+        self.edition.as_ref().map(|v| v.normalized()).transpose()
     }
 
-    pub fn resolved_rust_version(&self) -> Result<Option<&RustVersion>, UnresolvedError> {
-        self.rust_version.as_ref().map(|v| v.resolved()).transpose()
+    pub fn normalized_rust_version(&self) -> Result<Option<&RustVersion>, UnresolvedError> {
+        self.rust_version
+            .as_ref()
+            .map(|v| v.normalized())
+            .transpose()
     }
 
-    pub fn resolved_version(&self) -> Result<Option<&semver::Version>, UnresolvedError> {
-        self.version.as_ref().map(|v| v.resolved()).transpose()
+    pub fn normalized_version(&self) -> Result<Option<&semver::Version>, UnresolvedError> {
+        self.version.as_ref().map(|v| v.normalized()).transpose()
     }
 
-    pub fn resolved_authors(&self) -> Result<Option<&Vec<String>>, UnresolvedError> {
-        self.authors.as_ref().map(|v| v.resolved()).transpose()
+    pub fn normalized_authors(&self) -> Result<Option<&Vec<String>>, UnresolvedError> {
+        self.authors.as_ref().map(|v| v.normalized()).transpose()
     }
 
-    pub fn resolved_build(&self) -> Result<Option<&String>, UnresolvedError> {
+    pub fn normalized_build(&self) -> Result<Option<&String>, UnresolvedError> {
         let readme = self.build.as_ref().ok_or(UnresolvedError)?;
         match readme {
             StringOrBool::Bool(false) => Ok(None),
@@ -262,60 +265,66 @@ impl TomlPackage {
         }
     }
 
-    pub fn resolved_exclude(&self) -> Result<Option<&Vec<String>>, UnresolvedError> {
-        self.exclude.as_ref().map(|v| v.resolved()).transpose()
+    pub fn normalized_exclude(&self) -> Result<Option<&Vec<String>>, UnresolvedError> {
+        self.exclude.as_ref().map(|v| v.normalized()).transpose()
     }
 
-    pub fn resolved_include(&self) -> Result<Option<&Vec<String>>, UnresolvedError> {
-        self.include.as_ref().map(|v| v.resolved()).transpose()
+    pub fn normalized_include(&self) -> Result<Option<&Vec<String>>, UnresolvedError> {
+        self.include.as_ref().map(|v| v.normalized()).transpose()
     }
 
-    pub fn resolved_publish(&self) -> Result<Option<&VecStringOrBool>, UnresolvedError> {
-        self.publish.as_ref().map(|v| v.resolved()).transpose()
+    pub fn normalized_publish(&self) -> Result<Option<&VecStringOrBool>, UnresolvedError> {
+        self.publish.as_ref().map(|v| v.normalized()).transpose()
     }
 
-    pub fn resolved_description(&self) -> Result<Option<&String>, UnresolvedError> {
-        self.description.as_ref().map(|v| v.resolved()).transpose()
-    }
-
-    pub fn resolved_homepage(&self) -> Result<Option<&String>, UnresolvedError> {
-        self.homepage.as_ref().map(|v| v.resolved()).transpose()
-    }
-
-    pub fn resolved_documentation(&self) -> Result<Option<&String>, UnresolvedError> {
-        self.documentation
+    pub fn normalized_description(&self) -> Result<Option<&String>, UnresolvedError> {
+        self.description
             .as_ref()
-            .map(|v| v.resolved())
+            .map(|v| v.normalized())
             .transpose()
     }
 
-    pub fn resolved_readme(&self) -> Result<Option<&String>, UnresolvedError> {
+    pub fn normalized_homepage(&self) -> Result<Option<&String>, UnresolvedError> {
+        self.homepage.as_ref().map(|v| v.normalized()).transpose()
+    }
+
+    pub fn normalized_documentation(&self) -> Result<Option<&String>, UnresolvedError> {
+        self.documentation
+            .as_ref()
+            .map(|v| v.normalized())
+            .transpose()
+    }
+
+    pub fn normalized_readme(&self) -> Result<Option<&String>, UnresolvedError> {
         let readme = self.readme.as_ref().ok_or(UnresolvedError)?;
-        readme.resolved().and_then(|sb| match sb {
+        readme.normalized().and_then(|sb| match sb {
             StringOrBool::Bool(false) => Ok(None),
             StringOrBool::Bool(true) => Err(UnresolvedError),
             StringOrBool::String(value) => Ok(Some(value)),
         })
     }
 
-    pub fn resolved_keywords(&self) -> Result<Option<&Vec<String>>, UnresolvedError> {
-        self.keywords.as_ref().map(|v| v.resolved()).transpose()
+    pub fn normalized_keywords(&self) -> Result<Option<&Vec<String>>, UnresolvedError> {
+        self.keywords.as_ref().map(|v| v.normalized()).transpose()
     }
 
-    pub fn resolved_categories(&self) -> Result<Option<&Vec<String>>, UnresolvedError> {
-        self.categories.as_ref().map(|v| v.resolved()).transpose()
+    pub fn normalized_categories(&self) -> Result<Option<&Vec<String>>, UnresolvedError> {
+        self.categories.as_ref().map(|v| v.normalized()).transpose()
     }
 
-    pub fn resolved_license(&self) -> Result<Option<&String>, UnresolvedError> {
-        self.license.as_ref().map(|v| v.resolved()).transpose()
+    pub fn normalized_license(&self) -> Result<Option<&String>, UnresolvedError> {
+        self.license.as_ref().map(|v| v.normalized()).transpose()
     }
 
-    pub fn resolved_license_file(&self) -> Result<Option<&String>, UnresolvedError> {
-        self.license_file.as_ref().map(|v| v.resolved()).transpose()
+    pub fn normalized_license_file(&self) -> Result<Option<&String>, UnresolvedError> {
+        self.license_file
+            .as_ref()
+            .map(|v| v.normalized())
+            .transpose()
     }
 
-    pub fn resolved_repository(&self) -> Result<Option<&String>, UnresolvedError> {
-        self.repository.as_ref().map(|v| v.resolved()).transpose()
+    pub fn normalized_repository(&self) -> Result<Option<&String>, UnresolvedError> {
+        self.repository.as_ref().map(|v| v.normalized()).transpose()
     }
 }
 
@@ -330,7 +339,7 @@ pub enum InheritableField<T> {
 }
 
 impl<T> InheritableField<T> {
-    pub fn resolved(&self) -> Result<&T, UnresolvedError> {
+    pub fn normalized(&self) -> Result<&T, UnresolvedError> {
         self.as_value().ok_or(UnresolvedError)
     }
 
@@ -634,7 +643,7 @@ impl InheritableDependency {
         }
     }
 
-    pub fn resolved(&self) -> Result<&TomlDependency, UnresolvedError> {
+    pub fn normalized(&self) -> Result<&TomlDependency, UnresolvedError> {
         match self {
             InheritableDependency::Value(d) => Ok(d),
             InheritableDependency::Inherit(_) => Err(UnresolvedError),
@@ -1440,7 +1449,7 @@ pub struct InheritableLints {
 }
 
 impl InheritableLints {
-    pub fn resolved(&self) -> Result<&TomlLints, UnresolvedError> {
+    pub fn normalized(&self) -> Result<&TomlLints, UnresolvedError> {
         if self.workspace {
             Err(UnresolvedError)
         } else {

--- a/src/cargo/core/compiler/fingerprint/mod.rs
+++ b/src/cargo/core/compiler/fingerprint/mod.rs
@@ -1426,7 +1426,7 @@ fn calculate_normal(
     // HACK(#13975): duplicating the lookup logic here until `--check-cfg` is supported
     // on Cargo's MSRV and we can centralize the logic in `lints_to_rustflags`
     let mut lint_check_cfg = Vec::new();
-    if let Ok(Some(lints)) = unit.pkg.manifest().resolved_toml().resolved_lints() {
+    if let Ok(Some(lints)) = unit.pkg.manifest().normalized_toml().normalized_lints() {
         if let Some(rust_lints) = lints.get("rust") {
             if let Some(unexpected_cfgs) = rust_lints.get("unexpected_cfgs") {
                 if let Some(config) = unexpected_cfgs.config() {

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1355,7 +1355,7 @@ fn check_cfg_args(unit: &Unit) -> CargoResult<Vec<OsString>> {
     ];
 
     // Also include the custom arguments specified in `[lints.rust.unexpected_cfgs.check_cfg]`
-    if let Ok(Some(lints)) = unit.pkg.manifest().resolved_toml().resolved_lints() {
+    if let Ok(Some(lints)) = unit.pkg.manifest().normalized_toml().normalized_lints() {
         if let Some(rust_lints) = lints.get("rust") {
             if let Some(unexpected_cfgs) = rust_lints.get("unexpected_cfgs") {
                 if let Some(config) = unexpected_cfgs.config() {

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -64,7 +64,7 @@ pub struct Manifest {
     contents: Rc<String>,
     document: Rc<toml_edit::ImDocument<String>>,
     original_toml: Rc<TomlManifest>,
-    resolved_toml: Rc<TomlManifest>,
+    normalized_toml: Rc<TomlManifest>,
     summary: Summary,
 
     // this form of manifest:
@@ -110,7 +110,7 @@ pub struct VirtualManifest {
     contents: Rc<String>,
     document: Rc<toml_edit::ImDocument<String>>,
     original_toml: Rc<TomlManifest>,
-    resolved_toml: Rc<TomlManifest>,
+    normalized_toml: Rc<TomlManifest>,
 
     // this form of manifest:
     replace: Vec<(PackageIdSpec, Dependency)>,
@@ -422,7 +422,7 @@ impl Manifest {
         contents: Rc<String>,
         document: Rc<toml_edit::ImDocument<String>>,
         original_toml: Rc<TomlManifest>,
-        resolved_toml: Rc<TomlManifest>,
+        normalized_toml: Rc<TomlManifest>,
         summary: Summary,
 
         default_kind: Option<CompileKind>,
@@ -451,7 +451,7 @@ impl Manifest {
             contents,
             document,
             original_toml,
-            resolved_toml,
+            normalized_toml,
             summary,
 
             default_kind,
@@ -483,9 +483,9 @@ impl Manifest {
     pub fn contents(&self) -> &str {
         self.contents.as_str()
     }
-    /// See [`Manifest::resolved_toml`] for what "resolved" means
-    pub fn to_resolved_contents(&self) -> CargoResult<String> {
-        let toml = toml::to_string_pretty(self.resolved_toml())?;
+    /// See [`Manifest::normalized_toml`] for what "normalized" means
+    pub fn to_normalized_contents(&self) -> CargoResult<String> {
+        let toml = toml::to_string_pretty(self.normalized_toml())?;
         Ok(format!("{}\n{}", MANIFEST_PREAMBLE, toml))
     }
     /// Collection of spans for the original TOML
@@ -502,8 +502,8 @@ impl Manifest {
     /// useful for the operation of cargo, including
     /// - workspace inheritance
     /// - target discovery
-    pub fn resolved_toml(&self) -> &TomlManifest {
-        &self.resolved_toml
+    pub fn normalized_toml(&self) -> &TomlManifest {
+        &self.normalized_toml
     }
     pub fn summary(&self) -> &Summary {
         &self.summary
@@ -553,7 +553,7 @@ impl Manifest {
         &self.warnings
     }
     pub fn profiles(&self) -> Option<&TomlProfiles> {
-        self.resolved_toml.profile.as_ref()
+        self.normalized_toml.profile.as_ref()
     }
     pub fn publish(&self) -> &Option<Vec<String>> {
         &self.publish
@@ -664,7 +664,7 @@ impl VirtualManifest {
         contents: Rc<String>,
         document: Rc<toml_edit::ImDocument<String>>,
         original_toml: Rc<TomlManifest>,
-        resolved_toml: Rc<TomlManifest>,
+        normalized_toml: Rc<TomlManifest>,
         replace: Vec<(PackageIdSpec, Dependency)>,
         patch: HashMap<Url, Vec<Dependency>>,
         workspace: WorkspaceConfig,
@@ -675,7 +675,7 @@ impl VirtualManifest {
             contents,
             document,
             original_toml,
-            resolved_toml,
+            normalized_toml,
             replace,
             patch,
             workspace,
@@ -698,8 +698,8 @@ impl VirtualManifest {
         &self.original_toml
     }
     /// The [`TomlManifest`] with all fields expanded
-    pub fn resolved_toml(&self) -> &TomlManifest {
-        &self.resolved_toml
+    pub fn normalized_toml(&self) -> &TomlManifest {
+        &self.normalized_toml
     }
 
     pub fn replace(&self) -> &[(PackageIdSpec, Dependency)] {
@@ -715,7 +715,7 @@ impl VirtualManifest {
     }
 
     pub fn profiles(&self) -> Option<&TomlProfiles> {
-        self.resolved_toml.profile.as_ref()
+        self.normalized_toml.profile.as_ref()
     }
 
     pub fn warnings_mut(&mut self) -> &mut Warnings {

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1066,7 +1066,7 @@ impl<'gctx> Workspace<'gctx> {
                     );
                     self.gctx.shell().warn(&msg)
                 };
-                if manifest.resolved_toml().has_profiles() {
+                if manifest.normalized_toml().has_profiles() {
                     emit_warning("profiles")?;
                 }
                 if !manifest.replace().is_empty() {
@@ -1191,7 +1191,7 @@ impl<'gctx> Workspace<'gctx> {
         let mut error_count = 0;
         let toml_lints = pkg
             .manifest()
-            .resolved_toml()
+            .normalized_toml()
             .lints
             .clone()
             .map(|lints| lints.lints)

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -924,7 +924,7 @@ fn tar(
             }
             FileContents::Generated(generated_kind) => {
                 let contents = match generated_kind {
-                    GeneratedFile::Manifest => publish_pkg.manifest().to_resolved_contents()?,
+                    GeneratedFile::Manifest => publish_pkg.manifest().to_normalized_contents()?,
                     GeneratedFile::Lockfile => build_lock(ws, &publish_pkg, local_reg)?,
                     GeneratedFile::VcsInfo(ref s) => serde_json::to_string_pretty(s)?,
                 };

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -443,7 +443,7 @@ fn add_feature_for_unused_deps(
     let manifest = pkg.manifest();
 
     let activated_opt_deps = manifest
-        .resolved_toml()
+        .normalized_toml()
         .features()
         .map(|map| {
             map.values()
@@ -479,7 +479,7 @@ fn add_feature_for_unused_deps(
                 // only way to guarantee an optional dependency is available for use.
                 //
                 // The way we avoid implicitly creating features in Edition2024 is we remove the
-                // dependency from `resolved_toml` if there is no `dep:` syntax as that is the only
+                // dependency from `normalized_toml` if there is no `dep:` syntax as that is the only
                 // syntax that suppresses the creation of the implicit feature.
                 for (feature_name, activations) in features.iter_mut() {
                     let Some(activations) = activations.as_array_mut() else {

--- a/src/cargo/ops/registry/publish.rs
+++ b/src/cargo/ops/registry/publish.rs
@@ -411,7 +411,7 @@ pub(crate) fn prepare_transmit(
         }
     }
 
-    let string_features = match manifest.resolved_toml().features() {
+    let string_features = match manifest.normalized_toml().features() {
         Some(features) => features
             .iter()
             .map(|(feat, values)| {

--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -360,7 +360,7 @@ fn cp_sources(
         let cksum = if dst.file_name() == Some(OsStr::new("Cargo.toml"))
             && pkg.package_id().source_id().is_git()
         {
-            let contents = pkg.manifest().to_resolved_contents()?;
+            let contents = pkg.manifest().to_normalized_contents()?;
             copy_and_checksum(
                 &dst,
                 &mut dst_opts,

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -880,14 +880,14 @@ fn read_packages(
 
 fn nested_paths(manifest: &Manifest) -> Vec<PathBuf> {
     let mut nested_paths = Vec::new();
-    let resolved = manifest.resolved_toml();
-    let dependencies = resolved
+    let normalized = manifest.normalized_toml();
+    let dependencies = normalized
         .dependencies
         .iter()
-        .chain(resolved.build_dependencies())
-        .chain(resolved.dev_dependencies())
+        .chain(normalized.build_dependencies())
+        .chain(normalized.dev_dependencies())
         .chain(
-            resolved
+            normalized
                 .target
                 .as_ref()
                 .into_iter()

--- a/src/cargo/util/lints.rs
+++ b/src/cargo/util/lints.rs
@@ -456,7 +456,7 @@ pub fn check_im_a_teapot(
     }
 
     if manifest
-        .resolved_toml()
+        .normalized_toml()
         .package()
         .is_some_and(|p| p.im_a_teapot.is_some())
     {
@@ -560,7 +560,7 @@ pub fn check_implicit_features(
     }
 
     let activated_opt_deps = manifest
-        .resolved_toml()
+        .normalized_toml()
         .features()
         .map(|map| {
             map.values()


### PR DESCRIPTION
In a discussion on an issue, it became confusing to talk about "resolved" manifests and dependency resolution,
so I'm switching manifests to use the other term I considered, "normalized".

<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
