### PR TITLE
More helpful missing feature error message

### DIFF
--- a/tests/testsuite/package_features.rs
+++ b/tests/testsuite/package_features.rs
@@ -75,7 +75,9 @@ fn virtual_no_default_features() {
     p.cargo("check --features foo")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] none of the selected packages contains these features: foo, did you mean: f1?
+[ERROR] none of the selected packages contains this feature: foo
+selected packages: a, b
+[HELP] there is a similarly named feature: f1
 
 "#]])
         .run();
@@ -83,7 +85,9 @@ fn virtual_no_default_features() {
     p.cargo("check --features a/dep1,b/f1,b/f2,f2")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] none of the selected packages contains these features: b/f2, f2, did you mean: f1?
+[ERROR] none of the selected packages contains these features: b/f2, f2
+selected packages: a, b
+[HELP] there is a similarly named feature: f1
 
 "#]])
         .run();
@@ -91,7 +95,9 @@ fn virtual_no_default_features() {
     p.cargo("check --features a/dep,b/f1,b/f2,f2")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] none of the selected packages contains these features: a/dep, b/f2, f2, did you mean: a/dep1, f1?
+[ERROR] none of the selected packages contains these features: a/dep, b/f2, f2
+selected packages: a, b
+[HELP] there are similarly named features: a/dep1, f1
 
 "#]])
         .run();
@@ -99,7 +105,18 @@ fn virtual_no_default_features() {
     p.cargo("check --features a/dep,a/dep1")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] none of the selected packages contains these features: a/dep, did you mean: b/f1?
+[ERROR] none of the selected packages contains this feature: a/dep
+selected packages: a, b
+[HELP] there is a similarly named feature: b/f1
+
+"#]])
+        .run();
+
+    p.cargo("check -p b --features=dep1")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] the package 'b' does not contain this feature: dep1
+[HELP] package with the missing feature: a
 
 "#]])
         .run();
@@ -126,7 +143,8 @@ fn virtual_typo_member_feature() {
         .cargo("check --features a/deny-warning")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] none of the selected packages contains these features: a/deny-warning, did you mean: a/deny-warnings?
+[ERROR] the package 'a' does not contain this feature: a/deny-warning
+[HELP] there is a similarly named feature: a/deny-warnings
 
 "#]])
         .run();


### PR DESCRIPTION
The "none of the selected packages contains these features" error does not say which packages are selected, and does not say which packages do have the requested features.

If any package in the workspace has the requested feature (matching exactly), the error suggests selecting that package, instead of trying alternative spellings.
