### PR TITLE
[DO NOT MERGE] Force edition 2024 lint into action on crater

### DIFF
--- a/src/bin/cargo/commands/check.rs
+++ b/src/bin/cargo/commands/check.rs
@@ -1,6 +1,6 @@
-use crate::command_prelude::*;
-
 use cargo::ops;
+
+use crate::command_prelude::*;
 
 pub fn cli() -> Command {
     subcommand("check")
@@ -44,16 +44,62 @@ pub fn cli() -> Command {
 }
 
 pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
+    if std::env::var("CARGO_REAL_CHECK").is_err() {
+        fixit()?;
+        return Ok(());
+    }
     let ws = args.workspace(gctx)?;
     // This is a legacy behavior that causes `cargo check` to pass `--test`.
-    let test = matches!(
-        args.get_one::<String>("profile").map(String::as_str),
-        Some("test")
-    );
+    let test = matches!(args.get_one::<String>("profile").map(String::as_str), Some("test"));
     let mode = CompileMode::Check { test };
     let compile_opts =
         args.compile_options(gctx, mode, Some(&ws), ProfileChecking::LegacyTestOnly)?;
 
     ops::compile(&ws, &compile_opts)?;
+    Ok(())
+}
+
+fn fixit() -> CliResult {
+    use std::path::Path;
+
+    use anyhow::Context;
+    use cargo_util::{paths, ProcessBuilder};
+
+    eprintln!("Copying to /tmp/fixit");
+    ProcessBuilder::new("cp").args(&["-a", ".", "/tmp/fixit"]).exec()?;
+    std::env::set_current_dir("/tmp/fixit").map_err(|e| anyhow::format_err!("cd failed {}", e))?;
+
+    let ed_re = regex::Regex::new(r#"(?m)^ *edition *= *['"]([^'"]+)['"]"#).unwrap();
+    let manifest = paths::read(Path::new("Cargo.toml"))?;
+    let ed_cap = match ed_re.captures(&manifest) {
+        None => {
+            eprintln!("no edition found in manifest, probably 2015, skipping");
+            return Ok(());
+        }
+        Some(caps) => caps.get(1).unwrap(),
+    };
+    if ed_cap.as_str() != "2021" {
+        eprintln!("skipping non-2021 edition `{}`", ed_cap.as_str());
+        return Ok(());
+    }
+    eprintln!("Running `cargo fix --edition`");
+    // Skip "cargo check"
+    let args: Vec<_> = std::env::args().skip(2).collect();
+    ProcessBuilder::new("cargo")
+        .args(&["fix", "--edition", "--allow-no-vcs", "--allow-dirty"])
+        .args(&args)
+        .exec()
+        .with_context(|| "failed to migrate to next edition")?;
+    let mut manifest = paths::read(Path::new("Cargo.toml"))?;
+    let ed_cap = ed_re.captures(&manifest).unwrap().get(1).unwrap();
+    manifest.replace_range(ed_cap.range(), "2024");
+    paths::write("Cargo.toml", manifest)?;
+    eprintln!("Running `cargo check` to verify 2024");
+    ProcessBuilder::new("cargo")
+        .args(&["check"])
+        .args(&args)
+        .env("CARGO_REAL_CHECK", "1")
+        .exec()
+        .with_context(|| "failed to check after updating to 2024")?;
     Ok(())
 }

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1257,15 +1257,15 @@ pub fn to_real_manifest(
     //     features.require(Feature::edition20xx())?;
     // }
     // ```
-    if edition == Edition::Edition2024 {
-        features.require(Feature::edition2024())?;
-    } else if !edition.is_stable() {
-        // Guard in case someone forgets to add .require()
-        return Err(util::errors::internal(format!(
-            "edition {} should be gated",
-            edition
-        )));
-    }
+    // if edition == Edition::Edition2024 {
+    //     features.require(Feature::edition2024())?;
+    // } else if !edition.is_stable() {
+    //     // Guard in case someone forgets to add .require()
+    //     return Err(util::errors::internal(format!(
+    //         "edition {} should be gated",
+    //         edition
+    //     )));
+    // }
 
     if original_toml.project.is_some() {
         if Edition::Edition2024 <= edition {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->

This is to initiate a discussion on enabling crater to apply some lints as a trial while checking crates and make sure that lints marked as machine applicable are not rendering code invalid after the lint application.

Help is needed for this PR. rust-lang/rust#107251 is introducing a new machine applicable lint. The intention of this PR is to force application of `if-let-rescope` lint during the `cargo fix --edition ...` invocation. With this commit, it seems that the in the migration pass the lint is still suppressed but the second `cargo check` did activate the said lint. Here is the log.

```
Copying to /tmp/fixit
Running `cargo fix --edition`
   Migrating Cargo.toml from 2021 edition to 2024
       Dirty testfixer v0.1.0 (/tmp/fixit): the target configuration changed
    Checking testfixer v0.1.0 (/tmp/fixit)
     Running `/mnt/dev/rust/build/x86_64-unknown-linux-gnu/stage1-tools-bin/cargo /home/xxx/.rustup/toolchains/devrust-stage1/bin/rustc --crate-name testfixer --edition=2021 src/main.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --diagnostic-width=420 --emit=dep-info,metadata -C embed-bitcode=no -C debuginfo=2 --test --check-cfg 'cfg(docsrs)' --check-cfg 'cfg(feature, values())' -C metadata=225fa3b10800db73 -C extra-filename=-225fa3b10800db73 --out-dir /home/xxx/.cargo-target/debug/deps -C incremental=/home/xxx/.cargo-target/debug/incremental -L dependency=/home/xxx/.cargo-target/debug/deps`
     Running `/mnt/dev/rust/build/x86_64-unknown-linux-gnu/stage1-tools-bin/cargo /home/xxx/.rustup/toolchains/devrust-stage1/bin/rustc --crate-name testfixer --edition=2021 src/main.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --diagnostic-width=420 --crate-type bin --emit=dep-info,metadata -C embed-bitcode=no -C debuginfo=2 --check-cfg 'cfg(docsrs)' --check-cfg 'cfg(feature, values())' -C metadata=72e3d0a692bea088 -C extra-filename=-72e3d0a692bea088 --out-dir /home/xxx/.cargo-target/debug/deps -C incremental=/home/xxx/.cargo-target/debug/incremental -L dependency=/home/xxx/.cargo-target/debug/deps`
   Migrating src/main.rs from 2021 edition to 2024
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.06s
Running `cargo check` to verify 2024
       Dirty testfixer v0.1.0 (/tmp/fixit): the target configuration changed
    Checking testfixer v0.1.0 (/tmp/fixit)
     Running `/home/xxx/.rustup/toolchains/devrust-stage1/bin/rustc --crate-name testfixer --edition=2024 -Z unstable-options src/main.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --diagnostic-width=420 --crate-type bin --emit=dep-info,metadata -C embed-bitcode=no -C debuginfo=2 --check-cfg 'cfg(docsrs)' --check-cfg 'cfg(feature, values())' -C metadata=72e3d0a692bea088 -C extra-filename=-72e3d0a692bea088 --out-dir /home/xxx/.cargo-target/debug/deps -C incremental=/home/xxx/.cargo-target/debug/incremental -L dependency=/home/xxx/.cargo-target/debug/deps`
warning: `if let` assigns a shorter lifetime since Edition 2024
  --> src/main.rs:17:8
   |
17 |     if let Some(_value) = droppy().get() {
   |        ^^^^^^^^^^^^^^^^^^^--------^^^^^^
   |                           |
   |                           this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
   |
   = warning: this changes meaning in Rust 2024
   = note: for more information, see issue #124085 <https://github.com/rust-lang/rust/issues/124085>
help: the value is now dropped here in Edition 2024
  --> src/main.rs:18:5
   |
18 |     } else {
   |     ^
   = note: `#[warn(if_let_rescope)]` on by default
help: rewrite this `if let` into a `match` with a single arm to preserve the drop order up to Edition 2021
   |
17 ~     match droppy().get()  { Some(_value) => {
18 ~     } _ => {
19 ~     }}
   |

warning: `testfixer` (bin "testfixer") generated 1 warning (run `cargo fix --bin "testfixer"` to apply 1 suggestion)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.04
```
So it is really close to working, but preferably the lint should be applied in the `Migrating` phase already so that the check shows up successful.