### PR TITLE
Fix docs for `cargo publish --dry-run` vs `cargo package`

### DIFF
--- a/src/doc/src/reference/publishing.md
+++ b/src/doc/src/reference/publishing.md
@@ -74,8 +74,8 @@ steps:
    before adding it.
 
 It is recommended that you first run `cargo publish --dry-run` (or [`cargo
-package`] which is equivalent) to ensure there aren't any warnings or errors
-before publishing. This will perform the first three steps listed above.
+package`]) to ensure there aren't any warnings or errors before publishing.
+This will perform the first three steps listed above.
 
 ```console
 $ cargo publish --dry-run


### PR DESCRIPTION
In latest nightly at least, `cargo publish --dry-run` and `cargo package` are not equivalent:

```
e@e egui-tetra2 % cargo publish --dry-run
    Updating crates.io index
error: crate egui-tetra2@0.5.1 already exists on crates.io index
e@e egui-tetra2 % cargo package
   Packaging egui-tetra2 v0.5.1 (/Users/e/Documents/GitHub/egui-tetra2)
    Updating crates.io index
    Packaged 19 files, 135.3KiB (37.7KiB compressed)
   Verifying egui-tetra2 v0.5.1 (/Users/e/Documents/GitHub/egui-tetra2)
...
```