### PR TITLE
uplift windows gnullvm import libraries

### DIFF
--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -389,7 +389,10 @@ impl TargetInfo {
                     crate_type: Some(crate_type.clone()),
                     should_replace_hyphens: true,
                 });
-            } else if target_triple.ends_with("windows-gnu") && suffix == ".dll" {
+            } else if suffix == ".dll"
+                && (target_triple.ends_with("windows-gnu")
+                    || target_triple.ends_with("windows-gnullvm"))
+            {
                 // See https://cygwin.com/cygwin-ug-net/dll.html for more
                 // information about GNU import libraries.
                 // LD can link DLL directly, but LLD requires the import library.


### PR DESCRIPTION
Same changes as #8141, but for gnullvm.
gnullvm does not seem to be tested in CI, so tests were not adjusted.

### What does this PR try to resolve?

The `implib` for [gnullvm](https://doc.rust-lang.org/rustc/platform-support/pc-windows-gnullvm.html) targets should end up at the same location as for `gnu` targets.


### Background

I'm not a windows developer, so I may be wrong, but I believe the implib artifacts for gnullvm should be needed in the same way as for the normal windows-gnu target. In my downstream code, I need to know the location of the implib artifact, and would prefer for the location to be the same for both gnullvm and normal gnu.

