### PR TITLE
fix(toml): Don't require MSRV bump for pub/priv

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -786,12 +786,8 @@ fn normalize_dependencies<'a>(
                 warnings,
             )?;
             if d.public.is_some() {
-                let public_feature = features.require(Feature::public_dependency());
-                let with_public_feature = public_feature.is_ok();
+                let with_public_feature = features.require(Feature::public_dependency()).is_ok();
                 let with_z_public = gctx.cli_unstable().public_dependency;
-                if !with_public_feature && (!with_z_public && !gctx.nightly_features_allowed) {
-                    public_feature?;
-                }
                 if matches!(kind, None) {
                     if !with_public_feature && !with_z_public {
                         d.public = None;

--- a/tests/testsuite/pub_priv.rs
+++ b/tests/testsuite/pub_priv.rs
@@ -226,7 +226,6 @@ fn pub_dev_dependency_without_feature() {
         .build();
 
     p.cargo("check --message-format=short")
-        .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(str![[r#"
 [WARNING] 'public' specifier can only be used on regular dependencies, not dev-dependencies
 [UPDATING] `dummy-registry` index


### PR DESCRIPTION
### What does this PR try to resolve?

In #13308, we decided to make the feature gate for public/private dependencies non-blocking.
Generally, people opt-in to a feature that is non-blocking through `-Z` but some nightly users want an "always on" mode for this, so we offered both in #13340.
In #13340, we made both feature gates work but we did not make them non-blocking for stable, only nightly.

This change makes the feature gate non-blocking on stable.

Unfortunately, this means that 1.83 will be the MSRV for people using public dependencies.  Good thing the feature is indefinitely blocked in rustc as that gives us more time.

### How should we test and review this PR?


### Additional information

