### PR TITLE
Correctly parse arguments from environment variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,6 +324,7 @@ dependencies = [
  "serde_json",
  "sha1",
  "shell-escape",
+ "shlex",
  "snapbox",
  "supports-hyperlinks",
  "supports-unicode",
@@ -2169,7 +2170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3181,6 +3182,12 @@ name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signature"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ serde_json = "1.0.120"
 sha1 = "0.10.6"
 sha2 = "0.10.8"
 shell-escape = "0.1.5"
+shlex = "1.3.0"
 similar = "2.6.0"
 supports-hyperlinks = "3.0.0"
 snapbox = { version = "0.6.16", features = ["diff", "dir", "term-svg", "regex", "json"] }
@@ -192,6 +193,7 @@ serde_ignored.workspace = true
 serde_json = { workspace = true, features = ["raw_value"] }
 sha1.workspace = true
 shell-escape.workspace = true
+shlex.workspace = true
 supports-hyperlinks.workspace = true
 tar.workspace = true
 tempfile.workspace = true

--- a/src/cargo/util/context/mod.rs
+++ b/src/cargo/util/context/mod.rs
@@ -89,6 +89,7 @@ use lazycell::LazyCell;
 use serde::de::IntoDeserializer as _;
 use serde::Deserialize;
 use serde_untagged::UntaggedEnumVisitor;
+use shlex::Shlex;
 use time::OffsetDateTime;
 use toml_edit::Item;
 use url::Url;
@@ -973,8 +974,8 @@ impl GlobalContext {
             }
         } else {
             output.extend(
-                env_val
-                    .split_whitespace()
+                Shlex::new(env_val)
+                    .into_iter()
                     .map(|s| (s.to_string(), def.clone())),
             );
         }
@@ -3022,10 +3023,8 @@ mod tests {
 
         let values: &[(&str, &[&str])] = &[
             ("VAL1", &["--path"]),
-            // FIXME: this one is parsed as `["--path=\"y", "z\""]`.
-            // ("VAL2", &["--path=\"y z\""]),
-            // FIXME: this one is parsed as `["--path", "\"y", "z\""]`.
-            // ("VAL3", &["--path", "\"y z\""]),
+            ("VAL2", &["--path=\"y z\""]),
+            ("VAL3", &["--path", "\"y z\""]),
         ];
 
         let mut env = HashMap::new();


### PR DESCRIPTION
Fixes https://github.com/rust-lang/cargo/issues/14381.

The current parsing doesn't correctly handle arguments like `--x="y z"`. To be noted: if you don't want the dependency, I can write a parser by hand too, shouldn't take many lines of code to do.

r? @epage 