### PR TITLE
fix(build-std): remove hack on creating virtual std workspace 

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -244,25 +244,6 @@ impl<'gctx> Workspace<'gctx> {
         }
     }
 
-    pub fn new_virtual(
-        root_path: PathBuf,
-        current_manifest: PathBuf,
-        manifest: VirtualManifest,
-        gctx: &'gctx GlobalContext,
-    ) -> CargoResult<Workspace<'gctx>> {
-        let mut ws = Workspace::new_default(current_manifest, gctx);
-        ws.root_manifest = Some(root_path.join("Cargo.toml"));
-        ws.target_dir = gctx.target_dir()?;
-        ws.packages
-            .packages
-            .insert(root_path, MaybePackage::Virtual(manifest));
-        ws.find_members()?;
-        ws.set_resolve_behavior()?;
-        // TODO: validation does not work because it walks up the directory
-        // tree looking for the root which is a fake file that doesn't exist.
-        Ok(ws)
-    }
-
     /// Creates a "temporary workspace" from one package which only contains
     /// that package.
     ///

--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -119,8 +119,31 @@ fn basic() {
 
 "#]])
         .run();
-    p.cargo("run").build_std().target_host().run();
-    p.cargo("test").build_std().target_host().run();
+    p.cargo("run")
+        .build_std()
+        .target_host()
+        .with_stderr_data(str![[r#"
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[RUNNING] `target/[HOST_TARGET]/debug/foo`
+
+"#]])
+        .run();
+    p.cargo("test")
+        .build_std()
+        .target_host()
+        .with_stderr_data(str![[r#"
+[COMPILING] rustc-std-workspace-std [..]
+...
+[COMPILING] test v0.0.0 ([..])
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[RUNNING] unittests src/lib.rs (target/[HOST_TARGET]/debug/deps/foo-[HASH])
+[RUNNING] unittests src/main.rs (target/[HOST_TARGET]/debug/deps/foo-[HASH])
+[RUNNING] tests/smoke.rs (target/[HOST_TARGET]/debug/deps/smoke-[HASH])
+[DOCTEST] foo
+
+"#]])
+        .run();
 
     // Check for hack that removes dylibs.
     let deps_dir = Path::new("target")

--- a/tests/testsuite/mock-std/Cargo.toml
+++ b/tests/testsuite/mock-std/Cargo.toml
@@ -1,8 +1,0 @@
-[workspace]
-members = [
-  "library/alloc",
-  "library/core",
-  "library/proc_macro",
-  "library/std",
-  "library/test",
-]

--- a/tests/testsuite/mock-std/library/Cargo.toml
+++ b/tests/testsuite/mock-std/library/Cargo.toml
@@ -1,0 +1,11 @@
+[workspace]
+resolver = "1"
+members = [
+  "std",
+  "sysroot",
+]
+
+[patch.crates-io]
+rustc-std-workspace-core = { path = 'rustc-std-workspace-core' }
+rustc-std-workspace-alloc = { path = 'rustc-std-workspace-alloc' }
+rustc-std-workspace-std = { path = 'rustc-std-workspace-std' }


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

Starting from https://github.com/rust-lang/rust/pull/128534 (nightly-2024-08-05),
standard library has its own Cargo workspace.
Hence `-Zbuild-std` no longer need to fake a virtual workspace.

This also adjusts Cargo.toml in `mock-std` to align with std's Cargo.toml

### How should we test and review this PR?

I haven't done any e2e test for `-Zbuild-std` manually. Would appreciate if someone would like to.

### Additional information

There might be more clean-up we could do.
<!-- homu-ignore:end -->
