### PR TITLE
remove reference to incomplete crates.io feature from docs

### DIFF
--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -209,17 +209,13 @@ description = "A short description of my package"
 ### The `documentation` field
 
 The `documentation` field specifies a URL to a website hosting the crate's
-documentation. If no URL is specified in the manifest file, [crates.io] will
-automatically link your crate to the corresponding [docs.rs] page when the
-documentation has been built and is available (see [docs.rs queue]).
+documentation.
 
 ```toml
 [package]
 # ...
 documentation = "https://docs.rs/bitflags"
 ```
-
-[docs.rs queue]: https://docs.rs/releases/queue
 
 ### The `readme` field
 


### PR DESCRIPTION
The cargo docs for the `documentation` field currently are written in a way that makes it sound like if I want to use docs.rs, I can just leave the field empty. However, that is not the case: leaving the field empty will never show a "Documentation" link in the search results, so there's always an unnecessary extra click to go from "type crate name into search" to reaching the docs.

This crates.io limitation is tracked at https://github.com/rust-lang/crates.io/issues/1484. It doesn't really matter whether this is a bug or a missing feature, the point is that cargo docs are misrepresenting what crates.io does in a way that leads to a suboptimal user experience (many crates without "Documentation" link in crates.io search results). Since the suggestion to document what crates.io actually does was rejected (https://github.com/rust-lang/cargo/pull/13660), I suggest we instead stop mentioning this feature at all -- that's still clearly better than mentioning it while it is not yet fully implemented / while it has some significant *undocumented* limitation.

Fixes https://github.com/rust-lang/cargo/issues/11777