### PR TITLE
feat(resolve): Report MSRV compatible version instead of incomptible 

### DIFF
--- a/src/cargo/ops/cargo_update.rs
+++ b/src/cargo/ops/cargo_update.rs
@@ -765,7 +765,7 @@ fn report_latest(possibilities: &[IndexSummary], change: &PackageChange) -> Opti
     {
         let warn = style::WARN;
         let version = summary.version();
-        let report = format!(" {warn}(latest compatible: v{version}){warn:#}");
+        let report = format!(" {warn}(available: v{version}){warn:#}");
         return Some(report);
     }
 
@@ -781,7 +781,7 @@ fn report_latest(possibilities: &[IndexSummary], change: &PackageChange) -> Opti
             style::WARN
         };
         let version = summary.version();
-        let report = format!(" {warn}(latest: v{version}){warn:#}");
+        let report = format!(" {warn}(available: v{version}){warn:#}");
         return Some(report);
     }
 

--- a/src/cargo/ops/cargo_update.rs
+++ b/src/cargo/ops/cargo_update.rs
@@ -757,30 +757,30 @@ fn report_latest(possibilities: &[IndexSummary], change: &PackageChange) -> Opti
     }
 
     let version_req = package_id.version().to_caret_req();
-    if let Some(version) = possibilities
+    if let Some(summary) = possibilities
         .iter()
         .map(|s| s.as_summary())
         .filter(|s| package_id.version() != s.version() && version_req.matches(s.version()))
-        .map(|s| s.version().clone())
-        .max()
+        .max_by_key(|s| s.version())
     {
         let warn = style::WARN;
+        let version = summary.version();
         let report = format!(" {warn}(latest compatible: v{version}){warn:#}");
         return Some(report);
     }
 
-    if let Some(version) = possibilities
+    if let Some(summary) = possibilities
         .iter()
         .map(|s| s.as_summary())
         .filter(|s| is_latest(s.version(), package_id.version()))
-        .map(|s| s.version().clone())
-        .max()
+        .max_by_key(|s| s.version())
     {
         let warn = if change.is_transitive.unwrap_or(true) {
             Default::default()
         } else {
             style::WARN
         };
+        let version = summary.version();
         let report = format!(" {warn}(latest: v{version}){warn:#}");
         return Some(report);
     }

--- a/tests/testsuite/cargo_add/default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/default_features/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/list_features_path/stderr.term.svg
+++ b/tests/testsuite/cargo_add/list_features_path/stderr.term.svg
@@ -37,7 +37,7 @@
 </tspan>
     <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>

--- a/tests/testsuite/cargo_add/list_features_path_no_default/stderr.term.svg
+++ b/tests/testsuite/cargo_add/list_features_path_no_default/stderr.term.svg
@@ -37,7 +37,7 @@
 </tspan>
     <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>

--- a/tests/testsuite/cargo_add/namever/stderr.term.svg
+++ b/tests/testsuite/cargo_add/namever/stderr.term.svg
@@ -30,7 +30,7 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.2.3+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.2.3+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_add/no_default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/no_default_features/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_default_features/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_default_features_with_no_default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_default_features_with_no_default_features/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_no_default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_no_default_features/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_no_default_features_with_default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_no_default_features_with_default_features/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_path_with_version/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_path_with_version/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="844px" height="128px" xmlns="http://www.w3.org/2000/svg">
+<svg width="869px" height="128px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency v20.0.0+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency v20.0.0+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_rename_with_no_rename/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_rename_with_no_rename/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_rename_with_rename/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_rename_with_rename/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_rename_with_rename_noop/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_rename_with_rename_noop/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_with_rename/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_with_rename/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/preserve_sorted/stderr.term.svg
+++ b/tests/testsuite/cargo_add/preserve_sorted/stderr.term.svg
@@ -26,9 +26,9 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/preserve_unsorted/stderr.term.svg
+++ b/tests/testsuite/cargo_add/preserve_unsorted/stderr.term.svg
@@ -26,9 +26,9 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/rust_version_older/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rust_version_older/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest Rust 1.70 compatible version</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> rust-version-user v0.1.0 </tspan><tspan class="fg-yellow bold">(latest: v0.2.1)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> rust-version-user v0.1.0 </tspan><tspan class="fg-yellow bold">(available: v0.2.1)</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/rust_version_older/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rust_version_older/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest Rust 1.70 compatible version</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> rust-version-user v0.1.0 </tspan><tspan class="fg-yellow bold">(available: v0.2.1)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> rust-version-user v0.1.0 (available: v0.2.1, requires Rust 1.72)</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/rustc_latest/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rustc_latest/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> rust-version-user v0.1.1 </tspan><tspan class="fg-yellow bold">(latest: v0.2.1)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> rust-version-user v0.1.1 </tspan><tspan class="fg-yellow bold">(available: v0.2.1)</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/rustc_latest/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rustc_latest/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> rust-version-user v0.1.1 </tspan><tspan class="fg-yellow bold">(available: v0.2.1)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> rust-version-user v0.1.1 (available: v0.2.1, requires Rust 1.2345)</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/rustc_older/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rustc_older/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> rust-version-user v0.1.1 </tspan><tspan class="fg-yellow bold">(latest: v0.2.1)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> rust-version-user v0.1.1 </tspan><tspan class="fg-yellow bold">(available: v0.2.1)</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/rustc_older/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rustc_older/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> rust-version-user v0.1.1 </tspan><tspan class="fg-yellow bold">(available: v0.2.1)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> rust-version-user v0.1.1 (available: v0.2.1, requires Rust 1.2345)</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/sorted_table_with_dotted_item/stderr.term.svg
+++ b/tests/testsuite/cargo_add/sorted_table_with_dotted_item/stderr.term.svg
@@ -26,11 +26,11 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 4 packages to latest compatible versions</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-build-package1 v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-build-package1 v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> toml v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> toml v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_info/within_ws_without_lockfile/stderr.term.svg
+++ b/tests/testsuite/cargo_info/within_ws_without_lockfile/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package v0.2.3+my-package </tspan><tspan class="fg-yellow bold">(latest: v0.4.1+my-package)</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package v0.2.3+my-package </tspan><tspan class="fg-yellow bold">(available: v0.4.1+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-green bold"> Downloading</tspan><tspan> crates ...</tspan>
 </tspan>

--- a/tests/testsuite/cfg.rs
+++ b/tests/testsuite/cfg.rs
@@ -145,7 +145,7 @@ fn ignore_version_from_other_platform() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
-[ADDING] bar v0.1.0 (latest: v0.2.0)
+[ADDING] bar v0.1.0 (available: v0.2.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [CHECKING] bar v0.1.0

--- a/tests/testsuite/collisions.rs
+++ b/tests/testsuite/collisions.rs
@@ -207,7 +207,7 @@ fn collision_doc_multiple_versions() {
             str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest compatible versions
-[ADDING] bar v1.0.0 (latest: v2.0.0)
+[ADDING] bar v1.0.0 (available: v2.0.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v2.0.0 (registry `dummy-registry`)
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
@@ -503,7 +503,7 @@ fn collision_doc_target() {
             str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest compatible versions
-[ADDING] bar v1.0.0 (latest: v2.0.0)
+[ADDING] bar v1.0.0 (available: v2.0.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] orphaned v1.0.0 (registry `dummy-registry`)
 [DOWNLOADED] bar v2.0.0 (registry `dummy-registry`)

--- a/tests/testsuite/direct_minimal_versions.rs
+++ b/tests/testsuite/direct_minimal_versions.rs
@@ -33,7 +33,7 @@ fn simple() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package
-[ADDING] dep v1.0.0 (latest compatible: v1.1.0)
+[ADDING] dep v1.0.0 (available: v1.1.0)
 
 "#]])
         .run();
@@ -122,7 +122,7 @@ fn yanked() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package
-[ADDING] dep v1.1.0 (latest compatible: v1.2.0)
+[ADDING] dep v1.1.0 (available: v1.2.0)
 
 "#]])
         .run();
@@ -176,7 +176,7 @@ fn indirect() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages
-[ADDING] direct v1.0.0 (latest compatible: v1.1.0)
+[ADDING] direct v1.0.0 (available: v1.1.0)
 
 "#]])
         .run();

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -329,7 +329,7 @@ fn multiple() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to latest compatible version
-[ADDING] bar v0.1.0 (latest: v0.2.0)
+[ADDING] bar v0.1.0 (available: v0.2.0)
 [CHECKING] bar v0.1.0
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -2514,7 +2514,7 @@ fn self_referential() {
 [DOWNLOADED] foo v0.0.2 (registry `dummy-registry`)
 [INSTALLING] foo v0.0.2
 [LOCKING] 1 package to latest compatible version
-[ADDING] foo v0.0.1 (latest: v0.0.2)
+[ADDING] foo v0.0.1 (available: v0.0.2)
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
 [COMPILING] foo v0.0.1

--- a/tests/testsuite/minimal_versions.rs
+++ b/tests/testsuite/minimal_versions.rs
@@ -35,7 +35,7 @@ fn minimal_version_cli() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to earliest compatible version
-[ADDING] dep v1.0.0 (latest compatible: v1.1.0)
+[ADDING] dep v1.0.0 (available: v1.1.0)
 
 "#]])
         .run();

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -392,7 +392,7 @@ with the dependency requirements. If the patch has a different version from
 what is locked in the Cargo.lock file, run `cargo update` to use the new
 version. This may also occur with an optional dependency that is not enabled.
 [LOCKING] 1 package to latest compatible version
-[ADDING] bar v0.1.0 (latest: v0.2.0)
+[ADDING] bar v0.1.0 (available: v0.2.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [CHECKING] bar v0.1.0
@@ -469,7 +469,7 @@ with the dependency requirements. If the patch has a different version from
 what is locked in the Cargo.lock file, run `cargo update` to use the new
 version. This may also occur with an optional dependency that is not enabled.
 [LOCKING] 1 package to latest compatible version
-[ADDING] bar v0.1.0 (latest: v0.3.0)
+[ADDING] bar v0.1.0 (available: v0.3.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [CHECKING] bar v0.1.0
@@ -568,7 +568,7 @@ with the dependency requirements. If the patch has a different version from
 what is locked in the Cargo.lock file, run `cargo update` to use the new
 version. This may also occur with an optional dependency that is not enabled.
 [LOCKING] 1 package to latest compatible version
-[ADDING] bar v0.1.0 (latest: v0.2.0)
+[ADDING] bar v0.1.0 (available: v0.2.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [CHECKING] bar v0.1.0
@@ -642,7 +642,7 @@ with the dependency requirements. If the patch has a different version from
 what is locked in the Cargo.lock file, run `cargo update` to use the new
 version. This may also occur with an optional dependency that is not enabled.
 [LOCKING] 1 package to latest compatible version
-[ADDING] bar v0.1.0 (latest: v0.2.0)
+[ADDING] bar v0.1.0 (available: v0.2.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [CHECKING] bar v0.1.0

--- a/tests/testsuite/paths.rs
+++ b/tests/testsuite/paths.rs
@@ -60,7 +60,7 @@ fn broken_path_override_warns() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
-[ADDING] bar v0.1.0 (latest: v0.2.0)
+[ADDING] bar v0.1.0 (available: v0.2.0)
 [WARNING] path override for crate `a` has altered the original list of
 dependencies; the dependency on `bar` was either added or
 modified to not match the previously resolved version

--- a/tests/testsuite/registry_overlay.rs
+++ b/tests/testsuite/registry_overlay.rs
@@ -252,7 +252,7 @@ fn registry_dep_depends_on_new_local_package() {
             "\
 [UPDATING] [..]
 [LOCKING] 3 packages to latest compatible versions
-[ADDING] workspace-package v0.0.1 (latest: v0.1.1)
+[ADDING] workspace-package v0.0.1 (available: v0.1.1)
 [DOWNLOADING] crates ...
 [UNPACKING] [..]
 [DOWNLOADED] [..]

--- a/tests/testsuite/replace.rs
+++ b/tests/testsuite/replace.rs
@@ -465,7 +465,7 @@ fn use_a_spec_to_select() {
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[ROOTURL]/override`
 [LOCKING] 4 packages to latest compatible versions
-[ADDING] baz v0.1.1 (latest: v0.2.0)
+[ADDING] baz v0.1.1 (available: v0.2.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.1.1 (registry `dummy-registry`)
 [DOWNLOADED] bar v0.1.1 (registry `dummy-registry`)

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -242,7 +242,7 @@ foo v0.0.1 ([ROOT]/foo)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest Rust 1.60.0 compatible versions
-[ADDING] newer-and-older v1.5.0 (available: v1.6.0)
+[ADDING] newer-and-older v1.5.0 (available: v1.6.0, requires Rust 1.65.0)
 [ADDING] only-newer v1.6.0 (requires Rust 1.65.0)
 
 "#]])
@@ -319,7 +319,7 @@ foo v0.0.1 ([ROOT]/foo)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest Rust 1.60.0 compatible versions
-[ADDING] newer-and-older v1.5.0 (available: v1.6.0)
+[ADDING] newer-and-older v1.5.0 (available: v1.6.0, requires Rust 1.2345)
 [ADDING] only-newer v1.6.0 (requires Rust 1.2345)
 
 "#]])
@@ -490,7 +490,7 @@ higher v0.0.1 ([ROOT]/foo)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest Rust 1.50.0 compatible versions
-[ADDING] newer-and-older v1.5.0 (available: v1.6.0)
+[ADDING] newer-and-older v1.5.0 (available: v1.6.0, requires Rust 1.65.0)
 [ADDING] only-newer v1.6.0 (requires Rust 1.65.0)
 
 "#]])
@@ -619,7 +619,7 @@ fn resolve_edition2024() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest Rust 1.60.0 compatible versions
-[ADDING] newer-and-older v1.5.0 (available: v1.6.0)
+[ADDING] newer-and-older v1.5.0 (available: v1.6.0, requires Rust 1.65.0)
 [ADDING] only-newer v1.6.0 (requires Rust 1.65.0)
 
 "#]])
@@ -723,7 +723,7 @@ fn resolve_v3() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest Rust 1.60.0 compatible versions
-[ADDING] newer-and-older v1.5.0 (available: v1.6.0)
+[ADDING] newer-and-older v1.5.0 (available: v1.6.0, requires Rust 1.65.0)
 [ADDING] only-newer v1.6.0 (requires Rust 1.65.0)
 
 "#]])
@@ -871,7 +871,7 @@ fn update_msrv_resolve() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest Rust 1.60.0 compatible version
-[ADDING] bar v1.5.0 (available: v1.6.0)
+[ADDING] bar v1.5.0 (available: v1.6.0, requires Rust 1.65.0)
 
 "#]])
         .run();
@@ -932,7 +932,7 @@ fn update_precise_overrides_msrv_resolver() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest Rust 1.60.0 compatible version
-[ADDING] bar v1.5.0 (available: v1.6.0)
+[ADDING] bar v1.5.0 (available: v1.6.0, requires Rust 1.65.0)
 
 "#]])
         .run();
@@ -1019,7 +1019,7 @@ foo v0.0.1 ([ROOT]/foo)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest Rust 1.60.0 compatible versions
-[ADDING] newer-and-older v1.5.0 (available: v1.6.0)
+[ADDING] newer-and-older v1.5.0 (available: v1.6.0, requires Rust 1.65.0)
 [ADDING] only-newer v1.6.0 (requires Rust 1.65.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] newer-and-older v1.5.0 (registry `dummy-registry`)

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -242,7 +242,7 @@ foo v0.0.1 ([ROOT]/foo)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest Rust 1.60.0 compatible versions
-[ADDING] newer-and-older v1.5.0 (latest compatible: v1.6.0)
+[ADDING] newer-and-older v1.5.0 (available: v1.6.0)
 [ADDING] only-newer v1.6.0 (requires Rust 1.65.0)
 
 "#]])
@@ -319,7 +319,7 @@ foo v0.0.1 ([ROOT]/foo)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest Rust 1.60.0 compatible versions
-[ADDING] newer-and-older v1.5.0 (latest compatible: v1.6.0)
+[ADDING] newer-and-older v1.5.0 (available: v1.6.0)
 [ADDING] only-newer v1.6.0 (requires Rust 1.2345)
 
 "#]])
@@ -490,7 +490,7 @@ higher v0.0.1 ([ROOT]/foo)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest Rust 1.50.0 compatible versions
-[ADDING] newer-and-older v1.5.0 (latest compatible: v1.6.0)
+[ADDING] newer-and-older v1.5.0 (available: v1.6.0)
 [ADDING] only-newer v1.6.0 (requires Rust 1.65.0)
 
 "#]])
@@ -619,7 +619,7 @@ fn resolve_edition2024() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest Rust 1.60.0 compatible versions
-[ADDING] newer-and-older v1.5.0 (latest compatible: v1.6.0)
+[ADDING] newer-and-older v1.5.0 (available: v1.6.0)
 [ADDING] only-newer v1.6.0 (requires Rust 1.65.0)
 
 "#]])
@@ -723,7 +723,7 @@ fn resolve_v3() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest Rust 1.60.0 compatible versions
-[ADDING] newer-and-older v1.5.0 (latest compatible: v1.6.0)
+[ADDING] newer-and-older v1.5.0 (available: v1.6.0)
 [ADDING] only-newer v1.6.0 (requires Rust 1.65.0)
 
 "#]])
@@ -871,7 +871,7 @@ fn update_msrv_resolve() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest Rust 1.60.0 compatible version
-[ADDING] bar v1.5.0 (latest compatible: v1.6.0)
+[ADDING] bar v1.5.0 (available: v1.6.0)
 
 "#]])
         .run();
@@ -932,7 +932,7 @@ fn update_precise_overrides_msrv_resolver() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest Rust 1.60.0 compatible version
-[ADDING] bar v1.5.0 (latest compatible: v1.6.0)
+[ADDING] bar v1.5.0 (available: v1.6.0)
 
 "#]])
         .run();
@@ -1019,7 +1019,7 @@ foo v0.0.1 ([ROOT]/foo)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest Rust 1.60.0 compatible versions
-[ADDING] newer-and-older v1.5.0 (latest compatible: v1.6.0)
+[ADDING] newer-and-older v1.5.0 (available: v1.6.0)
 [ADDING] only-newer v1.6.0 (requires Rust 1.65.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] newer-and-older v1.5.0 (registry `dummy-registry`)

--- a/tests/testsuite/tree.rs
+++ b/tests/testsuite/tree.rs
@@ -1625,7 +1625,7 @@ fn ambiguous_name() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest compatible versions
-[ADDING] dep v1.0.0 (latest: v2.0.0)
+[ADDING] dep v1.0.0 (available: v2.0.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v2.0.0 (registry `dummy-registry`)
 [DOWNLOADED] dep v1.0.0 (registry `dummy-registry`)

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -1522,7 +1522,7 @@ fn report_behind() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
-[UPDATING] breaking v0.1.0 -> v0.1.1 (latest: v0.2.0)
+[UPDATING] breaking v0.1.0 -> v0.1.1 (available: v0.2.0)
 [NOTE] pass `--verbose` to see 2 unchanged dependencies behind latest
 [WARNING] not updating lockfile due to dry run
 
@@ -1533,9 +1533,9 @@ fn report_behind() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
-[UPDATING] breaking v0.1.0 -> v0.1.1 (latest: v0.2.0)
-[UNCHANGED] pre v1.0.0-alpha.0 (latest compatible: v1.0.0-alpha.1)
-[UNCHANGED] two-ver v0.1.0 (latest: v0.2.0)
+[UPDATING] breaking v0.1.0 -> v0.1.1 (available: v0.2.0)
+[UNCHANGED] pre v1.0.0-alpha.0 (available: v1.0.0-alpha.1)
+[UNCHANGED] two-ver v0.1.0 (available: v0.2.0)
 [NOTE] to see how you depend on a package, run `cargo tree --invert --package <dep>@<ver>`
 [WARNING] not updating lockfile due to dry run
 
@@ -1558,9 +1558,9 @@ fn report_behind() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 0 packages to latest compatible versions
-[UNCHANGED] breaking v0.1.1 (latest: v0.2.0)
-[UNCHANGED] pre v1.0.0-alpha.0 (latest compatible: v1.0.0-alpha.1)
-[UNCHANGED] two-ver v0.1.0 (latest: v0.2.0)
+[UNCHANGED] breaking v0.1.1 (available: v0.2.0)
+[UNCHANGED] pre v1.0.0-alpha.0 (available: v1.0.0-alpha.1)
+[UNCHANGED] two-ver v0.1.0 (available: v0.2.0)
 [NOTE] to see how you depend on a package, run `cargo tree --invert --package <dep>@<ver>`
 [WARNING] not updating lockfile due to dry run
 
@@ -2008,8 +2008,8 @@ fn update_breaking() {
 [LOCKING] 4 packages to latest compatible versions
 [UPDATING] compatible v1.0.0 -> v1.0.1
 [UPDATING] less-than v1.0.0 -> v2.0.0
-[UPDATING] pinned v1.0.0 -> v1.0.1 (latest: v2.0.0)
-[UPDATING] renamed-from v1.0.0 -> v1.0.1 (latest: v2.0.0)
+[UPDATING] pinned v1.0.0 -> v1.0.1 (available: v2.0.0)
+[UPDATING] renamed-from v1.0.0 -> v1.0.1 (available: v2.0.0)
 
 "#]])
         .run();
@@ -2180,10 +2180,10 @@ fn update_breaking_specific_packages_that_wont_update() {
 [UPDATING] `[..]` index
 [LOCKING] 5 packages to latest compatible versions
 [UPDATING] compatible v1.0.0 -> v1.0.1
-[UPDATING] non-semver v1.0.0 -> v1.0.1 (latest: v2.0.0)
-[UPDATING] renamed-from v1.0.0 -> v1.0.1 (latest: v2.0.0)
+[UPDATING] non-semver v1.0.0 -> v1.0.1 (available: v2.0.0)
+[UPDATING] renamed-from v1.0.0 -> v1.0.1 (available: v2.0.0)
 [UPDATING] transitive-compatible v1.0.0 -> v1.0.1
-[UPDATING] transitive-incompatible v1.0.0 -> v1.0.1 (latest: v2.0.0)
+[UPDATING] transitive-incompatible v1.0.0 -> v1.0.1 (available: v2.0.0)
 
 "#]])
     .run();
@@ -2397,7 +2397,7 @@ fn update_breaking_spec_version_transitive() {
         .with_stderr_data(str![[r#"
 [UPDATING] `[..]` index
 [LOCKING] 1 package to latest compatible version
-[UPDATING] dep v1.1.0 -> v1.1.1 (latest: v2.0.0)
+[UPDATING] dep v1.1.0 -> v1.1.1 (available: v2.0.0)
 
 "#]])
         .run();

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -697,7 +697,7 @@ fn share_dependencies() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
-[ADDING] dep1 v0.1.3 (latest compatible: v0.1.8)
+[ADDING] dep1 v0.1.3 (available: v0.1.8)
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep1 v0.1.3 (registry `dummy-registry`)
 [CHECKING] dep1 v0.1.3


### PR DESCRIPTION
### What does this PR try to resolve?

This expands on #14461 to where only MSRV-compatible versions are
"actionable".  MSRV-incompatible versions are therefore unstyled.

We report the MSRV needed so people can choose to unblock by updating
their MSRV.  I had wondered if we should report the the absolute latest
MSRV-incompatible version or the one with the next higher MSRV from
where the user is at.  Both are reasonable use cases, so I erred with
absolute latest version.

```console
$ cargo update --workspace -v
```
![image](https://github.com/user-attachments/assets/27e40dda-287b-4223-a377-0233205307a2)

### How should we test and review this PR?

I changed the label from `latest` to `available` to not have to keep coming up with relevant terms for each case.

### Additional information

This is the final step before asking for new feedback on #13908