### PR TITLE
fix: doctest respects Cargo's color options

### DIFF
--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -1,5 +1,6 @@
 use crate::core::compiler::{Compilation, CompileKind, Doctest, Metadata, Unit, UnitOutput};
 use crate::core::profiles::PanicStrategy;
+use crate::core::shell::ColorChoice;
 use crate::core::shell::Verbosity;
 use crate::core::{TargetKind, Workspace};
 use crate::ops;
@@ -176,6 +177,7 @@ fn run_doc_tests(
     let gctx = ws.gctx();
     let mut errors = Vec::new();
     let doctest_xcompile = gctx.cli_unstable().doctest_xcompile;
+    let color = gctx.shell().color_choice();
 
     for doctest_info in &compilation.to_doc_test {
         let Doctest {
@@ -215,6 +217,14 @@ fn run_doc_tests(
         for (var, value) in env {
             p.env(var, value);
         }
+
+        let color_arg = match color {
+            ColorChoice::Always => "always",
+            ColorChoice::Never => "never",
+            ColorChoice::CargoAuto => "auto",
+        };
+        p.arg("--color").arg(color_arg);
+
         p.arg("--crate-name").arg(&unit.target.crate_name());
         p.arg("--test");
 

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -2871,7 +2871,7 @@ fn env_test() {
 [RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
 [RUNNING] `[ROOT]/foo/target/debug/deps/test-[HASH][EXE]`
 [DOCTEST] foo
-[RUNNING] `rustdoc --edition=2015 --crate-type lib --crate-name foo[..]`
+[RUNNING] `rustdoc --edition=2015 --crate-type lib --color auto --crate-name foo[..]`
 
 "#]])
         .with_stdout_data(str![[r#"

--- a/tests/testsuite/lto.rs
+++ b/tests/testsuite/lto.rs
@@ -619,7 +619,7 @@ fn cdylib_and_rlib() {
 [RUNNING] `[ROOT]/foo/target/release/deps/bar-[HASH][EXE]`
 [RUNNING] `[ROOT]/foo/target/release/deps/b-[HASH][EXE]`
 [DOCTEST] bar
-[RUNNING] `rustdoc --edition=2015 --crate-type cdylib --crate-type rlib --crate-name bar --test [..]-C lto [..]
+[RUNNING] `rustdoc --edition=2015 --crate-type cdylib --crate-type rlib --color auto --crate-name bar --test [..]-C lto [..]
 
 "#]].unordered())
         .run();

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -5555,7 +5555,7 @@ fn cargo_test_print_env_verbose() {
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[..]CARGO_MANIFEST_DIR=[ROOT]/foo[..] [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
 [DOCTEST] foo
-[RUNNING] `[..]CARGO_MANIFEST_DIR=[ROOT]/foo[..] rustdoc --edition=2015 --crate-type lib --crate-name foo[..]`
+[RUNNING] `[..]CARGO_MANIFEST_DIR=[ROOT]/foo[..] rustdoc --edition=2015 --crate-type lib --color auto --crate-name foo[..]`
 
 "#]]).run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?

Explain the motivation behind this change.

This commit fixes the issue where cargo's test command doesn't respect the color parameter when it gets passed in like this command: `cargo t --color never --doc -- --color never`

Fixes #14403
### How should we test and review this PR?
Test on a basic rust project, with a file called lib.rs that looks like this 
```
/// ```
/// bar
/// ```
pub fn foo() {}
#[cfg(test)]
mod tests {
    #[test]
    fn foo() {
        bar
    }
}
```
You can try to replicate the same commands @zacknewman used in the description of this issue. 
`cargo t --color never --doc -- --color never`

You will see that compared to the official build of cargo, this build will respect the --color argument
