### PR TITLE
feat: lockfile path implies --locked on cargo install

### DIFF
--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -98,6 +98,7 @@ pub fn cli() -> Command {
         .arg_target_triple("Build for the target triple")
         .arg_target_dir()
         .arg_timings()
+        .arg_lockfile_path()
         .after_help(color_print::cstr!(
             "Run `<cyan,bold>cargo help install</>` for more detailed information.\n"
         ))
@@ -204,6 +205,13 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
     if args.dry_run() {
         gctx.cli_unstable().fail_if_stable_opt("--dry-run", 11123)?;
     }
+
+    let requested_lockfile_path = args.lockfile_path(gctx)?;
+    // 14421: lockfile path should imply --locked on running `install`
+    if requested_lockfile_path.is_some() {
+        gctx.set_locked(true);
+    }
+
     if args.flag("list") {
         ops::install_list(root, gctx)?;
     } else {
@@ -217,6 +225,7 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
             args.flag("force"),
             args.flag("no-track"),
             args.dry_run(),
+            requested_lockfile_path.as_deref(),
         )?;
     }
     Ok(())

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -662,6 +662,10 @@ impl<'gctx> Workspace<'gctx> {
         self.requested_lockfile_path = path;
     }
 
+    pub fn requested_lockfile_path(&self) -> Option<&Path> {
+        self.requested_lockfile_path.as_deref()
+    }
+
     /// Get the lowest-common denominator `package.rust-version` within the workspace, if specified
     /// anywhere
     pub fn rust_version(&self) -> Option<&RustVersion> {

--- a/src/cargo/util/context/mod.rs
+++ b/src/cargo/util/context/mod.rs
@@ -1142,6 +1142,10 @@ impl GlobalContext {
         self.locked
     }
 
+    pub fn set_locked(&mut self, locked: bool) {
+        self.locked = locked;
+    }
+
     pub fn lock_update_allowed(&self) -> bool {
         !self.frozen && !self.locked
     }

--- a/tests/testsuite/cargo_install/help/stdout.term.svg
+++ b/tests/testsuite/cargo_install/help/stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="844px" height="1064px" xmlns="http://www.w3.org/2000/svg">
+<svg width="844px" height="1082px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -83,57 +83,59 @@
 </tspan>
     <tspan x="10px" y="586px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-cyan bold">--ignore-rust-version</tspan><tspan>  Ignore `rust-version` specification in packages</tspan>
+    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>               Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>              Run without accessing the network</tspan>
+    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>               Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="676px">
+    <tspan x="10px" y="676px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan class="fg-green bold">Target Selection:</tspan>
+    <tspan x="10px" y="694px">
 </tspan>
-    <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-cyan bold">--bin</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>      Install only the specified binary</tspan>
+    <tspan x="10px" y="712px"><tspan class="fg-green bold">Target Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-cyan bold">--bins</tspan><tspan>              Install all binaries</tspan>
+    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-cyan bold">--bin</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>      Install only the specified binary</tspan>
 </tspan>
-    <tspan x="10px" y="748px"><tspan>      </tspan><tspan class="fg-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Install only the specified example</tspan>
+    <tspan x="10px" y="748px"><tspan>      </tspan><tspan class="fg-cyan bold">--bins</tspan><tspan>              Install all binaries</tspan>
 </tspan>
-    <tspan x="10px" y="766px"><tspan>      </tspan><tspan class="fg-cyan bold">--examples</tspan><tspan>          Install all examples</tspan>
+    <tspan x="10px" y="766px"><tspan>      </tspan><tspan class="fg-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Install only the specified example</tspan>
 </tspan>
-    <tspan x="10px" y="784px">
+    <tspan x="10px" y="784px"><tspan>      </tspan><tspan class="fg-cyan bold">--examples</tspan><tspan>          Install all examples</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan class="fg-green bold">Feature Selection:</tspan>
+    <tspan x="10px" y="802px">
 </tspan>
-    <tspan x="10px" y="820px"><tspan>  </tspan><tspan class="fg-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
+    <tspan x="10px" y="820px"><tspan class="fg-green bold">Feature Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="838px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
+    <tspan x="10px" y="838px"><tspan>  </tspan><tspan class="fg-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
 </tspan>
-    <tspan x="10px" y="856px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
+    <tspan x="10px" y="856px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
 </tspan>
-    <tspan x="10px" y="874px">
+    <tspan x="10px" y="874px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
 </tspan>
-    <tspan x="10px" y="892px"><tspan class="fg-green bold">Compilation Options:</tspan>
+    <tspan x="10px" y="892px">
 </tspan>
-    <tspan x="10px" y="910px"><tspan>  </tspan><tspan class="fg-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
+    <tspan x="10px" y="910px"><tspan class="fg-green bold">Compilation Options:</tspan>
 </tspan>
-    <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
+    <tspan x="10px" y="928px"><tspan>  </tspan><tspan class="fg-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
 </tspan>
-    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Install artifacts with the specified profile</tspan>
+    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
 </tspan>
-    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Build for the target triple</tspan>
+    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Install artifacts with the specified profile</tspan>
 </tspan>
-    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
+    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Build for the target triple</tspan>
 </tspan>
-    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
+    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
 </tspan>
-    <tspan x="10px" y="1018px">
+    <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
 </tspan>
-    <tspan x="10px" y="1036px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help install</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="1036px">
 </tspan>
-    <tspan x="10px" y="1054px">
+    <tspan x="10px" y="1054px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help install</tspan><tspan class="bold">` for more detailed information.</tspan>
+</tspan>
+    <tspan x="10px" y="1072px">
 </tspan>
   </text>
 


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/cargo/issues/14421
Resolving one of the items 
> cargo install should make --lockfile-path imply --locked

Simply mirrored behavior as if `--locked` was provided (on creating the workspace)   