### PR TITLE
feat(resolve): Report incompatible-with-rustc when MSRV-resolver is disabled

### DIFF
--- a/src/cargo/ops/cargo_update.rs
+++ b/src/cargo/ops/cargo_update.rs
@@ -1121,5 +1121,9 @@ fn annotate_required_rust_version(
                     .map(|(dep, _)| (Some(required_rust_version.clone()), dep)),
             );
         }
+    } else {
+        for change in changes.values_mut() {
+            change.required_rust_version = rustc_version.clone();
+        }
     }
 }

--- a/tests/testsuite/cargo_add/rustc_ignore/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rustc_ignore/stderr.term.svg
@@ -1,8 +1,10 @@
-<svg width="740px" height="92px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-cyan { fill: #00AAAA }
     .fg-green { fill: #00AA00 }
+    .fg-red { fill: #AA0000 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -24,7 +26,9 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
-    <tspan x="10px" y="82px">
+    <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> rust-version-user v0.2.1 </tspan><tspan class="fg-red bold">(requires Rust 1.2345)</tspan>
+</tspan>
+    <tspan x="10px" y="100px">
 </tspan>
   </text>
 

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -157,6 +157,8 @@ fn lint_dep_incompatible_with_rust_version() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest compatible versions
+[ADDING] too_new_child v0.0.1 (requires Rust 1.2345.0)
+[ADDING] too_new_parent v0.0.1 (requires Rust 1.2345.0)
 
 "#]])
         .run();
@@ -296,6 +298,8 @@ fn resolve_with_rustc() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
+[ADDING] newer-and-older v1.6.0 (requires Rust 1.2345)
+[ADDING] only-newer v1.6.0 (requires Rust 1.2345)
 
 "#]])
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

This builds on #14457 to report when deps are incompatible with rustc when an MSRV-aware resolver is not used.
This affects stable code.

### How should we test and review this PR?



### Additional information

