### PR TITLE
refactor(update): Prepare for smarter update messages

### DIFF
--- a/src/cargo/ops/cargo_update.rs
+++ b/src/cargo/ops/cargo_update.rs
@@ -523,7 +523,7 @@ fn print_lockfile_generation(
             if let Some(note) = note {
                 assert_eq!(change.kind, PackageChangeKind::Added);
                 ws.gctx().shell().status_with_color(
-                    "Adding",
+                    change.kind.status(),
                     format!("{package_id}{note}"),
                     &style::NOTE,
                 )?;
@@ -579,11 +579,11 @@ fn print_lockfile_sync(
             if change.kind == PackageChangeKind::Downgraded {
                 ws.gctx()
                     .shell()
-                    .status_with_color("Downgrading", msg, &style::WARN)?;
+                    .status_with_color(change.kind.status(), msg, &style::WARN)?;
             } else {
                 ws.gctx()
                     .shell()
-                    .status_with_color("Updating", msg, &style::GOOD)?;
+                    .status_with_color(change.kind.status(), msg, &style::GOOD)?;
             }
         } else {
             if change.kind == PackageChangeKind::Added {
@@ -592,7 +592,7 @@ fn print_lockfile_sync(
                 let note = required_rust_version.or(latest).unwrap_or_default();
 
                 ws.gctx().shell().status_with_color(
-                    "Adding",
+                    change.kind.status(),
                     format!("{package_id}{note}"),
                     &style::NOTE,
                 )?;
@@ -649,16 +649,16 @@ fn print_lockfile_updates(
             if change.kind == PackageChangeKind::Downgraded {
                 ws.gctx()
                     .shell()
-                    .status_with_color("Downgrading", msg, &style::WARN)?;
+                    .status_with_color(change.kind.status(), msg, &style::WARN)?;
             } else {
                 ws.gctx()
                     .shell()
-                    .status_with_color("Updating", msg, &style::GOOD)?;
+                    .status_with_color(change.kind.status(), msg, &style::GOOD)?;
             }
         } else {
             if change.kind == PackageChangeKind::Removed {
                 ws.gctx().shell().status_with_color(
-                    "Removing",
+                    change.kind.status(),
                     format!("{package_id}"),
                     &style::ERROR,
                 )?;
@@ -668,7 +668,7 @@ fn print_lockfile_updates(
                 let note = required_rust_version.or(latest).unwrap_or_default();
 
                 ws.gctx().shell().status_with_color(
-                    "Adding",
+                    change.kind.status(),
                     format!("{package_id}{note}"),
                     &style::NOTE,
                 )?;
@@ -685,7 +685,7 @@ fn print_lockfile_updates(
                 }
                 if ws.gctx().shell().verbosity() == Verbosity::Verbose {
                     ws.gctx().shell().status_with_color(
-                        "Unchanged",
+                        change.kind.status(),
                         format!("{package_id}{note}"),
                         &anstyle::Style::new().bold(),
                     )?;
@@ -917,6 +917,16 @@ impl PackageChangeKind {
         match self {
             Self::Added | Self::Upgraded | Self::Downgraded => true,
             Self::Removed | Self::Unchanged => false,
+        }
+    }
+
+    pub fn status(&self) -> &'static str {
+        match self {
+            Self::Added => "Adding",
+            Self::Removed => "Removing",
+            Self::Upgraded => "Updating",
+            Self::Downgraded => "Downgrading",
+            Self::Unchanged => "Unchanged",
         }
     }
 }

--- a/src/cargo/ops/cargo_update.rs
+++ b/src/cargo/ops/cargo_update.rs
@@ -563,7 +563,7 @@ fn print_lockfile_sync(
             let latest = report_latest(&possibilities, package_id);
             let note = required_rust_version.or(latest).unwrap_or_default();
 
-            let msg = if previous_id.source_id().is_git() {
+            let msg = if package_id.source_id().is_git() {
                 format!(
                     "{previous_id} -> #{}",
                     &package_id.source_id().precise_git_fragment().unwrap()[..8],
@@ -636,7 +636,7 @@ fn print_lockfile_updates(
             let latest = report_latest(&possibilities, package_id);
             let note = required_rust_version.or(latest).unwrap_or_default();
 
-            let msg = if previous_id.source_id().is_git() {
+            let msg = if package_id.source_id().is_git() {
                 format!(
                     "{previous_id} -> #{}{note}",
                     &package_id.source_id().precise_git_fragment().unwrap()[..8],

--- a/src/cargo/ops/cargo_update.rs
+++ b/src/cargo/ops/cargo_update.rs
@@ -513,9 +513,9 @@ fn print_lockfile_generation(
             vec![]
         };
 
-        for package_id in diff.added.iter() {
-            let required_rust_version = report_required_rust_version(ws, resolve, *package_id);
-            let latest = report_latest(&possibilities, *package_id);
+        for package_id in diff.added {
+            let required_rust_version = report_required_rust_version(ws, resolve, package_id);
+            let latest = report_latest(&possibilities, package_id);
             let note = required_rust_version.or(latest);
 
             if let Some(note) = note {
@@ -586,9 +586,9 @@ fn print_lockfile_sync(
                     .status_with_color("Updating", msg, &style::GOOD)?;
             }
         } else {
-            for package_id in diff.added.iter() {
-                let required_rust_version = report_required_rust_version(ws, resolve, *package_id);
-                let latest = report_latest(&possibilities, *package_id);
+            for package_id in diff.added {
+                let required_rust_version = report_required_rust_version(ws, resolve, package_id);
+                let latest = report_latest(&possibilities, package_id);
                 let note = required_rust_version.or(latest).unwrap_or_default();
 
                 ws.gctx().shell().status_with_color(
@@ -659,16 +659,16 @@ fn print_lockfile_updates(
                     .status_with_color("Updating", msg, &style::GOOD)?;
             }
         } else {
-            for package_id in diff.removed.iter() {
+            for package_id in diff.removed {
                 ws.gctx().shell().status_with_color(
                     "Removing",
                     format!("{package_id}"),
                     &style::ERROR,
                 )?;
             }
-            for package_id in diff.added.iter() {
-                let required_rust_version = report_required_rust_version(ws, resolve, *package_id);
-                let latest = report_latest(&possibilities, *package_id);
+            for package_id in diff.added {
+                let required_rust_version = report_required_rust_version(ws, resolve, package_id);
+                let latest = report_latest(&possibilities, package_id);
                 let note = required_rust_version.or(latest).unwrap_or_default();
 
                 ws.gctx().shell().status_with_color(
@@ -678,9 +678,9 @@ fn print_lockfile_updates(
                 )?;
             }
         }
-        for package_id in &diff.unchanged {
-            let required_rust_version = report_required_rust_version(ws, resolve, *package_id);
-            let latest = report_latest(&possibilities, *package_id);
+        for package_id in diff.unchanged {
+            let required_rust_version = report_required_rust_version(ws, resolve, package_id);
+            let latest = report_latest(&possibilities, package_id);
             let note = required_rust_version.as_deref().or(latest.as_deref());
 
             if let Some(note) = note {

--- a/src/cargo/ops/cargo_update.rs
+++ b/src/cargo/ops/cargo_update.rs
@@ -565,7 +565,7 @@ fn print_lockfile_sync(
 
             let msg = if package_id.source_id().is_git() {
                 format!(
-                    "{previous_id} -> #{}",
+                    "{previous_id} -> #{}{note}",
                     &package_id.source_id().precise_git_fragment().unwrap()[..8],
                 )
             } else {

--- a/src/cargo/ops/cargo_update.rs
+++ b/src/cargo/ops/cargo_update.rs
@@ -525,7 +525,7 @@ fn print_lockfile_generation(
                 ws.gctx().shell().status_with_color(
                     change.kind.status(),
                     format!("{package_id}{note}"),
-                    &style::NOTE,
+                    &change.kind.style(),
                 )?;
             }
         }
@@ -577,13 +577,17 @@ fn print_lockfile_sync(
             };
 
             if change.kind == PackageChangeKind::Downgraded {
-                ws.gctx()
-                    .shell()
-                    .status_with_color(change.kind.status(), msg, &style::WARN)?;
+                ws.gctx().shell().status_with_color(
+                    change.kind.status(),
+                    msg,
+                    &change.kind.style(),
+                )?;
             } else {
-                ws.gctx()
-                    .shell()
-                    .status_with_color(change.kind.status(), msg, &style::GOOD)?;
+                ws.gctx().shell().status_with_color(
+                    change.kind.status(),
+                    msg,
+                    &change.kind.style(),
+                )?;
             }
         } else {
             if change.kind == PackageChangeKind::Added {
@@ -594,7 +598,7 @@ fn print_lockfile_sync(
                 ws.gctx().shell().status_with_color(
                     change.kind.status(),
                     format!("{package_id}{note}"),
-                    &style::NOTE,
+                    &change.kind.style(),
                 )?;
             }
         }
@@ -647,20 +651,24 @@ fn print_lockfile_updates(
             };
 
             if change.kind == PackageChangeKind::Downgraded {
-                ws.gctx()
-                    .shell()
-                    .status_with_color(change.kind.status(), msg, &style::WARN)?;
+                ws.gctx().shell().status_with_color(
+                    change.kind.status(),
+                    msg,
+                    &change.kind.style(),
+                )?;
             } else {
-                ws.gctx()
-                    .shell()
-                    .status_with_color(change.kind.status(), msg, &style::GOOD)?;
+                ws.gctx().shell().status_with_color(
+                    change.kind.status(),
+                    msg,
+                    &change.kind.style(),
+                )?;
             }
         } else {
             if change.kind == PackageChangeKind::Removed {
                 ws.gctx().shell().status_with_color(
                     change.kind.status(),
                     format!("{package_id}"),
-                    &style::ERROR,
+                    &change.kind.style(),
                 )?;
             } else if change.kind == PackageChangeKind::Added {
                 let required_rust_version = report_required_rust_version(ws, resolve, package_id);
@@ -670,7 +678,7 @@ fn print_lockfile_updates(
                 ws.gctx().shell().status_with_color(
                     change.kind.status(),
                     format!("{package_id}{note}"),
-                    &style::NOTE,
+                    &change.kind.style(),
                 )?;
             }
         }
@@ -687,7 +695,7 @@ fn print_lockfile_updates(
                     ws.gctx().shell().status_with_color(
                         change.kind.status(),
                         format!("{package_id}{note}"),
-                        &anstyle::Style::new().bold(),
+                        &change.kind.style(),
                     )?;
                 }
             }
@@ -927,6 +935,16 @@ impl PackageChangeKind {
             Self::Upgraded => "Updating",
             Self::Downgraded => "Downgrading",
             Self::Unchanged => "Unchanged",
+        }
+    }
+
+    pub fn style(&self) -> anstyle::Style {
+        match self {
+            Self::Added => style::NOTE,
+            Self::Removed => style::ERROR,
+            Self::Upgraded => style::GOOD,
+            Self::Downgraded => style::WARN,
+            Self::Unchanged => anstyle::Style::new().bold(),
         }
     }
 }

--- a/src/cargo/ops/cargo_update.rs
+++ b/src/cargo/ops/cargo_update.rs
@@ -559,18 +559,9 @@ fn print_lockfile_sync(
         };
 
         if let Some((removed, added)) = diff.change() {
-            let latest = if !possibilities.is_empty() {
-                possibilities
-                    .iter()
-                    .map(|s| s.as_summary())
-                    .filter(|s| is_latest(s.version(), added.version()))
-                    .map(|s| s.version().clone())
-                    .max()
-                    .map(format_latest)
-            } else {
-                None
-            }
-            .unwrap_or_default();
+            let required_rust_version = report_required_rust_version(ws, resolve, added);
+            let latest = report_latest(&possibilities, added);
+            let note = required_rust_version.or(latest).unwrap_or_default();
 
             let msg = if removed.source_id().is_git() {
                 format!(
@@ -578,7 +569,7 @@ fn print_lockfile_sync(
                     &added.source_id().precise_git_fragment().unwrap()[..8],
                 )
             } else {
-                format!("{removed} -> v{}{latest}", added.version())
+                format!("{removed} -> v{}{note}", added.version())
             };
 
             // If versions differ only in build metadata, we call it an "update"

--- a/src/cargo/ops/cargo_update.rs
+++ b/src/cargo/ops/cargo_update.rs
@@ -641,8 +641,8 @@ fn print_lockfile_updates(
         };
 
         if let Some((removed, added)) = diff.change() {
-            let required_rust_version = report_required_rust_version(ws, resolve, *added);
-            let latest = report_latest(&possibilities, *added);
+            let required_rust_version = report_required_rust_version(ws, resolve, added);
+            let latest = report_latest(&possibilities, added);
             let note = required_rust_version.or(latest).unwrap_or_default();
 
             let msg = if removed.source_id().is_git() {
@@ -933,9 +933,9 @@ impl PackageDiff {
     /// All `PackageDiff` knows is that entries were added/removed within [`Resolve`].
     /// A package could be added or removed because of dependencies from other packages
     /// which makes it hard to definitively say "X was upgrade to N".
-    pub fn change(&self) -> Option<(&PackageId, &PackageId)> {
+    pub fn change(&self) -> Option<(PackageId, PackageId)> {
         if self.removed.len() == 1 && self.added.len() == 1 {
-            Some((&self.removed[0], &self.added[0]))
+            Some((self.removed[0], self.added[0]))
         } else {
             None
         }

--- a/tests/testsuite/global_cache_tracker.rs
+++ b/tests/testsuite/global_cache_tracker.rs
@@ -439,7 +439,7 @@ fn frequency() {
         .env("CARGO_GC_AUTO_FREQUENCY", "1 day")
         .masquerade_as_nightly_cargo(&["gc"])
         .run();
-    assert_eq!(get_index_names().len(), 1);
+    assert_eq!(get_index_names().len(), 0);
     assert_eq!(get_registry_names("src").len(), 0);
     assert_eq!(get_registry_names("cache").len(), 0);
 }
@@ -613,7 +613,7 @@ fn auto_gc_various_commands() {
             .acquire_package_cache_lock(CacheLockMode::MutateExclusive)
             .unwrap();
         let indexes = tracker.registry_index_all().unwrap();
-        assert_eq!(indexes.len(), 1);
+        assert_eq!(indexes.len(), 0);
         let crates = tracker.registry_crate_all().unwrap();
         assert_eq!(crates.len(), 0);
         let srcs = tracker.registry_src_all().unwrap();


### PR DESCRIPTION
### What does this PR try to resolve?

This is to make it easier to
- Make #14401 path aware
- Work on #13908, depending on what is decided
- Improve the heuristics for when we show `Locking` messages

There are fixes along the way that were found by making the code more consistent in prep for consolidating it, mostly for #14401.

### How should we test and review this PR?

Along the way, some odd code structures are used for the sake of making the diff easier to follow.  These get cleaned up towards the end

I didn't add tests for the fixes because of the code consolidation that happens that causes us to cover more real-world scenarios with fewer tests.

### Additional information

