### PR TITLE
Implement base paths (RFC 3529) 1/n: path dep and patch support

### DIFF
--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -776,6 +776,7 @@ pub struct TomlDetailedDependency<P: Clone = String> {
     // `path` is relative to the file it appears in. If that's a `Cargo.toml`, it'll be relative to
     // that TOML file, and if it's a `.cargo/config` file, it'll be relative to that file.
     pub path: Option<P>,
+    pub base: Option<PathBaseName>,
     pub git: Option<String>,
     pub branch: Option<String>,
     pub tag: Option<String>,
@@ -815,6 +816,7 @@ impl<P: Clone> Default for TomlDetailedDependency<P> {
             registry: Default::default(),
             registry_index: Default::default(),
             path: Default::default(),
+            base: Default::default(),
             git: Default::default(),
             branch: Default::default(),
             tag: Default::default(),
@@ -1409,6 +1411,16 @@ impl<T: AsRef<str>> FeatureName<T> {
     /// Validated feature name
     pub fn new(name: T) -> Result<Self, NameValidationError> {
         restricted_names::validate_feature_name(name.as_ref())?;
+        Ok(Self(name))
+    }
+}
+
+str_newtype!(PathBaseName);
+
+impl<T: AsRef<str>> PathBaseName<T> {
+    /// Validated path base name
+    pub fn new(name: T) -> Result<Self, NameValidationError> {
+        restricted_names::validate_path_base_name(name.as_ref())?;
         Ok(Self(name))
     }
 }

--- a/crates/cargo-util-schemas/src/restricted_names.rs
+++ b/crates/cargo-util-schemas/src/restricted_names.rs
@@ -238,6 +238,10 @@ pub(crate) fn validate_feature_name(name: &str) -> Result<()> {
     Ok(())
 }
 
+pub(crate) fn validate_path_base_name(name: &str) -> Result<()> {
+    validate_name(name, "path base name")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -513,6 +513,9 @@ features! {
 
     /// Allow multiple packages to participate in the same API namespace
     (unstable, open_namespaces, "", "reference/unstable.html#open-namespaces"),
+
+    /// Allow paths that resolve relatively to a base specified in the config.
+    (unstable, path_bases, "", "reference/unstable.html#path-bases"),
 }
 
 /// Status and metadata for a single unstable feature.

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -101,6 +101,7 @@ Each new feature described below should explain how to use it.
     * [Edition 2024](#edition-2024) — Adds support for the 2024 Edition.
     * [Profile `trim-paths` option](#profile-trim-paths-option) --- Control the sanitization of file paths in build outputs.
     * [`[lints.cargo]`](#lintscargo) --- Allows configuring lints for Cargo.
+    * [path bases](#path-bases) --- Named base directories for path dependencies.
 * Information and metadata
     * [Build-plan](#build-plan) --- Emits JSON information on which commands will be run.
     * [unit-graph](#unit-graph) --- Emits JSON for Cargo's internal graph structure.
@@ -1569,6 +1570,60 @@ implicit-features = "warn"
 [lints]
 workspace = true
 ```
+
+## Path Bases
+
+* Tracking Issue: [#14355](https://github.com/rust-lang/cargo/issues/14355)
+
+A `path` dependency may optionally specify a base by setting the `base` key to
+the name of a path base from the `[path-bases]` table in either the
+[configuration](config.md) or one of the [built-in path bases](#built-in-path-bases).
+The value of that path base is prepended to the `path` value (along with a path
+separator if necessary) to produce the actual location where Cargo will look for
+the dependency.
+
+For example, if the `Cargo.toml` contains:
+
+```toml
+cargo-features = ["path-bases"]
+
+[dependencies]
+foo = { base = "dev", path = "foo" }
+```
+
+Given a `[path-bases]` table in the configuration that contains:
+
+```toml
+[path-bases]
+dev = "/home/user/dev/rust/libraries/"
+```
+
+This will produce a `path` dependency `foo` located at
+`/home/user/dev/rust/libraries/foo`.
+
+Path bases can be either absolute or relative. Relative path bases are relative
+to the parent directory of the configuration file that declared that path base.
+
+The name of a path base must use only [alphanumeric](https://doc.rust-lang.org/std/primitive.char.html#method.is_alphanumeric)
+characters or `-` or `_`, must start with an [alphabetic](https://doc.rust-lang.org/std/primitive.char.html#method.is_alphabetic)
+character, and must not be empty.
+
+If the name of path base used in a dependency is neither in the configuration
+nor one of the built-in path base, then Cargo will raise an error.
+
+#### Built-in path bases
+
+Cargo provides implicit path bases that can be used without the need to specify
+them in a `[path-bases]` table.
+
+* `workspace` - If a project is [a workspace or workspace member](workspaces.md)
+then this path base is defined as the parent directory of the root `Cargo.toml`
+of the workspace.
+
+If a built-in path base name is also declared in the configuration, then Cargo
+will prefer the value in the configuration. The allows Cargo to add new built-in
+path bases without compatibility issues (as existing uses will shadow the
+built-in name).
 
 # Stabilized and removed features
 

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -3028,3 +3028,49 @@ foo v0.0.0 ([ROOT]/foo)
 
     assert_eq!(p.read_file("Cargo.lock"), p.read_file("Cargo.lock.orig"));
 }
+
+#[cargo_test]
+fn patch_with_base() {
+    let bar = project()
+        .at("bar")
+        .file("Cargo.toml", &basic_manifest("bar", "0.5.0"))
+        .file("src/lib.rs", "pub fn hello() {}")
+        .build();
+    Package::new("bar", "0.5.0").publish();
+
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            &format!(
+                r#"
+                    [path-bases]
+                    test = '{}'
+                "#,
+                bar.root().parent().unwrap().display()
+            ),
+        )
+        .file(
+            "Cargo.toml",
+            r#"
+                cargo-features = ["path-bases"]
+
+                [package]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
+                edition = "2018"
+
+                [dependencies]
+                bar = "0.5.0"
+
+                [patch.crates-io]
+                bar = { base = 'test', path = 'bar' }
+            "#,
+        )
+        .file("src/lib.rs", "use bar::hello as _;")
+        .build();
+
+    p.cargo("build -v")
+        .masquerade_as_nightly_cargo(&["path-bases"])
+        .run();
+}

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -590,6 +590,618 @@ Caused by:
 }
 
 #[cargo_test]
+fn path_bases_not_stable() {
+    let bar = project()
+        .at("bar")
+        .file("Cargo.toml", &basic_manifest("bar", "0.5.0"))
+        .file("src/lib.rs", "")
+        .build();
+
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            &format!(
+                r#"
+                    [path-bases]
+                    test = '{}'
+                "#,
+                bar.root().parent().unwrap().display()
+            ),
+        )
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
+
+                [dependencies]
+                bar = { base = 'test', path = 'bar' }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("build")
+        .with_status(101)
+        .with_stderr_data(
+            "\
+[ERROR] failed to parse manifest at `[..]/foo/Cargo.toml`
+
+Caused by:
+  resolving path dependency bar
+
+Caused by:
+  feature `path-bases` is required
+
+  The package requires the Cargo feature called `path-bases`, but that feature is not stabilized in this version of Cargo ([..]).
+  Consider trying a newer version of Cargo (this may require the nightly release).
+  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#path-bases for more information about the status of this feature.
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn path_with_base() {
+    let bar = project()
+        .at("bar")
+        .file("Cargo.toml", &basic_manifest("bar", "0.5.0"))
+        .file("src/lib.rs", "")
+        .build();
+
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            &format!(
+                r#"
+                    [path-bases]
+                    test = '{}'
+                "#,
+                bar.root().parent().unwrap().display()
+            ),
+        )
+        .file(
+            "Cargo.toml",
+            r#"
+                cargo-features = ["path-bases"]
+
+                [package]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
+
+                [dependencies]
+                bar = { base = 'test', path = 'bar' }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("build -v")
+        .masquerade_as_nightly_cargo(&["path-bases"])
+        .run();
+}
+
+#[cargo_test]
+fn current_dir_with_base() {
+    let bar = project()
+        .at("bar")
+        .file("Cargo.toml", &basic_manifest("bar", "0.5.0"))
+        .file("src/lib.rs", "")
+        .build();
+
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            &format!(
+                r#"
+                    [path-bases]
+                    test = '{}'
+                "#,
+                bar.root().display()
+            ),
+        )
+        .file(
+            "Cargo.toml",
+            r#"
+                cargo-features = ["path-bases"]
+
+                [package]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
+
+                [dependencies]
+                bar = { base = 'test', path = '.' }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("build -v")
+        .masquerade_as_nightly_cargo(&["path-bases"])
+        .run();
+}
+
+#[cargo_test]
+fn parent_dir_with_base() {
+    let bar = project()
+        .at("bar")
+        .file("Cargo.toml", &basic_manifest("bar", "0.5.0"))
+        .file("src/lib.rs", "")
+        .build();
+
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            &format!(
+                r#"
+                    [path-bases]
+                    test = '{}/subdir'
+                "#,
+                bar.root().display()
+            ),
+        )
+        .file(
+            "Cargo.toml",
+            r#"
+                cargo-features = ["path-bases"]
+
+                [package]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
+
+                [dependencies]
+                bar = { base = 'test', path = '..' }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("build -v")
+        .masquerade_as_nightly_cargo(&["path-bases"])
+        .run();
+}
+
+#[cargo_test]
+fn inherit_dependency_using_base() {
+    let bar = project()
+        .at("dep_with_base")
+        .file("Cargo.toml", &basic_manifest("dep_with_base", "0.5.0"))
+        .file("src/lib.rs", "")
+        .build();
+
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            &format!(
+                r#"
+                    [path-bases]
+                    test = '{}'
+                "#,
+                bar.root().parent().unwrap().display()
+            ),
+        )
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "parent"
+                version = "0.1.0"
+                authors = []
+
+                [workspace]
+                members = ["child"]
+
+                [workspace.dependencies]
+                dep_with_base = { base = 'test', path = 'dep_with_base' }
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file(
+            "child/Cargo.toml",
+            r#"
+                cargo-features = ["path-bases"]
+
+                [package]
+                name = "child"
+                version = "0.1.0"
+                authors = []
+
+                [dependencies]
+                dep_with_base = { workspace = true }
+            "#,
+        )
+        .file("child/src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build -v")
+        .masquerade_as_nightly_cargo(&["path-bases"])
+        .run();
+}
+
+#[cargo_test]
+fn path_with_relative_base() {
+    project()
+        .at("shared_proj/bar")
+        .file("Cargo.toml", &basic_manifest("bar", "0.5.0"))
+        .file("src/lib.rs", "")
+        .build();
+
+    let p = project()
+        .file(
+            "../.cargo/config.toml",
+            r#"
+                [path-bases]
+                test = 'shared_proj'
+            "#,
+        )
+        .file(
+            "Cargo.toml",
+            r#"
+                cargo-features = ["path-bases"]
+
+                [package]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
+
+                [dependencies]
+                bar = { base = 'test', path = 'bar' }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("build -v")
+        .masquerade_as_nightly_cargo(&["path-bases"])
+        .run();
+}
+
+#[cargo_test]
+fn workspace_builtin_base() {
+    project()
+        .at("dep_with_base")
+        .file("Cargo.toml", &basic_manifest("dep_with_base", "0.5.0"))
+        .file("src/lib.rs", "")
+        .build();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "parent"
+                version = "0.1.0"
+                authors = []
+
+                [workspace]
+                members = ["child"]
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file(
+            "child/Cargo.toml",
+            r#"
+                cargo-features = ["path-bases"]
+
+                [package]
+                name = "child"
+                version = "0.1.0"
+                authors = []
+
+                [dependencies]
+                dep_with_base = { base = 'workspace', path = '../dep_with_base' }
+            "#,
+        )
+        .file("child/src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build -v")
+        .masquerade_as_nightly_cargo(&["path-bases"])
+        .run();
+}
+
+#[cargo_test]
+fn workspace_builtin_base_not_a_workspace() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                cargo-features = ["path-bases"]
+
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
+
+                [dependencies]
+                bar = { base = 'workspace', path = 'bar' }
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build")
+        .masquerade_as_nightly_cargo(&["path-bases"])
+        .with_status(101)
+        .with_stderr_data(
+            "\
+[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
+
+Caused by:
+  resolving path dependency bar
+
+Caused by:
+  failed to find a workspace root
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn shadow_workspace_builtin_base() {
+    let bar = project()
+        .at("dep_with_base")
+        .file("Cargo.toml", &basic_manifest("dep_with_base", "0.5.0"))
+        .file("src/lib.rs", "")
+        .build();
+
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            &format!(
+                r#"
+                    [path-bases]
+                    workspace = '{}/subdir/anotherdir'
+                "#,
+                bar.root().parent().unwrap().display()
+            ),
+        )
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "parent"
+                version = "0.1.0"
+                authors = []
+
+                [workspace]
+                members = ["child"]
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file(
+            "child/Cargo.toml",
+            r#"
+                cargo-features = ["path-bases"]
+
+                [package]
+                name = "child"
+                version = "0.1.0"
+                authors = []
+
+                [dependencies]
+                dep_with_base = { base = 'workspace', path = '../../dep_with_base' }
+            "#,
+        )
+        .file("child/src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build -v")
+        .masquerade_as_nightly_cargo(&["path-bases"])
+        .run();
+}
+
+#[cargo_test]
+fn unknown_base() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                cargo-features = ["path-bases"]
+
+                [package]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
+
+                [dependencies]
+                bar = { base = 'test', path = 'bar' }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("build")
+        .masquerade_as_nightly_cargo(&["path-bases"])
+        .with_status(101)
+        .with_stderr_data(
+            "\
+[ERROR] failed to parse manifest at `[..]/foo/Cargo.toml`
+
+Caused by:
+  resolving path dependency bar
+
+Caused by:
+  path base `test` is undefined. You must add an entry for `test` in the Cargo configuration [path-bases] table.
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn base_without_path() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                cargo-features = ["path-bases"]
+
+                [package]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
+
+                [dependencies]
+                bar = { version = '1.0.0', base = 'test' }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("build")
+        .masquerade_as_nightly_cargo(&["path-bases"])
+        .with_status(101)
+        .with_stderr_data(
+            "\
+[ERROR] failed to parse manifest at `[..]/foo/Cargo.toml`
+
+Caused by:
+  resolving path dependency bar
+
+Caused by:
+  `base` can only be used with path dependencies
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn invalid_base() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                cargo-features = ["path-bases"]
+
+                [package]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
+
+                [dependencies]
+                bar = { base = '^^not-valid^^', path = 'bar' }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("build")
+        .masquerade_as_nightly_cargo(&["path-bases"])
+        .with_status(101)
+        .with_stderr_data(
+            "\
+[ERROR] invalid character `^` in path base name: `^^not-valid^^`, the first character must be a Unicode XID start character (most letters or `_`)
+
+
+  --> Cargo.toml:10:23
+   |
+10 |                 bar = { base = '^^not-valid^^', path = 'bar' }
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn invalid_path_with_base() {
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [path-bases]
+            test = 'shared_proj'
+        "#,
+        )
+        .file(
+            "Cargo.toml",
+            r#"
+                cargo-features = ["path-bases"]
+
+                [package]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
+                edition = "2015"
+
+                [dependencies]
+                bar = { base = 'test', path = '"' }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("build")
+        .masquerade_as_nightly_cargo(&["path-bases"])
+        .with_status(101)
+        .with_stderr_data(
+            "\
+[ERROR] failed to get `bar` as a dependency of package `foo v0.5.0 ([ROOT]/foo)`
+
+Caused by:
+  failed to load source for dependency `bar`
+
+Caused by:
+  Unable to update [ROOT]/foo/shared_proj/\"
+
+Caused by:
+  failed to read `[ROOT]/foo/shared_proj/\"/Cargo.toml`
+
+Caused by:
+  [NOT_FOUND]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn self_dependency_using_base() {
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [path-bases]
+            test = '.'
+        "#,
+        )
+        .file(
+            "Cargo.toml",
+            r#"
+                cargo-features = ["path-bases"]
+
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
+                edition = "2015"
+
+                [dependencies]
+                foo = { base = 'test', path = '.' }
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build")
+        .masquerade_as_nightly_cargo(&["path-bases"])
+        .with_status(101)
+        .with_stderr_data(
+            "\
+[ERROR] cyclic package dependency: package `foo v0.1.0 ([ROOT]/foo)` depends on itself. Cycle:
+package `foo v0.1.0 ([ROOT]/foo)`
+    ... which satisfies path dependency `foo` of package `foo v0.1.0 ([ROOT]/foo)`
+",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn override_relative() {
     let bar = project()
         .at("bar")


### PR DESCRIPTION
RFC: https://github.com/rust-lang/rfcs/pull/3529
Tracking Issue: https://github.com/rust-lang/cargo/issues/14355

This PR add support in path dependencies and `patch` table and the `workspace` built-in path base.