### PR TITLE
fix(resolve): Dont show locking workspace members 

### DIFF
--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -35,7 +35,7 @@ fn depend_on_alt_registry() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
 [CHECKING] bar v0.0.1 (registry `alternative`)
@@ -88,7 +88,7 @@ fn depend_on_alt_registry_depends_on_same_registry_no_index() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.0.1 (registry `alternative`)
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
@@ -131,7 +131,7 @@ fn depend_on_alt_registry_depends_on_same_registry() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.0.1 (registry `alternative`)
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
@@ -176,7 +176,7 @@ fn depend_on_alt_registry_depends_on_crates_io() {
             str![[r#"
 [UPDATING] `alternative` index
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.0.1 (registry `dummy-registry`)
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
@@ -217,7 +217,7 @@ fn registry_and_path_dep_works() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.0.1 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -435,7 +435,7 @@ fn alt_registry_and_crates_io_deps() {
             str![[r#"
 [UPDATING] `alternative` index
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] crates_io_dep v0.0.1 (registry `dummy-registry`)
 [DOWNLOADED] alt_reg_dep v0.1.0 (registry `alternative`)
@@ -710,7 +710,7 @@ fn patch_alt_reg() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -804,7 +804,7 @@ fn no_api() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
 [CHECKING] bar v0.0.1 (registry `alternative`)
@@ -1657,7 +1657,7 @@ fn registries_index_relative_url() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `relative` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `relative`)
 [CHECKING] bar v0.0.1 (registry `relative`)

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -218,7 +218,7 @@ fn disallow_artifact_and_no_artifact_dep_to_same_package_within_the_same_dep_cat
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [WARNING] foo v0.0.0 ([ROOT]/foo) ignoring invalid dependency `bar_stable` which is missing a lib target
 [ERROR] the crate `foo v0.0.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
 
@@ -328,7 +328,7 @@ fn features_are_unified_among_lib_and_bin_dep_of_same_target() {
     p.cargo("build -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] d2 v0.0.1 ([ROOT]/foo/d2)
 [COMPILING] d1 v0.0.1 ([ROOT]/foo/d1)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -439,7 +439,7 @@ fn features_are_not_unified_among_lib_and_bin_dep_of_different_target() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] d2 v0.0.1 ([ROOT]/foo/d2)
 [COMPILING] d1 v0.0.1 ([ROOT]/foo/d1)
 error[E0425]: cannot find function `f2` in crate `d2`
@@ -601,7 +601,7 @@ fn build_script_with_bin_artifacts() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -795,7 +795,7 @@ fn build_script_with_selected_dashed_bin_artifact_and_lib_true() {
     p.cargo("build -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar-baz v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -891,7 +891,7 @@ fn lib_with_selected_dashed_bin_artifact_and_lib_true() {
     p.cargo("build -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar-baz v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -942,7 +942,7 @@ fn allow_artifact_and_no_artifact_dep_to_same_package_within_different_dep_categ
     p.cargo("test -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1017,7 +1017,7 @@ fn disallow_using_example_binaries_as_artifacts() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [ERROR] dependency `bar` in package `foo` requires a `bin:one-example` artifact to be present.
 
 "#]])
@@ -1070,7 +1070,7 @@ fn allow_artifact_and_non_artifact_dependency_to_same_crate() {
     p.cargo("check -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1194,7 +1194,7 @@ fn build_script_deps_adopt_do_not_allow_multiple_targets_under_different_name_an
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [ERROR] the crate `foo v0.0.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
 
 "#]])
@@ -1300,7 +1300,7 @@ fn no_cross_doctests_works_with_artifacts() {
         .arg(&target)
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1447,7 +1447,7 @@ fn profile_override_basic() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..] -C opt-level=1 [..]`
@@ -1559,7 +1559,7 @@ fn artifact_dep_target_specified() {
     p.cargo("check -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bindep v0.0.0 ([ROOT]/foo/bindep)
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1796,7 +1796,7 @@ fn allow_dep_renames_with_multiple_versions() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [COMPILING] bar v1.0.0
@@ -1858,7 +1858,7 @@ fn allow_artifact_and_non_artifact_dependency_to_same_crate_if_these_are_not_the
     p.cargo("build -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1894,7 +1894,7 @@ fn prevent_no_lib_warning_with_artifact_dependencies() {
     p.cargo("check -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1931,7 +1931,7 @@ fn show_no_lib_warning_with_artifact_dependencies_that_have_no_lib_but_lib_true(
     p.cargo("check -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [WARNING] foo v0.0.0 ([ROOT]/foo) ignoring invalid dependency `bar` which is missing a lib target
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
@@ -1999,7 +1999,7 @@ fn check_missing_crate_type_in_package_fails() {
             .masquerade_as_nightly_cargo(&["bindeps"])
             .with_status(101)
             .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [ERROR] dependency `bar` in package `foo` requires a [..] artifact to be present.
 
 "#]])
@@ -2150,7 +2150,7 @@ fn env_vars_and_build_products_for_various_build_targets() {
     p.cargo("test -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2335,7 +2335,7 @@ fn doc_lib_true() {
     p.cargo("doc -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [DOCUMENTING] bar v0.0.1 ([ROOT]/foo/bar)
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
@@ -2417,7 +2417,7 @@ fn rustdoc_works_on_libs_with_artifacts_and_lib_false() {
     p.cargo("doc -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2624,7 +2624,7 @@ fn calc_bin_artifact_fingerprint() {
     p.cargo("check -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2703,7 +2703,7 @@ fn with_target_and_optional() {
     p.cargo("check -Z bindeps -F d1 -v")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] d1 v0.0.1 ([ROOT]/foo/d1)
 [RUNNING] `rustc --crate-name d1 [..]--crate-type bin[..]
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -2753,7 +2753,7 @@ fn with_assumed_host_target_and_optional_build_dep() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [COMPILING] d1 v0.0.1 ([ROOT]/foo/d1)
 [RUNNING] `rustc --crate-name build_script_build --edition=2021 [..]--crate-type bin[..]
@@ -2882,7 +2882,7 @@ fn decouple_same_target_transitive_dep_from_artifact_dep() {
     p.cargo("build -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 5 packages to latest compatible versions
+[LOCKING] 4 packages to latest compatible versions
 [COMPILING] c v0.1.0 ([ROOT]/foo/c)
 [COMPILING] b v0.1.0 ([ROOT]/foo/b)
 [COMPILING] a v0.1.0 ([ROOT]/foo/a)
@@ -2985,7 +2985,7 @@ fn decouple_same_target_transitive_dep_from_artifact_dep_lib() {
     p.cargo("build -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] b v0.1.0 ([ROOT]/foo/b)
 [COMPILING] a v0.1.0 ([ROOT]/foo/a)
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
@@ -3112,7 +3112,7 @@ fn decouple_same_target_transitive_dep_from_artifact_dep_and_proc_macro() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(
             str![[r#"
-[LOCKING] 6 packages to latest compatible versions
+[LOCKING] 5 packages to latest compatible versions
 [COMPILING] d v0.1.0 ([ROOT]/foo/d)
 [COMPILING] a v0.1.0 ([ROOT]/foo/a)
 [COMPILING] b v0.1.0 ([ROOT]/foo/b)
@@ -3179,7 +3179,7 @@ fn same_target_artifact_dep_sharing() {
     p.cargo(&format!("build -Z bindeps --target {target}"))
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] a v0.1.0 ([ROOT]/foo/a)
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
@@ -3235,7 +3235,7 @@ fn check_transitive_artifact_dependency_with_different_target() {
     p.cargo("check -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [ERROR] failed to determine target information for target `custom-target`.
   Artifact dependency `baz` in package `bar v0.0.0 ([ROOT]/foo/bar)` requires building for `custom-target`
 

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -824,7 +824,7 @@ fn dev_dependencies2() {
     p.cargo("check").with_stderr_data(str![[r#"
 [WARNING] `dev_dependencies` is deprecated in favor of `dev-dependencies` and will not work in the 2024 edition
 (in the `foo` package)
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -905,7 +905,7 @@ fn dev_dependencies2_conflict() {
         .build();
     p.cargo("check").with_stderr_data(str![[r#"
 [WARNING] `dev_dependencies` is redundant with `dev-dependencies`, preferring `dev-dependencies` in the `foo` package
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -942,7 +942,7 @@ fn build_dependencies2() {
     p.cargo("check").with_stderr_data(str![[r#"
 [WARNING] `build_dependencies` is deprecated in favor of `build-dependencies` and will not work in the 2024 edition
 (in the `foo` package)
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1023,7 +1023,7 @@ fn build_dependencies2_conflict() {
         .build();
     p.cargo("check").with_stderr_data(str![[r#"
 [WARNING] `build_dependencies` is redundant with `build-dependencies`, preferring `build-dependencies` in the `foo` package
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1401,7 +1401,7 @@ fn cargo_platform_build_dependencies2() {
         .with_stderr_data(str![[r#"
 [WARNING] `build_dependencies` is deprecated in favor of `build-dependencies` and will not work in the 2024 edition
 (in the `[HOST_TARGET]` platform target)
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] build v0.5.0 ([ROOT]/foo/build)
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1492,7 +1492,7 @@ fn cargo_platform_build_dependencies2_conflict() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [WARNING] `build_dependencies` is redundant with `build-dependencies`, preferring `build-dependencies` in the `[HOST_TARGET]` platform target
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] build v0.5.0 ([ROOT]/foo/build)
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1535,7 +1535,7 @@ fn cargo_platform_dev_dependencies2() {
         .with_stderr_data(str![[r#"
 [WARNING] `dev_dependencies` is deprecated in favor of `dev-dependencies` and will not work in the 2024 edition
 (in the `[HOST_TARGET]` platform target)
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1622,7 +1622,7 @@ fn cargo_platform_dev_dependencies2_conflict() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [WARNING] `dev_dependencies` is redundant with `dev-dependencies`, preferring `dev-dependencies` in the `[HOST_TARGET]` platform target
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1667,7 +1667,7 @@ fn default_features2() {
     p.cargo("check").with_stderr_data(str![[r#"
 [WARNING] `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition
 (in the `a` dependency)
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] a v0.1.0 ([ROOT]/foo/a)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1761,7 +1761,7 @@ fn default_features2_conflict() {
 
     p.cargo("check").with_stderr_data(str![[r#"
 [WARNING] `default_features` is redundant with `default-features`, preferring `default-features` in the `a` dependency
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] a v0.1.0 ([ROOT]/foo/a)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1840,7 +1840,6 @@ fn workspace_default_features2() {
             str![[r#"
 [WARNING] [ROOT]/foo/workspace_only/Cargo.toml: `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition
 (in the `dep_workspace_only` dependency)
-[LOCKING] 4 packages to latest compatible versions
 [CHECKING] dep_package_only v0.1.0 ([ROOT]/foo/dep_package_only)
 [CHECKING] dep_workspace_only v0.1.0 ([ROOT]/foo/dep_workspace_only)
 [CHECKING] package_only v0.1.0 ([ROOT]/foo/package_only)
@@ -2782,7 +2781,7 @@ fn warn_semver_metadata() {
     p.cargo("check").with_stderr_data(str![[r#"
 [WARNING] version requirement `1.0.0+1234` for dependency `bar` includes semver metadata which will be ignored, removing the metadata is recommended to avoid confusion
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [CHECKING] bar v1.0.0

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -543,7 +543,7 @@ fn bench_with_deep_lib_dep() {
 
     p.cargo("bench")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [COMPILING] bar v0.0.1 ([ROOT]/bar)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
@@ -1094,7 +1094,7 @@ fn bench_dylib() {
 
     p.cargo("bench -v")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] [..] -C opt-level=3 [..]
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -1605,7 +1605,7 @@ fn test_bench_multiple_packages() {
 "#]])
         .with_stderr_data(
             str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.1.0 ([ROOT]/bar)
 [COMPILING] baz v0.1.0 ([ROOT]/baz)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
@@ -1668,7 +1668,6 @@ fn bench_all_workspace() {
 
     p.cargo("bench --workspace")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
@@ -1860,7 +1859,6 @@ fn bench_all_virtual_manifest() {
     p.cargo("bench --workspace")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [COMPILING] baz v0.1.0 ([ROOT]/foo/baz)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
@@ -1943,7 +1941,6 @@ fn bench_virtual_manifest_glob() {
     // This should not have `bar` built or benched
     p.cargo("bench -p '*z'")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [COMPILING] baz v0.1.0 ([ROOT]/foo/baz)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
 [RUNNING] unittests src/lib.rs (target/release/deps/baz-[HASH][EXE])
@@ -2052,7 +2049,6 @@ fn bench_virtual_manifest_all_implied() {
     p.cargo("bench")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [COMPILING] baz v0.1.0 ([ROOT]/foo/baz)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -870,7 +870,6 @@ fn cargo_compile_with_invalid_code_in_deps() {
         .with_status(101)
         .with_stderr_data(
             str![[r#"
-[LOCKING] 3 packages to latest compatible versions
 [COMPILING] bar v0.1.0 ([ROOT]/bar)
 [COMPILING] baz v0.1.0 ([ROOT]/baz)
 [ERROR] could not compile `bar` (lib) due to 1 previous error
@@ -939,7 +938,7 @@ fn cargo_compile_with_warnings_in_a_dep_package() {
 
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [WARNING] [..]dead[..]
 ...
@@ -3423,7 +3422,7 @@ fn bad_platform_specific_dependency() {
     p.cargo("build")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 error[E0463]: can't find crate for `bar`
 ...
@@ -3653,7 +3652,7 @@ fn transitive_dependencies_not_available() {
     p.cargo("build -v")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bbbbb v0.0.1 ([ROOT]/foo/b)
 [RUNNING] `rustc [..]
 [COMPILING] aaaaa v0.0.1 ([ROOT]/foo/a)
@@ -4064,7 +4063,7 @@ fn invalid_spec() {
     p.cargo("build -p notAValidDep")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [ERROR] package ID specification `notAValidDep` did not match any packages
 
 "#]])
@@ -4511,7 +4510,6 @@ fn build_all_workspace() {
 
     p.cargo("build --workspace")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -4545,7 +4543,6 @@ fn build_all_exclude() {
     p.cargo("build --workspace --exclude baz")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 3 packages to latest compatible versions
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -4617,7 +4614,6 @@ fn build_all_exclude_not_found() {
         .with_stderr_data(
             str![[r#"
 [WARNING] excluded package(s) `baz` not found in workspace `[ROOT]/foo`
-[LOCKING] 2 packages to latest compatible versions
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -4653,7 +4649,6 @@ fn build_all_exclude_glob() {
     p.cargo("build --workspace --exclude '*z'")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 3 packages to latest compatible versions
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -4688,7 +4683,6 @@ fn build_all_exclude_glob_not_found() {
         .with_stderr_data(
             str![[r#"
 [WARNING] excluded package pattern(s) `*z` not found in workspace `[ROOT]/foo`
-[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -4747,7 +4741,6 @@ fn build_all_workspace_implicit_examples() {
 
     p.cargo("build --workspace --examples")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -4784,7 +4777,6 @@ fn build_all_virtual_manifest() {
     p.cargo("build --workspace")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [COMPILING] baz v0.1.0 ([ROOT]/foo/baz)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -4815,7 +4807,6 @@ fn build_virtual_manifest_all_implied() {
     p.cargo("build")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [COMPILING] baz v0.1.0 ([ROOT]/foo/baz)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -4844,7 +4835,6 @@ fn build_virtual_manifest_one_project() {
 
     p.cargo("build -p bar")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -4870,7 +4860,6 @@ fn build_virtual_manifest_glob() {
 
     p.cargo("build -p '*z'")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [COMPILING] baz v0.1.0 ([ROOT]/foo/baz)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -4955,7 +4944,6 @@ fn build_all_virtual_manifest_implicit_examples() {
     p.cargo("build --workspace --examples")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [COMPILING] baz v0.1.0 ([ROOT]/foo/baz)
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -5004,7 +4992,7 @@ fn build_all_member_dependency_same_name() {
     p.cargo("build --workspace")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] a v0.1.0 (registry `dummy-registry`)
 [COMPILING] a v0.1.0
@@ -5240,7 +5228,7 @@ fn rustc_wrapper_relative() {
         .env("RUSTC_WRAPPER", &relative_path)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [COMPILING] bar v1.0.0
@@ -5773,7 +5761,7 @@ fn building_a_dependent_crate_without_bin_should_fail() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] testless v0.1.0 (registry `dummy-registry`)
 [ERROR] failed to download replaced source registry `crates-io`
@@ -6017,7 +6005,7 @@ fn no_linkable_target() {
         .build();
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [WARNING] The package `the_lib` provides no linkable target. The compiler might raise an error while compiling `foo`. Consider adding 'dylib' or 'rlib' to key `crate-type` in `the_lib`'s Cargo.toml. This warning might turn into a hard error in the future.
 [COMPILING] the_lib v0.1.0 ([ROOT]/foo/the_lib)
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
@@ -6173,7 +6161,6 @@ fn target_filters_workspace() {
     ws.cargo("build -v --example ex")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [ERROR] no example target named `ex`
 
 	Did you mean `ex1`?
@@ -6235,7 +6222,6 @@ fn target_filters_workspace_not_found() {
     ws.cargo("build -v --lib")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [ERROR] no library targets found in packages: a, b
 
 "#]])
@@ -6295,7 +6281,7 @@ fn signal_display() {
 
     foo.cargo("build")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] pm v0.1.0 ([ROOT]/foo/pm)
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [ERROR] could not compile `foo` (lib)
@@ -6353,7 +6339,7 @@ fn pipelining_works() {
     foo.cargo("build")
         .with_stdout_data(str![])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -6418,7 +6404,6 @@ fn pipelining_big_graph() {
         .with_status(101)
         .with_stderr_data(
             str![[r#"
-[LOCKING] 61 packages to latest compatible versions
 [COMPILING] a30 v0.5.0 ([ROOT]/foo/a30)
 [ERROR] don't actually build me
 ...
@@ -6485,7 +6470,7 @@ b
 
 "#]])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 c

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -882,7 +882,7 @@ fn custom_build_script_rustc_flags() {
         .build();
 
     p.cargo("build --verbose").with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] foo v0.5.0 ([ROOT]/foo/foo)
 [RUNNING] `rustc --crate-name build_script_build --edition=2015 foo/build.rs [..]`
 [RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
@@ -936,7 +936,7 @@ fn custom_build_script_rustc_flags_no_space() {
         .build();
 
     p.cargo("build --verbose").with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] foo v0.5.0 ([ROOT]/foo/foo)
 [RUNNING] `rustc --crate-name build_script_build --edition=2015 foo/build.rs [..]`
 [RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
@@ -1071,7 +1071,7 @@ fn links_duplicates_old_registry() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [ERROR] multiple packages link to native library `a`, but a native library can be linked only once
@@ -1221,7 +1221,7 @@ fn overrides_and_links() {
     p.cargo("build -v")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] a v0.5.0 ([ROOT]/foo/a)
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]`
@@ -1698,7 +1698,7 @@ fn build_deps_simple() {
         .build();
 
     p.cargo("build -v").with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] a v0.5.0 ([ROOT]/foo/a)
 [RUNNING] `rustc --crate-name a [..]`
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
@@ -1811,7 +1811,7 @@ fn build_cmd_with_a_build_cmd() {
         .build();
 
     p.cargo("build -v").with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] b v0.5.0 ([ROOT]/foo/b)
 [RUNNING] `rustc --crate-name b [..]`
 [COMPILING] a v0.5.0 ([ROOT]/foo/a)
@@ -2980,7 +2980,7 @@ fn flags_go_into_tests() {
 
     p.cargo("test -v --test=foo")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] a v0.5.0 ([ROOT]/foo/a)
 [RUNNING] `rustc [..] a/build.rs [..]`
 [RUNNING] `[ROOT]/foo/target/debug/build/a-[HASH]/build-script-build`
@@ -3094,7 +3094,7 @@ fn diamond_passes_args_only_once() {
 
     p.cargo("build -v")
         .with_stderr_data(str![[r#"
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] c v0.5.0 ([ROOT]/foo/c)
 [RUNNING] `rustc --crate-name build_script_build [..]`
 [RUNNING] `[ROOT]/foo/target/debug/build/c-[HASH]/build-script-build`
@@ -3970,7 +3970,7 @@ fn warnings_hidden_for_upstream() {
     p.cargo("build -v")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [COMPILING] bar v0.1.0
@@ -4031,7 +4031,7 @@ fn warnings_printed_on_vv() {
     p.cargo("build -vv")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [COMPILING] bar v0.1.0
@@ -4811,7 +4811,7 @@ fn optional_build_dep_and_required_normal_dep() {
 
 "#]])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/build_script_extra_link_arg.rs
+++ b/tests/testsuite/build_script_extra_link_arg.rs
@@ -275,7 +275,7 @@ fn link_arg_transitive_not_allowed() {
     p.cargo("build -v")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [COMPILING] bar v1.0.0

--- a/tests/testsuite/cache_messages.rs
+++ b/tests/testsuite/cache_messages.rs
@@ -277,7 +277,7 @@ fn very_verbose() {
     p.cargo("check -vv")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [CHECKING] bar v1.0.0

--- a/tests/testsuite/cargo_add/add_basic/stderr.term.svg
+++ b/tests/testsuite/cargo_add/add_basic/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/add_multiple/stderr.term.svg
+++ b/tests/testsuite/cargo_add/add_multiple/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/add_no_vendored_package_with_alter_registry/stderr.term.svg
+++ b/tests/testsuite/cargo_add/add_no_vendored_package_with_alter_registry/stderr.term.svg
@@ -42,7 +42,7 @@
 </tspan>
     <tspan x="10px" y="208px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> serde_test</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="226px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="244px">
 </tspan>

--- a/tests/testsuite/cargo_add/add_normalized_name_external/stderr.term.svg
+++ b/tests/testsuite/cargo_add/add_normalized_name_external/stderr.term.svg
@@ -56,7 +56,7 @@
 </tspan>
     <tspan x="10px" y="334px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> unstable</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="352px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="370px">
 </tspan>

--- a/tests/testsuite/cargo_add/build/stderr.term.svg
+++ b/tests/testsuite/cargo_add/build/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-build-package2 v99999.0.0 to build-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/build_prefer_existing_version/stderr.term.svg
+++ b/tests/testsuite/cargo_add/build_prefer_existing_version/stderr.term.svg
@@ -27,7 +27,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> two</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/change_rename_target/stderr.term.svg
+++ b/tests/testsuite/cargo_add/change_rename_target/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `some-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/cyclic_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/cyclic_features/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> feature-two</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_add/default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/default_features/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v0.4.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/detect_workspace_inherit/stderr.term.svg
+++ b/tests/testsuite/cargo_add/detect_workspace_inherit/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="74px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -20,9 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> foo (workspace) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
-</tspan>
-    <tspan x="10px" y="64px">
+    <tspan x="10px" y="46px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_add/detect_workspace_inherit_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/detect_workspace_inherit_features/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="236px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="218px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -39,9 +39,7 @@
 </tspan>
     <tspan x="10px" y="190px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> unrelated</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
-</tspan>
-    <tspan x="10px" y="226px">
+    <tspan x="10px" y="208px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_add/detect_workspace_inherit_optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/detect_workspace_inherit_optional/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="92px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="74px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -22,9 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `foo`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
-</tspan>
-    <tspan x="10px" y="82px">
+    <tspan x="10px" y="64px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_add/detect_workspace_inherit_public/stderr.term.svg
+++ b/tests/testsuite/cargo_add/detect_workspace_inherit_public/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="74px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -20,9 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> foo (workspace) to public dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
-</tspan>
-    <tspan x="10px" y="64px">
+    <tspan x="10px" y="46px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_add/dev/stderr.term.svg
+++ b/tests/testsuite/cargo_add/dev/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-dev-package2 v99999.0.0 to dev-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/dev_prefer_existing_version/stderr.term.svg
+++ b/tests/testsuite/cargo_add/dev_prefer_existing_version/stderr.term.svg
@@ -27,7 +27,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> two</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_activated_over_limit/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_activated_over_limit/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan>             100 deactivated features</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_deactivated_over_limit/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_deactivated_over_limit/stderr.term.svg
@@ -86,7 +86,7 @@
 </tspan>
     <tspan x="10px" y="622px"><tspan>             170 deactivated features</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="640px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="658px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_empty/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_empty/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_multiple_occurrences/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_multiple_occurrences/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_preserve/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_preserve/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_spaced_values/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_spaced_values/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/git/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_branch/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_branch/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_dev/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_dev/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_inferred_name/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_inferred_name/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_multiple_names/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_multiple_names/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_multiple_packages_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_multiple_packages_features/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_rev/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_rev/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_tag/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_tag/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/infer_prerelease/stderr.term.svg
+++ b/tests/testsuite/cargo_add/infer_prerelease/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> prerelease_only v0.2.0-alpha.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/list_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/list_features/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/list_features_path/stderr.term.svg
+++ b/tests/testsuite/cargo_add/list_features_path/stderr.term.svg
@@ -35,7 +35,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 4 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/list_features_path_no_default/stderr.term.svg
+++ b/tests/testsuite/cargo_add/list_features_path_no_default/stderr.term.svg
@@ -35,7 +35,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 4 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/manifest_path_package/stderr.term.svg
+++ b/tests/testsuite/cargo_add/manifest_path_package/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="74px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -20,9 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
-</tspan>
-    <tspan x="10px" y="64px">
+    <tspan x="10px" y="46px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_add/merge_activated_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/merge_activated_features/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="236px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="218px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -39,9 +39,7 @@
 </tspan>
     <tspan x="10px" y="190px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> unrelated</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
-</tspan>
-    <tspan x="10px" y="226px">
+    <tspan x="10px" y="208px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_add/namever/stderr.term.svg
+++ b/tests/testsuite/cargo_add/namever/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 4 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.2.3+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/no_default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/no_default_features/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v0.4.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/no_optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/no_optional/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/no_public/stderr.term.svg
+++ b/tests/testsuite/cargo_add/no_public/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/optional/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `my-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_default_features/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v0.4.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_default_features_with_no_default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_default_features_with_no_default_features/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v0.4.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_features/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_git_with_path/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_git_with_path/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `cargo-list-test-fixture-dependency`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_inherit_features_noop/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_inherit_features_noop/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="92px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -24,9 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> test</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
-</tspan>
-    <tspan x="10px" y="100px">
+    <tspan x="10px" y="82px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_add/overwrite_inherit_noop/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_inherit_noop/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="74px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -20,9 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> foo (workspace) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
-</tspan>
-    <tspan x="10px" y="64px">
+    <tspan x="10px" y="46px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_add/overwrite_inherit_optional_noop/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_inherit_optional_noop/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="92px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="74px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -22,9 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `foo`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
-</tspan>
-    <tspan x="10px" y="82px">
+    <tspan x="10px" y="64px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_add/overwrite_inline_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_inline_features/stderr.term.svg
@@ -34,7 +34,7 @@
 </tspan>
     <tspan x="10px" y="154px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_name_dev_noop/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_name_dev_noop/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_name_noop/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_name_noop/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `your-face`</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_no_default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_no_default_features/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v0.4.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_no_default_features_with_default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_no_default_features_with_default_features/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v0.4.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_no_optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_no_optional/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_no_optional_with_optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_no_optional_with_optional/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `my-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_no_public/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_no_public/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_no_public_with_public/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_no_public_with_public/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.1.0 to public dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_optional/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `my-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_optional_with_no_optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_optional_with_no_optional/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_optional_with_optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_optional_with_optional/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package1 v99999.0.0 to optional dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_path_noop/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_path_noop/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `your-face`</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_path_with_version/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_path_with_version/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `cargo-list-test-fixture-dependency`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency v20.0.0+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_preserves_inline_table/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_preserves_inline_table/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_public/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_public/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.1.0 to public dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_public_with_no_public/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_public_with_no_public/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_rename_with_no_rename/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_rename_with_no_rename/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> versioned-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_rename_with_rename/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_rename_with_rename/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> versioned-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_rename_with_rename_noop/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_rename_with_rename_noop/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `a1`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_version_with_git/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_version_with_git/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/versioned-package`</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_version_with_path/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_version_with_path/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `cargo-list-test-fixture-dependency`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_with_rename/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_with_rename/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> versioned-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_workspace_dep/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_workspace_dep/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="74px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -20,9 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> foo (local) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
-</tspan>
-    <tspan x="10px" y="64px">
+    <tspan x="10px" y="46px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_add/overwrite_workspace_dep_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_workspace_dep_features/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="236px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="218px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -39,9 +39,7 @@
 </tspan>
     <tspan x="10px" y="190px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> unrelated</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
-</tspan>
-    <tspan x="10px" y="226px">
+    <tspan x="10px" y="208px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_add/path/stderr.term.svg
+++ b/tests/testsuite/cargo_add/path/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/path_dev/stderr.term.svg
+++ b/tests/testsuite/cargo_add/path_dev/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dev-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/path_inferred_name/stderr.term.svg
+++ b/tests/testsuite/cargo_add/path_inferred_name/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/preserve_dep_std_table/stderr.term.svg
+++ b/tests/testsuite/cargo_add/preserve_dep_std_table/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/preserve_features_sorted/stderr.term.svg
+++ b/tests/testsuite/cargo_add/preserve_features_sorted/stderr.term.svg
@@ -34,7 +34,7 @@
 </tspan>
     <tspan x="10px" y="154px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> e</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>

--- a/tests/testsuite/cargo_add/preserve_features_table/stderr.term.svg
+++ b/tests/testsuite/cargo_add/preserve_features_table/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/preserve_features_unsorted/stderr.term.svg
+++ b/tests/testsuite/cargo_add/preserve_features_unsorted/stderr.term.svg
@@ -34,7 +34,7 @@
 </tspan>
     <tspan x="10px" y="154px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> e</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>

--- a/tests/testsuite/cargo_add/preserve_sorted/stderr.term.svg
+++ b/tests/testsuite/cargo_add/preserve_sorted/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> toml v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 4 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/preserve_unsorted/stderr.term.svg
+++ b/tests/testsuite/cargo_add/preserve_unsorted/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> toml v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 4 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/public/stderr.term.svg
+++ b/tests/testsuite/cargo_add/public/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.1.0 to public dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/registry/stderr.term.svg
+++ b/tests/testsuite/cargo_add/registry/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/rename/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rename/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/require_weak/stderr.term.svg
+++ b/tests/testsuite/cargo_add/require_weak/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/rust_version_ignore/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rust_version_ignore/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> rust-version-user v0.2.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/rust_version_latest/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rust_version_latest/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> rust-version-user v0.2.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest Rust 1.72 compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest Rust 1.72 compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/rust_version_older/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rust_version_older/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> rust-version-user v0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest Rust 1.70 compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest Rust 1.70 compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> rust-version-user v0.1.0 </tspan><tspan class="fg-yellow bold">(latest: v0.2.1)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/rustc_ignore/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rustc_ignore/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> rust-version-user v0.2.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/rustc_latest/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rustc_latest/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="953px" height="128px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1020px" height="128px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> rust-version-user v0.1.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest Rust [..] compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> rust-version-user v0.1.1 </tspan><tspan class="fg-yellow bold">(latest: v0.2.1)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/rustc_older/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rustc_older/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="953px" height="128px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1020px" height="128px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> rust-version-user v0.1.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest Rust [..] compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> rust-version-user v0.1.1 </tspan><tspan class="fg-yellow bold">(latest: v0.2.1)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/sorted_table_with_dotted_item/stderr.term.svg
+++ b/tests/testsuite/cargo_add/sorted_table_with_dotted_item/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> unrelateed-crate v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 5 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 4 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-build-package1 v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/target/stderr.term.svg
+++ b/tests/testsuite/cargo_add/target/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v99999.0.0 to dependencies for target `wasm32-unknown-unknown`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/target_cfg/stderr.term.svg
+++ b/tests/testsuite/cargo_add/target_cfg/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v99999.0.0 to dependencies for target `cfg(target_os="linux")`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/vers/stderr.term.svg
+++ b/tests/testsuite/cargo_add/vers/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package &gt;=0.1.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/workspace_name/stderr.term.svg
+++ b/tests/testsuite/cargo_add/workspace_name/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="74px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -20,9 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
-</tspan>
-    <tspan x="10px" y="64px">
+    <tspan x="10px" y="46px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_add/workspace_path/stderr.term.svg
+++ b/tests/testsuite/cargo_add/workspace_path/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="74px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -20,9 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
-</tspan>
-    <tspan x="10px" y="64px">
+    <tspan x="10px" y="46px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_add/workspace_path_dev/stderr.term.svg
+++ b/tests/testsuite/cargo_add/workspace_path_dev/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="74px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -20,9 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dev-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
-</tspan>
-    <tspan x="10px" y="64px">
+    <tspan x="10px" y="46px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -100,7 +100,7 @@ fn feature_required_dependency() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [ERROR] failed to download replaced source registry `crates-io`
@@ -484,7 +484,7 @@ fn nightly_feature_requires_nightly_in_dep() {
     p.cargo("check")
         .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] a v0.0.1 ([ROOT]/foo/a)
 [CHECKING] b v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/cargo_info/pick_msrv_compatible_package_within_ws/stderr.term.svg
+++ b/tests/testsuite/cargo_info/pick_msrv_compatible_package_within_ws/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="92px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -18,15 +18,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green bold"> Downloading</tspan><tspan> crates ...</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold"> Downloading</tspan><tspan> crates ...</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v0.2.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v0.2.0 (registry `dummy-registry`)</tspan>
-</tspan>
-    <tspan x="10px" y="100px">
+    <tspan x="10px" y="82px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_info/pick_msrv_compatible_package_within_ws_and_use_msrv_from_ws/stderr.term.svg
+++ b/tests/testsuite/cargo_info/pick_msrv_compatible_package_within_ws_and_use_msrv_from_ws/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="92px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -18,15 +18,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green bold"> Downloading</tspan><tspan> crates ...</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold"> Downloading</tspan><tspan> crates ...</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v0.2.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v0.2.0 (registry `dummy-registry`)</tspan>
-</tspan>
-    <tspan x="10px" y="100px">
+    <tspan x="10px" y="82px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_info/within_ws_without_lockfile/stderr.term.svg
+++ b/tests/testsuite/cargo_info/within_ws_without_lockfile/stderr.term.svg
@@ -22,7 +22,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package v0.2.3+my-package </tspan><tspan class="fg-yellow bold">(latest: v0.4.1+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cfg.rs
+++ b/tests/testsuite/cfg.rs
@@ -56,7 +56,7 @@ fn dont_include() {
         .build();
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] a v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -95,7 +95,7 @@ fn works_through_the_registry() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.1.0 (registry `dummy-registry`)
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
@@ -144,7 +144,7 @@ fn ignore_version_from_other_platform() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [ADDING] bar v0.1.0 (latest: v0.2.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -355,7 +355,7 @@ fn rustc_check_err() {
     foo.cargo("rustc --profile check -- --emit=metadata")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.1.0 ([ROOT]/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 error[E0425]: [..]
@@ -426,7 +426,6 @@ fn check_all_exclude() {
     p.cargo("check --workspace --exclude baz")
         .with_stderr_does_not_contain("[CHECKING] baz v0.1.0 [..]")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -454,7 +453,6 @@ fn check_all_exclude_glob() {
     p.cargo("check --workspace --exclude '*z'")
         .with_stderr_does_not_contain("[CHECKING] baz v0.1.0 [..]")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -481,7 +479,6 @@ fn check_virtual_all_implied() {
     p.cargo("check -v")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [CHECKING] baz v0.1.0 ([ROOT]/foo/baz)
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [RUNNING] `rustc --crate-name baz [..] baz/src/lib.rs [..]`
@@ -514,7 +511,6 @@ fn check_virtual_manifest_one_project() {
     p.cargo("check -p bar")
         .with_stderr_does_not_contain("[CHECKING] baz v0.1.0 [..]")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -542,7 +538,6 @@ fn check_virtual_manifest_glob() {
     p.cargo("check -p '*z'")
         .with_stderr_does_not_contain("[CHECKING] bar v0.1.0 [..]")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [CHECKING] baz v0.1.0 ([ROOT]/foo/baz)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1195,7 +1190,7 @@ fn git_manifest_package_and_project() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.0.1 ([ROOTURL]/bar#[..])
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1244,7 +1239,7 @@ fn git_manifest_with_project() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.0.1 ([ROOTURL]/bar#[..])
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1597,7 +1592,7 @@ fn check_unused_manifest_keys() {
 [WARNING] unused manifest key: target.cfg(windows).dependencies.foo.wxz
 [WARNING] unused manifest key: target.wasm32-wasip1.dev-dependencies.foo.wxz
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.1.0 (registry `dummy-registry`)
 [DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)

--- a/tests/testsuite/collisions.rs
+++ b/tests/testsuite/collisions.rs
@@ -206,7 +206,7 @@ fn collision_doc_multiple_versions() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 3 packages to latest compatible versions
 [ADDING] bar v1.0.0 (latest: v2.0.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v2.0.0 (registry `dummy-registry`)
@@ -384,7 +384,7 @@ fn collision_doc_profile_split() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] common v1.0.0 (registry `dummy-registry`)
 [COMPILING] common v1.0.0
@@ -445,7 +445,7 @@ fn collision_doc_sources() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [WARNING] output filename collision.
@@ -502,7 +502,7 @@ fn collision_doc_target() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 3 packages to latest compatible versions
 [ADDING] bar v1.0.0 (latest: v2.0.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] orphaned v1.0.0 (registry `dummy-registry`)
@@ -572,7 +572,7 @@ fn collision_with_root() {
     p.cargo("doc -j=1")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo-macro v1.0.0 (registry `dummy-registry`)
 [WARNING] output filename collision.

--- a/tests/testsuite/credential_process.rs
+++ b/tests/testsuite/credential_process.rs
@@ -610,7 +610,7 @@ fn basic_provider() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 CARGO=Some([..])
 CARGO_REGISTRY_NAME_OPT=Some("alternative")
 CARGO_REGISTRY_INDEX_URL=Some("[ROOTURL]/alternative-registry")

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -761,7 +761,7 @@ fn build_script_needed_for_host_and_target() {
     p.cargo("build -v --target")
         .arg(&target)
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] d1 v0.0.0 ([ROOT]/foo/d1)
 [RUNNING] `rustc [..] d1/build.rs [..] --out-dir [ROOT]/foo/target/debug/build/d1-[HASH] [..]
 [RUNNING] `[ROOT]/foo/target/debug/build/d1-[HASH]/build-script-build`
@@ -937,7 +937,7 @@ fn build_script_with_platform_specific_dependencies() {
     p.cargo("build -v --target")
         .arg(&target)
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] d2 v0.0.0 ([ROOT]/foo/d2)
 [RUNNING] `rustc [..] d2/src/lib.rs [..]`
 [COMPILING] d1 v0.0.0 ([ROOT]/foo/d1)
@@ -1188,7 +1188,7 @@ fn cross_test_dylib() {
     p.cargo("test --target")
         .arg(&target)
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/direct_minimal_versions.rs
+++ b/tests/testsuite/direct_minimal_versions.rs
@@ -32,7 +32,7 @@ fn simple() {
         .masquerade_as_nightly_cargo(&["direct-minimal-versions"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 1 package
 [ADDING] dep v1.0.0 (latest: v1.1.0)
 
 "#]])
@@ -121,7 +121,7 @@ fn yanked() {
         .masquerade_as_nightly_cargo(&["direct-minimal-versions"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 1 package
 [ADDING] dep v1.1.0 (latest: v1.2.0)
 
 "#]])
@@ -175,7 +175,7 @@ fn indirect() {
         .masquerade_as_nightly_cargo(&["direct-minimal-versions"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages
+[LOCKING] 2 packages
 [ADDING] direct v1.0.0 (latest: v1.1.0)
 
 "#]])

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -107,7 +107,7 @@ fn simple() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.1.0
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -147,7 +147,7 @@ fn simple_install() {
     cargo_process("install bar")
         .with_stderr_data(str![[r#"
 [INSTALLING] bar v0.1.0
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] foo v0.0.1
 [COMPILING] bar v0.1.0
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
@@ -241,7 +241,7 @@ fn install_without_feature_dep() {
     cargo_process("install bar")
         .with_stderr_data(str![[r#"
 [INSTALLING] bar v0.1.0
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] foo v0.0.1
 [COMPILING] bar v0.1.0
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
@@ -328,7 +328,7 @@ fn multiple() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [ADDING] bar v0.1.0 (latest: v0.2.0)
 [CHECKING] bar v0.1.0
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
@@ -367,7 +367,7 @@ fn crates_io_then_directory() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [CHECKING] bar v0.1.0
@@ -476,7 +476,7 @@ fn bad_file_checksum() {
     p.cargo("check")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [ERROR] the listed checksum of `[ROOT]/index/bar/src/lib.rs` has changed:
 expected: [..]
 actual:   [..]
@@ -734,7 +734,7 @@ fn workspace_different_locations() {
     p.cargo("check")
         .cwd("bar")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -110,7 +110,7 @@ fn doc_deps() {
     p.cargo("doc")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOCUMENTING] bar v0.0.1 ([ROOT]/foo/bar)
 [CHECKING] bar v0.0.1 ([ROOT]/foo/bar)
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
@@ -167,7 +167,7 @@ fn doc_no_deps() {
 
     p.cargo("doc --no-deps")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.0.1 ([ROOT]/foo/bar)
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -248,7 +248,6 @@ fn doc_multiple_targets_same_name_lib() {
     p.cargo("doc --workspace")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [ERROR] document output filename collision
 The lib `foo_lib` in package `foo v0.1.0 ([ROOT]/foo/foo)` has the same name as the lib `foo_lib` in package `bar v0.1.0 ([ROOT]/foo/bar)`.
 Only one may be documented at once since they output to the same path.
@@ -297,7 +296,6 @@ fn doc_multiple_targets_same_name() {
 
     p.cargo("doc --workspace")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [WARNING] output filename collision.
 The bin target `foo_lib` in package `foo v0.1.0 ([ROOT]/foo/foo)` has the same output filename as the lib target `foo_lib` in package `bar v0.1.0 ([ROOT]/foo/bar)`.
 Colliding filename is: [ROOT]/foo/target/doc/foo_lib/index.html
@@ -348,7 +346,6 @@ fn doc_multiple_targets_same_name_bin() {
     p.cargo("doc --workspace")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [ERROR] document output filename collision
 The bin `foo-cli` in package `foo v0.1.0 ([ROOT]/foo/foo)` has the same name as the bin `foo-cli` in package `bar v0.1.0 ([ROOT]/foo/bar)`.
 Only one may be documented at once since they output to the same path.
@@ -729,7 +726,7 @@ fn doc_dash_p() {
     p.cargo("doc -p a")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOCUMENTING] b v0.0.1 ([ROOT]/foo/b)
 [CHECKING] b v0.0.1 ([ROOT]/foo/b)
 [DOCUMENTING] a v0.0.1 ([ROOT]/foo/a)
@@ -760,7 +757,6 @@ fn doc_all_exclude() {
 
     p.cargo("doc --workspace --exclude baz")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [DOCUMENTING] bar v0.1.0 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/bar/index.html
@@ -787,7 +783,6 @@ fn doc_all_exclude_glob() {
 
     p.cargo("doc --workspace --exclude '*z'")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [DOCUMENTING] bar v0.1.0 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/bar/index.html
@@ -1072,7 +1067,7 @@ fn features() {
         .build();
     p.cargo("doc --features foo")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [DOCUMENTING] bar v0.0.1 ([ROOT]/foo/bar)
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
@@ -1204,7 +1199,6 @@ fn doc_all_workspace() {
     p.cargo("doc --workspace")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [DOCUMENTING] bar v0.1.0 ([ROOT]/foo/bar)
 [DOCUMENTING] foo v0.1.0 ([ROOT]/foo)
@@ -1243,7 +1237,6 @@ fn doc_all_workspace_verbose() {
     p.cargo("doc --workspace -v")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [DOCUMENTING] bar v0.1.0 ([ROOT]/foo/bar)
 [DOCUMENTING] foo v0.1.0 ([ROOT]/foo)
 [RUNNING] `rustdoc [..]
@@ -1280,7 +1273,6 @@ fn doc_all_virtual_manifest() {
     p.cargo("doc --workspace")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [DOCUMENTING] baz v0.1.0 ([ROOT]/foo/baz)
 [DOCUMENTING] bar v0.1.0 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1312,7 +1304,6 @@ fn doc_virtual_manifest_all_implied() {
     p.cargo("doc")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [GENERATED] [ROOT]/foo/target/doc/bar/index.html and 1 other file
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [DOCUMENTING] bar v0.1.0 ([ROOT]/foo/bar)
@@ -1342,7 +1333,6 @@ fn doc_virtual_manifest_one_project() {
 
     p.cargo("doc -p bar")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [DOCUMENTING] bar v0.1.0 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/bar/index.html
@@ -1369,7 +1359,6 @@ fn doc_virtual_manifest_glob() {
 
     p.cargo("doc -p '*z'")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [DOCUMENTING] baz v0.1.0 ([ROOT]/foo/baz)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/baz/index.html
@@ -1408,7 +1397,7 @@ fn doc_all_member_dependency_same_name() {
     p.cargo("doc --workspace")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [WARNING] output filename collision.
@@ -1448,7 +1437,6 @@ fn doc_workspace_open_help_message() {
         .env("BROWSER", tools::echo())
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [DOCUMENTING] foo v0.1.0 ([ROOT]/foo/foo)
 [DOCUMENTING] bar v0.1.0 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1789,7 +1777,6 @@ fn doc_private_ws() {
     p.cargo("doc --workspace --bins --lib --document-private-items -v")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [DOCUMENTING] b v0.0.1 ([ROOT]/foo/b)
 [CHECKING] b v0.0.1 ([ROOT]/foo/b)
 [DOCUMENTING] a v0.0.1 ([ROOT]/foo/a)
@@ -1848,7 +1835,7 @@ fn doc_cap_lints() {
     p.cargo("doc")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [UPDATING] git repository `[..]`
 [DOCUMENTING] a v0.5.0 ([..])
 [CHECKING] a v0.5.0 ([..])
@@ -2212,7 +2199,7 @@ fn bin_private_items_deps() {
     p.cargo("doc")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOCUMENTING] bar v0.0.1 ([ROOT]/foo/bar)
 [CHECKING] bar v0.0.1 ([ROOT]/foo/bar)
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
@@ -2790,7 +2777,7 @@ fn doc_lib_false() {
 
     p.cargo("doc")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [DOCUMENTING] foo v0.1.0 ([ROOT]/foo)
@@ -2840,7 +2827,7 @@ fn doc_lib_false_dep() {
 
     p.cargo("doc")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [DOCUMENTING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/docscrape.rs
+++ b/tests/testsuite/docscrape.rs
@@ -116,7 +116,7 @@ impl Foo {
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] a v0.0.1 ([ROOT]/foo/crates/a)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [SCRAPING] foo v0.0.1 ([ROOT]/foo)
@@ -612,7 +612,7 @@ fn no_scrape_with_dev_deps() {
     p.cargo("doc -Zunstable-options -Z rustdoc-scrape-examples")
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [WARNING] Rustdoc did not scrape the following examples because they require dev-dependencies: ex
     If you want Rustdoc to scrape these examples, then add `doc-scrape-examples = true`
     to the [[example]] target configuration of at least one example.
@@ -682,7 +682,7 @@ fn use_dev_deps_if_explicitly_enabled() {
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] a v0.0.1 ([ROOT]/foo/a)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [SCRAPING] foo v0.0.1 ([ROOT]/foo)

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -98,7 +98,7 @@ fn same_name() {
     p.cargo("tree -f")
         .arg("{p} [{f}]")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -361,7 +361,7 @@ fn invalid9() {
 
     p.cargo("check --features bar")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [ERROR] Package `foo v0.0.1 ([ROOT]/foo)` does not have feature `bar`. It has a required dependency with that name, but only optional dependencies can be used as features.
 
 "#]])
@@ -529,7 +529,7 @@ fn no_feature_doesnt_build() {
 
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -605,7 +605,7 @@ fn default_feature_pulled_in() {
 
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -748,7 +748,7 @@ fn groups_on_groups_on_groups() {
     p.cargo("check")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.0.1 ([ROOT]/foo/bar)
 [CHECKING] baz v0.0.1 ([ROOT]/foo/baz)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -801,7 +801,7 @@ fn many_cli_features() {
         .arg("bar baz")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.0.1 ([ROOT]/foo/bar)
 [CHECKING] baz v0.0.1 ([ROOT]/foo/baz)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -889,7 +889,7 @@ fn union_features() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] d2 v0.0.1 ([ROOT]/foo/d2)
 [CHECKING] d1 v0.0.1 ([ROOT]/foo/d1)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -937,7 +937,7 @@ fn many_features_no_rebuilds() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] a v0.1.0 ([ROOT]/foo/a)
 [CHECKING] b v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1238,7 +1238,7 @@ fn optional_and_dev_dep() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] test v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1526,7 +1526,7 @@ fn many_cli_features_comma_delimited() {
     p.cargo("check --features bar,baz")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.0.1 ([ROOT]/foo/bar)
 [CHECKING] baz v0.0.1 ([ROOT]/foo/baz)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -1595,7 +1595,7 @@ fn many_cli_features_comma_and_space_delimited() {
         .arg("bar,baz bam bap")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 5 packages to latest compatible versions
+[LOCKING] 4 packages to latest compatible versions
 [CHECKING] bam v0.0.1 ([ROOT]/foo/bam)
 [CHECKING] bap v0.0.1 ([ROOT]/foo/bap)
 [CHECKING] bar v0.0.1 ([ROOT]/foo/bar)
@@ -1767,7 +1767,7 @@ fn warn_if_default_features() {
 
     p.cargo("check").with_stderr_data(str![[r#"
 [WARNING] `default-features = [".."]` was found in [features]. Did you mean to use `default = [".."]`?
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2182,7 +2182,7 @@ fn registry_summary_order_doesnt_matter() {
     p.cargo("run")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -908,7 +908,7 @@ fn required_features_host_dep() {
     p.cargo("run")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [ERROR] target `x` in package `foo` requires the features: `bdep/f1`
 Consider enabling them by passing, e.g., `--features="bdep/f1"`
 
@@ -1026,7 +1026,7 @@ fn required_features_inactive_dep() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -1284,7 +1284,7 @@ fn has_dev_dep_for_test() {
 
     p.cargo("check -v")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1698,7 +1698,7 @@ fn resolver_enables_new_features() {
         .env("EXPECTED_FEATS", "1")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] common v1.0.0 (registry `dummy-registry`)
 [COMPILING] common v1.0.0
@@ -1945,7 +1945,6 @@ fn shared_dep_same_but_dependencies() {
         // unordered because bin1 and bin2 build at the same time
         .with_stderr_data(
             str![[r#"
-[LOCKING] 4 packages to latest compatible versions
 [COMPILING] subdep v0.1.0 ([ROOT]/foo/subdep)
 [COMPILING] dep v0.1.0 ([ROOT]/foo/dep)
 [COMPILING] bin1 v0.1.0 ([ROOT]/foo/bin1)
@@ -2103,7 +2102,7 @@ fn doc_optional() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] spin v1.0.0 (registry `dummy-registry`)
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
@@ -2220,7 +2219,7 @@ fn minimal_download() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 15 packages to latest compatible versions
+[LOCKING] 14 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] normal_pm v1.0.0 (registry `dummy-registry`)
 [DOWNLOADED] normal v1.0.0 (registry `dummy-registry`)
@@ -2466,7 +2465,6 @@ fn pm_with_int_shared() {
     p.cargo("build --workspace --all-targets --all-features -v")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 3 packages to latest compatible versions
 [COMPILING] shared v0.1.0 ([ROOT]/foo/shared)
 [RUNNING] `rustc --crate-name shared [..]--crate-type lib [..]`
 [RUNNING] `rustc --crate-name shared [..]--crate-type lib [..]`
@@ -2670,7 +2668,7 @@ fn all_features_merges_with_features() {
     p.cargo("run --example ex --all-features --features dep/feat1")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)
 [COMPILING] dep v0.1.0
@@ -2760,7 +2758,7 @@ fn dep_with_optional_host_deps_activated() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] serde_build v0.1.0 ([ROOT]/foo/serde_build)
 [COMPILING] serde_derive v0.1.0 ([ROOT]/foo/serde_derive)
 [COMPILING] serde v0.1.0 ([ROOT]/foo/serde)
@@ -2805,7 +2803,7 @@ fn dont_unify_proc_macro_example_from_dependency() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] pm_helper v0.0.0 ([ROOT]/foo/pm_helper)
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/features_namespaced.rs
+++ b/tests/testsuite/features_namespaced.rs
@@ -34,7 +34,7 @@ fn dependency_with_crate_syntax() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v1.0.0 (registry `dummy-registry`)
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
@@ -172,7 +172,7 @@ fn namespaced_implicit_feature() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -321,7 +321,7 @@ fn namespaced_same_name() {
     p.cargo("run")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `target/debug/foo[EXE]`
@@ -385,7 +385,7 @@ fn no_implicit_feature() {
     p.cargo("run")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `target/debug/foo[EXE]`
@@ -563,7 +563,7 @@ fn crate_required_features() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [ERROR] invalid feature `dep:bar` in required-features of target `foo`: `dep:` prefixed feature values are not allowed in required-features
 
 "#]])
@@ -692,7 +692,7 @@ fn crate_feature_with_explicit() {
     p.cargo("check --features f1")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [CHECKING] bar v1.0.0
@@ -1309,7 +1309,7 @@ foo v0.1.0 ([ROOT]/foo) features=
 
 "#]])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 
 "#]])
         .run();

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -104,7 +104,6 @@ fn fix_path_deps() {
         .with_stdout_data("")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [FIXED] bar/src/lib.rs (1 fix)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
@@ -271,7 +270,6 @@ fn upgrade_extern_crate() {
     p.cargo("fix --allow-no-vcs")
         .env("__CARGO_FIX_YOLO", "1")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FIXED] src/lib.rs (1 fix)
@@ -1144,7 +1142,6 @@ fn doesnt_rebuild_dependencies() {
         .env("__CARGO_FIX_YOLO", "1")
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1252,7 +1249,7 @@ fn only_warn_for_relevant_crates() {
     p.cargo("fix --allow-no-vcs --edition")
         .with_stderr_data(str![[r#"
 [MIGRATING] Cargo.toml from 2015 edition to 2018
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] a v0.1.0 ([ROOT]/foo/a)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [MIGRATING] src/lib.rs from 2015 edition to 2018
@@ -1471,7 +1468,7 @@ fn edition_v2_resolver_report() {
         .with_stderr_data(str![[r#"
 [MIGRATING] Cargo.toml from 2018 edition to 2021
 [UPDATING] `dummy-registry` index
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] common v1.0.0 (registry `dummy-registry`)
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
@@ -1593,7 +1590,6 @@ fn fix_shared_cross_workspace() {
         .env("__CARGO_FIX_YOLO", "1")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [CHECKING] foo v0.1.0 ([ROOT]/foo/foo)
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [FIXED] [..]foo/src/shared.rs (2 fixes)
@@ -2536,7 +2532,6 @@ a = {path = "a", default_features = false}
         .with_stderr_data(str![[r#"
 [MIGRATING] Cargo.toml from 2021 edition to 2024
 [FIXED] Cargo.toml (11 fixes)
-[LOCKING] 2 packages to latest compatible versions
 [CHECKING] a v0.0.1 ([ROOT]/foo/a)
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
 [MIGRATING] src/lib.rs from 2021 edition to 2024
@@ -2634,7 +2629,7 @@ target-dep = { version = "0.1.0", optional = true }
 [MIGRATING] Cargo.toml from 2021 edition to 2024
 [FIXED] Cargo.toml (3 fixes)
 [UPDATING] `dummy-registry` index
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 3 packages to latest compatible versions
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [MIGRATING] src/lib.rs from 2021 edition to 2024
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2696,7 +2691,7 @@ existing = []
 [MIGRATING] Cargo.toml from 2021 edition to 2024
 [FIXED] Cargo.toml (1 fix)
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [MIGRATING] src/lib.rs from 2021 edition to 2024
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2773,7 +2768,7 @@ unrelated-dep-feature = ["unrelated-feature/a", "unrelated-feature/b"]
 [MIGRATING] Cargo.toml from 2021 edition to 2024
 [FIXED] Cargo.toml (4 fixes)
 [UPDATING] `dummy-registry` index
-[LOCKING] 5 packages to latest compatible versions
+[LOCKING] 4 packages to latest compatible versions
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [MIGRATING] src/lib.rs from 2021 edition to 2024
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2907,7 +2902,7 @@ dep_df_false = { version = "0.1.0", default-features = false }
 [MIGRATING] pkg_df_false/Cargo.toml from 2021 edition to 2024
 [FIXED] pkg_df_false/Cargo.toml (6 fixes)
 [UPDATING] `dummy-registry` index
-[LOCKING] 6 packages to latest compatible versions
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep_simple v0.1.0 (registry `dummy-registry`)
 [DOWNLOADED] dep_df_true v0.1.0 (registry `dummy-registry`)

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -146,7 +146,7 @@ fn rebuild_sub_package_then_while_package() {
 
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] b v0.0.1 ([ROOT]/foo/b)
 [COMPILING] a v0.0.1 ([ROOT]/foo/a)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -400,7 +400,7 @@ ftest off
 
 "#]])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] dep_crate v0.0.1 ([ROOT]/foo/dep_crate)
 [COMPILING] a v0.0.1 ([ROOT]/foo/a)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -431,7 +431,7 @@ ftest on
 
 "#]])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] dep_crate v0.0.1 ([ROOT]/foo/dep_crate)
 [COMPILING] b v0.0.1 ([ROOT]/foo/b)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -817,7 +817,7 @@ fn same_build_dir_cached_packages() {
     p.cargo("build")
         .cwd("a1")
         .with_stderr_data(str![[r#"
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] d v0.0.1 ([ROOT]/foo/d)
 [COMPILING] c v0.0.1 ([ROOT]/foo/c)
 [COMPILING] b v0.0.1 ([ROOT]/foo/b)
@@ -829,7 +829,7 @@ fn same_build_dir_cached_packages() {
     p.cargo("build")
         .cwd("a2")
         .with_stderr_data(str![[r#"
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] a2 v0.0.1 ([ROOT]/foo/a2)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1400,7 +1400,7 @@ fn update_dependency_mtime_does_not_rebuild() {
         .masquerade_as_nightly_cargo(&["mtime-on-use"])
         .env("RUSTFLAGS", "-C linker=cc")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1558,7 +1558,7 @@ fn reuse_panic_build_dep_test() {
     // Check that `bar` is not built twice. It is only needed once (without `panic`).
     p.cargo("test --lib --no-run -v")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `rustc --crate-name bar [..]
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -1621,7 +1621,7 @@ fn reuse_panic_pm() {
     p.cargo("build -v")
             .with_stderr_unordered(
                 "\
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar [..]
 [RUNNING] `rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]
 [RUNNING] `rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort[..]-C debuginfo=2 [..]
@@ -1787,7 +1787,6 @@ fn rebuild_on_mid_build_file_modification() {
 
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [COMPILING] proc_macro_dep v0.1.0 ([ROOT]/foo/proc_macro_dep)
 [COMPILING] root v0.1.0 ([ROOT]/foo/root)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/generate_lockfile.rs
+++ b/tests/testsuite/generate_lockfile.rs
@@ -64,11 +64,11 @@ fn no_index_update_sparse() {
     no_index_update(
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 
 "#]],
         str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 
 "#]],
     );
@@ -79,11 +79,11 @@ fn no_index_update_git() {
     no_index_update(
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 
 "#]],
         str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 
 "#]],
     );
@@ -272,14 +272,14 @@ fn generate_lockfile_holds_lock_and_offline() {
     p.cargo("generate-lockfile")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 
 "#]])
         .run();
 
     p.cargo("generate-lockfile --offline")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 
 "#]])
         .run();

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -62,7 +62,7 @@ fn cargo_compile_simple_git_dep() {
         .cargo("build")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep1`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] dep1 v0.5.0 ([ROOTURL]/dep1#[..])
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -134,7 +134,7 @@ fn cargo_compile_git_dep_branch() {
         .cargo("build")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep1`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] dep1 v0.5.0 ([ROOTURL]/dep1?branch=branchy#[..])
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -211,7 +211,7 @@ fn cargo_compile_git_dep_tag() {
         .cargo("build")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep1`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] dep1 v0.5.0 ([ROOTURL]/dep1?tag=v0.1.0#[..])
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -282,7 +282,7 @@ fn cargo_compile_git_dep_pull_request() {
         .cargo("build")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep1`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] dep1 v0.5.0 ([ROOTURL]/dep1?rev=refs/pull/330/head#[..])
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -607,7 +607,7 @@ fn recompilation() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.5.0 ([ROOTURL]/bar#[..])
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -775,7 +775,7 @@ fn update_with_shared_deps() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 3 packages to latest compatible versions
 [CHECKING] bar v0.5.0 ([ROOTURL]/bar#[..])
 [CHECKING] dep1 v0.5.0 ([ROOT]/foo/dep1)
 [CHECKING] dep2 v0.5.0 ([ROOT]/foo/dep2)
@@ -912,7 +912,7 @@ fn dep_with_submodule() {
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep1`
 [UPDATING] git submodule `[ROOTURL]/dep2`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] dep1 v0.5.0 ([ROOTURL]/dep1#[..])
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -981,7 +981,7 @@ fn dep_with_relative_submodule() {
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/base`
 [UPDATING] git submodule `[ROOTURL]/deployment`
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] deployment v0.5.0 ([ROOTURL]/base#[..])
 [CHECKING] base v0.5.0 ([ROOTURL]/base#[..])
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
@@ -1117,7 +1117,7 @@ fn dep_with_skipped_submodule() {
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
 [SKIPPING] git submodule `[ROOTURL]/qux` due to update strategy in .gitmodules
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.0.0 ([ROOTURL]/bar#[..])
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1346,7 +1346,7 @@ fn two_deps_only_update_one() {
             str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep1`
 [UPDATING] git repository `[ROOTURL]/dep2`
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] dep1 v0.5.0 ([ROOTURL]/dep1#[..])
 [CHECKING] dep2 v0.5.0 ([ROOTURL]/dep2#[..])
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
@@ -1507,7 +1507,7 @@ fn dep_with_changed_submodule() {
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep1`
 [UPDATING] git submodule `[ROOTURL]/dep2`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] dep1 v0.5.0 ([ROOTURL]/dep1#[..])
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1629,7 +1629,7 @@ fn dev_deps_with_testing() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1748,7 +1748,7 @@ fn git_name_not_always_needed() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1790,7 +1790,7 @@ fn git_repo_changing_no_rebuild() {
     p1.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] p1 v0.5.0 ([ROOT]/p1)
 [CHECKING] bar v0.5.0 ([ROOTURL]/bar#[..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1827,7 +1827,7 @@ fn git_repo_changing_no_rebuild() {
     p2.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.5.0 ([ROOTURL]/bar#[..])
 [CHECKING] p2 v0.5.0 ([ROOT]/p2)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1956,7 +1956,7 @@ fn fetch_downloads() {
     p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 
 "#]])
         .run();
@@ -2002,7 +2002,7 @@ fn fetch_downloads_with_git2_first_then_with_gitoxide_and_vice_versa() {
         .masquerade_as_nightly_cargo(&["unstable features must be available for -Z gitoxide"])
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 
 "#]])
         .run();
@@ -2041,7 +2041,7 @@ fn warnings_in_git_dep() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.5.0 ([ROOTURL]/bar#[..])
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2231,7 +2231,7 @@ fn switch_deps_does_not_update_transitive() {
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep1`
 [UPDATING] git repository `[ROOTURL]/transitive`
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] transitive v0.5.0 ([ROOTURL]/transitive#[..])
 [CHECKING] dep v0.5.0 ([ROOTURL]/dep1#[..])
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
@@ -2380,7 +2380,7 @@ fn switch_sources() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/a1`
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] a v0.5.0 ([ROOTURL]/a1#[..])
 [CHECKING] b v0.5.0 ([ROOT]/foo/b)
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
@@ -2542,7 +2542,7 @@ fn lints_are_suppressed() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/a`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] a v0.5.0 ([ROOTURL]/a#[..])
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2586,7 +2586,7 @@ fn denied_lints_are_allowed() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/a`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] a v0.5.0 ([ROOTURL]/a#[..])
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2957,7 +2957,7 @@ fn use_the_cli() {
 [RUNNING] `git fetch --verbose --force --update-head-ok [..][ROOTURL]/dep1[..] [..]+HEAD:refs/remotes/origin/HEAD[..]`
 From [ROOTURL]/dep1
  * [new ref] [..] -> origin/HEAD[..]
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] dep1 v0.5.0 ([ROOTURL]/dep1#[..])
 [RUNNING] `rustc --crate-name dep1 [..]`
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
@@ -3293,7 +3293,7 @@ fn default_not_master() {
         .cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep1`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] dep1 v0.5.0 ([ROOTURL]/dep1#[..])
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -3476,7 +3476,7 @@ fn two_dep_forms() {
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep1`
 [UPDATING] git repository `[ROOTURL]/dep1`
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 3 packages to latest compatible versions
 [CHECKING] dep1 v0.5.0 ([ROOTURL]/dep1#[..])
 [CHECKING] dep1 v0.5.0 ([ROOTURL]/dep1?branch=master#[..])
 [CHECKING] a v0.5.0 ([ROOT]/foo/a)
@@ -3981,7 +3981,7 @@ fn different_user_relative_submodules() {
 [UPDATING] git repository `[ROOTURL]/user1/dep1`
 [UPDATING] git submodule `[ROOTURL]/user2/dep1`
 [UPDATING] git submodule `[ROOTURL]/user2/dep2`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] dep1 v0.5.0 ([ROOTURL]/user1/dep1#[..])
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/global_cache_tracker.rs
+++ b/tests/testsuite/global_cache_tracker.rs
@@ -1251,7 +1251,7 @@ fn package_cache_lock_during_build() {
         .env("CARGO_LOG", "gc=debug")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
    [..]s DEBUG gc: unable to acquire mutate lock, auto gc disabled
 [CHECKING] bar v1.0.0
 [CHECKING] foo2 v0.1.0 ([ROOT]/foo2)

--- a/tests/testsuite/https.rs
+++ b/tests/testsuite/https.rs
@@ -131,7 +131,7 @@ fn self_signed_with_cacert() {
     p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `https://127.0.0.1:[..]/repos/bar.git`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 
 "#]])
         .run();
@@ -158,7 +158,7 @@ fn github_works() {
     p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `https://github.com/rust-lang/bitflags.git`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 
 "#]])
         .run();

--- a/tests/testsuite/inheritable_workspace_fields.rs
+++ b/tests/testsuite/inheritable_workspace_fields.rs
@@ -290,7 +290,7 @@ fn inherit_own_dependencies() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v0.1.2 (registry `dummy-registry`)
 [DOWNLOADED] dep-build v0.8.2 (registry `dummy-registry`)
@@ -452,7 +452,7 @@ fn inherit_own_detailed_dependencies() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v0.1.2 (registry `dummy-registry`)
 [CHECKING] dep v0.1.2
@@ -630,7 +630,7 @@ fn inherited_dependencies_union_features() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] fancy_dep v0.2.4 (registry `dummy-registry`)
 [DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)
@@ -861,7 +861,7 @@ fn inherit_dependencies() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v0.1.2 (registry `dummy-registry`)
 [DOWNLOADED] dep-build v0.8.2 (registry `dummy-registry`)
@@ -1026,7 +1026,7 @@ fn inherit_target_dependencies() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v0.1.2 (registry `dummy-registry`)
 [CHECKING] dep v0.1.2
@@ -1073,7 +1073,7 @@ fn inherit_dependency_override_optional() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.2.0 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1116,7 +1116,7 @@ fn inherit_dependency_features() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] fancy_dep v0.2.4 (registry `dummy-registry`)
 [DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)
@@ -1186,7 +1186,7 @@ fn inherit_detailed_dependencies() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/detailed`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] detailed v0.5.0 ([ROOTURL]/detailed?branch=branchy#[..])
 [CHECKING] bar v0.2.0 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1227,7 +1227,6 @@ fn inherit_path_dependencies() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [CHECKING] dep v0.9.0 ([ROOT]/foo/dep)
 [CHECKING] bar v0.2.0 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1488,7 +1487,7 @@ fn warn_inherit_def_feat_true_member_def_feat_false() {
     p.cargo("check").with_stderr_data(str![[r#"
 [WARNING] [ROOT]/foo/Cargo.toml: `default-features` is ignored for dep, since `default-features` was true for `workspace.dependencies.dep`, this could become a hard error in the future
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] fancy_dep v0.2.4 (registry `dummy-registry`)
 [DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)
@@ -1583,7 +1582,7 @@ fn warn_inherit_simple_member_def_feat_false() {
     p.cargo("check").with_stderr_data(str![[r#"
 [WARNING] [ROOT]/foo/Cargo.toml: `default-features` is ignored for dep, since `default-features` was not specified for `workspace.dependencies.dep`, this could become a hard error in the future
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] fancy_dep v0.2.4 (registry `dummy-registry`)
 [DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)
@@ -1678,7 +1677,7 @@ fn inherit_def_feat_false_member_def_feat_true() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] fancy_dep v0.2.4 (registry `dummy-registry`)
 [DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)
@@ -1764,7 +1763,7 @@ fn warn_inherit_unused_manifest_key_dep() {
 [WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: workspace.dependencies.dep.wxz
 [WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: dependencies.dep.wxz
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)
 [CHECKING] dep v0.1.0

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -2513,7 +2513,7 @@ fn self_referential() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.2 (registry `dummy-registry`)
 [INSTALLING] foo v0.0.2
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [ADDING] foo v0.0.1 (latest: v0.0.2)
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
@@ -2558,7 +2558,7 @@ fn ambiguous_registry_vs_local_package() {
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.1.0 ([ROOT]/foo)
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
 [COMPILING] foo v0.0.1

--- a/tests/testsuite/lints/implicit_features.rs
+++ b/tests/testsuite/lints/implicit_features.rs
@@ -26,7 +26,7 @@ bar = { version = "0.1.0", optional = true }
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -87,7 +87,7 @@ implicit_features = "warn"
    | ----------
    |
 [UPDATING] `dummy-registry` index
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 3 packages to latest compatible versions
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -127,7 +127,7 @@ unused_optional_dependency = "allow"
         .masquerade_as_nightly_cargo(&["cargo-lints", "edition2024"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest Rust [..] compatible versions
+[LOCKING] 1 package to latest Rust 1.82.0-nightly compatible version
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/lints/mod.rs
+++ b/tests/testsuite/lints/mod.rs
@@ -214,7 +214,7 @@ implicit_features = "warn"
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [CHECKING] bar v0.1.0

--- a/tests/testsuite/lints/unused_optional_dependencies.rs
+++ b/tests/testsuite/lints/unused_optional_dependencies.rs
@@ -89,7 +89,7 @@ implicit_features = "allow"
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/lints_table.rs
+++ b/tests/testsuite/lints_table.rs
@@ -44,7 +44,7 @@ fn dependency_warning_ignored() {
 
     foo.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.0.1 ([ROOT]/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/local_registry.rs
+++ b/tests/testsuite/local_registry.rs
@@ -53,7 +53,7 @@ fn simple() {
 
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [UNPACKING] bar v0.0.1 (registry `[ROOT]/registry`)
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -178,7 +178,7 @@ fn multiple_versions() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [UNPACKING] bar v0.1.0 (registry `[ROOT]/registry`)
 [CHECKING] bar v0.1.0
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -244,7 +244,7 @@ fn multiple_names() {
     p.cargo("check")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [UNPACKING] bar v0.0.1 (registry `[ROOT]/registry`)
 [UNPACKING] baz v0.1.0 (registry `[ROOT]/registry`)
 [CHECKING] bar v0.0.1
@@ -301,7 +301,7 @@ fn interdependent() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [UNPACKING] bar v0.0.1 (registry `[ROOT]/registry`)
 [UNPACKING] baz v0.1.0 (registry `[ROOT]/registry`)
 [CHECKING] bar v0.0.1
@@ -371,7 +371,7 @@ fn path_dep_rewritten() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [UNPACKING] bar v0.0.1 (registry `[ROOT]/registry`)
 [UNPACKING] baz v0.1.0 (registry `[ROOT]/registry`)
 [CHECKING] bar v0.0.1
@@ -536,7 +536,7 @@ fn crates_io_registry_url_is_optional() {
 
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [UNPACKING] bar v0.0.1 (registry `[ROOT]/registry`)
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 ([ROOT]/foo)

--- a/tests/testsuite/lockfile_compat.rs
+++ b/tests/testsuite/lockfile_compat.rs
@@ -1039,9 +1039,8 @@ dependencies = [
         .with_stderr_data(format!(
             "\
 [UPDATING] git repository `[ROOTURL]/dep1`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [ADDING] dep1 v0.5.0 ([ROOTURL]/dep1?{ref_kind}={git_ref}#[..])
-[ADDING] foo v0.0.1 ([ROOT]/foo)
 [CHECKING] dep1 v0.5.0 ([ROOTURL]/dep1?{ref_kind}={git_ref}#[..])
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1135,9 +1134,8 @@ dependencies = [
         .with_stderr_data(format!(
             "\
 [UPDATING] git repository `[ROOTURL]/dep1`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [ADDING] dep1 v0.5.0 ([ROOTURL]/dep1?{ref_kind}={git_ref}#[..])
-[ADDING] foo v0.0.1 ([ROOT]/foo)
 [CHECKING] dep1 v0.5.0 ([ROOTURL]/dep1?{ref_kind}={git_ref}#[..])
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/lto.rs
+++ b/tests/testsuite/lto.rs
@@ -30,7 +30,7 @@ fn with_deps() {
     p.cargo("build -v --release")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [COMPILING] bar v0.0.1
@@ -73,7 +73,7 @@ fn shared_deps() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [COMPILING] bar v0.0.1
@@ -117,7 +117,7 @@ fn build_dep_not_ltod() {
     p.cargo("build -v --release")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [COMPILING] bar v0.0.1
@@ -299,7 +299,7 @@ fn off_in_manifest_works() {
     p.cargo("build -v --release")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [COMPILING] bar v0.0.1
@@ -751,7 +751,7 @@ fn test_profile() {
         // unordered because the two `foo` builds start in parallel
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [COMPILING] bar v0.0.1
@@ -809,7 +809,7 @@ fn doctest() {
     p.cargo("test --doc --release -v")
         // embed-bitcode should be harmless here
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [RUNNING] `rustc --crate-name bar [..]--crate-type lib [..]-C linker-plugin-lto [..]`
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
@@ -900,7 +900,7 @@ fn fresh_swapping_commands() {
     p.cargo("build --release -v")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [COMPILING] bar v1.0.0

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -1986,7 +1986,7 @@ fn cargo_metadata_with_invalid_artifact_deps() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [WARNING] please specify `--format-version` flag explicitly to avoid compatibility problems
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [ERROR] dependency `artifact` in package `foo` requires a `bin:notfound` artifact to be present.
 
 "#]])
@@ -2017,7 +2017,7 @@ fn cargo_metadata_with_invalid_duplicate_renamed_deps() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [WARNING] please specify `--format-version` flag explicitly to avoid compatibility problems
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [ERROR] the crate `foo v0.5.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
 
 "#]])
@@ -3650,7 +3650,7 @@ fn filter_platform() {
             str![[r#"
 [WARNING] please specify `--format-version` flag explicitly to avoid compatibility problems
 [UPDATING] `dummy-registry` index
-[LOCKING] 5 packages to latest compatible versions
+[LOCKING] 4 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] normal-dep v0.0.1 (registry `dummy-registry`)
 [DOWNLOADED] host-dep v0.0.1 (registry `dummy-registry`)

--- a/tests/testsuite/minimal_versions.rs
+++ b/tests/testsuite/minimal_versions.rs
@@ -34,7 +34,7 @@ fn minimal_version_cli() {
         .masquerade_as_nightly_cargo(&["minimal-versions"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to earliest compatible versions
+[LOCKING] 1 package to earliest compatible version
 [ADDING] dep v1.0.0 (latest: v1.1.0)
 
 "#]])

--- a/tests/testsuite/offline.rs
+++ b/tests/testsuite/offline.rs
@@ -150,7 +150,7 @@ fn cargo_compile_with_downloaded_dependency_with_offline() {
 
     p2.cargo("check --offline")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] present_dep v1.2.3
 [CHECKING] bar v0.1.0 ([ROOT]/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -263,7 +263,7 @@ fn main(){
 
     p2.cargo("run --offline")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] present_dep v1.2.3
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -521,7 +521,7 @@ fn compile_offline_with_cached_git_dep(shallow: bool) {
     let mut cargo = p.cargo("build --offline");
     cargo.with_stderr_data(format!(
         "\
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] dep1 v0.5.0 ([ROOTURL]/dep1#[..])
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -703,7 +703,7 @@ fn main(){
 
     p2.cargo("build --offline")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] present_dep v1.2.9
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/package_features.rs
+++ b/tests/testsuite/package_features.rs
@@ -62,7 +62,7 @@ fn virtual_no_default_features() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] a v0.1.0 ([ROOT]/foo/a)
 [CHECKING] b v0.1.0 ([ROOT]/foo/b)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -169,7 +169,6 @@ fn virtual_features() {
     p.cargo("check --features f1")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [CHECKING] a v0.1.0 ([ROOT]/foo/a)
 [CHECKING] b v0.1.0 ([ROOT]/foo/b)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -240,7 +239,6 @@ fn virtual_with_specific() {
     p.cargo("check -p a -p b --features f1,f2,f3")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [CHECKING] a v0.1.0 ([ROOT]/foo/a)
 [CHECKING] b v0.1.0 ([ROOT]/foo/b)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -579,7 +577,7 @@ fn non_member() {
     p.cargo("check -p dep")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v1.0.0 (registry `dummy-registry`)
 [CHECKING] dep v1.0.0

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -55,7 +55,7 @@ fn replace() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.1.0 (registry `dummy-registry`)
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
@@ -107,7 +107,7 @@ fn from_config() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.1.1 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -149,7 +149,7 @@ fn from_config_relative() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.1.1 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -194,7 +194,7 @@ fn from_config_precedence() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.1.1 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -235,7 +235,7 @@ fn nonexistent() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -288,7 +288,7 @@ fn patch_git() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/override`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -342,7 +342,7 @@ fn patch_to_git() {
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/override`
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.1.0 ([ROOTURL]/override#[..])
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -391,7 +391,7 @@ Check that the patched package version and available features are compatible
 with the dependency requirements. If the patch has a different version from
 what is locked in the Cargo.lock file, run `cargo update` to use the new
 version. This may also occur with an optional dependency that is not enabled.
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [ADDING] bar v0.1.0 (latest: v0.2.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
@@ -468,7 +468,7 @@ Check that the patched package version and available features are compatible
 with the dependency requirements. If the patch has a different version from
 what is locked in the Cargo.lock file, run `cargo update` to use the new
 version. This may also occur with an optional dependency that is not enabled.
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [ADDING] bar v0.1.0 (latest: v0.3.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
@@ -509,7 +509,7 @@ fn prefer_patch_version() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.1.1 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -567,7 +567,7 @@ Check that the patched package version and available features are compatible
 with the dependency requirements. If the patch has a different version from
 what is locked in the Cargo.lock file, run `cargo update` to use the new
 version. This may also occur with an optional dependency that is not enabled.
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [ADDING] bar v0.1.0 (latest: v0.2.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
@@ -641,7 +641,7 @@ Check that the patched package version and available features are compatible
 with the dependency requirements. If the patch has a different version from
 what is locked in the Cargo.lock file, run `cargo update` to use the new
 version. This may also occur with an optional dependency that is not enabled.
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [ADDING] bar v0.1.0 (latest: v0.2.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
@@ -690,7 +690,7 @@ fn add_patch() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [CHECKING] bar v0.1.0
@@ -767,7 +767,7 @@ fn add_patch_from_config() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [CHECKING] bar v0.1.0
@@ -835,7 +835,7 @@ fn add_ignored_patch() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [CHECKING] bar v0.1.0
@@ -931,7 +931,7 @@ fn add_patch_with_features() {
     p.cargo("check").with_stderr_data(str![[r#"
 [WARNING] patch for `bar` uses the features mechanism. default-features and features will not take effect because the patch dependency does not support this mechanism
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -973,7 +973,7 @@ fn add_patch_with_setting_default_features() {
     p.cargo("check").with_stderr_data(str![[r#"
 [WARNING] patch for `bar` uses the features mechanism. default-features and features will not take effect because the patch dependency does not support this mechanism
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1024,7 +1024,6 @@ fn no_warn_ws_patch() {
     p.cargo("check -p a")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
 [CHECKING] a v0.1.0 ([ROOT]/foo/a)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1061,7 +1060,7 @@ fn new_minor() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.1.1 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1113,7 +1112,7 @@ fn transitive_new_minor() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] baz v0.1.1 ([ROOT]/foo/baz)
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -1152,7 +1151,7 @@ fn new_major() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.2.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1240,7 +1239,7 @@ fn transitive_new_major() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] baz v0.2.0 ([ROOT]/foo/baz)
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -1299,7 +1298,7 @@ fn shared_by_transitive() {
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/override`
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] baz v0.1.2 ([ROOTURL]/override#[..])
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
@@ -1649,7 +1648,7 @@ fn patch_older() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] baz v1.0.1 ([ROOT]/foo/baz)
 [CHECKING] bar v0.5.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
@@ -2263,7 +2262,7 @@ fn patch_walks_backwards() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.1.1 ([ROOT]/foo/bar)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2317,7 +2316,7 @@ fn patch_walks_backwards_restricted() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.1.1 ([ROOT]/foo/bar)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2388,7 +2387,7 @@ fn patched_dep_new_version() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.1.0 (registry `dummy-registry`)
 [CHECKING] baz v0.1.0
@@ -2475,7 +2474,7 @@ fn patch_update_doesnt_update_other_sources() {
             str![[r#"
 [UPDATING] `dummy-registry` index
 [UPDATING] `alternative` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `alternative`)
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
@@ -2548,7 +2547,7 @@ fn can_update_with_alt_reg() {
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.1 (registry `alternative`)
 [CHECKING] bar v0.1.1 (registry `alternative`)

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -75,7 +75,7 @@ fn cargo_compile_with_nested_deps_shorthand() {
 
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] baz v0.5.0 ([ROOT]/foo/bar/baz)
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
@@ -160,7 +160,7 @@ fn cargo_compile_with_root_dev_deps() {
     p.cargo("check")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 error[E0463]: can't find crate for `bar`
 ...
@@ -207,7 +207,7 @@ fn cargo_compile_with_root_dev_deps_with_testing() {
 
     p.cargo("test")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/bar)
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -276,7 +276,7 @@ fn cargo_compile_with_transitive_dev_deps() {
 
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -318,7 +318,7 @@ fn no_rebuild_dependency() {
     // First time around we should compile both foo and bar
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.5.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -387,7 +387,7 @@ fn deep_dependencies_trigger_rebuild() {
         .build();
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] baz v0.5.0 ([ROOT]/foo/baz)
 [CHECKING] bar v0.5.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
@@ -481,7 +481,7 @@ fn no_rebuild_two_deps() {
         .build();
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] baz v0.5.0 ([ROOT]/foo/baz)
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
@@ -525,7 +525,7 @@ fn nested_deps_recompile() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.5.0 ([ROOT]/foo/src/bar)
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1385,7 +1385,7 @@ fn path_dep_build_cmd() {
 
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1455,7 +1455,7 @@ fn dev_deps_no_rebuild_lib() {
     p.cargo("build")
         .env("FOO", "bar")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1517,7 +1517,6 @@ fn custom_target_no_rebuild() {
         .build();
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
 [CHECKING] a v0.5.0 ([ROOT]/foo/a)
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1577,7 +1576,7 @@ fn override_and_depend() {
     p.cargo("check")
         .cwd("b")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] a2 v0.5.0 ([ROOT]/foo/a)
 [CHECKING] a1 v0.5.0 ([ROOT]/foo/a)
 [CHECKING] b v0.5.0 ([ROOT]/foo/b)
@@ -1889,7 +1888,7 @@ fn same_name_version_changed() {
 
     p.cargo("tree")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 
 "#]])
         .with_stdout_data(str![[r#"

--- a/tests/testsuite/paths.rs
+++ b/tests/testsuite/paths.rs
@@ -59,7 +59,7 @@ fn broken_path_override_warns() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [ADDING] bar v0.1.0 (latest: v0.2.0)
 [WARNING] path override for crate `a` has altered the original list of
 dependencies; the dependency on `bar` was either added or
@@ -179,7 +179,7 @@ fn paths_ok_with_optional() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar2)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -228,7 +228,7 @@ fn paths_add_optional_bad() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [WARNING] path override for crate `bar` has altered the original list of
 dependencies; the dependency on `baz` was either added or
 modified to not match the previously resolved version

--- a/tests/testsuite/proc_macro.rs
+++ b/tests/testsuite/proc_macro.rs
@@ -553,7 +553,6 @@ fn proc_macro_built_once() {
     p.cargo("build --verbose")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 3 packages to latest compatible versions
 [COMPILING] the-macro v0.1.0 ([ROOT]/foo/the-macro)
 [RUNNING] `rustc --crate-name the_macro [..]`
 [COMPILING] b v0.1.0 ([ROOT]/foo/b)

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -228,7 +228,7 @@ fn profile_config_override_spec_multiple() {
     p.cargo("build -v")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [ERROR] multiple package overrides in profile `dev` match package `bar v0.5.0 ([ROOT]/foo/bar)`
 found package specs: bar, bar@0.5.0
 
@@ -305,7 +305,7 @@ fn profile_config_override_precedence() {
 
     p.cargo("build -v")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [RUNNING] `rustc --crate-name bar [..] -C opt-level=2[..]-C codegen-units=2 [..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -512,7 +512,7 @@ fn test_with_dev_profile() {
         .env("CARGO_PROFILE_DEV_DEBUG", "0")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] somedep v1.0.0 (registry `dummy-registry`)
 [COMPILING] somedep v1.0.0

--- a/tests/testsuite/profile_custom.rs
+++ b/tests/testsuite/profile_custom.rs
@@ -326,7 +326,7 @@ fn overrides_with_custom() {
     p.cargo("build -v")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] xxx v0.5.0 ([ROOT]/foo/xxx)
 [COMPILING] yyy v0.5.0 ([ROOT]/foo/yyy)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)

--- a/tests/testsuite/profile_overrides.rs
+++ b/tests/testsuite/profile_overrides.rs
@@ -33,7 +33,7 @@ fn profile_override_basic() {
 
     p.cargo("check -v")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.5.0 ([ROOT]/foo/bar)
 [RUNNING] `rustc --crate-name bar [..] -C opt-level=3 [..]`
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -226,7 +226,7 @@ fn profile_override_hierarchy() {
 
     p.cargo("build -v")
         .with_stderr_data(str![[r#"
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] m3 v0.5.0 ([ROOT]/foo/m3)
 [COMPILING] dep v0.5.0 ([ROOT]/dep)
 [RUNNING] `rustc --crate-name m3 --edition=2015 m3/src/lib.rs [..] --crate-type lib --emit=[..]link[..]-C codegen-units=4 [..]`
@@ -514,7 +514,6 @@ fn no_warning_ws() {
 
     p.cargo("check -p b")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [CHECKING] b v0.1.0 ([ROOT]/foo/b)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/profile_targets.rs
+++ b/tests/testsuite/profile_targets.rs
@@ -90,7 +90,7 @@ fn profile_selection_build() {
     //   are built with debuginfo=0.
     p.cargo("build -vv")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]
@@ -128,7 +128,7 @@ fn profile_selection_build_release() {
     // `build --release`
     p.cargo("build --release -vv")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3 -C panic=abort[..]-C codegen-units=2 [..]
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=6 [..]
@@ -194,7 +194,7 @@ fn profile_selection_build_all_targets() {
     //   example  dev        build
     p.cargo("build --all-targets -vv")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C embed-bitcode=[..]-C codegen-units=1 -C debuginfo=2 [..]`
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort -C embed-bitcode=[..]-C codegen-units=1 -C debuginfo=2 [..]`
@@ -267,7 +267,7 @@ fn profile_selection_build_all_targets_release() {
     //   example  release        build
     p.cargo("build --all-targets --release -vv")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3 -C embed-bitcode=[..]-C codegen-units=2 [..]`
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3 -C panic=abort -C embed-bitcode=[..]-C codegen-units=2 [..]`
@@ -330,7 +330,7 @@ fn profile_selection_test() {
     //
     p.cargo("test -vv")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C embed-bitcode=[..]-C codegen-units=3 -C debuginfo=2 [..]`
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C embed-bitcode=[..]-C codegen-units=5 [..]`
@@ -403,7 +403,7 @@ fn profile_selection_test_release() {
     //
     p.cargo("test --release -vv")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=6 [..]`
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3 -C panic=abort[..]-C codegen-units=2 [..]`
@@ -475,7 +475,7 @@ fn profile_selection_bench() {
     //
     p.cargo("bench -vv")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3 -C embed-bitcode=[..]-C codegen-units=4 [..]`
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3 -C panic=abort -C embed-bitcode=[..]-C codegen-units=4 [..]`
@@ -546,7 +546,7 @@ fn profile_selection_check_all_targets() {
     //
     p.cargo("check --all-targets -vv")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C embed-bitcode=[..]-C codegen-units=5 [..]`
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]metadata -C embed-bitcode=[..]-C codegen-units=1 -C debuginfo=2 [..]`
@@ -597,7 +597,7 @@ fn profile_selection_check_all_targets_release() {
     // `dev` for all targets.
     p.cargo("check --all-targets --release -vv")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=6 [..]
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]metadata -C opt-level=3 -C panic=abort[..]-C codegen-units=2 [..]
@@ -662,7 +662,7 @@ fn profile_selection_check_all_targets_test() {
     //
     p.cargo("check --all-targets --profile=test -vv")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]`
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]metadata[..]-C codegen-units=3 -C debuginfo=2 [..]`
@@ -713,7 +713,7 @@ fn profile_selection_doc() {
     //   `*` = wants panic, but it is cleared when args are built.
     p.cargo("doc -vv")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [DOCUMENTING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]`

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -233,7 +233,7 @@ fn registry_dependency() {
 "#]]) // Omit the hash of Source URL
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [COMPILING] bar v0.0.1
@@ -285,7 +285,7 @@ fn git_dependency() {
 "#]]) // Omit the hash of Source URL and commit
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.0.1 ([ROOTURL]/bar#[..])
 [RUNNING] `rustc [..]-Zremap-path-scope=object --remap-path-prefix=[ROOT]/home/.cargo/git/checkouts= --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -330,7 +330,7 @@ cocktail-bar/src/lib.rs
 
 "#]])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/foo/cocktail-bar)
 [RUNNING] `rustc [..]-Zremap-path-scope=object --remap-path-prefix=[ROOT]/foo=. --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -376,7 +376,7 @@ bar-0.0.1/src/lib.rs
 
 "#]])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/bar)
 [RUNNING] `rustc [..]-Zremap-path-scope=object --remap-path-prefix=[ROOT]/bar=bar-0.0.1 --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)

--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -187,7 +187,7 @@ fn top_level_overrides_deps() {
     p.cargo("build -v --release")
         .with_stderr_data(&format!(
             "\
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] foo v0.0.0 ([ROOT]/foo/foo)
 [RUNNING] `rustc --crate-name foo --edition=2015 foo/src/lib.rs [..]\
         --crate-type dylib --crate-type rlib \
@@ -260,7 +260,6 @@ fn profile_in_non_root_manifest_triggers_a_warning() {
 [WARNING] profiles for the non root package will be ignored, specify profiles at the workspace root:
 package:   [ROOT]/foo/bar/Cargo.toml
 workspace: [ROOT]/foo/Cargo.toml
-[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [RUNNING] `rustc [..]`
 [FINISHED] `dev` profile [unoptimized] target(s) in [ELAPSED]s

--- a/tests/testsuite/pub_priv.rs
+++ b/tests/testsuite/pub_priv.rs
@@ -79,7 +79,7 @@ fn exported_pub_dep() {
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] pub_dep v0.1.0 (registry `dummy-registry`)
 [CHECKING] pub_dep v0.1.0
@@ -143,7 +143,7 @@ fn requires_feature() {
         .with_stderr_data(str![[r#"
 [WARNING] ignoring `public` on dependency pub_dep, pass `-Zpublic-dependency` to enable support for it
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] pub_dep v0.1.0 (registry `dummy-registry`)
 [CHECKING] pub_dep v0.1.0
@@ -230,7 +230,7 @@ fn pub_dev_dependency_without_feature() {
         .with_stderr_data(str![[r#"
 [WARNING] 'public' specifier can only be used on regular dependencies, not dev-dependencies
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -329,7 +329,7 @@ fn allow_priv_in_tests() {
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] priv_dep v0.1.0 (registry `dummy-registry`)
 [CHECKING] priv_dep v0.1.0
@@ -374,7 +374,7 @@ fn allow_priv_in_benchs() {
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] priv_dep v0.1.0 (registry `dummy-registry`)
 [CHECKING] priv_dep v0.1.0
@@ -420,7 +420,7 @@ fn allow_priv_in_bins() {
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] priv_dep v0.1.0 (registry `dummy-registry`)
 [CHECKING] priv_dep v0.1.0
@@ -466,7 +466,7 @@ fn allow_priv_in_examples() {
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] priv_dep v0.1.0 (registry `dummy-registry`)
 [CHECKING] priv_dep v0.1.0
@@ -513,7 +513,7 @@ fn allow_priv_in_custom_build() {
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] priv_dep v0.1.0 (registry `dummy-registry`)
 [COMPILING] priv_dep v0.1.0
@@ -567,7 +567,7 @@ fn publish_package_with_public_dependency() {
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] pub_bar v0.1.0 (registry `dummy-registry`)
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)

--- a/tests/testsuite/publish_lockfile.rs
+++ b/tests/testsuite/publish_lockfile.rs
@@ -262,8 +262,6 @@ fn outdated_lock_version_change_does_not_warn() {
 
     p.cargo("package --no-verify")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
-[UPDATING] foo v0.1.0 ([ROOT]/foo) -> v0.2.0
 [PACKAGING] foo v0.2.0 ([ROOT]/foo)
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 
@@ -403,7 +401,7 @@ dependencies = [
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [INSTALLING] foo v0.1.0
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.1 (registry `dummy-registry`)
 [COMPILING] bar v0.1.1

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -33,7 +33,7 @@ fn simple_http() {
     simple(
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [CHECKING] bar v0.0.1
@@ -55,7 +55,7 @@ fn simple_git() {
     simple(
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [CHECKING] bar v0.0.1
@@ -107,7 +107,7 @@ fn deps_http() {
     let _server = setup_http();
     deps(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] ba[..] v0.0.1 (registry `dummy-registry`)
 [DOWNLOADED] ba[..] v0.0.1 (registry `dummy-registry`)
@@ -123,7 +123,7 @@ fn deps_http() {
 fn deps_git() {
     deps(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] ba[..] v0.0.1 (registry `dummy-registry`)
 [DOWNLOADED] ba[..] v0.0.1 (registry `dummy-registry`)
@@ -407,7 +407,7 @@ fn bad_cksum_http() {
     let _server = setup_http();
     bad_cksum(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bad-cksum v0.0.1 (registry `dummy-registry`)
 [ERROR] failed to download replaced source registry `crates-io`
@@ -422,7 +422,7 @@ Caused by:
 fn bad_cksum_git() {
     bad_cksum(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bad-cksum v0.0.1 (registry `dummy-registry`)
 [ERROR] failed to download replaced source registry `crates-io`
@@ -474,7 +474,7 @@ required by package `foo v0.0.1 ([ROOT]/foo)`
 "#]],
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] notyet v0.0.1 (registry `dummy-registry`)
 [CHECKING] notyet v0.0.1
@@ -497,7 +497,7 @@ required by package `foo v0.0.1 ([ROOT]/foo)`
 "#]],
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] notyet v0.0.1 (registry `dummy-registry`)
 [CHECKING] notyet v0.0.1
@@ -646,7 +646,7 @@ fn lockfile_locks_http() {
     lockfile_locks(
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [CHECKING] bar v0.0.1
@@ -666,7 +666,7 @@ fn lockfile_locks_git() {
     lockfile_locks(
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [CHECKING] bar v0.0.1
@@ -719,7 +719,7 @@ fn lockfile_locks_transitively_http() {
     lockfile_locks_transitively(
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] ba[..] v0.0.1 (registry `dummy-registry`)
 [DOWNLOADED] ba[..] v0.0.1 (registry `dummy-registry`)
@@ -741,7 +741,7 @@ fn lockfile_locks_transitively_git() {
     lockfile_locks_transitively(
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] ba[..] v0.0.1 (registry `dummy-registry`)
 [DOWNLOADED] ba[..] v0.0.1 (registry `dummy-registry`)
@@ -800,7 +800,7 @@ fn yanks_are_not_used_http() {
     let _server = setup_http();
     yanks_are_not_used(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] ba[..] v0.0.1 (registry `dummy-registry`)
 [DOWNLOADED] ba[..] v0.0.1 (registry `dummy-registry`)
@@ -816,7 +816,7 @@ fn yanks_are_not_used_http() {
 fn yanks_are_not_used_git() {
     yanks_are_not_used(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] ba[..] v0.0.1 (registry `dummy-registry`)
 [DOWNLOADED] ba[..] v0.0.1 (registry `dummy-registry`)
@@ -1366,7 +1366,7 @@ fn dev_dependency_not_used_http() {
     let _server = setup_http();
     dev_dependency_not_used(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [CHECKING] bar v0.0.1
@@ -1380,7 +1380,7 @@ fn dev_dependency_not_used_http() {
 fn dev_dependency_not_used_git() {
     dev_dependency_not_used(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [CHECKING] bar v0.0.1
@@ -1471,7 +1471,7 @@ fn updating_a_dep_http() {
     updating_a_dep(
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [CHECKING] bar v0.0.1
@@ -1500,7 +1500,7 @@ fn updating_a_dep_git() {
     updating_a_dep(
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [CHECKING] bar v0.0.1
@@ -1600,7 +1600,7 @@ fn git_and_registry_dep_http() {
         str![[r#"
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[ROOTURL]/b`
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] a v0.0.1 (registry `dummy-registry`)
 [CHECKING] a v0.0.1
@@ -1622,7 +1622,7 @@ fn git_and_registry_dep_git() {
         str![[r#"
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[ROOTURL]/b`
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] a v0.0.1 (registry `dummy-registry`)
 [CHECKING] a v0.0.1
@@ -1782,7 +1782,7 @@ fn fetch_downloads_http() {
     let _server = setup_http();
     fetch_downloads(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] a v0.1.0 (registry `dummy-registry`)
 
@@ -1793,7 +1793,7 @@ fn fetch_downloads_http() {
 fn fetch_downloads_git() {
     fetch_downloads(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] a v0.1.0 (registry `dummy-registry`)
 
@@ -2272,7 +2272,7 @@ fn only_download_relevant_http() {
     let _server = setup_http();
     only_download_relevant(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.1.0 (registry `dummy-registry`)
 [CHECKING] baz v0.1.0
@@ -2286,7 +2286,7 @@ fn only_download_relevant_http() {
 fn only_download_relevant_git() {
     only_download_relevant(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.1.0 (registry `dummy-registry`)
 [CHECKING] baz v0.1.0
@@ -2560,8 +2560,6 @@ fn add_dep_dont_update_registry(expected: impl IntoData) {
 fn bump_version_dont_update_registry_http() {
     let _server = setup_http();
     bump_version_dont_update_registry(str![[r#"
-[LOCKING] 1 package to latest compatible version
-[UPDATING] bar v0.5.0 ([ROOT]/foo) -> v0.6.0
 [CHECKING] bar v0.6.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2571,8 +2569,6 @@ fn bump_version_dont_update_registry_http() {
 #[cargo_test]
 fn bump_version_dont_update_registry_git() {
     bump_version_dont_update_registry(str![[r#"
-[LOCKING] 1 package to latest compatible version
-[UPDATING] bar v0.5.0 ([ROOT]/foo) -> v0.6.0
 [CHECKING] bar v0.6.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2727,7 +2723,7 @@ fn bad_and_or_malicious_packages_rejected_http() {
     let _server = setup_http();
     bad_and_or_malicious_packages_rejected(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.2.0 (registry `dummy-registry`)
 [ERROR] failed to download replaced source registry `crates-io`
@@ -2745,7 +2741,7 @@ Caused by:
 fn bad_and_or_malicious_packages_rejected_git() {
     bad_and_or_malicious_packages_rejected(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.2.0 (registry `dummy-registry`)
 [ERROR] failed to download replaced source registry `crates-io`
@@ -3289,7 +3285,7 @@ fn reach_max_unpack_size() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [ERROR] failed to download replaced source registry `crates-io`
@@ -3361,7 +3357,7 @@ internal server error
 [WARNING] spurious network error (2 tries remaining): failed to get successful HTTP response from `http://127.0.0.1:[..]/index/3/b/bar` (127.0.0.1), got 500
 body:
 internal server error
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [CHECKING] bar v0.0.1
@@ -3446,7 +3442,7 @@ fn sparse_retry_multiple() {
     write!(
         &mut expected,
         "\
-[LOCKING] 94 packages to latest compatible versions
+[LOCKING] 93 packages to latest compatible versions
 "
     )
     .unwrap();
@@ -3499,7 +3495,7 @@ fn dl_retry_single() {
         .build();
     p.cargo("fetch").with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [WARNING] spurious network error (3 tries remaining): failed to get successful HTTP response from `http://127.0.0.1:[..]/dl/bar/1.0.0/download` (127.0.0.1), got 500
 body:
@@ -3595,7 +3591,7 @@ fn dl_retry_multiple() {
     }
     write!(
         &mut expected,
-        "[LOCKING] 94 packages to latest compatible versions\n"
+        "[LOCKING] 93 packages to latest compatible versions\n"
     )
     .unwrap();
     let _server = builder.build();
@@ -3641,7 +3637,7 @@ fn deleted_entry() {
     p.cargo("tree")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.1 (registry `dummy-registry`)
 
@@ -3677,7 +3673,7 @@ foo v0.1.0 ([ROOT]/foo)
     p.cargo("tree")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 
@@ -3744,7 +3740,7 @@ fn corrupted_ok_overwritten() {
     p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 
@@ -4009,7 +4005,7 @@ fn debug_header_message_dl() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [WARNING] spurious network error (3 tries remaining): failed to get successful HTTP response from `http://127.0.0.1:[..]/dl/bar/1.0.0/download` (127.0.0.1), got 503
 body:
@@ -4064,7 +4060,7 @@ fn set_mask_during_unpacking() {
     p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 
@@ -4114,7 +4110,7 @@ fn unpack_again_when_cargo_ok_is_unrecognized() {
     p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 
@@ -4188,7 +4184,7 @@ fn differ_only_by_metadata() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.0.1+b (registry `dummy-registry`)
 [CHECKING] baz v0.0.1+b
@@ -4285,7 +4281,7 @@ fn builtin_source_replacement() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] crates.io index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bad-cksum v0.0.1
 [ERROR] failed to verify the checksum of `bad-cksum v0.0.1`

--- a/tests/testsuite/registry_auth.rs
+++ b/tests/testsuite/registry_auth.rs
@@ -52,7 +52,7 @@ fn requires_credential_provider() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [ERROR] failed to download `bar v0.0.1 (registry `alternative`)`
 
 Caused by:
@@ -78,7 +78,7 @@ fn simple() {
     cargo(&p, "build")
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
 [COMPILING] bar v0.0.1 (registry `alternative`)
@@ -102,7 +102,7 @@ fn simple_with_asymmetric() {
     cargo(&p, "build")
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
 [COMPILING] bar v0.0.1 (registry `alternative`)
@@ -131,7 +131,7 @@ fn environment_config() {
         .env("CARGO_REGISTRIES_ALTERNATIVE_TOKEN", registry.token())
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
 [COMPILING] bar v0.0.1 (registry `alternative`)
@@ -156,7 +156,7 @@ fn environment_token() {
         .env("CARGO_REGISTRIES_ALTERNATIVE_TOKEN", registry.token())
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
 [COMPILING] bar v0.0.1 (registry `alternative`)
@@ -186,7 +186,7 @@ fn environment_token_with_asymmetric() {
         .env("CARGO_REGISTRIES_ALTERNATIVE_SECRET_KEY", registry.key())
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
 [COMPILING] bar v0.0.1 (registry `alternative`)
@@ -346,7 +346,7 @@ fn missing_token_git() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [ERROR] failed to download `bar v0.0.1 (registry `alternative`)`
 
 Caused by:
@@ -405,7 +405,7 @@ fn incorrect_token_git() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [ERROR] failed to download from `http://127.0.0.1:[..]/dl/bar/0.0.1/download`
 
@@ -497,7 +497,7 @@ fn duplicate_index() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [ERROR] failed to download `bar v0.0.1 (registry `alternative`)`
 
 Caused by:

--- a/tests/testsuite/registry_overlay.rs
+++ b/tests/testsuite/registry_overlay.rs
@@ -80,7 +80,7 @@ fn registry_version_wins() {
         .with_stderr_data(
             "\
 [UPDATING] [..]
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.1.1 (registry [..])
 [CHECKING] baz v0.1.1
@@ -123,7 +123,7 @@ fn overlay_version_wins() {
         .with_stderr_data(
             "\
 [UPDATING] [..]
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [UNPACKING] baz v0.1.1 (registry [..])
 [CHECKING] baz v0.1.1
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -251,7 +251,7 @@ fn registry_dep_depends_on_new_local_package() {
         .with_stderr_data(
             "\
 [UPDATING] [..]
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 3 packages to latest compatible versions
 [ADDING] workspace-package v0.0.1 (latest: v0.1.1)
 [DOWNLOADING] crates ...
 [UNPACKING] [..]

--- a/tests/testsuite/rename_deps.rs
+++ b/tests/testsuite/rename_deps.rs
@@ -192,7 +192,7 @@ fn rename_twice() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.1.0 (registry `dummy-registry`)
 [ERROR] the crate `test v0.1.0 ([ROOT]/foo)` depends on crate `foo v0.1.0` multiple times with different names

--- a/tests/testsuite/replace.rs
+++ b/tests/testsuite/replace.rs
@@ -45,7 +45,7 @@ fn override_simple() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[ROOTURL]/override`
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.0 ([ROOTURL]/override#[..])
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -92,7 +92,7 @@ fn override_with_features() {
     p.cargo("check").with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[ROOTURL]/override`
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [WARNING] replacement for `bar` uses the features mechanism. default-features and features will not take effect because the replacement dependency does not support this mechanism
 [CHECKING] bar v0.1.0 ([ROOTURL]/override#[..])
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -139,7 +139,7 @@ fn override_with_setting_default_features() {
     p.cargo("check").with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[ROOTURL]/override`
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [WARNING] replacement for `bar` uses the features mechanism. default-features and features will not take effect because the replacement dependency does not support this mechanism
 [CHECKING] bar v0.1.0 ([ROOTURL]/override#[..])
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -287,7 +287,7 @@ fn transitive() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[ROOTURL]/override`
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.2.0 (registry `dummy-registry`)
 [CHECKING] bar v0.1.0 ([ROOTURL]/override#[..])
@@ -345,7 +345,7 @@ fn persists_across_rebuilds() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[ROOTURL]/override`
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.0 ([ROOTURL]/override#[..])
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -397,7 +397,7 @@ fn replace_registry_with_path() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.0 ([ROOT]/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -464,7 +464,7 @@ fn use_a_spec_to_select() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[ROOTURL]/override`
-[LOCKING] 5 packages to latest compatible versions
+[LOCKING] 4 packages to latest compatible versions
 [ADDING] baz v0.1.1 (latest: v0.2.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.1.1 (registry `dummy-registry`)
@@ -528,7 +528,7 @@ fn override_adds_some_deps() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[ROOTURL]/override`
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.1.1 (registry `dummy-registry`)
 [CHECKING] baz v0.1.1
@@ -856,7 +856,7 @@ fn test_override_dep() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[ROOTURL]/override`
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [ERROR] There are multiple `bar` packages in your project, and the specification `bar` is ambiguous.
 Please re-run this command with one of the following specifications:
   registry+https://github.com/rust-lang/crates.io-index#bar@0.1.0
@@ -1172,7 +1172,7 @@ fn no_warnings_when_replace_is_used_in_another_workspace_member() {
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.0 ([ROOT]/foo/local_bar)
 [CHECKING] first_crate v0.1.0 ([ROOT]/foo/first_crate)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1438,7 +1438,7 @@ fn override_respects_spec_metadata() {
 
     p.cargo("check").with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [WARNING] package replacement is not used: https://github.com/rust-lang/crates.io-index#bar@0.1.0+notTheBuild
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0+a (registry `dummy-registry`)
@@ -1490,7 +1490,7 @@ fn override_spec_metadata_is_optional() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[ROOTURL]/override`
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.0+a ([ROOTURL]/override#[..])
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/required_features.rs
+++ b/tests/testsuite/required_features.rs
@@ -1153,7 +1153,7 @@ fn dep_feature_in_cmd_line() {
     // This is a no-op
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -1251,7 +1251,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured; 0 filtered out; fini
     p.cargo("install --path .")
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.0.1 ([ROOT]/foo)
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 [WARNING] none of the package's binaries are available for install using the selected features
   bin "foo" requires the features: `bar/a`
@@ -1511,7 +1511,7 @@ fn renamed_required_features() {
     p.cargo("run")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [ERROR] target `x` in package `foo` requires the features: `a1/f1`
 Consider enabling them by passing, e.g., `--features="a1/f1"`
 

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -874,7 +874,7 @@ fn example_with_release_flag() {
 
     p.cargo("run -v --release --example a")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [RUNNING] `rustc --crate-name bar --edition=2015 bar/src/bar.rs [..]--crate-type lib --emit=[..]link -C opt-level=3[..] -C metadata=[..] --out-dir [ROOT]/foo/target/release/deps -C strip=debuginfo -L dependency=[ROOT]/foo/target/release/deps`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -981,7 +981,7 @@ fn run_with_bin_dep() {
 
     p.cargo("run")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [WARNING] foo v0.0.1 ([ROOT]/foo) ignoring invalid dependency `bar` which is missing a lib target
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1045,7 +1045,7 @@ fn run_with_bin_deps() {
 
     p.cargo("run")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [WARNING] foo v0.0.1 ([ROOT]/foo) ignoring invalid dependency `bar1` which is missing a lib target
 [WARNING] foo v0.0.1 ([ROOT]/foo) ignoring invalid dependency `bar2` which is missing a lib target
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -1143,7 +1143,6 @@ available binaries: bar1, bar2, foo1, foo2
 
     p.cargo("run --bin foo1")
         .with_stderr_data(str![[r#"
-[LOCKING] 4 packages to latest compatible versions
 [WARNING] foo1 v0.0.1 ([ROOT]/foo/foo1) ignoring invalid dependency `bar1` which is missing a lib target
 [WARNING] foo2 v0.0.1 ([ROOT]/foo/foo2) ignoring invalid dependency `bar2` which is missing a lib target
 [COMPILING] foo1 v0.0.1 ([ROOT]/foo/foo1)

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -156,7 +156,7 @@ fn lint_dep_incompatible_with_rust_version() {
     p.cargo("generate-lockfile")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 3 packages to latest compatible versions
 
 "#]])
         .run();
@@ -220,7 +220,7 @@ fn resolve_with_rust_version() {
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 
 "#]])
         .run();
@@ -239,7 +239,7 @@ foo v0.0.1 ([ROOT]/foo)
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest Rust 1.60.0 compatible versions
+[LOCKING] 2 packages to latest Rust 1.60.0 compatible versions
 [ADDING] newer-and-older v1.5.0 (latest: v1.6.0)
 [ADDING] only-newer v1.6.0 (requires Rust 1.65.0)
 
@@ -295,7 +295,7 @@ fn resolve_with_rustc() {
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 
 "#]])
         .run();
@@ -314,7 +314,7 @@ foo v0.0.1 ([ROOT]/foo)
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest Rust 1.60.0 compatible versions
+[LOCKING] 2 packages to latest Rust 1.60.0 compatible versions
 [ADDING] newer-and-older v1.5.0 (latest: v1.6.0)
 [ADDING] only-newer v1.6.0 (requires Rust 1.2345)
 
@@ -368,7 +368,7 @@ fn resolve_with_backtracking() {
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 
 "#]])
         .run();
@@ -388,7 +388,7 @@ foo v0.0.1 ([ROOT]/foo)
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest Rust 1.60.0 compatible versions
+[LOCKING] 2 packages to latest Rust 1.60.0 compatible versions
 [ADDING] has-rust-version v1.6.0 (requires Rust 1.65.0)
 
 "#]])
@@ -466,7 +466,7 @@ fn resolve_with_multiple_rust_versions() {
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 
 "#]])
         .run();
@@ -485,7 +485,7 @@ higher v0.0.1 ([ROOT]/foo)
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 4 packages to latest Rust 1.50.0 compatible versions
+[LOCKING] 2 packages to latest Rust 1.50.0 compatible versions
 [ADDING] newer-and-older v1.5.0 (latest: v1.6.0)
 [ADDING] only-newer v1.6.0 (requires Rust 1.65.0)
 
@@ -540,7 +540,7 @@ fn resolve_unstable_config_on_stable() {
         .with_stderr_data(str![[r#"
 [WARNING] ignoring `resolver` config table without `-Zmsrv-policy`
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 
 "#]])
         .run();
@@ -558,7 +558,7 @@ foo v0.0.1 ([ROOT]/foo)
         .with_stderr_data(str![[r#"
 [WARNING] ignoring `resolver` config table without `-Zmsrv-policy`
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 
 "#]])
         .run();
@@ -614,7 +614,7 @@ fn resolve_edition2024() {
         .masquerade_as_nightly_cargo(&["edition2024", "msrv-policy"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest Rust 1.60.0 compatible versions
+[LOCKING] 2 packages to latest Rust 1.60.0 compatible versions
 [ADDING] newer-and-older v1.5.0 (latest: v1.6.0)
 [ADDING] only-newer v1.6.0 (requires Rust 1.65.0)
 
@@ -635,7 +635,7 @@ foo v0.0.1 ([ROOT]/foo)
     p.cargo("generate-lockfile --ignore-rust-version")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 
 "#]])
         .arg("-Zmsrv-policy")
@@ -657,7 +657,7 @@ foo v0.0.1 ([ROOT]/foo)
         .env("CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS", "allow")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 
 "#]])
         .arg("-Zmsrv-policy")
@@ -718,7 +718,7 @@ fn resolve_v3() {
         .masquerade_as_nightly_cargo(&["edition2024", "msrv-policy"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest Rust 1.60.0 compatible versions
+[LOCKING] 2 packages to latest Rust 1.60.0 compatible versions
 [ADDING] newer-and-older v1.5.0 (latest: v1.6.0)
 [ADDING] only-newer v1.6.0 (requires Rust 1.65.0)
 
@@ -739,7 +739,7 @@ foo v0.0.1 ([ROOT]/foo)
     p.cargo("generate-lockfile --ignore-rust-version")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 
 "#]])
         .arg("-Zmsrv-policy")
@@ -761,7 +761,7 @@ foo v0.0.1 ([ROOT]/foo)
         .env("CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS", "allow")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 
 "#]])
         .arg("-Zmsrv-policy")
@@ -866,7 +866,7 @@ fn update_msrv_resolve() {
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest Rust 1.60.0 compatible versions
+[LOCKING] 1 package to latest Rust 1.60.0 compatible version
 [ADDING] bar v1.5.0 (latest: v1.6.0)
 
 "#]])
@@ -927,7 +927,7 @@ fn update_precise_overrides_msrv_resolver() {
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest Rust 1.60.0 compatible versions
+[LOCKING] 1 package to latest Rust 1.60.0 compatible version
 [ADDING] bar v1.5.0 (latest: v1.6.0)
 
 "#]])
@@ -985,7 +985,7 @@ fn check_msrv_resolve() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] only-newer v1.6.0 (registry `dummy-registry`)
 [DOWNLOADED] newer-and-older v1.6.0 (registry `dummy-registry`)
@@ -1014,7 +1014,7 @@ foo v0.0.1 ([ROOT]/foo)
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest Rust 1.60.0 compatible versions
+[LOCKING] 2 packages to latest Rust 1.60.0 compatible versions
 [ADDING] newer-and-older v1.5.0 (latest: v1.6.0)
 [ADDING] only-newer v1.6.0 (requires Rust 1.65.0)
 [DOWNLOADING] crates ...
@@ -1063,7 +1063,7 @@ fn cargo_install_ignores_msrv_config() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
 [INSTALLING] foo v0.0.1
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v1.1.0 (registry `dummy-registry`)
 [COMPILING] dep v1.1.0

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -220,7 +220,7 @@ fn build_with_crate_type_for_foo_with_deps() {
 
     p.cargo("rustc -v --crate-type cdylib")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] a v0.1.0 ([ROOT]/foo/a)
 [RUNNING] `rustc --crate-name a --edition=2015 a/src/lib.rs [..]--crate-type lib [..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -391,7 +391,7 @@ fn build_foo_with_bar_dependency() {
 
     foo.cargo("rustc -v -- -C debug-assertions")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.1.0 ([ROOT]/bar)
 [RUNNING] `rustc --crate-name bar [..] -C debuginfo=2[..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -428,7 +428,7 @@ fn build_only_bar_dependency() {
 
     foo.cargo("rustc -v -p bar -- -C debug-assertions")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.1.0 ([ROOT]/bar)
 [RUNNING] `rustc --crate-name bar [..]--crate-type lib [..] -C debug-assertions [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/rustdoc.rs
+++ b/tests/testsuite/rustdoc.rs
@@ -155,7 +155,7 @@ fn rustdoc_foo_with_bar_dependency() {
 
     foo.cargo("rustdoc -v -- --cfg=foo")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.0.1 ([ROOT]/bar)
 [RUNNING] `rustc [..] [ROOT]/bar/src/lib.rs [..]`
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
@@ -193,7 +193,7 @@ fn rustdoc_only_bar_dependency() {
 
     foo.cargo("rustdoc -v -p bar -- --cfg=foo")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOCUMENTING] bar v0.0.1 ([ROOT]/bar)
 [RUNNING] `rustdoc [..] --crate-name bar [ROOT]/bar/src/lib.rs -o [ROOT]/foo/target/doc [..] --cfg=foo -C metadata=[..] -L dependency=[ROOT]/foo/target/debug/deps [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/rustflags.rs
+++ b/tests/testsuite/rustflags.rs
@@ -1688,7 +1688,7 @@ fn host_config_shared_build_dep() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] cc v1.0.0 (registry `dummy-registry`)
 [COMPILING] cc v1.0.0

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -709,7 +709,7 @@ Hello world!
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to `2021`
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] script v1.0.0 (registry `dummy-registry`)
 [COMPILING] script v1.0.0
@@ -747,7 +747,7 @@ Hello world!
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to `2021`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [COMPILING] script v0.0.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/source_replacement.rs
+++ b/tests/testsuite/source_replacement.rs
@@ -284,7 +284,7 @@ fn source_replacement_with_registry_url() {
         .replace_crates_io(crates_io.index_url())
         .with_stderr_data(str![[r#"
 [UPDATING] `using-registry-url` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `using-registry-url`)
 [CHECKING] bar v0.0.1

--- a/tests/testsuite/ssh.rs
+++ b/tests/testsuite/ssh.rs
@@ -203,7 +203,7 @@ fn known_host_works() {
         .env("SSH_AUTH_SOCK", &agent.sock)
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `ssh://testuser@127.0.0.1:[..]/repos/bar.git`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 
 "#]])
         .run();
@@ -275,7 +275,7 @@ fn known_host_without_port() {
         .env("SSH_AUTH_SOCK", &agent.sock)
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `ssh://testuser@127.0.0.1:[..]/repos/bar.git`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 
 "#]])
         .run();
@@ -312,7 +312,7 @@ fn hostname_case_insensitive() {
         .with_stderr_data(&format!(
             "\
 [UPDATING] git repository `ssh://testuser@{hostname}:{port}/repos/bar.git`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 "
         ))
         .run();
@@ -383,7 +383,7 @@ Caused by:
         .env("SSH_AUTH_SOCK", &agent.sock)
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `ssh://testuser@127.0.0.1:[..]/repos/bar.git`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 
 "#]])
         .run();
@@ -628,7 +628,7 @@ fn ssh_key_in_config() {
         .env("SSH_AUTH_SOCK", &agent.sock)
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `ssh://testuser@127.0.0.1:[..]/repos/bar.git`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 
 "#]])
         .run();

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -100,7 +100,7 @@ fn cargo_test_release() {
 
     p.cargo("test -v --release")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `rustc [..]-C opt-level=3 [..]`
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
@@ -635,7 +635,7 @@ fn test_with_deep_lib_dep() {
 
     p.cargo("test")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1480,7 +1480,7 @@ fn test_dylib() {
 
     p.cargo("test")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2098,7 +2098,7 @@ fn selective_testing() {
     println!("d1");
     p.cargo("test -p d1")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] d1 v0.0.1 ([ROOT]/foo/d1)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] unittests src/lib.rs (target/debug/deps/d1-[HASH][EXE])
@@ -2328,7 +2328,7 @@ fn selective_testing_with_docs() {
 
     p.cargo("test -p d1")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] d1 v0.0.1 ([ROOT]/foo/d1)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] unittests d1.rs (target/debug/deps/d1-[HASH][EXE])
@@ -2437,7 +2437,7 @@ fn example_with_dev_dep() {
     p.cargo("test -v")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [COMPILING] a v0.0.1 ([ROOT]/foo/a)
 [RUNNING] `rustc --crate-name foo [..]`
@@ -2744,7 +2744,7 @@ fn cyclic_dev_dep_doc_test() {
         .build();
     p.cargo("test")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -3023,7 +3023,7 @@ fn selective_test_optional_dep() {
 
     p.cargo("test -v --no-run --features a -p a")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [COMPILING] a v0.0.1 ([ROOT]/foo/a)
 [RUNNING] `rustc [..] a/src/lib.rs [..]`
 [RUNNING] `rustc [..] a/src/lib.rs [..]`
@@ -4254,7 +4254,6 @@ fn test_hint_workspace_virtual() {
     p.cargo("test")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 3 packages to latest compatible versions
 [COMPILING] c v0.1.0 ([ROOT]/foo/c)
 [COMPILING] a v0.1.0 ([ROOT]/foo/a)
 [COMPILING] b v0.1.0 ([ROOT]/foo/b)
@@ -4753,7 +4752,7 @@ fn test_dep_with_dev() {
     p.cargo("test -p bar")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [ERROR] package `bar` cannot be tested because it requires dev-dependencies and is not a member of the workspace
 
 "#]])

--- a/tests/testsuite/timings.rs
+++ b/tests/testsuite/timings.rs
@@ -31,7 +31,7 @@ fn timings_works() {
     p.cargo("build --all-targets --timings")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)
 [COMPILING] dep v0.1.0

--- a/tests/testsuite/tree.rs
+++ b/tests/testsuite/tree.rs
@@ -1624,7 +1624,7 @@ fn ambiguous_name() {
     p.cargo("tree -p dep")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 3 packages to latest compatible versions
 [ADDING] dep v1.0.0 (latest: v2.0.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v2.0.0 (registry `dummy-registry`)

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -1100,7 +1100,7 @@ rustdns.workspace = true
     p.cargo("generate-lockfile")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/rustdns`
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 
 "#]])
         .run();
@@ -1190,7 +1190,7 @@ rustdns.workspace = true
     p.cargo("generate-lockfile")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/rustdns`
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 
 "#]])
         .run();
@@ -1280,7 +1280,7 @@ rustdns.workspace = true
     p.cargo("generate-lockfile")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/rustdns`
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 
 "#]])
         .run();
@@ -1340,7 +1340,7 @@ fn update_precise_git_revisions() {
     p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/git`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 
 "#]])
         .run();
@@ -2222,7 +2222,7 @@ fn update_breaking_without_lock_file() {
         .with_stderr_data(str![[r#"
 [UPDATING] `[..]` index
 [UPGRADING] incompatible ^1.0 -> ^2.0
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 
 "#]])
         .run();

--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -1342,7 +1342,7 @@ fn git_duplicate() {
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/a`
 [UPDATING] `dummy-registry` index
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] b v0.5.0 (registry `dummy-registry`)
 [ERROR] failed to sync
@@ -1805,7 +1805,7 @@ fn no_remote_dependency_no_vendor() {
 
     p.cargo("vendor")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 There is no dependency to vendor in this project.
 
 "#]])

--- a/tests/testsuite/warn_on_failure.rs
+++ b/tests/testsuite/warn_on_failure.rs
@@ -66,7 +66,7 @@ fn no_warning_on_success() {
         .cargo("build")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [COMPILING] bar v0.0.1

--- a/tests/testsuite/weak_dep_features.rs
+++ b/tests/testsuite/weak_dep_features.rs
@@ -54,7 +54,7 @@ fn simple() {
     p.cargo("check --features f1")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
@@ -108,7 +108,7 @@ fn deferred() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v1.0.0 (registry `dummy-registry`)
 [DOWNLOADED] bar_activator v1.0.0 (registry `dummy-registry`)
@@ -188,7 +188,7 @@ fn optional_cli_syntax() {
     p.cargo("check --features bar?/feat")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
@@ -259,7 +259,7 @@ fn required_features() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [ERROR] invalid feature `bar?/feat` in required-features of target `foo`: optional dependency with `?` is not allowed in required-features
 
 "#]])
@@ -353,7 +353,7 @@ fn weak_with_host_decouple() {
     p.cargo("run")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] common v1.0.0 (registry `dummy-registry`)
 [DOWNLOADED] bar_activator v1.0.0 (registry `dummy-registry`)
@@ -399,7 +399,7 @@ fn weak_namespaced() {
     p.cargo("check --features f1")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -114,7 +114,6 @@ fn non_virtual_default_members_build_other_member() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
 [CHECKING] baz v0.1.0 ([ROOT]/foo/baz)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -154,7 +153,6 @@ fn non_virtual_default_members_build_root_project() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -698,7 +696,7 @@ fn share_dependencies() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [ADDING] dep1 v0.1.3 (latest: v0.1.8)
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep1 v0.1.3 (registry `dummy-registry`)
@@ -748,7 +746,7 @@ fn fetch_fetches_all() {
     p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep1 v0.1.3 (registry `dummy-registry`)
 
@@ -798,7 +796,7 @@ fn lock_works_for_everyone() {
     p.cargo("generate-lockfile")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 2 packages to latest compatible versions
 
 "#]])
         .run();
@@ -975,7 +973,6 @@ fn virtual_default_members_build_other_member() {
 
     p.cargo("check --manifest-path bar/Cargo.toml")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2051,7 +2048,6 @@ fn dep_used_with_separate_features() {
     // Build the entire workspace.
     p.cargo("build --workspace")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
 [COMPILING] feat_lib v0.1.0 ([ROOT]/foo/feat_lib)
 [COMPILING] caller1 v0.1.0 ([ROOT]/foo/caller1)
 [COMPILING] caller2 v0.1.0 ([ROOT]/foo/caller2)


### PR DESCRIPTION
### What does this PR try to resolve?
This is for `cargo generate-lockfile` and when syncing the lockfile with
the manifest.
We still show it for `cargo update` because of `cargo update
--workspace`.

We hacked around this previously by filtering out the `num_pkgs==1` case
for single packages but this didn't help with workspaces.

### How should we test and review this PR?


### Additional information

This builds on #14440