### PR TITLE
Normalize the `target` paths

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -9,7 +9,7 @@ use crate::core::summary::MissingDependencyError;
 use crate::AlreadyPrintedError;
 use anyhow::{anyhow, bail, Context as _};
 use cargo_platform::Platform;
-use cargo_util::paths::{self, normalize_path};
+use cargo_util::paths;
 use cargo_util_schemas::manifest::{
     self, PackageName, PathBaseName, TomlDependency, TomlDetailedDependency, TomlManifest,
 };
@@ -2712,7 +2712,7 @@ fn prepare_toml_for_publish(
     let mut package = me.package().unwrap().clone();
     package.workspace = None;
     if let Some(StringOrBool::String(path)) = &package.build {
-        let path = paths::normalize_path(Path::new(path));
+        let path = Path::new(path).to_path_buf();
         let included = packaged_files.map(|i| i.contains(&path)).unwrap_or(true);
         let build = if included {
             let path = path
@@ -3017,7 +3017,7 @@ pub fn prepare_target_for_publish(
     gctx: &GlobalContext,
 ) -> CargoResult<Option<manifest::TomlTarget>> {
     let path = target.path.as_ref().expect("previously normalized");
-    let path = normalize_path(&path.0);
+    let path = &path.0;
     if let Some(packaged_files) = packaged_files {
         if !packaged_files.contains(&path) {
             let name = target.name.as_ref().expect("previously normalized");
@@ -3030,7 +3030,7 @@ pub fn prepare_target_for_publish(
     }
 
     let mut target = target.clone();
-    let path = normalize_path_sep(path, context)?;
+    let path = normalize_path_sep(path.to_path_buf(), context)?;
     target.path = Some(manifest::PathValue(path.into()));
 
     Ok(Some(target))

--- a/tests/testsuite/binary_name.rs
+++ b/tests/testsuite/binary_name.rs
@@ -413,11 +413,11 @@ fn targets_with_relative_path_in_workspace_members() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 ...
- --> relative-bar/./build.rs:1:17
+ --> relative-bar/build.rs:1:17
 ...
- --> relative-bar/./src/lib.rs:1:4
+ --> relative-bar/src/lib.rs:1:4
 ...
- --> relative-bar/./src/main.rs:1:17
+ --> relative-bar/src/main.rs:1:17
 ...
 "#]])
         .run();
@@ -425,7 +425,7 @@ fn targets_with_relative_path_in_workspace_members() {
     p.cargo("check --example example")
         .with_stderr_data(str![[r#"
 ...
- --> relative-bar/./example.rs:1:17
+ --> relative-bar/example.rs:1:17
 ...
 "#]])
         .run();
@@ -433,7 +433,7 @@ fn targets_with_relative_path_in_workspace_members() {
     p.cargo("check --test test")
         .with_stderr_data(str![[r#"
 ...
- --> relative-bar/./test.rs:5:35
+ --> relative-bar/test.rs:5:35
 ...
 "#]])
         .run();
@@ -442,7 +442,7 @@ fn targets_with_relative_path_in_workspace_members() {
         p.cargo("check --bench bench")
             .with_stderr_data(str![[r#"
 ...
- --> relative-bar/./bench.rs:7:58
+ --> relative-bar/bench.rs:7:58
 ...
 "#]])
             .run();
@@ -490,11 +490,11 @@ fn targets_with_relative_path_in_workspace_members() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 ...
- --> relative-bar/./build.rs:1:17
+ --> relative-bar/build.rs:1:17
 ...
- --> relative-bar/./src/lib.rs:1:4
+ --> relative-bar/src/lib.rs:1:4
 ...
- --> relative-bar/./src/main.rs:1:17
+ --> relative-bar/src/main.rs:1:17
 ...
 "#]])
         .run();
@@ -502,7 +502,7 @@ fn targets_with_relative_path_in_workspace_members() {
     p.cargo("check --example example")
         .with_stderr_data(str![[r#"
 ...
- --> relative-bar/./example.rs:1:17
+ --> relative-bar/example.rs:1:17
 ...
 "#]])
         .run();
@@ -510,7 +510,7 @@ fn targets_with_relative_path_in_workspace_members() {
     p.cargo("check --test test")
         .with_stderr_data(str![[r#"
 ...
- --> relative-bar/./test.rs:5:35
+ --> relative-bar/test.rs:5:35
 ...
 "#]])
         .run();
@@ -519,7 +519,7 @@ fn targets_with_relative_path_in_workspace_members() {
         p.cargo("check --bench bench")
             .with_stderr_data(str![[r#"
 ...
- --> relative-bar/./bench.rs:7:58
+ --> relative-bar/bench.rs:7:58
 ...
 "#]])
             .run();

--- a/tests/testsuite/binary_name.rs
+++ b/tests/testsuite/binary_name.rs
@@ -2,6 +2,7 @@
 
 use cargo_test_support::install::assert_has_installed_exe;
 use cargo_test_support::install::assert_has_not_installed_exe;
+use cargo_test_support::is_nightly;
 use cargo_test_support::paths;
 use cargo_test_support::prelude::*;
 use cargo_test_support::project;
@@ -339,4 +340,188 @@ fn check_msg_format_json() {
             .against_jsonlines(),
         )
         .run();
+}
+
+#[cargo_test]
+fn targets_with_relative_path_in_workspace_members() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["relative-bar"]
+            resolver = "2"
+        "#,
+        )
+        .file(
+            "relative-bar/Cargo.toml",
+            r#"
+                [package]
+                name = "relative-bar"
+                version = "0.1.0"
+                edition = "2021"
+
+                build = "./build.rs"
+
+                [[bin]]
+                name = "bar"
+                path = "./src/main.rs"
+
+                [lib]
+                name = "lib"
+                path = "./src/lib.rs"
+
+                [[example]]
+                name = "example"
+                path = "./example.rs"
+
+                [[test]]
+                name = "test"
+                path = "./test.rs"
+
+                [[bench]]
+                name = "bench"
+                path = "./bench.rs"
+            "#,
+        )
+        .file("relative-bar/build.rs", "fn main() { let a = 1; }")
+        .file("relative-bar/src/main.rs", "fn main() { let a = 1; }")
+        .file("relative-bar/src/lib.rs", "fn a() {}")
+        .file("relative-bar/example.rs", "fn main() { let a = 1; }")
+        .file(
+            "relative-bar/test.rs",
+            r#"
+                fn main() {}
+
+                #[test]
+                fn test_a() { let a = 1; } 
+            "#,
+        )
+        .file(
+            "relative-bar/bench.rs",
+            r#"  
+                #![feature(test)]
+                #[cfg(test)]
+                extern crate test;
+
+                #[bench]
+                fn bench_a(_b: &mut test::Bencher) { let a = 1; }
+            "#,
+        )
+        .build();
+
+    p.cargo("check")
+        .with_stderr_data(str![[r#"
+...
+ --> relative-bar/./build.rs:1:17
+...
+ --> relative-bar/./src/lib.rs:1:4
+...
+ --> relative-bar/./src/main.rs:1:17
+...
+"#]])
+        .run();
+
+    p.cargo("check --example example")
+        .with_stderr_data(str![[r#"
+...
+ --> relative-bar/./example.rs:1:17
+...
+"#]])
+        .run();
+
+    p.cargo("check --test test")
+        .with_stderr_data(str![[r#"
+...
+ --> relative-bar/./test.rs:5:35
+...
+"#]])
+        .run();
+
+    if is_nightly() {
+        p.cargo("check --bench bench")
+            .with_stderr_data(str![[r#"
+...
+ --> relative-bar/./bench.rs:7:58
+...
+"#]])
+            .run();
+    }
+
+    // Disable Cargo target auto-discovery.
+    p.change_file(
+        "relative-bar/Cargo.toml",
+        r#"
+            [package]
+            name = "relative-bar"
+            version = "0.1.0"
+            edition = "2021"
+
+            autolib = false
+            autobins = false
+            autoexamples = false
+            autotests = false
+            autobenches = false
+
+            build = "./build.rs"
+
+            [[bin]]
+            name = "bar"
+            path = "./src/main.rs"
+
+            [lib]
+            name = "lib"
+            path = "./src/lib.rs"
+
+            [[example]]
+            name = "example"
+            path = "./example.rs"
+
+            [[test]]
+            name = "test"
+            path = "./test.rs"
+
+            [[bench]]
+            name = "bench"
+            path = "./bench.rs"
+        "#,
+    );
+
+    p.cargo("check")
+        .with_stderr_data(str![[r#"
+...
+ --> relative-bar/./build.rs:1:17
+...
+ --> relative-bar/./src/lib.rs:1:4
+...
+ --> relative-bar/./src/main.rs:1:17
+...
+"#]])
+        .run();
+
+    p.cargo("check --example example")
+        .with_stderr_data(str![[r#"
+...
+ --> relative-bar/./example.rs:1:17
+...
+"#]])
+        .run();
+
+    p.cargo("check --test test")
+        .with_stderr_data(str![[r#"
+...
+ --> relative-bar/./test.rs:5:35
+...
+"#]])
+        .run();
+
+    if is_nightly() {
+        p.cargo("check --bench bench")
+            .with_stderr_data(str![[r#"
+...
+ --> relative-bar/./bench.rs:7:58
+...
+"#]])
+            .run();
+    }
 }


### PR DESCRIPTION
### What does this PR try to resolve?

The `targets` path of the `normalized_toml` could be relative,   which isn't user-friendly.

What is this PR doing?

This PR applys the `paths::normalize_path` to remove the relative part. 

Fixes #14227 

### How should we test and review this PR?

Add a test originted from the issue,  and fixing it in the next commit.

### Additional information



