### PR TITLE
`cargo package --workspace` must support `publish = false`

### DIFF
--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -207,7 +207,7 @@ fn infer_registry(
         let reg_name = publish_registry.as_deref().unwrap_or(CRATES_IO_REGISTRY);
         for pkg in pkgs {
             if let Some(allowed) = pkg.publish().as_ref() {
-                if !allowed.iter().any(|a| a == reg_name) {
+                if !allowed.is_empty() && !allowed.iter().any(|a| a == reg_name) {
                     bail!(
                         "`{}` cannot be packaged.\n\
                          The registry `{}` is not listed in the `package.publish` value in Cargo.toml.",

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -2868,21 +2868,30 @@ fn in_workspace_with_publish_false() {
         .build();
 
     p.cargo("package --workspace")
-        // FIXME: This reproduces https://github.com/rust-lang/cargo/issues/14356
-        .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] `no-publish` cannot be packaged.
-The registry `crates-io` is not listed in the `package.publish` value in Cargo.toml.
+[WARNING] manifest has no documentation, homepage or repository.
+See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
+[PACKAGING] foo v0.0.1 ([ROOT]/foo)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[WARNING] manifest has no documentation, homepage or repository.
+See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
+[PACKAGING] no-publish v0.0.1 ([ROOT]/foo/no-publish)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[VERIFYING] foo v0.0.1 ([ROOT]/foo)
+[COMPILING] foo v0.0.1 ([ROOT]/foo/target/package/foo-0.0.1)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[VERIFYING] no-publish v0.0.1 ([ROOT]/foo/no-publish)
+[COMPILING] no-publish v0.0.1 ([ROOT]/foo/target/package/no-publish-0.0.1)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
         .run();
 
-    // FIXME: Enable these
-    // assert!(p.root().join("target/package/foo-0.0.1.crate").is_file());
-    // assert!(p
-    //     .root()
-    //     .join("target/package/no-publish-0.0.1.crate")
-    //     .is_file());
+    assert!(p.root().join("target/package/foo-0.0.1.crate").is_file());
+    assert!(p
+        .root()
+        .join("target/package/no-publish-0.0.1.crate")
+        .is_file());
 }
 
 #[cargo_test]


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->

Fixes #14356.

OK, so the issue _can_ be fixed quite easily. But I'm not sure if it is the correct fix. So in this PR we are simply skipping validating the published-to registry if `publish = false` when inferring what registry to use. But that means we allow any workspace where one of the packages, possibly a crucial dependency, is configured to not get published. So the final, published packages may not work for anybody.

Do we need a smarter validation, that only allows this for packages that are not dependencies of other packages that are scheduled to get published? 