### PR TITLE
fix: remove list owners feature of info subcommand

### DIFF
--- a/src/cargo/ops/registry/info/view.rs
+++ b/src/cargo/ops/registry/info/view.rs
@@ -15,7 +15,6 @@ use crate::{
 pub(super) fn pretty_view(
     package: &Package,
     summaries: &[IndexSummary],
-    owners: &Option<Vec<String>>,
     suggest_cargo_tree_command: bool,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
@@ -152,10 +151,6 @@ pub(super) fn pretty_view(
         stdout,
         gctx,
     )?;
-
-    if let Some(owners) = owners {
-        pretty_owners(owners, stdout)?;
-    }
 
     if suggest_cargo_tree_command {
         suggest_cargo_tree(package_id, stdout)?;
@@ -394,19 +389,6 @@ fn pretty_features(
             stdout,
             "  {summary}{total_deactivated} deactivated features{summary:#}",
         )?;
-    }
-
-    Ok(())
-}
-
-fn pretty_owners(owners: &Vec<String>, stdout: &mut dyn Write) -> CargoResult<()> {
-    let header = HEADER;
-
-    if !owners.is_empty() {
-        writeln!(stdout, "{header}owners:{header:#}",)?;
-        for owner in owners {
-            writeln!(stdout, "  {}", owner)?;
-        }
     }
 
     Ok(())

--- a/tests/testsuite/cargo_info/features_activated_over_limit_verbose/stderr.term.svg
+++ b/tests/testsuite/cargo_info/features_activated_over_limit_verbose/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="92px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -24,9 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> your-face v99999.0.0+my-package (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">  Credential</tspan><tspan> cargo:token get dummy-registry</tspan>
-</tspan>
-    <tspan x="10px" y="100px">
+    <tspan x="10px" y="82px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_info/specify_version_within_ws_and_match_with_lockfile/stderr.term.svg
+++ b/tests/testsuite/cargo_info/specify_version_within_ws_and_match_with_lockfile/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="92px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -24,9 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v0.1.1+my-package (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">    Updating</tspan><tspan> crates.io index</tspan>
-</tspan>
-    <tspan x="10px" y="100px">
+    <tspan x="10px" y="82px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/ws-stderr.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/ws-stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="92px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -24,9 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v2.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">    Updating</tspan><tspan> crates.io index</tspan>
-</tspan>
-    <tspan x="10px" y="100px">
+    <tspan x="10px" y="82px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_info/verbose/stderr.term.svg
+++ b/tests/testsuite/cargo_info/verbose/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="92px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -24,9 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v0.1.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">  Credential</tspan><tspan> cargo:token get dummy-registry</tspan>
-</tspan>
-    <tspan x="10px" y="100px">
+    <tspan x="10px" y="82px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_info/within_ws/stderr.term.svg
+++ b/tests/testsuite/cargo_info/within_ws/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="92px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -24,9 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v0.1.1+my-package (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">    Updating</tspan><tspan> crates.io index</tspan>
-</tspan>
-    <tspan x="10px" y="100px">
+    <tspan x="10px" y="82px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_info/within_ws_without_lockfile/stderr.term.svg
+++ b/tests/testsuite/cargo_info/within_ws_without_lockfile/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="146px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="128px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -30,9 +30,7 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v0.2.3+my-package (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">    Updating</tspan><tspan> crates.io index</tspan>
-</tspan>
-    <tspan x="10px" y="136px">
+    <tspan x="10px" y="118px">
 </tspan>
   </text>
 


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

close https://github.com/rust-lang/cargo/issues/14409

Because this API requires authentication, the cargo info command should prompt the user to enter a password every time it is used(for those with a hardware token, a hardware key).

Since this commit https://github.com/rust-lang/cargo/commit/0c25226b35447a51918d5a17ba62a36b109757fe, authentication is required for this API.

So we cannot simply 'fix' it. So we decided to delete this feature first.

### How should we test and review this PR?

Check the updated test snapshots.

### Additional information

None

<!-- homu-ignore:end -->
