### PR TITLE
test: Migrate remaining with_stdout/with_stderr calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,7 @@ version = "0.3.2"
 
 [[package]]
 name = "cargo-test-support"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ cargo-credential-macos-keychain = { version = "0.4.7", path = "credential/cargo-
 cargo-credential-wincred = { version = "0.4.7", path = "credential/cargo-credential-wincred" }
 cargo-platform = { path = "crates/cargo-platform", version = "0.1.5" }
 cargo-test-macro = { version = "0.3.0", path = "crates/cargo-test-macro" }
-cargo-test-support = { version = "0.4.0", path = "crates/cargo-test-support" }
+cargo-test-support = { version = "0.5.0", path = "crates/cargo-test-support" }
 cargo-util = { version = "0.2.14", path = "crates/cargo-util" }
 cargo-util-schemas = { version = "0.6.0", path = "crates/cargo-util-schemas" }
 cargo_metadata = "0.18.1"

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-test-support"
-version = "0.4.1"
+version = "0.5.0"
 edition.workspace = true
 rust-version = "1.81"  # MSRV:1
 license.workspace = true

--- a/crates/cargo-test-support/src/compare.rs
+++ b/crates/cargo-test-support/src/compare.rs
@@ -3,7 +3,7 @@
 //! # Deprecated comparisons
 //!
 //! Cargo's tests are in transition from internal-only pattern and normalization routines used in
-//! asserts like [`crate::Execs::with_stdout`] to [`assert_e2e`] and [`assert_ui`].
+//! asserts like [`crate::Execs::with_stdout_contains`] to [`assert_e2e`] and [`assert_ui`].
 //!
 //! ## Patterns
 //!

--- a/crates/cargo-test-support/src/compare.rs
+++ b/crates/cargo-test-support/src/compare.rs
@@ -208,7 +208,7 @@ fn add_regex_redactions(subs: &mut snapbox::Redactions) {
     .unwrap();
     subs.insert(
         "[FILE_NUM]",
-        regex!(r"\[(REMOVED|SUMMARY)\] (?<redacted>[0-9]+) files"),
+        regex!(r"\[(REMOVED|SUMMARY)\] (?<redacted>[1-9][0-9]*) files"),
     )
     .unwrap();
     subs.insert(

--- a/crates/cargo-test-support/src/registry.rs
+++ b/crates/cargo-test-support/src/registry.rs
@@ -5,6 +5,7 @@
 //! ```no_run
 //! use cargo_test_support::registry::Package;
 //! use cargo_test_support::project;
+//! use cargo_test_support::str;
 //!
 //! // Publish package "a" depending on "b".
 //! Package::new("a", "1.0.0")
@@ -38,7 +39,7 @@
 //!     "#)
 //!     .build();
 //!
-//! p.cargo("run").with_stdout("24").run();
+//! p.cargo("run").with_stdout_data(str!["24"]).run();
 //! ```
 
 use crate::git::repo;

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -687,7 +687,7 @@ fn build_script_with_bin_artifact_and_lib_false() {
         )
         .build();
 
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     p.cargo("build -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
@@ -731,7 +731,7 @@ fn lib_with_bin_artifact_and_lib_false() {
         )
         .build();
 
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     p.cargo("build -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
@@ -1117,7 +1117,7 @@ fn build_script_deps_adopt_specified_target_unconditionally() {
         .file("bar/src/lib.rs", "pub fn doit() {}")
         .build();
 
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     p.cargo("check -v -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_does_not_contain(format!(
@@ -1237,7 +1237,7 @@ fn non_build_script_deps_adopt_specified_target_unconditionally() {
         .file("bar/src/lib.rs", "pub fn doit() {}")
         .build();
 
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     p.cargo("check -v -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_contains(format!(
@@ -1385,7 +1385,7 @@ fn build_script_deps_adopts_target_platform_if_target_equals_target() {
         .build();
 
     let alternate_target = cross_compile::alternate();
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     p.cargo("check -v -Z bindeps --target")
         .arg(alternate_target)
         .masquerade_as_nightly_cargo(&["bindeps"])

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -132,7 +132,7 @@ fn cargo_compile_incremental() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn incremental_profile() {
     let p = project()
@@ -176,7 +176,7 @@ fn incremental_profile() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn incremental_config() {
     let p = project()
@@ -1524,7 +1524,6 @@ fn ignores_carriage_return_in_lockfile() {
     p.cargo("build").run();
 }
 
-#[allow(deprecated)]
 #[cargo_test]
 fn cargo_default_env_metadata_env_var() {
     // Ensure that path dep + dylib + env_var get metadata
@@ -4124,7 +4123,7 @@ fn panic_abort_compiles_with_panic_abort() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn compiler_json_error_format() {
     let p = project()
@@ -4314,7 +4313,7 @@ fn wrong_message_format_option() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn message_format_json_forward_stderr() {
     let p = project()
@@ -5177,7 +5176,7 @@ WRAPPER CALLED: rustc --crate-name foo [..]
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn rustc_wrapper_queries() {
     // Check that the invocations querying rustc for information are done with the wrapper.
@@ -5917,7 +5916,7 @@ fn build_filter_infer_profile() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn targets_selected_default() {
     let p = project().file("src/main.rs", "fn main() {}").build();
@@ -6871,7 +6870,7 @@ Caused by:
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn build_script_o0_default() {
     let p = project()
@@ -6884,7 +6883,7 @@ fn build_script_o0_default() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn build_script_o0_default_even_with_release() {
     let p = project()

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -3779,7 +3779,7 @@ fn custom_target_dir() {
     p.cargo("build -v").run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn panic_abort_with_build_scripts() {
     let p = project()

--- a/tests/testsuite/build_script_extra_link_arg.rs
+++ b/tests/testsuite/build_script_extra_link_arg.rs
@@ -233,7 +233,7 @@ the future. For more information, see <https://github.com/rust-lang/cargo/issues
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn link_arg_transitive_not_allowed() {
     // Verify that transitive dependencies don't pass link args.

--- a/tests/testsuite/cache_messages.rs
+++ b/tests/testsuite/cache_messages.rs
@@ -527,7 +527,7 @@ WRAPPER CALLED: rustc [..]
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn wacky_hashless_fingerprint() {
     // On Windows, executables don't have hashes. This checks for a bad

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -358,7 +358,6 @@ fn override_cargo_home() {
     assert!(paths::root().join("foo2/.git").is_dir());
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn cargo_subcommand_env() {
     let src = format!(
@@ -390,7 +389,7 @@ fn cargo_subcommand_env() {
 
     cargo_process("envtest")
         .env("PATH", &path)
-        .with_stdout(cargo.to_str().unwrap())
+        .with_stdout_data(format!("{}\n", cargo.to_str().unwrap()).raw())
         .run();
 
     // Check that subcommands inherit an overridden $CARGO
@@ -403,7 +402,7 @@ fn cargo_subcommand_env() {
     cargo_process("envtest")
         .env("PATH", &path)
         .env(cargo::CARGO_ENV, &envtest_bin)
-        .with_stdout(envtest_bin)
+        .with_stdout_data(format!("{}\n", envtest_bin).raw().raw())
         .run();
 }
 

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -137,7 +137,7 @@ fn list_command_looks_at_path_case_mismatch() {
     );
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn list_command_handles_known_external_commands() {
     let p = project()
@@ -358,7 +358,7 @@ fn override_cargo_home() {
     assert!(paths::root().join("foo2/.git").is_dir());
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn cargo_subcommand_env() {
     let src = format!(

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -406,7 +406,7 @@ fn check_all() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn check_all_exclude() {
     let p = project()
@@ -433,7 +433,7 @@ fn check_all_exclude() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn check_all_exclude_glob() {
     let p = project()
@@ -491,7 +491,7 @@ fn check_virtual_all_implied() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn check_virtual_manifest_one_project() {
     let p = project()
@@ -518,7 +518,7 @@ fn check_virtual_manifest_one_project() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn check_virtual_manifest_glob() {
     let p = project()
@@ -559,7 +559,7 @@ fn exclude_warns_on_non_existing_package() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn targets_selected_default() {
     let foo = project()
@@ -633,7 +633,7 @@ error[E0425]: cannot find value `badtext` in this scope
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 // Verify what is checked with various command-line filters.
 #[cargo_test]
 fn check_filters() {
@@ -1000,7 +1000,7 @@ WRAPPER CALLED: rustc --crate-name foo [..]
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn rustc_workspace_wrapper_respects_primary_units() {
     let p = project()
@@ -1024,7 +1024,7 @@ fn rustc_workspace_wrapper_respects_primary_units() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn rustc_workspace_wrapper_excludes_published_deps() {
     let p = project()

--- a/tests/testsuite/check_cfg.rs
+++ b/tests/testsuite/check_cfg.rs
@@ -30,7 +30,7 @@ macro_rules! x {
     }};
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn features() {
     let p = project()
@@ -56,7 +56,7 @@ fn features() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn features_with_deps() {
     let p = project()
@@ -87,7 +87,7 @@ fn features_with_deps() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn features_with_opt_deps() {
     let p = project()
@@ -119,7 +119,7 @@ fn features_with_opt_deps() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn features_with_namespaced_features() {
     let p = project()
@@ -150,7 +150,7 @@ fn features_with_namespaced_features() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn features_fingerprint() {
     let p = project()
@@ -228,7 +228,7 @@ fn features_fingerprint() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn well_known_names_values() {
     let p = project()
@@ -242,7 +242,7 @@ fn well_known_names_values() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn features_test() {
     let p = project()
@@ -268,7 +268,7 @@ fn features_test() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn features_doctest() {
     let p = project()
@@ -297,7 +297,7 @@ fn features_doctest() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn well_known_names_values_test() {
     let p = project()
@@ -311,7 +311,7 @@ fn well_known_names_values_test() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn well_known_names_values_doctest() {
     let p = project()
@@ -327,7 +327,7 @@ fn well_known_names_values_doctest() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn features_doc() {
     let p = project()
@@ -354,7 +354,7 @@ fn features_doc() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn build_script_feedback() {
     let p = project()
@@ -382,7 +382,7 @@ fn build_script_feedback() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn build_script_doc() {
     let p = project()
@@ -421,7 +421,7 @@ fn build_script_doc() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn build_script_override() {
     let target = cargo_test_support::rustc_host();
@@ -531,7 +531,7 @@ test [..] ... ok
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn config_simple() {
     let p = project()
@@ -557,7 +557,7 @@ fn config_simple() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn config_workspace() {
     let p = project()
@@ -599,7 +599,7 @@ fn config_workspace() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn config_workspace_not_inherited() {
     let p = project()
@@ -631,7 +631,7 @@ fn config_workspace_not_inherited() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn config_invalid_position() {
     let p = project()
@@ -746,7 +746,7 @@ Caused by:
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn config_and_features() {
     let p = project()
@@ -836,7 +836,7 @@ fn config_with_cargo_test() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn config_and_build_script() {
     let p = project()
@@ -866,7 +866,7 @@ fn config_and_build_script() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn config_features_and_build_script() {
     let p = project()
@@ -902,7 +902,7 @@ fn config_features_and_build_script() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn config_fingerprint() {
     let p = project()

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -849,7 +849,7 @@ fn clean_dry_run() {
     p.cargo("clean --dry-run")
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
-[SUMMARY] [FILE_NUM] files
+[SUMMARY] 0 files
 [WARNING] no files deleted due to --dry-run
 
 "#]])

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -824,7 +824,7 @@ fn clean_spec_reserved() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn clean_dry_run() {
     // Basic `clean --dry-run` test.

--- a/tests/testsuite/collisions.rs
+++ b/tests/testsuite/collisions.rs
@@ -226,7 +226,7 @@ fn collision_doc_multiple_versions() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn collision_doc_host_target_feature_split() {
     // Same dependency built twice due to different features.

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1859,7 +1859,6 @@ fn doc_cap_lints() {
         .run();
 }
 
-#[allow(deprecated)]
 #[cargo_test]
 fn doc_message_format() {
     let p = project().file("src/lib.rs", BAD_INTRA_LINK_LIB).build();
@@ -1889,7 +1888,6 @@ fn doc_message_format() {
         .run();
 }
 
-#[allow(deprecated)]
 #[cargo_test]
 fn doc_json_artifacts() {
     // Checks the output of json artifact messages.

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -1153,7 +1153,7 @@ it is false
         .exists());
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn proc_macro_ws() {
     // Checks for bug with proc-macro in a workspace with dependency (shouldn't panic).

--- a/tests/testsuite/fetch.rs
+++ b/tests/testsuite/fetch.rs
@@ -67,7 +67,7 @@ fn fetch_all_platform_dependencies_when_no_target_is_given() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn fetch_platform_specific_dependencies() {
     if cross_compile::disabled() {

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -869,7 +869,7 @@ fn prepare_for_already_on_latest_unstable() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn prepare_for_already_on_latest_stable() {
     // Stable counterpart of prepare_for_already_on_latest_unstable.
@@ -1393,7 +1393,7 @@ fn fix_in_existing_repo_weird_ignore() {
     p.cargo("fix").cwd("src").run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn fix_color_message() {
     // Check that color appears in diagnostics.
@@ -1688,7 +1688,7 @@ Original diagnostics will follow.
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn fix_with_run_cargo_in_proc_macros() {
     let p = project()

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -1617,7 +1617,7 @@ fn reuse_panic_pm() {
     // bar is built once without panic (for proc-macro) and once with (for the
     // normal dependency).
     // TODO: Migrating to Snapbox might cause flakyness here. See https://github.com/rust-lang/cargo/pull/14161/files#r1660071433
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     p.cargo("build -v")
             .with_stderr_unordered(
                 "\

--- a/tests/testsuite/future_incompat_report.rs
+++ b/tests/testsuite/future_incompat_report.rs
@@ -93,7 +93,7 @@ fn test_zero_future_incompat() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test(
     nightly,
     reason = "-Zfuture-incompat-test requires nightly (permanently)"
@@ -163,7 +163,7 @@ frequency = 'never'
     }
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test(
     nightly,
     reason = "-Zfuture-incompat-test requires nightly (permanently)"
@@ -316,7 +316,7 @@ The package `second-dep v0.0.2` currently triggers the following future incompat
     assert_eq!(lines.next(), None);
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test(
     nightly,
     reason = "-Zfuture-incompat-test requires nightly (permanently)"

--- a/tests/testsuite/git_auth.rs
+++ b/tests/testsuite/git_auth.rs
@@ -346,7 +346,7 @@ Caused by:
     t.join().ok().unwrap();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn net_err_suggests_fetch_with_cli() {
     let p = project()

--- a/tests/testsuite/global_cache_tracker.rs
+++ b/tests/testsuite/global_cache_tracker.rs
@@ -993,7 +993,6 @@ fn max_size() {
     }
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn max_size_untracked_crate() {
     // When a .crate file exists from an older version of cargo that did not
@@ -1018,7 +1017,10 @@ fn max_size_untracked_crate() {
     // This should scan the directory and populate the db with the size information.
     cargo_process("clean gc -Zgc -v --max-crate-size=100000")
         .masquerade_as_nightly_cargo(&["gc"])
-        .with_stderr("[REMOVED] 0 files")
+        .with_stderr_data(str![[r#"
+[REMOVED] 0 files
+
+"#]])
         .run();
     // Check that it stored the size data.
     let _lock = gctx
@@ -1070,7 +1072,6 @@ fn max_size_untracked_verify(gctx: &GlobalContext) {
     drop(lock);
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn max_size_untracked_src_from_use() {
     // When a src directory exists from an older version of cargo that did not
@@ -1095,12 +1096,14 @@ fn max_size_untracked_src_from_use() {
     // Fix the size.
     p.cargo("clean gc -v --max-src-size=10000 -Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
-        .with_stderr("[REMOVED] 0 files")
+        .with_stderr_data(str![[r#"
+[REMOVED] 0 files
+
+"#]])
         .run();
     max_size_untracked_verify(&gctx);
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn max_size_untracked_src_from_clean() {
     // When a src directory exists from an older version of cargo that did not
@@ -1111,7 +1114,10 @@ fn max_size_untracked_src_from_clean() {
     // Clean should scan the src and update the db.
     p.cargo("clean gc -v --max-src-size=10000 -Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
-        .with_stderr("[REMOVED] 0 files")
+        .with_stderr_data(str![[r#"
+[REMOVED] 0 files
+
+"#]])
         .run();
     max_size_untracked_verify(&gctx);
 }
@@ -1363,7 +1369,6 @@ fn delete_index_also_deletes_crates() {
     assert_eq!(get_registry_names("cache").len(), 0);
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn clean_syncs_missing_files() {
     // When files go missing in the cache, clean operations that need to track
@@ -1417,7 +1422,10 @@ fn clean_syncs_missing_files() {
     // Clean should update the db.
     p.cargo("clean gc -v --max-download-size=1GB -Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
-        .with_stderr("[REMOVED] 0 files")
+        .with_stderr_data(str![[r#"
+[REMOVED] 0 files
+
+"#]])
         .run();
 
     // Verify
@@ -1460,7 +1468,6 @@ fn offline_doesnt_auto_gc() {
     assert_eq!(get_registry_names("cache"), &[] as &[String]);
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn can_handle_future_schema() -> anyhow::Result<()> {
     // It should work when a future version of cargo has made schema changes
@@ -1484,7 +1491,10 @@ fn can_handle_future_schema() -> anyhow::Result<()> {
     // Verify it doesn't blow up.
     p.cargo("clean gc --max-download-size=0 -Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
-        .with_stderr("[REMOVED] 4 files, [..] total")
+        .with_stderr_data(str![[r#"
+[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
+
+"#]])
         .run();
     Ok(())
 }
@@ -1746,9 +1756,9 @@ fn clean_max_git_size() {
 
     p.cargo(&format!("clean gc --max-git-size={threshold} -Zgc -v"))
         .masquerade_as_nightly_cargo(&["gc"])
-        .with_stderr(&format!(
+        .with_stderr_data(&format!(
             "\
-[REMOVING] [ROOT]/home/.cargo/git/checkouts/{db_name}/{first_co_name}
+[REMOVING] [ROOT]/home/.cargo/git/checkouts/bar-[HASH]/{first_co_name}
 [REMOVED] [..]
 "
         ))

--- a/tests/testsuite/global_cache_tracker.rs
+++ b/tests/testsuite/global_cache_tracker.rs
@@ -749,7 +749,7 @@ fn both_git_and_http_index_cleans() {
     drop(lock);
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn clean_gc_dry_run() {
     // Basic `clean --gc --dry-run` test.
@@ -895,7 +895,7 @@ fn tracks_sizes() {
     assert!(db_sizes[1] > 26000);
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn max_size() {
     // Checks --max-crate-size and --max-src-size with various cleaning thresholds.
@@ -993,7 +993,7 @@ fn max_size() {
     }
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn max_size_untracked_crate() {
     // When a .crate file exists from an older version of cargo that did not
@@ -1070,7 +1070,7 @@ fn max_size_untracked_verify(gctx: &GlobalContext) {
     drop(lock);
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn max_size_untracked_src_from_use() {
     // When a src directory exists from an older version of cargo that did not
@@ -1100,7 +1100,7 @@ fn max_size_untracked_src_from_use() {
     max_size_untracked_verify(&gctx);
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn max_size_untracked_src_from_clean() {
     // When a src directory exists from an older version of cargo that did not
@@ -1116,7 +1116,7 @@ fn max_size_untracked_src_from_clean() {
     max_size_untracked_verify(&gctx);
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn max_download_size() {
     // --max-download-size
@@ -1363,7 +1363,7 @@ fn delete_index_also_deletes_crates() {
     assert_eq!(get_registry_names("cache").len(), 0);
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn clean_syncs_missing_files() {
     // When files go missing in the cache, clean operations that need to track
@@ -1460,7 +1460,7 @@ fn offline_doesnt_auto_gc() {
     assert_eq!(get_registry_names("cache"), &[] as &[String]);
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn can_handle_future_schema() -> anyhow::Result<()> {
     // It should work when a future version of cargo has made schema changes
@@ -1673,7 +1673,7 @@ fn clean_max_src_crate_age() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn clean_max_git_size() {
     // clean --max-git-size

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -1437,7 +1437,7 @@ fn use_path_workspace() {
     assert_eq!(lock, lock2, "different lockfiles");
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn path_install_workspace_root_despite_default_members() {
     let p = project()
@@ -1484,7 +1484,7 @@ fn path_install_workspace_root_despite_default_members() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn git_install_workspace_root_despite_default_members() {
     let p = git::repo(&paths::root().join("foo"))
@@ -2087,7 +2087,7 @@ fn install_path_config() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn install_version_req() {
     // Try using a few versionreq styles.

--- a/tests/testsuite/lto.rs
+++ b/tests/testsuite/lto.rs
@@ -132,7 +132,7 @@ fn build_dep_not_ltod() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn complicated() {
     Package::new("dep-shared", "0.0.1")

--- a/tests/testsuite/message_format.rs
+++ b/tests/testsuite/message_format.rs
@@ -46,7 +46,7 @@ fn double_json_works() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn cargo_renders() {
     let p = project()
@@ -101,7 +101,7 @@ error[E0601]: `main` function not found in crate `foo`
 }
 
 #[cargo_test]
-#[allow(deprecated)]
+#[expect(deprecated)]
 fn cargo_renders_ansi() {
     let p = project()
         .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))

--- a/tests/testsuite/message_format.rs
+++ b/tests/testsuite/message_format.rs
@@ -68,9 +68,21 @@ fn cargo_renders() {
 
     p.cargo("check --message-format json-render-diagnostics")
         .with_status(101)
-        .with_stdout(
-            "{\"reason\":\"compiler-artifact\",[..]\n\
-             {\"reason\":\"build-finished\",\"success\":false}",
+        .with_stdout_data(
+            str![[r#"
+[
+  {
+    "reason": "compiler-artifact",
+    "...": "{...}"
+  },
+  {
+    "reason": "build-finished",
+    "success": false
+  }
+]
+"#]]
+            .is_json()
+            .against_jsonlines(),
         )
         .with_stderr_contains(
             "\

--- a/tests/testsuite/metabuild.rs
+++ b/tests/testsuite/metabuild.rs
@@ -162,7 +162,7 @@ Caused by:
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn metabuild_optional_dep() {
     let p = project()
@@ -244,7 +244,7 @@ fn metabuild_lib_name() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn metabuild_fresh() {
     if is_coarse_mtime() {
@@ -378,7 +378,7 @@ fn metabuild_override() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn metabuild_workspace() {
     let p = project()
@@ -735,7 +735,6 @@ fn metabuild_external_dependency() {
     assert_eq!(p.glob("target/.metabuild/metabuild-dep-*.rs").count(), 1);
 }
 
-#[allow(deprecated)]
 #[cargo_test]
 fn metabuild_json_artifact() {
     let p = basic_project();
@@ -787,7 +786,6 @@ fn metabuild_json_artifact() {
         .run();
 }
 
-#[allow(deprecated)]
 #[cargo_test]
 fn metabuild_failed_build_json() {
     let p = basic_project();

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -3511,7 +3511,7 @@ fn deps_with_bin_only() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn filter_platform() {
     // Testing the --filter-platform flag.

--- a/tests/testsuite/offline.rs
+++ b/tests/testsuite/offline.rs
@@ -9,7 +9,7 @@ use cargo_test_support::{
     str, Execs,
 };
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn offline_unused_target_dep() {
     // --offline with a target dependency that is not used and not downloaded.
@@ -45,7 +45,7 @@ fn offline_unused_target_dep() {
     p.cargo("check --offline").run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn offline_missing_optional() {
     Package::new("opt_dep", "1.0.0").publish();

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -630,7 +630,7 @@ fn package_git_submodule() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 /// Tests if a symlink to a git submodule is properly handled.
 ///

--- a/tests/testsuite/package_features.rs
+++ b/tests/testsuite/package_features.rs
@@ -426,7 +426,7 @@ feature set
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn virtual_member_slash() {
     // member slash feature syntax

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -316,7 +316,7 @@ fn profile_config_override_precedence() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn profile_config_no_warn_unknown_override() {
     let p = project()
@@ -487,7 +487,7 @@ fn named_env_profile() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn test_with_dev_profile() {
     // The `test` profile inherits from `dev` for both local crates and

--- a/tests/testsuite/profile_overrides.rs
+++ b/tests/testsuite/profile_overrides.rs
@@ -420,7 +420,7 @@ fn profile_override_spec() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn override_proc_macro() {
     Package::new("shared", "1.0.0").publish();

--- a/tests/testsuite/profile_targets.rs
+++ b/tests/testsuite/profile_targets.rs
@@ -77,7 +77,7 @@ fn all_target_project() -> Project {
         .build()
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn profile_selection_build() {
     let p = all_target_project();
@@ -158,7 +158,7 @@ fn profile_selection_build_release() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn profile_selection_build_all_targets() {
     let p = all_target_project();

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -91,7 +91,7 @@ fn release_profile_default_to_object() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test(nightly, reason = "-Zremap-path-scope is unstable")]
 fn one_option() {
     let build = |option| {
@@ -388,7 +388,7 @@ bar-0.0.1/src/lib.rs
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test(nightly, reason = "-Zremap-path-scope is unstable")]
 fn diagnostics_works() {
     Package::new("bar", "0.0.1")

--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -439,7 +439,7 @@ fn panic_unwind_does_not_build_twice() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn debug_0_report() {
     // The finished line handles 0 correctly.
@@ -584,7 +584,7 @@ fn strip_accepts_true_to_strip_symbols() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn strip_accepts_false_to_disable_strip() {
     let p = project()
@@ -670,7 +670,7 @@ fn strip_debuginfo_without_debug() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn do_not_strip_debuginfo_with_requested_debug() {
     let p = project()
@@ -834,7 +834,7 @@ Caused by:
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn debug_options_valid() {
     let build = |option| {

--- a/tests/testsuite/progress.rs
+++ b/tests/testsuite/progress.rs
@@ -125,7 +125,7 @@ fn always_shows_progress() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn never_progress() {
     const N: usize = 3;

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -1366,7 +1366,7 @@ You may press ctrl-c to skip waiting; the crate should be available shortly.
     );
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn publish_checks_for_token_before_verify() {
     let registry = registry::RegistryBuilder::new()

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -437,7 +437,7 @@ fn build_only_bar_dependency() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn targets_selected_default() {
     let p = project().file("src/main.rs", "fn main() {}").build();
@@ -589,7 +589,7 @@ fn rustc_with_other_profile() {
     p.cargo("rustc --profile test").run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn rustc_fingerprint() {
     // Verify that the fingerprint includes the rustc args.

--- a/tests/testsuite/rustc_info_cache.rs
+++ b/tests/testsuite/rustc_info_cache.rs
@@ -10,7 +10,7 @@ const MISS: &str = "[..] rustc info cache miss[..]";
 const HIT: &str = "[..]rustc info cache hit[..]";
 const UPDATE: &str = "[..]updated rustc info cache[..]";
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn rustc_info_cache() {
     let p = project()
@@ -106,7 +106,7 @@ fn rustc_info_cache() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn rustc_info_cache_with_wrappers() {
     let wrapper_project = project()

--- a/tests/testsuite/rustdoc_extern_html.rs
+++ b/tests/testsuite/rustdoc_extern_html.rs
@@ -33,7 +33,7 @@ fn basic_project() -> Project {
         .build()
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn ignores_on_stable() {
     // Requires -Zrustdoc-map to use.
@@ -61,7 +61,7 @@ fn simple() {
     assert!(myfun.contains(r#"href="https://docs.rs/bar/1.0.0/bar/struct.Straw.html""#));
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[ignore = "Broken, temporarily disabled until https://github.com/rust-lang/rust/pull/82776 is resolved."]
 #[cargo_test]
 // #[cargo_test(nightly, reason = "--extern-html-root-url is unstable")]
@@ -451,7 +451,7 @@ fn alt_sparse_registry() {
     assert!(gold.contains(r#"href="https://docs.rs/grimm/1.0.0/grimm/struct.Gold.html""#));
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test(nightly, reason = "--extern-html-root-url is unstable")]
 fn same_deps_multi_occurrence_in_dep_tree() {
     // rust-lang/cargo#13543

--- a/tests/testsuite/search.rs
+++ b/tests/testsuite/search.rs
@@ -178,7 +178,7 @@ fn ignore_quiet() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn colored_results() {
     let registry = setup().build();

--- a/tests/testsuite/standard_lib.rs
+++ b/tests/testsuite/standard_lib.rs
@@ -281,7 +281,7 @@ fn simple_bin_std() {
     p.cargo("run -v").build_std(&setup).target_host().run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test(build_std_mock)]
 fn lib_nostd() {
     let setup = setup();
@@ -594,7 +594,7 @@ fn ignores_incremental() {
         .starts_with("foo-"));
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test(build_std_mock)]
 fn cargo_config_injects_compiler_builtins() {
     let setup = setup();
@@ -693,7 +693,7 @@ fn proc_macro_only() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test(build_std_mock)]
 fn fetch() {
     let setup = setup();

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -1834,7 +1834,7 @@ test test_in_bench ... ok
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn test_run_implicit_example_target() {
     let prj = project()
@@ -1922,7 +1922,7 @@ fn test_run_implicit_example_target() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn test_filtered_excludes_compiling_examples() {
     let p = project()
@@ -3621,7 +3621,7 @@ test b ... ok
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn test_virtual_manifest_one_project() {
     let p = project()
@@ -3644,7 +3644,7 @@ fn test_virtual_manifest_one_project() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn test_virtual_manifest_glob() {
     let p = project()
@@ -3897,7 +3897,7 @@ fn doctest_and_registry() {
     p.cargo("test --workspace -v").run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn cargo_test_env() {
     let src = format!(
@@ -4361,7 +4361,6 @@ fn test_hint_workspace_nonvirtual() {
         .run();
 }
 
-#[allow(deprecated)]
 #[cargo_test]
 fn json_artifact_includes_test_flag() {
     // Verify that the JSON artifact output includes `test` flag.
@@ -4422,7 +4421,6 @@ fn json_artifact_includes_test_flag() {
         .run();
 }
 
-#[allow(deprecated)]
 #[cargo_test]
 fn json_artifact_includes_executable_for_library_tests() {
     let p = project()
@@ -4470,7 +4468,6 @@ fn json_artifact_includes_executable_for_library_tests() {
         .run();
 }
 
-#[allow(deprecated)]
 #[cargo_test]
 fn json_artifact_includes_executable_for_integration_tests() {
     let p = project()
@@ -4587,7 +4584,7 @@ fn doctest_skip_staticlib() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn can_not_mix_doc_tests_and_regular_tests() {
     let p = project()
@@ -5439,7 +5436,7 @@ Caused by:
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn nonzero_exit_status() {
     // Tests for nonzero exit codes from tests.

--- a/tests/testsuite/warn_on_failure.rs
+++ b/tests/testsuite/warn_on_failure.rs
@@ -77,7 +77,7 @@ fn no_warning_on_success() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn no_warning_on_bin_failure() {
     make_lib("");
@@ -96,7 +96,7 @@ fn no_warning_on_bin_failure() {
         .run();
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cargo_test]
 fn warning_on_lib_failure() {
     make_lib("err()");


### PR DESCRIPTION
### What does this PR try to resolve?

This is part of #14039 and is another step towards us not needing our own redaction logic.

Along the way, I switched us to using `expect` to make it easier to tell when `allow(deprecated)` should be removed.

### How should we test and review this PR?

### Additional information
