### PR TITLE
CI: Switch macos aarch64 to nightly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,17 +140,17 @@ jobs:
           os: ubuntu-latest
           rust: nightly
           other: i686-unknown-linux-gnu
-        - name: macOS x86_64 stable
-          os: macos-13
+        - name: macOS aarch64 stable
+          os: macos-14
           rust: stable
-          other: x86_64-apple-ios
+          other: x86_64-apple-darwin
         - name: macOS x86_64 nightly
           os: macos-13
           rust: nightly
           other: x86_64-apple-ios
-        - name: macOS aarch64 stable
+        - name: macOS aarch64 nightly
           os: macos-14
-          rust: stable
+          rust: nightly
           other: x86_64-apple-darwin
         - name: Windows x86_64 MSVC stable
           os: windows-latest


### PR DESCRIPTION
We will be promoting aarch64-apple-darwin to tier 1 soon via https://github.com/rust-lang/rust/pull/128592. This updates our CI so that aarch64-apple-darwin runs the full test suite on nightly to keep this in-line with tier-1 support.

This also removes the x86_64 stable macos job and replaces it with aarch64, mainly because aarch64 runs much faster, and presumably x86_64 support will go away some day.
