### PR TITLE
Gate shell_completions tests on availability

### DIFF
--- a/tests/testsuite/shell_completions.rs
+++ b/tests/testsuite/shell_completions.rs
@@ -4,13 +4,9 @@ use cargo_test_support::cargo_test;
 use completest_pty::Runtime;
 use snapbox::assert_data_eq;
 
-#[cargo_test]
+#[cargo_test(requires_bash)]
+#[cfg_attr(target_os = "macos", ignore = "bash is not working on macOS")]
 fn bash() {
-    // HACK: At least on CI, bash is not working on macOS
-    if cfg!(target_os = "macos") {
-        return;
-    }
-
     let input = "cargo \t\t";
     let expected = snapbox::str![
         "% 
@@ -29,13 +25,9 @@ fn bash() {
     assert_data_eq!(actual, expected);
 }
 
-#[cargo_test]
+#[cargo_test(requires_elvish)]
+#[cfg_attr(target_os = "macos", ignore = "elvish is not working on macOS")]
 fn elvish() {
-    // HACK: At least on CI, elvish is not working on macOS
-    if cfg!(target_os = "macos") {
-        return;
-    }
-
     let input = "cargo \t\t";
     let expected = snapbox::str![
         "% cargo --config
@@ -55,13 +47,9 @@ fn elvish() {
     assert_data_eq!(actual, expected);
 }
 
-#[cargo_test]
+#[cargo_test(requires_fish)]
+#[cfg_attr(target_os = "macos", ignore = "fish is not working on macOS")]
 fn fish() {
-    // HACK: At least on CI, fish is not working on macOS
-    if cfg!(target_os = "macos") {
-        return;
-    }
-
     let input = "cargo \t\t";
     let expected = snapbox::str![
         "% cargo 
@@ -125,7 +113,7 @@ yank                                                                            
     assert_data_eq!(actual, expected);
 }
 
-#[cargo_test]
+#[cargo_test(requires_zsh)]
 fn zsh() {
     let input = "cargo \t\t";
     let expected = snapbox::str![


### PR DESCRIPTION
This changes the shell_completions tests to only run if the corresponding external program is installed. Generally, cargo's tests shouldn't require any external commands to be installed.

This also uses the `ignore` attribute for disabling on macos. It is quite confusing when running on macos to see a successful test when it isn't running. This ensures that the test output indicates that it is ignored and the reason.

cc @shannmu 
