### PR TITLE
Log details of failure if no errors were seen

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -409,7 +409,17 @@ fn rustc(
                         )
                     },
                 )
-                .map_err(verbose_if_simple_exit_code)
+                .map_err(|e| {
+                    if output_options.errors_seen == 0 {
+                        // If we didn't expect an error, do not require --verbose to fail.
+                        // This is intended to debug
+                        // https://github.com/rust-lang/crater/issues/733, where we are seeing
+                        // Cargo exit unsuccessfully while seeming to not show any errors.
+                        e
+                    } else {
+                        verbose_if_simple_exit_code(e)
+                    }
+                })
                 .with_context(|| {
                     // adapted from rustc_errors/src/lib.rs
                     let warnings = match output_options.warnings_seen {


### PR DESCRIPTION
### What does this PR try to resolve?

Crater has started (some time ago, though exact point is not known) to see failures in crates without logging an error. We're suspecting that there's something wrong in Cargo or rustc, but it's also possible that Crater itself is at fault. In any case, this should provide more details.

cc https://github.com/rust-lang/crater/issues/733

### How should we test and review this PR?

My hope is that this is reasonable to land without additional tests -- as-is, we expect it to never happen (there's even a debug assert later in the same code path) but it seems it *is* happening sometimes in the wild.