### PR TITLE
docs: Feature resolver version 2: clarify use of 'target'

### DIFF
--- a/src/doc/src/reference/features.md
+++ b/src/doc/src/reference/features.md
@@ -365,11 +365,11 @@ that unification can be unwanted. The exact situations are described in the
 [resolver chapter][resolver-v2], but in short, it avoids unifying in these
 situations:
 
-* Features enabled on [platform-specific dependencies] for targets not
+* Features enabled on [platform-specific dependencies] for [target architectures][target] not
   currently being built are ignored.
 * [Build-dependencies] and proc-macros do not share features with normal
   dependencies.
-* [Dev-dependencies] do not activate features unless building a target that
+* [Dev-dependencies] do not activate features unless building a [cargo target][target] that
   needs them (like tests or examples).
 
 Avoiding the unification is necessary for some situations. For example, if a
@@ -392,6 +392,8 @@ features](#inspecting-resolved-features) for more on fetching information on
 the resolved features. For build dependencies, this is not necessary if you
 are cross-compiling with the `--target` flag because build dependencies are
 always built separately from normal dependencies in that scenario.
+
+[target]: ../appendix/glossary.md#target
 
 ### Resolver version 2 command-line flags
 


### PR DESCRIPTION
IIUC, these two uses of the word `target` right next to each other in the docs actually have different meaning. That is kind of confusing, so add disambiguators and links to the glossary that should help clarify this.