### PR TITLE
feat: Add custom completer for `cargo help <TAB>`

### DIFF
--- a/src/bin/cargo/commands/help.rs
+++ b/src/bin/cargo/commands/help.rs
@@ -15,7 +15,19 @@ const COMPRESSED_MAN: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/man.tgz"
 pub fn cli() -> Command {
     subcommand("help")
         .about("Displays help for a cargo subcommand")
-        .arg(Arg::new("COMMAND").action(ArgAction::Set))
+        .arg(Arg::new("COMMAND").action(ArgAction::Set).add(
+            clap_complete::ArgValueCandidates::new(|| {
+                super::builtin()
+                    .iter()
+                    .map(|cmd| {
+                        let name = cmd.get_name();
+                        clap_complete::CompletionCandidate::new(name)
+                            .help(cmd.get_about().cloned())
+                            .hide(cmd.is_hide_set())
+                    })
+                    .collect()
+            }),
+        ))
 }
 
 pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->

### What does this PR try to resolve?
Tracking issue https://github.com/rust-lang/cargo/issues/14520

Add custom completer for `cargo help <TAB>`

### Additional information
The current completer function is quite slow because it executes too many functions. One idea I have is to use the file!() macro to list the filenames under the commands directory, excluding mod.rs, and return them as the completion results. Would this approach be too hacky?
