### PR TITLE
feat(update): Report when incompatible-rust-version packages are selected

### DIFF
--- a/src/cargo/ops/cargo_update.rs
+++ b/src/cargo/ops/cargo_update.rs
@@ -498,10 +498,6 @@ fn print_lockfile_generation(
     status_locking(ws, num_pkgs)?;
 
     for diff in diff {
-        fn format_latest(version: semver::Version) -> String {
-            let warn = style::WARN;
-            format!(" {warn}(latest: v{version}){warn:#}")
-        }
         let possibilities = if let Some(query) = diff.alternatives_query() {
             loop {
                 match registry.query_vec(&query, QueryKind::Exact) {
@@ -555,10 +551,6 @@ fn print_lockfile_sync(
     status_locking(ws, num_pkgs)?;
 
     for diff in diff {
-        fn format_latest(version: semver::Version) -> String {
-            let warn = style::WARN;
-            format!(" {warn}(latest: v{version}){warn:#}")
-        }
         let possibilities = if let Some(query) = diff.alternatives_query() {
             loop {
                 match registry.query_vec(&query, QueryKind::Exact) {
@@ -650,10 +642,6 @@ fn print_lockfile_updates(
 
     let mut unchanged_behind = 0;
     for diff in diff {
-        fn format_latest(version: semver::Version) -> String {
-            let warn = style::WARN;
-            format!(" {warn}(latest: v{version}){warn:#}")
-        }
         let possibilities = if let Some(query) = diff.alternatives_query() {
             loop {
                 match registry.query_vec(&query, QueryKind::Exact) {
@@ -805,6 +793,11 @@ fn status_locking(ws: &Workspace<'_>, num_pkgs: usize) -> CargoResult<()> {
         .shell()
         .status("Locking", format!("{num_pkgs} package{plural}{cfg}"))?;
     Ok(())
+}
+
+fn format_latest(version: semver::Version) -> String {
+    let warn = style::WARN;
+    format!(" {warn}(latest: v{version}){warn:#}")
 }
 
 fn is_latest(candidate: &semver::Version, current: &semver::Version) -> bool {

--- a/src/cargo/ops/cargo_update.rs
+++ b/src/cargo/ops/cargo_update.rs
@@ -752,6 +752,10 @@ fn required_rust_version(ws: &Workspace<'_>) -> Option<PartialVersion> {
 }
 
 fn report_latest(possibilities: &[IndexSummary], package: PackageId) -> Option<String> {
+    if !package.source_id().is_registry() {
+        return None;
+    }
+
     possibilities
         .iter()
         .map(|s| s.as_summary())

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -241,6 +241,7 @@ foo v0.0.1 ([ROOT]/foo)
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest Rust 1.60.0 compatible versions
 [ADDING] newer-and-older v1.5.0 (latest: v1.6.0)
+[ADDING] only-newer v1.6.0 (requires Rust 1.65.0)
 
 "#]])
         .run();
@@ -315,6 +316,7 @@ foo v0.0.1 ([ROOT]/foo)
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest Rust 1.60.0 compatible versions
 [ADDING] newer-and-older v1.5.0 (latest: v1.6.0)
+[ADDING] only-newer v1.6.0 (requires Rust 1.2345)
 
 "#]])
         .run();
@@ -387,6 +389,7 @@ foo v0.0.1 ([ROOT]/foo)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest Rust 1.60.0 compatible versions
+[ADDING] has-rust-version v1.6.0 (requires Rust 1.65.0)
 
 "#]])
         .run();
@@ -484,6 +487,7 @@ higher v0.0.1 ([ROOT]/foo)
 [UPDATING] `dummy-registry` index
 [LOCKING] 4 packages to latest Rust 1.50.0 compatible versions
 [ADDING] newer-and-older v1.5.0 (latest: v1.6.0)
+[ADDING] only-newer v1.6.0 (requires Rust 1.65.0)
 
 "#]])
         .run();
@@ -612,6 +616,7 @@ fn resolve_edition2024() {
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest Rust 1.60.0 compatible versions
 [ADDING] newer-and-older v1.5.0 (latest: v1.6.0)
+[ADDING] only-newer v1.6.0 (requires Rust 1.65.0)
 
 "#]])
         .run();
@@ -715,6 +720,7 @@ fn resolve_v3() {
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest Rust 1.60.0 compatible versions
 [ADDING] newer-and-older v1.5.0 (latest: v1.6.0)
+[ADDING] only-newer v1.6.0 (requires Rust 1.65.0)
 
 "#]])
         .run();
@@ -932,7 +938,7 @@ fn update_precise_overrides_msrv_resolver() {
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[UPDATING] bar v1.5.0 -> v1.6.0
+[UPDATING] bar v1.5.0 -> v1.6.0 (requires Rust 1.65.0)
 
 "#]])
         .run();
@@ -1010,6 +1016,7 @@ foo v0.0.1 ([ROOT]/foo)
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest Rust 1.60.0 compatible versions
 [ADDING] newer-and-older v1.5.0 (latest: v1.6.0)
+[ADDING] only-newer v1.6.0 (requires Rust 1.65.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] newer-and-older v1.5.0 (registry `dummy-registry`)
 [CHECKING] newer-and-older v1.5.0


### PR DESCRIPTION
### What does this PR try to resolve?

In discussin this in #13873, it highlighted that we need to make sure we
tell people when incompatible-rust-version packages are selected.

I decided to keep "latest" and "required rust version" messages mutually
exclusive to avoid too much noise.  I gave "required rust version"
higher precedence as its the more critical to operation and, if you are
using an MSRV-incompatible package, it likely is "latest" already.

### How should we test and review this PR?


### Additional information

I was tempted to change colors to make "required rust version" stand out
from "latest" but was unsure what direction to go, so I held off.
Options included
- red for "required rust version", yellow for "latest"
- yellow for "required rust version", nothing for "latest"

There is also more discussion on how to format "latest" at #13908.