### PR TITLE
Fix: `cargo package` failed on bare commit git repo.

### DIFF
--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -87,8 +87,7 @@ struct VcsInfo {
 
 #[derive(Serialize)]
 struct GitVcsInfo {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    sha1: Option<String>,
+    sha1: String,
     /// Indicate whether or not the Git worktree is dirty.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     dirty: bool,
@@ -744,10 +743,12 @@ fn check_repo_state(
                         .and_then(|p| p.to_str())
                         .unwrap_or("")
                         .replace("\\", "/");
-                    return Ok(Some(VcsInfo {
-                        git: git(p, src_files, &repo, &opts)?,
-                        path_in_vcs,
-                    }));
+                    let Some(git) = git(p, src_files, &repo, &opts)? else {
+                        // If the git repo lacks essensial field like `sha1`, and since this field exists from the beginning,
+                        // then don't generate the corresponding file in order to maintain consistency with past behavior.
+                        return Ok(None);
+                    };
+                    return Ok(Some(VcsInfo { git, path_in_vcs }));
                 }
             }
             gctx.shell().verbose(|shell| {
@@ -773,7 +774,7 @@ fn check_repo_state(
         src_files: &[PathBuf],
         repo: &git2::Repository,
         opts: &PackageOpts<'_>,
-    ) -> CargoResult<GitVcsInfo> {
+    ) -> CargoResult<Option<GitVcsInfo>> {
         // This is a collection of any dirty or untracked files. This covers:
         // - new/modified/deleted/renamed/type change (index or worktree)
         // - untracked files (which are "new" worktree files)
@@ -800,14 +801,16 @@ fn check_repo_state(
             .collect();
         let dirty = !dirty_src_files.is_empty();
         if !dirty || opts.allow_dirty {
+            // Must check whetherthe repo has no commit firstly, otherwise `revparse_single` would fail on bare commit repo.
+            // Due to lacking the `sha1` field, it's better not record the `GitVcsInfo` for consistency.
             if repo.is_empty()? {
-                return Ok(GitVcsInfo { sha1: None, dirty });
+                return Ok(None);
             }
             let rev_obj = repo.revparse_single("HEAD")?;
-            Ok(GitVcsInfo {
-                sha1: Some(rev_obj.id().to_string()),
+            Ok(Some(GitVcsInfo {
+                sha1: rev_obj.id().to_string(),
                 dirty,
-            })
+            }))
         } else {
             anyhow::bail!(
                 "{} files in the working directory contain changes that were \

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -87,7 +87,8 @@ struct VcsInfo {
 
 #[derive(Serialize)]
 struct GitVcsInfo {
-    sha1: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sha1: Option<String>,
     /// Indicate whether or not the Git worktree is dirty.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     dirty: bool,
@@ -799,9 +800,12 @@ fn check_repo_state(
             .collect();
         let dirty = !dirty_src_files.is_empty();
         if !dirty || opts.allow_dirty {
+            if repo.is_empty()? {
+                return Ok(GitVcsInfo { sha1: None, dirty });
+            }
             let rev_obj = repo.revparse_single("HEAD")?;
             Ok(GitVcsInfo {
-                sha1: rev_obj.id().to_string(),
+                sha1: Some(rev_obj.id().to_string()),
                 dirty,
             })
         } else {

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1273,13 +1273,28 @@ fn issue_14354_allowing_dirty_bare_commit() {
         )
         .file("src/lib.rs", "");
 
-    p.cargo("package --allow-dirty")
-        .with_status(101)
-        .with_stderr_data(str![[r#"
-[ERROR] revspec 'HEAD' not found; class=Reference (4); code=NotFound (-3)
+    p.cargo("package --allow-dirty").run();
 
-"#]])
-        .run();
+    let f = File::open(&p.root().join("target/package/foo-0.1.0.crate")).unwrap();
+    validate_crate_contents(
+        f,
+        "foo-0.1.0.crate",
+        &[
+            ".cargo_vcs_info.json",
+            "Cargo.toml",
+            "Cargo.toml.orig",
+            "src/lib.rs",
+        ],
+        &[(
+            ".cargo_vcs_info.json",
+            r#"{
+  "git": {
+    "dirty": true
+  },
+  "path_in_vcs": ""
+}"#,
+        )],
+    );
 }
 
 #[cargo_test]

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1255,6 +1255,34 @@ fn issue_13695_allowing_dirty_vcs_info_but_clean() {
 }
 
 #[cargo_test]
+fn issue_14354_allowing_dirty_bare_commit() {
+    let p = project().build();
+    // Init a bare commit git repo
+    let _ = git::repo(&paths::root().join("foo"))
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            edition = "2015"
+            description = "foo"
+            license = "foo"
+            documentation = "foo"
+        "#,
+        )
+        .file("src/lib.rs", "");
+
+    p.cargo("package --allow-dirty")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] revspec 'HEAD' not found; class=Reference (4); code=NotFound (-3)
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn generated_manifest() {
     let registry = registry::alt_init();
     Package::new("abc", "1.0.0").publish();

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1279,21 +1279,8 @@ fn issue_14354_allowing_dirty_bare_commit() {
     validate_crate_contents(
         f,
         "foo-0.1.0.crate",
-        &[
-            ".cargo_vcs_info.json",
-            "Cargo.toml",
-            "Cargo.toml.orig",
-            "src/lib.rs",
-        ],
-        &[(
-            ".cargo_vcs_info.json",
-            r#"{
-  "git": {
-    "dirty": true
-  },
-  "path_in_vcs": ""
-}"#,
-        )],
+        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs"],
+        &[],
     );
 }
 


### PR DESCRIPTION
### What does this PR try to resolve?
Fixes #14354 

This approach chose to not generate a `.cargo_vcs_info.json` for bare commit git repo.

### How should we test and review this PR?
Compare the test changes before and after the two commits

### Additional information


