### PR TITLE
fix(complete): Harden `--target` completions

### DIFF
--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -1123,11 +1123,13 @@ fn get_target_triples() -> Vec<clap_complete::CompletionCandidate> {
 
     if is_rustup() {
         if let Ok(targets) = get_target_triples_from_rustup() {
-            candidates.extend(targets);
+            candidates = targets;
         }
-    } else {
+    }
+
+    if candidates.is_empty() {
         if let Ok(targets) = get_target_triples_from_rustc() {
-            candidates.extend(targets);
+            candidates = targets;
         }
     }
 

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -1121,10 +1121,8 @@ fn get_targets_from_metadata() -> CargoResult<Vec<Target>> {
 fn get_target_triples() -> Vec<clap_complete::CompletionCandidate> {
     let mut candidates = Vec::new();
 
-    if is_rustup() {
-        if let Ok(targets) = get_target_triples_from_rustup() {
-            candidates = targets;
-        }
+    if let Ok(targets) = get_target_triples_from_rustup() {
+        candidates = targets;
     }
 
     if candidates.is_empty() {


### PR DESCRIPTION
### What does this PR try to resolve?

I found `--target` wasn't working with rustup as I expected, so this fixes it.  We generally only reference rustup if we are running under it but I think in UX code like this, with a fallback scheme, this should be reasonable enough.

### How should we test and review this PR?


### Additional information
