### PR TITLE
[mdman] Normalize newlines when rendering options

### DIFF
--- a/crates/mdman/src/hbs.rs
+++ b/crates/mdman/src/hbs.rs
@@ -139,6 +139,9 @@ impl HelperDef for OptionHelper<'_> {
         // Render the block.
         let block = t.renders(r, gctx, rc)?;
 
+        // Windows newlines can break some rendering, so normalize.
+        let block = block.replace("\r\n", "\n");
+
         // Get the name of this page.
         let man_name = gctx
             .data()

--- a/crates/mdman/tests/compare/expected/options.1
+++ b/crates/mdman/tests/compare/expected/options.1
@@ -72,7 +72,7 @@ Alternate syntax for optional value (with required = for disambiguation).
 .sp
 \fB\-\-split\-block\fR
 .RS 4
-An option where the description has a \fBblock statement  that is split across multiple lines\fR
+An option where the description has a \fBblock statement that is split across multiple lines\fR
 .RE
 .SH "EXAMPLES"
 .sp

--- a/crates/mdman/tests/compare/expected/options.1
+++ b/crates/mdman/tests/compare/expected/options.1
@@ -69,6 +69,11 @@ Flag with optional value.
 .RS 4
 Alternate syntax for optional value (with required = for disambiguation).
 .RE
+.sp
+\fB\-\-split\-block\fR
+.RS 4
+An option where the description has a \fBblock statement  that is split across multiple lines\fR
+.RE
 .SH "EXAMPLES"
 .sp
 .RS 4

--- a/crates/mdman/tests/compare/expected/options.md
+++ b/crates/mdman/tests/compare/expected/options.md
@@ -59,7 +59,7 @@ A description of the command.
 
 
 <dt class="option-term" id="option-options---split-block"><a class="option-anchor" href="#option-options---split-block"></a><code>--split-block</code></dt>
-<dd class="option-desc">An option where the description has a <code>block statement  that is split across multiple lines</code></dd>
+<dd class="option-desc">An option where the description has a <code>block statement that is split across multiple lines</code></dd>
 
 
 </dl>

--- a/crates/mdman/tests/compare/expected/options.md
+++ b/crates/mdman/tests/compare/expected/options.md
@@ -58,6 +58,10 @@ A description of the command.
 <dd class="option-desc">Alternate syntax for optional value (with required = for disambiguation).</dd>
 
 
+<dt class="option-term" id="option-options---split-block"><a class="option-anchor" href="#option-options---split-block"></a><code>--split-block</code></dt>
+<dd class="option-desc">An option where the description has a <code>block statement  that is split across multiple lines</code></dd>
+
+
 </dl>
 
 

--- a/crates/mdman/tests/compare/expected/options.txt
+++ b/crates/mdman/tests/compare/expected/options.txt
@@ -43,6 +43,10 @@ OPTIONS
            Alternate syntax for optional value (with required = for
            disambiguation).
 
+       --split-block
+           An option where the description has a block statement that is split
+           across multiple lines
+
 EXAMPLES
        1. An example
 

--- a/crates/mdman/tests/compare/includes/options-common.md
+++ b/crates/mdman/tests/compare/includes/options-common.md
@@ -11,4 +11,9 @@ Flag with optional value.
 Alternate syntax for optional value (with required = for disambiguation).
 {{/option}}
 
+{{#option "`--split-block`"}}
+An option where the description has a `block statement
+that is split across multiple lines`
+{{/option}}
+
 {{/options}}


### PR DESCRIPTION
When using `cargo build-man` on Windows, I noticed that some files I didn't modify were getting modified, specifically they had an extra space added in the middle of a code block in an option description.

The root cause appears to be that if a code block in a handlebars template was split across multiple lines, then both the `\r` and the `\n` were being converted to spaces.

The fix for this is to normalize newlines to `\n` after templates are expanded by handlebars but before the individual formatters render the block as an option.