### PR TITLE
fix: std Cargo.lock moved to `library` dir

### DIFF
--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -73,7 +73,7 @@ pub fn resolve_std<'gctx>(
     }
 
     let src_path = detect_sysroot_src_path(target_data)?;
-    let std_ws_manifest_path = src_path.join("library").join("Cargo.toml");
+    let std_ws_manifest_path = src_path.join("Cargo.toml");
     let gctx = ws.gctx();
     // TODO: Consider doing something to enforce --locked? Or to prevent the
     // lock file from being written, such as setting ephemeral.
@@ -192,7 +192,8 @@ fn detect_sysroot_src_path(target_data: &RustcTargetData<'_>) -> CargoResult<Pat
         .join("lib")
         .join("rustlib")
         .join("src")
-        .join("rust");
+        .join("rust")
+        .join("library");
     let lock = src_path.join("Cargo.lock");
     if !lock.exists() {
         let msg = format!(

--- a/tests/testsuite/standard_lib.rs
+++ b/tests/testsuite/standard_lib.rs
@@ -132,7 +132,7 @@ fn setup() -> Setup {
 fn enable_build_std(e: &mut Execs, setup: &Setup) {
     // First up, force Cargo to use our "mock sysroot" which mimics what
     // libstd looks like upstream.
-    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/testsuite/mock-std");
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/testsuite/mock-std/library");
     e.env("__CARGO_TESTS_ONLY_SRC_ROOT", &root);
 
     e.masquerade_as_nightly_cargo(&["build-std"]);


### PR DESCRIPTION
https://github.com/rust-lang/cargo/pull/14358 didn't check the correct Cargo.lock existence
Perhaps it was there so the test passed,
but after a new nightly is out it is gone.

```
    Blocking waiting for file lock on package cache
error: "/home/user/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/Cargo.lock" does not exist, unable to build with the standard library, try:
        rustup component add rust-src --toolchain nightly-aarch64-apple-darwin

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Fixes https://github.com/rust-lang/rust/issues/128808


### How to test the change:

The current nightly `cargo 1.82.0-nightly (94977cb1f 2024-08-06)` would fail when running

```
cargo +nightly build -Zbuild-std --target <host-triple>
```

After this fix, it should just work

```
RUSTC=~/.rustup/toolchains/nightly-<host-triple>/bin/rustc ./target/debug/cargo build -Zbuild-std --target <host-triple>
```