### PR TITLE
Tests rely on absence of RUST_BACKTRACE

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1456,6 +1456,7 @@ pub trait TestEnvCommandExt: Sized {
             .env_remove("MFLAGS")
             .env_remove("MSYSTEM") // assume cmd.exe everywhere on windows
             .env_remove("RUSTC")
+            .env_remove("RUST_BACKTRACE")
             .env_remove("RUSTC_WORKSPACE_WRAPPER")
             .env_remove("RUSTC_WRAPPER")
             .env_remove("RUSTDOC")


### PR DESCRIPTION
I have it set in my default environment, and it causes tests to fail