### PR TITLE
Correct diagnostic for `TomlDebugInfo`

### DIFF
--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -1088,7 +1088,7 @@ impl<'de> de::Deserialize<'de> for TomlDebugInfo {
         D: de::Deserializer<'de>,
     {
         use serde::de::Error as _;
-        let expecting = "a boolean, 0, 1, 2, \"line-tables-only\", or \"line-directives-only\"";
+        let expecting = "a boolean, 0, 1, 2, \"none\", \"limited\", \"full\", \"line-tables-only\", or \"line-directives-only\"";
         UntaggedEnumVisitor::new()
             .expecting(expecting)
             .bool(|value| {

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -2686,7 +2686,7 @@ fn bad_debuginfo() {
     p.cargo("check")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] invalid value: string "a", expected a boolean, 0, 1, 2, "line-tables-only", or "line-directives-only"
+[ERROR] invalid value: string "a", expected a boolean, 0, 1, 2, "none", "limited", "full", "line-tables-only", or "line-directives-only"
  --> Cargo.toml:9:25
   |
 9 |                 debug = 'a'
@@ -2719,7 +2719,7 @@ fn bad_debuginfo2() {
     p.cargo("check")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] invalid type: floating point `3.6`, expected a boolean, 0, 1, 2, "line-tables-only", or "line-directives-only"
+[ERROR] invalid type: floating point `3.6`, expected a boolean, 0, 1, 2, "none", "limited", "full", "line-tables-only", or "line-directives-only"
  --> Cargo.toml:9:25
   |
 9 |                 debug = 3.6


### PR DESCRIPTION
This is missing the friendly aliases introduced in 3dbb474c.

### What does this PR try to resolve?

I wrote: 

```
[profile.bench]
debug = "all"
```

I got this diagnostic:

```
error: invalid value: string "all", expected a boolean, 0, 1, 2, "line-tables-only", or "line-directives-only"
  --> Cargo.toml:31:9
   |
31 | debug = "all"
   |         ^^^^^
   |
```

I meant to write "full", as [documented here](https://doc.rust-lang.org/cargo/reference/profiles.html#debug), but that wasn't mentioned in the diagnostic.

### How should we test and review this PR?

Updated the existing tests for this diagnostic.
