### PR TITLE
refactor(info): Use the `shell.note` to print the note

### DIFF
--- a/src/cargo/ops/registry/info/view.rs
+++ b/src/cargo/ops/registry/info/view.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::io::Write;
 
+use crate::core::Shell;
 use crate::util::style::{ERROR, HEADER, LITERAL, NOP, NOTE, WARN};
 use crate::{
     core::{
@@ -153,7 +154,7 @@ pub(super) fn pretty_view(
     )?;
 
     if suggest_cargo_tree_command {
-        suggest_cargo_tree(package_id, stdout)?;
+        suggest_cargo_tree(package_id, &mut shell)?;
     }
 
     Ok(())
@@ -395,23 +396,14 @@ fn pretty_features(
 }
 
 // Suggest the cargo tree command to view the dependency tree.
-fn suggest_cargo_tree(package_id: PackageId, stdout: &mut dyn Write) -> CargoResult<()> {
+fn suggest_cargo_tree(package_id: PackageId, shell: &mut Shell) -> CargoResult<()> {
     let literal = LITERAL;
 
-    note(format_args!(
+    shell.note(format_args!(
         "to see how you depend on {name}, run `{literal}cargo tree --invert --package {name}@{version}{literal:#}`",
         name = package_id.name(),
         version = package_id.version(),
-    ), stdout)
-}
-
-pub(super) fn note(msg: impl std::fmt::Display, stdout: &mut dyn Write) -> CargoResult<()> {
-    let note = NOTE;
-    let bold = anstyle::Style::new() | anstyle::Effects::BOLD;
-
-    writeln!(stdout, "{note}note{note:#}{bold}:{bold:#} {msg}",)?;
-
-    Ok(())
+    ))
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/tests/testsuite/cargo_info/specify_version_within_ws_and_match_with_lockfile/stderr.term.svg
+++ b/tests/testsuite/cargo_info/specify_version_within_ws_and_match_with_lockfile/stderr.term.svg
@@ -1,7 +1,8 @@
-<svg width="740px" height="92px" xmlns="http://www.w3.org/2000/svg">
+<svg width="911px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-cyan { fill: #00AAAA }
     .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
@@ -24,7 +25,9 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v0.1.1+my-package (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="82px">
+    <tspan x="10px" y="82px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-cyan bold">cargo tree --invert --package my-package@0.1.1+my-package</tspan><tspan>`</tspan>
+</tspan>
+    <tspan x="10px" y="100px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_info/specify_version_within_ws_and_match_with_lockfile/stdout.term.svg
+++ b/tests/testsuite/cargo_info/specify_version_within_ws_and_match_with_lockfile/stdout.term.svg
@@ -1,8 +1,7 @@
-<svg width="911px" height="164px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="146px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
     .fg-green { fill: #00AA00 }
     .fg-red { fill: #AA0000 }
     .fg-yellow { fill: #AA5500 }
@@ -33,9 +32,7 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-green bold">crates.io:</tspan><tspan> https://crates.io/crates/my-package/0.1.1+my-package</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-cyan bold">cargo tree --invert --package my-package@0.1.1+my-package</tspan><tspan>`</tspan>
-</tspan>
-    <tspan x="10px" y="154px">
+    <tspan x="10px" y="136px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/direct1-stderr.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/direct1-stderr.term.svg
@@ -1,7 +1,8 @@
-<svg width="740px" height="74px" xmlns="http://www.w3.org/2000/svg">
+<svg width="818px" height="92px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-cyan { fill: #00AAAA }
     .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
@@ -22,7 +23,9 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="64px">
+    <tspan x="10px" y="64px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-cyan bold">cargo tree --invert --package my-package@1.0.0</tspan><tspan>`</tspan>
+</tspan>
+    <tspan x="10px" y="82px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/direct1-stdout.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/direct1-stdout.term.svg
@@ -1,8 +1,7 @@
-<svg width="818px" height="164px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="146px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
     .fg-green { fill: #00AA00 }
     .fg-red { fill: #AA0000 }
     .fg-yellow { fill: #AA5500 }
@@ -33,9 +32,7 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-green bold">crates.io:</tspan><tspan> https://crates.io/crates/my-package/1.0.0</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-cyan bold">cargo tree --invert --package my-package@1.0.0</tspan><tspan>`</tspan>
-</tspan>
-    <tspan x="10px" y="154px">
+    <tspan x="10px" y="136px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/direct2-stderr.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/direct2-stderr.term.svg
@@ -1,0 +1,27 @@
+<svg width="818px" height="56px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-cyan { fill: #00AAAA }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-cyan bold">cargo tree --invert --package my-package@2.0.0</tspan><tspan>`</tspan>
+</tspan>
+    <tspan x="10px" y="46px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/direct2-stdout.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/direct2-stdout.term.svg
@@ -1,8 +1,7 @@
-<svg width="818px" height="164px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="146px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
     .fg-green { fill: #00AA00 }
     .fg-red { fill: #AA0000 }
     .fg-yellow { fill: #AA5500 }
@@ -33,9 +32,7 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-green bold">crates.io:</tspan><tspan> https://crates.io/crates/my-package/2.0.0</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-cyan bold">cargo tree --invert --package my-package@2.0.0</tspan><tspan>`</tspan>
-</tspan>
-    <tspan x="10px" y="154px">
+    <tspan x="10px" y="136px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/mod.rs
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/mod.rs
@@ -48,7 +48,7 @@ fn case() {
         .current_dir(transitive1_directory)
         .assert()
         .stdout_eq(file!["transitive1-stdout.term.svg"])
-        .stderr_eq("");
+        .stderr_eq(file!["transitive1-stderr.term.svg"]);
     snapbox::cmd::Command::cargo_ui()
         .arg("info")
         .arg("my-package")
@@ -56,7 +56,7 @@ fn case() {
         .current_dir(transitive2_directory)
         .assert()
         .stdout_eq(file!["transitive2-stdout.term.svg"])
-        .stderr_eq("");
+        .stderr_eq(file!["transitive2-stderr.term.svg"]);
     snapbox::cmd::Command::cargo_ui()
         .arg("info")
         .arg("my-package")
@@ -72,7 +72,7 @@ fn case() {
         .current_dir(direct2_directory)
         .assert()
         .stdout_eq(file!["direct2-stdout.term.svg"])
-        .stderr_eq("");
+        .stderr_eq(file!["direct2-stderr.term.svg"]);
 
     assert_ui().subset_matches(current_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/transitive1-stderr.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/transitive1-stderr.term.svg
@@ -1,0 +1,27 @@
+<svg width="818px" height="56px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-cyan { fill: #00AAAA }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-cyan bold">cargo tree --invert --package my-package@2.0.0</tspan><tspan>`</tspan>
+</tspan>
+    <tspan x="10px" y="46px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/transitive1-stdout.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/transitive1-stdout.term.svg
@@ -1,8 +1,7 @@
-<svg width="818px" height="164px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="146px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
     .fg-green { fill: #00AA00 }
     .fg-red { fill: #AA0000 }
     .fg-yellow { fill: #AA5500 }
@@ -33,9 +32,7 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-green bold">crates.io:</tspan><tspan> https://crates.io/crates/my-package/2.0.0</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-cyan bold">cargo tree --invert --package my-package@2.0.0</tspan><tspan>`</tspan>
-</tspan>
-    <tspan x="10px" y="154px">
+    <tspan x="10px" y="136px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/transitive2-stderr.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/transitive2-stderr.term.svg
@@ -1,0 +1,27 @@
+<svg width="818px" height="56px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-cyan { fill: #00AAAA }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-cyan bold">cargo tree --invert --package my-package@2.0.0</tspan><tspan>`</tspan>
+</tspan>
+    <tspan x="10px" y="46px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/transitive2-stdout.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/transitive2-stdout.term.svg
@@ -1,8 +1,7 @@
-<svg width="818px" height="164px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="146px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
     .fg-green { fill: #00AA00 }
     .fg-red { fill: #AA0000 }
     .fg-yellow { fill: #AA5500 }
@@ -33,9 +32,7 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-green bold">crates.io:</tspan><tspan> https://crates.io/crates/my-package/2.0.0</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-cyan bold">cargo tree --invert --package my-package@2.0.0</tspan><tspan>`</tspan>
-</tspan>
-    <tspan x="10px" y="154px">
+    <tspan x="10px" y="136px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/ws-stderr.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/ws-stderr.term.svg
@@ -1,7 +1,8 @@
-<svg width="740px" height="92px" xmlns="http://www.w3.org/2000/svg">
+<svg width="818px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-cyan { fill: #00AAAA }
     .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
@@ -24,7 +25,9 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v2.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="82px">
+    <tspan x="10px" y="82px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-cyan bold">cargo tree --invert --package my-package@2.0.0</tspan><tspan>`</tspan>
+</tspan>
+    <tspan x="10px" y="100px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/ws-stdout.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/ws-stdout.term.svg
@@ -1,8 +1,7 @@
-<svg width="818px" height="164px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="146px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
     .fg-green { fill: #00AA00 }
     .fg-red { fill: #AA0000 }
     .fg-yellow { fill: #AA5500 }
@@ -33,9 +32,7 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-green bold">crates.io:</tspan><tspan> https://crates.io/crates/my-package/2.0.0</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-cyan bold">cargo tree --invert --package my-package@2.0.0</tspan><tspan>`</tspan>
-</tspan>
-    <tspan x="10px" y="154px">
+    <tspan x="10px" y="136px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_info/within_ws/stderr.term.svg
+++ b/tests/testsuite/cargo_info/within_ws/stderr.term.svg
@@ -1,7 +1,8 @@
-<svg width="740px" height="92px" xmlns="http://www.w3.org/2000/svg">
+<svg width="911px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-cyan { fill: #00AAAA }
     .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
@@ -24,7 +25,9 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v0.1.1+my-package (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="82px">
+    <tspan x="10px" y="82px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-cyan bold">cargo tree --invert --package my-package@0.1.1+my-package</tspan><tspan>`</tspan>
+</tspan>
+    <tspan x="10px" y="100px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_info/within_ws/stdout.term.svg
+++ b/tests/testsuite/cargo_info/within_ws/stdout.term.svg
@@ -1,8 +1,7 @@
-<svg width="911px" height="164px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="146px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
     .fg-green { fill: #00AA00 }
     .fg-red { fill: #AA0000 }
     .fg-yellow { fill: #AA5500 }
@@ -33,9 +32,7 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-green bold">crates.io:</tspan><tspan> https://crates.io/crates/my-package/0.1.1+my-package</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-cyan bold">cargo tree --invert --package my-package@0.1.1+my-package</tspan><tspan>`</tspan>
-</tspan>
-    <tspan x="10px" y="154px">
+    <tspan x="10px" y="136px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_info/within_ws_without_lockfile/stderr.term.svg
+++ b/tests/testsuite/cargo_info/within_ws_without_lockfile/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="128px" xmlns="http://www.w3.org/2000/svg">
+<svg width="911px" height="146px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -30,7 +30,9 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v0.2.3+my-package (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="118px">
+    <tspan x="10px" y="118px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-cyan bold">cargo tree --invert --package my-package@0.2.3+my-package</tspan><tspan>`</tspan>
+</tspan>
+    <tspan x="10px" y="136px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_info/within_ws_without_lockfile/stdout.term.svg
+++ b/tests/testsuite/cargo_info/within_ws_without_lockfile/stdout.term.svg
@@ -1,8 +1,7 @@
-<svg width="911px" height="164px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="146px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
     .fg-green { fill: #00AA00 }
     .fg-red { fill: #AA0000 }
     .fg-yellow { fill: #AA5500 }
@@ -33,9 +32,7 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-green bold">crates.io:</tspan><tspan> https://crates.io/crates/my-package/0.2.3+my-package</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-cyan bold">cargo tree --invert --package my-package@0.2.3+my-package</tspan><tspan>`</tspan>
-</tspan>
-    <tspan x="10px" y="154px">
+    <tspan x="10px" y="136px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_info/without_requiring_registry_auth/stderr.term.svg
+++ b/tests/testsuite/cargo_info/without_requiring_registry_auth/stderr.term.svg
@@ -1,7 +1,8 @@
-<svg width="740px" height="92px" xmlns="http://www.w3.org/2000/svg">
+<svg width="911px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-cyan { fill: #00AAAA }
     .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
@@ -24,7 +25,9 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v0.1.1+my-package (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="82px">
+    <tspan x="10px" y="82px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-cyan bold">cargo tree --invert --package my-package@0.1.1+my-package</tspan><tspan>`</tspan>
+</tspan>
+    <tspan x="10px" y="100px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_info/without_requiring_registry_auth/stdout.term.svg
+++ b/tests/testsuite/cargo_info/without_requiring_registry_auth/stdout.term.svg
@@ -1,8 +1,7 @@
-<svg width="911px" height="164px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="146px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
     .fg-green { fill: #00AA00 }
     .fg-red { fill: #AA0000 }
     .fg-yellow { fill: #AA5500 }
@@ -33,9 +32,7 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-green bold">crates.io:</tspan><tspan> https://crates.io/crates/my-package/0.1.1+my-package</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-cyan bold">cargo tree --invert --package my-package@0.1.1+my-package</tspan><tspan>`</tspan>
-</tspan>
-    <tspan x="10px" y="154px">
+    <tspan x="10px" y="136px">
 </tspan>
   </text>
 


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

It was suggested in another PR that we should simply use `shell.note` instead of creating a new function for it.

See: https://github.com/rust-lang/cargo/pull/14537#discussion_r1763464154

### How should we test and review this PR?

All related tests were updated.

### Additional information

r? @epage 

<!-- homu-ignore:end -->
