### PR TITLE
Fix expected output in `build-std` test

### DIFF
--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -114,6 +114,7 @@ fn basic() {
         // Importantly, this should not say [UPDATING]
         // There have been multiple bugs where every build triggers and update.
         .with_stderr_data(str![[r#"
+[UPDATING] crates.io index
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 


### PR DESCRIPTION
A recent nightly update caused one of the [`build-test`](https://github.com/rust-lang/cargo/blob/master/tests/build-std/main.rs#L66) tests (`basic`) to fail, due to changed output. A few CI builds failed for this reason, for example [here](https://github.com/rust-lang/cargo/actions/runs/10246133822/job/28342625398?pr=14352) or [here](https://github.com/rust-lang/cargo/actions/runs/10245183876/job/28339676372?pr=13709).

This change updates the expected `stdout` output to include the missing line.