### PR TITLE
Implement path-bases (RFC 3529) 2/n: support for nested packages

### DIFF
--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1612,7 +1612,7 @@ character, and must not be empty.
 If the name of path base used in a dependency is neither in the configuration
 nor one of the built-in path base, then Cargo will raise an error.
 
-#### Built-in path bases
+### Built-in path bases
 
 Cargo provides implicit path bases that can be used without the need to specify
 them in a `[path-bases]` table.
@@ -1625,6 +1625,12 @@ If a built-in path base name is also declared in the configuration, then Cargo
 will prefer the value in the configuration. The allows Cargo to add new built-in
 path bases without compatibility issues (as existing uses will shadow the
 built-in name).
+
+### Path bases in git dependencies and patches
+
+Configuration files in git dependencies and patches are not loaded by Cargo and
+so any path bases used in those packages will need to be defined in some
+configuration that is loaded by Cargo.
 
 ## lockfile-path
 * Original Issue: [#5707](https://github.com/rust-lang/cargo/issues/5707)


### PR DESCRIPTION
Cargo has the ability to discover "nested packages" when loading the dependencies of a package. For example, if a git dependency has a path dependency pointing to somewhere else in the repo, or a submodule, then Cargo needs to discover those dependencies as well.

This change makes the "nested packages" loading code aware of the "path bases" feature so that it can build the correct manifest path for any path dependencies that may be using a `base`.

RFC: https://github.com/rust-lang/rfcs/pull/3529
Tracking Issue: https://github.com/rust-lang/cargo/issues/14355