### PR TITLE
feat(trim-paths): rustdoc supports trim-paths for diagnostics 

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1242,71 +1242,74 @@ fn trim_paths_args(
     cmd.arg("-Zunstable-options");
     cmd.arg(format!("-Zremap-path-scope={trim_paths}"));
 
-    let sysroot_remap = {
-        let sysroot = &build_runner.bcx.target_data.info(unit.kind).sysroot;
-        let mut remap = OsString::from("--remap-path-prefix=");
-        remap.push(sysroot);
-        remap.push("/lib/rustlib/src/rust"); // See also `detect_sysroot_src_path()`.
-        remap.push("=");
-        remap.push("/rustc/");
-        // This remap logic aligns with rustc:
-        // <https://github.com/rust-lang/rust/blob/c2ef3516/src/bootstrap/src/lib.rs#L1113-L1116>
-        if let Some(commit_hash) = build_runner.bcx.rustc().commit_hash.as_ref() {
-            remap.push(commit_hash);
-        } else {
-            remap.push(build_runner.bcx.rustc().version.to_string());
-        }
-        remap
-    };
-    let package_remap = {
-        let pkg_root = unit.pkg.root();
-        let ws_root = build_runner.bcx.ws.root();
-        let mut remap = OsString::from("--remap-path-prefix=");
-        // Remap rules for dependencies
-        //
-        // * Git dependencies: remove ~/.cargo/git/checkouts prefix.
-        // * Registry dependencies: remove ~/.cargo/registry/src prefix.
-        // * Others (e.g. path dependencies):
-        //     * relative paths to workspace root if inside the workspace directory.
-        //     * otherwise remapped to `<pkg>-<version>`.
-        let source_id = unit.pkg.package_id().source_id();
-        if source_id.is_git() {
-            remap.push(
-                build_runner
-                    .bcx
-                    .gctx
-                    .git_checkouts_path()
-                    .as_path_unlocked(),
-            );
-            remap.push("=");
-        } else if source_id.is_registry() {
-            remap.push(
-                build_runner
-                    .bcx
-                    .gctx
-                    .registry_source_path()
-                    .as_path_unlocked(),
-            );
-            remap.push("=");
-        } else if pkg_root.strip_prefix(ws_root).is_ok() {
-            remap.push(ws_root);
-            remap.push("=."); // remap to relative rustc work dir explicitly
-        } else {
-            remap.push(pkg_root);
-            remap.push("=");
-            remap.push(unit.pkg.name());
-            remap.push("-");
-            remap.push(unit.pkg.version().to_string());
-        }
-        remap
-    };
-
     // Order of `--remap-path-prefix` flags is important for `-Zbuild-std`.
     // We want to show `/rustc/<hash>/library/std` instead of `std-0.0.0`.
-    cmd.arg(package_remap);
-    cmd.arg(sysroot_remap);
+    cmd.arg(package_remap(build_runner, unit));
+    cmd.arg(sysroot_remap(build_runner, unit));
 
     Ok(())
+}
+
+/// Path prefix remap rules for sysroot.
+///
+/// This remap logic aligns with rustc:
+/// <https://github.com/rust-lang/rust/blob/c2ef3516/src/bootstrap/src/lib.rs#L1113-L1116>
+fn sysroot_remap(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> OsString {
+    let sysroot = &build_runner.bcx.target_data.info(unit.kind).sysroot;
+    let mut remap = OsString::from("--remap-path-prefix=");
+    remap.push(sysroot);
+    remap.push("/lib/rustlib/src/rust"); // See also `detect_sysroot_src_path()`.
+    remap.push("=");
+    remap.push("/rustc/");
+    if let Some(commit_hash) = build_runner.bcx.rustc().commit_hash.as_ref() {
+        remap.push(commit_hash);
+    } else {
+        remap.push(build_runner.bcx.rustc().version.to_string());
+    }
+    remap
+}
+
+/// Path prefix remap rules for dependencies.
+///
+/// * Git dependencies: remove `~/.cargo/git/checkouts` prefix.
+/// * Registry dependencies: remove `~/.cargo/registry/src` prefix.
+/// * Others (e.g. path dependencies):
+///     * relative paths to workspace root if inside the workspace directory.
+///     * otherwise remapped to `<pkg>-<version>`.
+fn package_remap(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> OsString {
+    let pkg_root = unit.pkg.root();
+    let ws_root = build_runner.bcx.ws.root();
+    let mut remap = OsString::from("--remap-path-prefix=");
+    let source_id = unit.pkg.package_id().source_id();
+    if source_id.is_git() {
+        remap.push(
+            build_runner
+                .bcx
+                .gctx
+                .git_checkouts_path()
+                .as_path_unlocked(),
+        );
+        remap.push("=");
+    } else if source_id.is_registry() {
+        remap.push(
+            build_runner
+                .bcx
+                .gctx
+                .registry_source_path()
+                .as_path_unlocked(),
+        );
+        remap.push("=");
+    } else if pkg_root.strip_prefix(ws_root).is_ok() {
+        remap.push(ws_root);
+        remap.push("=."); // remap to relative rustc work dir explicitly
+    } else {
+        remap.push(pkg_root);
+        remap.push("=");
+        remap.push(unit.pkg.name());
+        remap.push("-");
+        remap.push(unit.pkg.version().to_string());
+    }
+    remap
 }
 
 /// Generates the `--check-cfg` arguments for the `unit`.

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -752,3 +752,88 @@ Hello, Ferris!
 "#]],
     );
 }
+
+#[cargo_test(nightly, reason = "rustdoc --remap-path-prefix is unstable")]
+fn rustdoc_without_diagnostics_scope() {
+    Package::new("bar", "0.0.1")
+        .file("Cargo.toml", &basic_manifest("bar", "0.0.1"))
+        .file(
+            "src/lib.rs",
+            r#"
+            /// </script>
+            pub struct Bar;
+            "#,
+        )
+        .publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                edition = "2015"
+
+                [dependencies]
+                bar = "0.0.1"
+
+                [profile.dev]
+                trim-paths = "object"
+           "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("doc -vv -Ztrim-paths")
+        .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
+        .with_stderr_data(str![[r#"
+...
+[WARNING] unopened HTML tag `script`
+ --> [ROOT]/home/.cargo/registry/src/-[HASH]/bar-0.0.1/src/lib.rs:2:17
+...
+"#]])
+        .run();
+}
+
+#[cargo_test(nightly, reason = "rustdoc --remap-path-prefix is unstable")]
+fn rustdoc_diagnostics_works() {
+    // This is expected to work after rust-lang/rust#128736
+    Package::new("bar", "0.0.1")
+        .file("Cargo.toml", &basic_manifest("bar", "0.0.1"))
+        .file(
+            "src/lib.rs",
+            r#"
+            /// </script>
+            pub struct Bar;
+            "#,
+        )
+        .publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                edition = "2015"
+
+                [dependencies]
+                bar = "0.0.1"
+
+                [profile.dev]
+                trim-paths = "diagnostics"
+           "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("doc -vv -Ztrim-paths")
+        .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
+        .with_stderr_data(str![[r#"
+...
+[WARNING] unopened HTML tag `script`
+ --> [ROOT]/home/.cargo/registry/src/-[HASH]/bar-0.0.1/src/lib.rs:2:17
+...
+"#]])
+        .run();
+}

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -831,8 +831,10 @@ fn rustdoc_diagnostics_works() {
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stderr_data(str![[r#"
 ...
+[RUNNING] `[..]rustc [..]-Zremap-path-scope=diagnostics --remap-path-prefix=[ROOT]/home/.cargo/registry/src= --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
+...
 [WARNING] unopened HTML tag `script`
- --> [ROOT]/home/.cargo/registry/src/-[HASH]/bar-0.0.1/src/lib.rs:2:17
+ --> -[..]/bar-0.0.1/src/lib.rs:2:17
 ...
 "#]])
         .run();


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

Part of #12137

This enables rustdoc invocation from `cargo doc` to trim paths
in diagnostics. 

### How should we test and review this PR?

Tests were added and followed by the behavior changing commit.

### Additional information

Doc tests are out-of-scope, as they are handled
in a different mechanism, which needs more cares.

<!-- homu-ignore:end -->
