### PR TITLE
Don't specify the depedency name in the `cargo add` inferred name test

### DIFF
--- a/tests/testsuite/cargo_add/path_inferred_name/mod.rs
+++ b/tests/testsuite/cargo_add/path_inferred_name/mod.rs
@@ -27,7 +27,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("add")
-        .arg_line("cargo-list-test-fixture-dependency --path ../dependency")
+        .arg_line("--path ../dependency")
         .current_dir(&cwd)
         .assert()
         .success()


### PR DESCRIPTION
The `cargo_add/path_inferred_name` was incorrectly adding the name of the dependency to add in its command line.