### PR TITLE
Fix elided lifetime

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -577,7 +577,7 @@ impl<'gctx> Workspace<'gctx> {
     }
 
     /// Returns an iterator over default packages in this workspace
-    pub fn default_members<'a>(&'a self) -> impl Iterator<Item = &Package> {
+    pub fn default_members<'a>(&'a self) -> impl Iterator<Item = &'a Package> {
         let packages = &self.packages;
         self.default_members
             .iter()

--- a/tests/testsuite/lints/implicit_features.rs
+++ b/tests/testsuite/lints/implicit_features.rs
@@ -127,7 +127,7 @@ unused_optional_dependency = "allow"
         .masquerade_as_nightly_cargo(&["cargo-lints", "edition2024"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest Rust 1.82.0-nightly compatible version
+[LOCKING] 1 package to latest Rust 1.[..] compatible version
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 


### PR DESCRIPTION
This fixes an issue with the recent nightly that has added a lint (https://github.com/rust-lang/rust/pull/129207) that warns about the lack of a lifetime, which looks like:

```
warning: elided lifetime has a name
   --> src/cargo/core/workspace.rs:580:66
    |
580 |     pub fn default_members<'a>(&'a self) -> impl Iterator<Item = &Package> {
    |                            -- lifetime `'a` declared here        ^ this elided lifetime gets resolved as `'a`
    |
    = note: `#[warn(elided_named_lifetimes)]` on by default
```
