### PR TITLE
fix(pkgid): Allow open namespaces in PackageIdSpec's

### DIFF
--- a/crates/cargo-util-schemas/src/core/package_id_spec.rs
+++ b/crates/cargo-util-schemas/src/core/package_id_spec.rs
@@ -437,6 +437,7 @@ mod tests {
             },
             "foo",
         );
+        err!("foo::bar", ErrorKind::PartialVersion(_));
         ok(
             "foo:1.2.3",
             PackageIdSpec {
@@ -447,6 +448,7 @@ mod tests {
             },
             "foo@1.2.3",
         );
+        err!("foo::bar:1.2.3", ErrorKind::PartialVersion(_));
         ok(
             "foo@1.2.3",
             PackageIdSpec {
@@ -457,6 +459,7 @@ mod tests {
             },
             "foo@1.2.3",
         );
+        err!("foo::bar@1.2.3", ErrorKind::PartialVersion(_));
         ok(
             "foo@1.2",
             PackageIdSpec {
@@ -592,6 +595,16 @@ mod tests {
             "file:///path/to/my/project/foo",
         );
         ok(
+            "file:///path/to/my/project/foo::bar",
+            PackageIdSpec {
+                name: String::from("foo::bar"),
+                version: None,
+                url: Some(Url::parse("file:///path/to/my/project/foo::bar").unwrap()),
+                kind: None,
+            },
+            "file:///path/to/my/project/foo::bar",
+        );
+        ok(
             "file:///path/to/my/project/foo#1.1.8",
             PackageIdSpec {
                 name: String::from("foo"),
@@ -610,6 +623,48 @@ mod tests {
                 kind: Some(SourceKind::Path),
             },
             "path+file:///path/to/my/project/foo#1.1.8",
+        );
+        ok(
+            "path+file:///path/to/my/project/foo#bar",
+            PackageIdSpec {
+                name: String::from("bar"),
+                version: None,
+                url: Some(Url::parse("file:///path/to/my/project/foo").unwrap()),
+                kind: Some(SourceKind::Path),
+            },
+            "path+file:///path/to/my/project/foo#bar",
+        );
+        err!(
+            "path+file:///path/to/my/project/foo#foo::bar",
+            ErrorKind::PartialVersion(_)
+        );
+        ok(
+            "path+file:///path/to/my/project/foo#bar:1.1.8",
+            PackageIdSpec {
+                name: String::from("bar"),
+                version: Some("1.1.8".parse().unwrap()),
+                url: Some(Url::parse("file:///path/to/my/project/foo").unwrap()),
+                kind: Some(SourceKind::Path),
+            },
+            "path+file:///path/to/my/project/foo#bar@1.1.8",
+        );
+        err!(
+            "path+file:///path/to/my/project/foo#foo::bar:1.1.8",
+            ErrorKind::PartialVersion(_)
+        );
+        ok(
+            "path+file:///path/to/my/project/foo#bar@1.1.8",
+            PackageIdSpec {
+                name: String::from("bar"),
+                version: Some("1.1.8".parse().unwrap()),
+                url: Some(Url::parse("file:///path/to/my/project/foo").unwrap()),
+                kind: Some(SourceKind::Path),
+            },
+            "path+file:///path/to/my/project/foo#bar@1.1.8",
+        );
+        err!(
+            "path+file:///path/to/my/project/foo#foo::bar@1.1.8",
+            ErrorKind::PartialVersion(_)
         );
     }
 

--- a/tests/testsuite/open_namespaces.rs
+++ b/tests/testsuite/open_namespaces.rs
@@ -328,6 +328,106 @@ fn main() {}
 }
 
 #[cargo_test]
+fn generate_pkgid_with_namespace() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                cargo-features = ["open-namespaces"]
+
+                [package]
+                name = "foo::bar"
+                version = "0.0.1"
+                edition = "2015"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("generate-lockfile")
+        .masquerade_as_nightly_cargo(&["open-namespaces"])
+        .run();
+    p.cargo("pkgid")
+        .masquerade_as_nightly_cargo(&["open-namespaces"])
+        .with_stdout_data(str![[r#"
+path+[ROOTURL]/foo#foo::bar@0.0.1
+
+"#]])
+        .with_stderr_data("")
+        .run()
+}
+
+#[cargo_test]
+fn update_spec_accepts_namespaced_name() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                cargo-features = ["open-namespaces"]
+
+                [package]
+                name = "foo::bar"
+                version = "0.0.1"
+                edition = "2015"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("generate-lockfile")
+        .masquerade_as_nightly_cargo(&["open-namespaces"])
+        .run();
+    p.cargo("update foo::bar")
+        .masquerade_as_nightly_cargo(&["open-namespaces"])
+        .with_status(101)
+        .with_stdout_data(str![""])
+        .with_stderr_data(str![[r#"
+[ERROR] invalid package ID specification: `foo::bar`
+
+	Did you mean `foo::bar`?
+
+Caused by:
+  expected a version like "1.32"
+
+"#]])
+        .run()
+}
+
+#[cargo_test]
+fn update_spec_accepts_namespaced_pkgid() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                cargo-features = ["open-namespaces"]
+
+                [package]
+                name = "foo::bar"
+                version = "0.0.1"
+                edition = "2015"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("generate-lockfile")
+        .masquerade_as_nightly_cargo(&["open-namespaces"])
+        .run();
+    p.cargo(&format!("update path+{}#foo::bar@0.0.1", p.url()))
+        .masquerade_as_nightly_cargo(&["open-namespaces"])
+        .with_status(101)
+        .with_stdout_data(str![""])
+        .with_stderr_data(str![[r#"
+[ERROR] invalid package ID specification: `path+[ROOTURL]/foo#foo::bar@0.0.1`
+
+Caused by:
+  expected a version like "1.32"
+
+"#]])
+        .run()
+}
+
+#[cargo_test]
 #[cfg(unix)] // until we get proper packaging support
 fn publish_namespaced() {
     use cargo_test_support::registry::RegistryBuilder;

--- a/tests/testsuite/open_namespaces.rs
+++ b/tests/testsuite/open_namespaces.rs
@@ -379,15 +379,9 @@ fn update_spec_accepts_namespaced_name() {
         .run();
     p.cargo("update foo::bar")
         .masquerade_as_nightly_cargo(&["open-namespaces"])
-        .with_status(101)
         .with_stdout_data(str![""])
         .with_stderr_data(str![[r#"
-[ERROR] invalid package ID specification: `foo::bar`
-
-	Did you mean `foo::bar`?
-
-Caused by:
-  expected a version like "1.32"
+[LOCKING] 0 packages to latest compatible versions
 
 "#]])
         .run()
@@ -415,13 +409,9 @@ fn update_spec_accepts_namespaced_pkgid() {
         .run();
     p.cargo(&format!("update path+{}#foo::bar@0.0.1", p.url()))
         .masquerade_as_nightly_cargo(&["open-namespaces"])
-        .with_status(101)
         .with_stdout_data(str![""])
         .with_stderr_data(str![[r#"
-[ERROR] invalid package ID specification: `path+[ROOTURL]/foo#foo::bar@0.0.1`
-
-Caused by:
-  expected a version like "1.32"
+[LOCKING] 0 packages to latest compatible versions
 
 "#]])
         .run()


### PR DESCRIPTION
### What does this PR try to resolve?

This is a part of #13576

This unblocks #14433.  We have a test to ensure you can't publish a namespaced package and the error for that is getting masked in #14433 because the package name is getting  parsed as a `PackageIdSpec` which wasn't supported until this PR.

### How should we test and review this PR?



### Additional information

