### PR TITLE
Suggest `cargo info` command in the `cargo search` result

### DIFF
--- a/src/cargo/ops/registry/search.rs
+++ b/src/cargo/ops/registry/search.rs
@@ -8,6 +8,7 @@ use anyhow::Context as _;
 use url::Url;
 
 use crate::util::style;
+use crate::util::style::LITERAL;
 use crate::util::truncate_with_ellipsis;
 use crate::CargoResult;
 use crate::GlobalContext;
@@ -85,6 +86,13 @@ pub fn search(
             total_crates - limit,
             extra
         );
+    }
+
+    if total_crates > 0 {
+        let literal = LITERAL;
+        shell.note(format_args!(
+            "to learn more about a package, run `{literal}cargo info <name>{literal:#}`",
+        ))?;
     }
 
     Ok(())

--- a/tests/testsuite/search.rs
+++ b/tests/testsuite/search.rs
@@ -115,7 +115,11 @@ fn not_update() {
     cargo_process("search postgres")
         .replace_crates_io(registry.index_url())
         .with_stdout_data(SEARCH_RESULTS)
-        .with_stderr_data("") // without "Updating ... index"
+        // without "Updating ... index"
+        .with_stderr_data(str![[r#"
+[NOTE] to learn more about a package, run `cargo info <name>`
+
+"#]])
         .run();
 }
 
@@ -128,6 +132,7 @@ fn replace_default() {
         .with_stdout_data(SEARCH_RESULTS)
         .with_stderr_data(str![[r#"
 [UPDATING] crates.io index
+[NOTE] to learn more about a package, run `cargo info <name>`
 
 "#]])
         .run();
@@ -140,6 +145,11 @@ fn simple() {
     cargo_process("search postgres --index")
         .arg(registry.index_url().as_str())
         .with_stdout_data(SEARCH_RESULTS)
+        .with_stderr_data(str![[r#"
+[UPDATING] `[ROOT]/registry` index
+[NOTE] to learn more about a package, run `cargo info <name>`
+
+"#]])
         .run();
 }
 
@@ -150,6 +160,11 @@ fn multiple_query_params() {
     cargo_process("search postgres sql --index")
         .arg(registry.index_url().as_str())
         .with_stdout_data(SEARCH_RESULTS)
+        .with_stderr_data(str![[r#"
+[UPDATING] `[ROOT]/registry` index
+[NOTE] to learn more about a package, run `cargo info <name>`
+
+"#]])
         .run();
 }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->


### What does this PR try to resolve?

close https://github.com/rust-lang/cargo/issues/14518

Suggest `cargo info` command in the `cargo search` result.

### How should we test and review this PR?

The old tests were updated.

### Additional information

~~I am not sure if the `note` function should be put into util. Does it make sense? Do you have a better place for it?~~ Use the `shell.note` instead.

<!-- homu-ignore:end -->
