### PR TITLE
fix(resolve): Report incompatible packages with precise Rust version

### DIFF
--- a/src/cargo/ops/cargo_update.rs
+++ b/src/cargo/ops/cargo_update.rs
@@ -748,9 +748,9 @@ fn report_required_rust_version(resolve: &Resolve, change: &PackageChange) -> Op
         return None;
     }
 
-    let warn = style::WARN;
+    let error = style::ERROR;
     Some(format!(
-        " {warn}(requires Rust {package_rust_version}){warn:#}"
+        " {error}(requires Rust {package_rust_version}){error:#}"
     ))
 }
 

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -1180,10 +1180,8 @@ fn report_rust_versions() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 9 packages to latest Rust 1.60.0 compatible versions
-[ADDING] dep-only-high-compatible v1.65.0 (requires Rust 1.65.0)
 [ADDING] dep-only-high-incompatible v1.75.0 (requires Rust 1.75.0)
 [ADDING] dep-only-low-incompatible v1.75.0 (requires Rust 1.75.0)
-[ADDING] dep-only-unset-compatible v1.75.0 (requires Rust 1.75.0)
 [ADDING] dep-only-unset-incompatible v1.2345.0 (requires Rust 1.2345.0)
 [ADDING] dep-shared-incompatible v1.75.0 (requires Rust 1.75.0)
 

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -1076,3 +1076,117 @@ fn cargo_install_ignores_msrv_config() {
 "#]])
         .run();
 }
+
+#[cargo_test]
+fn report_rust_versions() {
+    Package::new("dep-only-low-compatible", "1.55.0")
+        .rust_version("1.55.0")
+        .file("src/lib.rs", "fn other_stuff() {}")
+        .publish();
+    Package::new("dep-only-low-incompatible", "1.75.0")
+        .rust_version("1.75.0")
+        .file("src/lib.rs", "fn other_stuff() {}")
+        .publish();
+    Package::new("dep-only-high-compatible", "1.65.0")
+        .rust_version("1.65.0")
+        .file("src/lib.rs", "fn other_stuff() {}")
+        .publish();
+    Package::new("dep-only-high-incompatible", "1.75.0")
+        .rust_version("1.75.0")
+        .file("src/lib.rs", "fn other_stuff() {}")
+        .publish();
+    Package::new("dep-only-unset-unset", "1.0.0")
+        .file("src/lib.rs", "fn other_stuff() {}")
+        .publish();
+    Package::new("dep-only-unset-compatible", "1.75.0")
+        .rust_version("1.75.0")
+        .file("src/lib.rs", "fn other_stuff() {}")
+        .publish();
+    Package::new("dep-only-unset-incompatible", "1.2345.0")
+        .rust_version("1.2345.0")
+        .file("src/lib.rs", "fn other_stuff() {}")
+        .publish();
+    Package::new("dep-shared-compatible", "1.55.0")
+        .rust_version("1.55.0")
+        .file("src/lib.rs", "fn other_stuff() {}")
+        .publish();
+    Package::new("dep-shared-incompatible", "1.75.0")
+        .rust_version("1.75.0")
+        .file("src/lib.rs", "fn other_stuff() {}")
+        .publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [workspace]
+                members = ["high", "low", "unset"]
+            "#,
+        )
+        .file(
+            "high/Cargo.toml",
+            r#"
+                [package]
+                name = "high"
+                edition = "2015"
+                rust-version = "1.70.0"
+
+                [dependencies]
+                dep-only-high-compatible = "1"
+                dep-only-high-incompatible = "1"
+                dep-shared-compatible = "1"
+                dep-shared-incompatible = "1"
+            "#,
+        )
+        .file("high/src/main.rs", "fn main(){}")
+        .file(
+            "low/Cargo.toml",
+            r#"
+                [package]
+                name = "low"
+                edition = "2015"
+                rust-version = "1.60.0"
+
+                [dependencies]
+                dep-only-low-compatible = "1"
+                dep-only-low-incompatible = "1"
+                dep-shared-compatible = "1"
+                dep-shared-incompatible = "1"
+            "#,
+        )
+        .file("low/src/main.rs", "fn main(){}")
+        .file(
+            "unset/Cargo.toml",
+            r#"
+                [package]
+                name = "unset"
+                edition = "2015"
+
+                [dependencies]
+                dep-only-unset-unset = "1"
+                dep-only-unset-compatible = "1"
+                dep-only-unset-incompatible = "1"
+                dep-shared-compatible = "1"
+                dep-shared-incompatible = "1"
+            "#,
+        )
+        .file("unset/src/main.rs", "fn main(){}")
+        .build();
+
+    p.cargo("update")
+        .env("CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS", "fallback")
+        .arg("-Zmsrv-policy")
+        .masquerade_as_nightly_cargo(&["msrv-policy"])
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
+[LOCKING] 9 packages to latest Rust 1.60.0 compatible versions
+[ADDING] dep-only-high-compatible v1.65.0 (requires Rust 1.65.0)
+[ADDING] dep-only-high-incompatible v1.75.0 (requires Rust 1.75.0)
+[ADDING] dep-only-low-incompatible v1.75.0 (requires Rust 1.75.0)
+[ADDING] dep-only-unset-compatible v1.75.0 (requires Rust 1.75.0)
+[ADDING] dep-only-unset-incompatible v1.2345.0 (requires Rust 1.2345.0)
+[ADDING] dep-shared-incompatible v1.75.0 (requires Rust 1.75.0)
+
+"#]])
+        .run();
+}


### PR DESCRIPTION
### What does this PR try to resolve?

In #14401, we reported about MSRV issues as if we were the resolver.  We can be smarter than that though and report precise MSRV information.  This allows us to elevate the message from color from yellow to red.

This is also prep work for telling users when a newer, MSRV-compatible version of a package is available.

### How should we test and review this PR?

The report function I added is a little odd because a follow up commit will update it to report when a package is incompatible with rustc when the MSRV resolver is disabled and do this on stable.

### Additional information

This builds on #14445 to improve #14401