### PR TITLE
fix(resolve): Don't list transitive, incompatible dependencies as available

### DIFF
--- a/src/cargo/ops/cargo_update.rs
+++ b/src/cargo/ops/cargo_update.rs
@@ -774,7 +774,7 @@ fn report_latest(possibilities: &[IndexSummary], change: &PackageChange) -> Opti
     let version_req = package_id.version().to_caret_req();
     let required_rust_version = change.required_rust_version.as_ref();
 
-    if let Some(summary) = possibilities
+    let compat_ver_compat_msrv_summary = possibilities
         .iter()
         .map(|s| s.as_summary())
         .filter(|s| {
@@ -787,15 +787,15 @@ fn report_latest(possibilities: &[IndexSummary], change: &PackageChange) -> Opti
             }
         })
         .filter(|s| package_id.version() != s.version() && version_req.matches(s.version()))
-        .max_by_key(|s| s.version())
-    {
+        .max_by_key(|s| s.version());
+    if let Some(summary) = compat_ver_compat_msrv_summary {
         let warn = style::WARN;
         let version = summary.version();
         let report = format!(" {warn}(available: v{version}){warn:#}");
         return Some(report);
     }
 
-    if let Some(summary) = possibilities
+    let incompat_ver_compat_msrv_summary = possibilities
         .iter()
         .map(|s| s.as_summary())
         .filter(|s| {
@@ -808,8 +808,8 @@ fn report_latest(possibilities: &[IndexSummary], change: &PackageChange) -> Opti
             }
         })
         .filter(|s| is_latest(s.version(), package_id.version()))
-        .max_by_key(|s| s.version())
-    {
+        .max_by_key(|s| s.version());
+    if let Some(summary) = incompat_ver_compat_msrv_summary {
         let warn = if change.is_transitive.unwrap_or(true) {
             Default::default()
         } else {
@@ -820,12 +820,12 @@ fn report_latest(possibilities: &[IndexSummary], change: &PackageChange) -> Opti
         return Some(report);
     }
 
-    if let Some(summary) = possibilities
+    let compat_ver_summary = possibilities
         .iter()
         .map(|s| s.as_summary())
         .filter(|s| package_id.version() != s.version() && version_req.matches(s.version()))
-        .max_by_key(|s| s.version())
-    {
+        .max_by_key(|s| s.version());
+    if let Some(summary) = compat_ver_summary {
         let msrv_note = summary
             .rust_version()
             .map(|rv| format!(", requires Rust {rv}"))
@@ -836,12 +836,12 @@ fn report_latest(possibilities: &[IndexSummary], change: &PackageChange) -> Opti
         return Some(report);
     }
 
-    if let Some(summary) = possibilities
+    let incompat_ver_summary = possibilities
         .iter()
         .map(|s| s.as_summary())
         .filter(|s| is_latest(s.version(), package_id.version()))
-        .max_by_key(|s| s.version())
-    {
+        .max_by_key(|s| s.version());
+    if let Some(summary) = incompat_ver_summary {
         let msrv_note = summary
             .rust_version()
             .map(|rv| format!(", requires Rust {rv}"))

--- a/tests/testsuite/paths.rs
+++ b/tests/testsuite/paths.rs
@@ -60,7 +60,6 @@ fn broken_path_override_warns() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
-[ADDING] bar v0.1.0 (available: v0.2.0)
 [WARNING] path override for crate `a` has altered the original list of
 dependencies; the dependency on `bar` was either added or
 modified to not match the previously resolved version

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -406,7 +406,6 @@ fn update_precise() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [DOWNGRADING] serde v0.2.1 -> v0.2.0
-[NOTE] pass `--verbose` to see 1 unchanged dependencies behind latest
 
 "#]])
         .run();
@@ -2183,7 +2182,7 @@ fn update_breaking_specific_packages_that_wont_update() {
 [UPDATING] non-semver v1.0.0 -> v1.0.1 (available: v2.0.0)
 [UPDATING] renamed-from v1.0.0 -> v1.0.1 (available: v2.0.0)
 [UPDATING] transitive-compatible v1.0.0 -> v1.0.1
-[UPDATING] transitive-incompatible v1.0.0 -> v1.0.1 (available: v2.0.0)
+[UPDATING] transitive-incompatible v1.0.0 -> v1.0.1
 
 "#]])
     .run();
@@ -2397,7 +2396,7 @@ fn update_breaking_spec_version_transitive() {
         .with_stderr_data(str![[r#"
 [UPDATING] `[..]` index
 [LOCKING] 1 package to latest compatible version
-[UPDATING] dep v1.1.0 -> v1.1.1 (available: v2.0.0)
+[UPDATING] dep v1.1.0 -> v1.1.1
 
 "#]])
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

We have limited capability to clearly communicate to the user the different update states without overwhelming them. 
Before we showed all versions that were behind, with color distinguishing how actionable they are.
Color doesn't communicate enough though and we don't want to add footnotes to clarify everything.
For now, the least useful messages will be removed, available, transitive, incompatible versions.  These only give the user a hint of tech debt within their dependencies and can't be acted upon.

This is part of #13908

### How should we test and review this PR?


### Additional information
