### PR TITLE
doc: convert comments to rustdoc in workspace

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -46,65 +46,70 @@ use pathdiff::diff_paths;
 /// package is loaded and/or learned about.
 #[derive(Debug)]
 pub struct Workspace<'gctx> {
+    /// Cargo configuration information. See [`GlobalContext`].
     gctx: &'gctx GlobalContext,
 
-    // This path is a path to where the current cargo subcommand was invoked
-    // from. That is the `--manifest-path` argument to Cargo, and
-    // points to the "main crate" that we're going to worry about.
+    /// This path is a path to where the current cargo subcommand was invoked
+    /// from. That is the `--manifest-path` argument to Cargo, and
+    /// points to the "main crate" that we're going to worry about.
     current_manifest: PathBuf,
 
-    // A list of packages found in this workspace. Always includes at least the
-    // package mentioned by `current_manifest`.
+    /// A list of packages found in this workspace. Always includes at least the
+    /// package mentioned by `current_manifest`.
     packages: Packages<'gctx>,
 
-    // If this workspace includes more than one crate, this points to the root
-    // of the workspace. This is `None` in the case that `[workspace]` is
-    // missing, `package.workspace` is missing, and no `Cargo.toml` above
-    // `current_manifest` was found on the filesystem with `[workspace]`.
+    /// If this workspace includes more than one crate, this points to the root
+    /// of the workspace. This is `None` in the case that `[workspace]` is
+    /// missing, `package.workspace` is missing, and no `Cargo.toml` above
+    /// `current_manifest` was found on the filesystem with `[workspace]`.
     root_manifest: Option<PathBuf>,
 
-    // Shared target directory for all the packages of this workspace.
-    // `None` if the default path of `root/target` should be used.
+    /// Shared target directory for all the packages of this workspace.
+    /// `None` if the default path of `root/target` should be used.
     target_dir: Option<Filesystem>,
 
-    // List of members in this workspace with a listing of all their manifest
-    // paths. The packages themselves can be looked up through the `packages`
-    // set above.
+    /// List of members in this workspace with a listing of all their manifest
+    /// paths. The packages themselves can be looked up through the `packages`
+    /// set above.
     members: Vec<PathBuf>,
+    /// Set of ids of workspace members
     member_ids: HashSet<PackageId>,
 
-    // The subset of `members` that are used by the
-    // `build`, `check`, `test`, and `bench` subcommands
-    // when no package is selected with `--package` / `-p` and `--workspace`
-    // is not used.
-    //
-    // This is set by the `default-members` config
-    // in the `[workspace]` section.
-    // When unset, this is the same as `members` for virtual workspaces
-    // (`--workspace` is implied)
-    // or only the root package for non-virtual workspaces.
+    /// The subset of `members` that are used by the
+    /// `build`, `check`, `test`, and `bench` subcommands
+    /// when no package is selected with `--package` / `-p` and `--workspace`
+    /// is not used.
+    ///
+    /// This is set by the `default-members` config
+    /// in the `[workspace]` section.
+    /// When unset, this is the same as `members` for virtual workspaces
+    /// (`--workspace` is implied)
+    /// or only the root package for non-virtual workspaces.
     default_members: Vec<PathBuf>,
 
-    // `true` if this is a temporary workspace created for the purposes of the
-    // `cargo install` or `cargo package` commands.
+    /// `true` if this is a temporary workspace created for the purposes of the
+    /// `cargo install` or `cargo package` commands.
     is_ephemeral: bool,
 
-    // `true` if this workspace should enforce optional dependencies even when
-    // not needed; false if this workspace should only enforce dependencies
-    // needed by the current configuration (such as in cargo install). In some
-    // cases `false` also results in the non-enforcement of dev-dependencies.
+    /// `true` if this workspace should enforce optional dependencies even when
+    /// not needed; false if this workspace should only enforce dependencies
+    /// needed by the current configuration (such as in cargo install). In some
+    /// cases `false` also results in the non-enforcement of dev-dependencies.
     require_optional_deps: bool,
 
-    // A cache of loaded packages for particular paths which is disjoint from
-    // `packages` up above, used in the `load` method down below.
+    /// A cache of loaded packages for particular paths which is disjoint from
+    /// `packages` up above, used in the `load` method down below.
     loaded_packages: RefCell<HashMap<PathBuf, Package>>,
 
-    // If `true`, then the resolver will ignore any existing `Cargo.lock`
-    // file. This is set for `cargo install` without `--locked`.
+    /// If `true`, then the resolver will ignore any existing `Cargo.lock`
+    /// file. This is set for `cargo install` without `--locked`.
     ignore_lock: bool,
 
     /// The resolver behavior specified with the `resolver` field.
     resolve_behavior: ResolveBehavior,
+    /// If `true`, then workspace `rust_version` would be used in `cargo resolve`
+    /// and other places that use rust version.
+    /// This is set based on the resolver version, config settings, and CLI flags.
     resolve_honors_rust_version: bool,
 
     /// Workspace-level custom metadata


### PR DESCRIPTION
Converting workspace comments into docs and adding docs on members that were missing it.
[Original discussion](https://github.com/rust-lang/cargo/pull/14326#discussion_r1702452550) 