### PR TITLE
Fix renamed disallowed cfg lint name

### DIFF
--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -6575,7 +6575,7 @@ fn user_specific_cfgs_are_filtered_out() {
         )
         .build();
 
-    p.cargo("rustc -- --cfg debug_assertions --cfg proc_macro -Aunknown_lints -Aunexpected_builtin_cfgs")
+    p.cargo("rustc -- --cfg debug_assertions --cfg proc_macro -Aunknown_lints -Aexplicit_builtin_cfgs_in_flags")
         .run();
     p.process(&p.bin("foo")).run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?

In https://github.com/rust-lang/cargo/pull/14153 we allow the to be merged https://github.com/rust-lang/rust/pull/126158 lint. Since then a FCP was conducted and the lint was renamed to `explicit_builtin_cfgs_in_flags`. This PR renames the lint in the test so that https://github.com/rust-lang/rust/pull/126158 can be merged.

### Additional information

https://github.com/rust-lang/rust/pull/126158#issuecomment-2267984311 shows the failing test.