### PR TITLE
fix(config): Don't double-warn about `$CARGO_HOME/config`

### DIFF
--- a/src/cargo/util/context/mod.rs
+++ b/src/cargo/util/context/mod.rs
@@ -1581,12 +1581,12 @@ impl GlobalContext {
     where
         F: FnMut(&Path) -> CargoResult<()>,
     {
-        let mut stash: HashSet<PathBuf> = HashSet::new();
+        let mut seen = HashSet::new();
 
         for current in paths::ancestors(pwd, self.search_stop_path.as_deref()) {
             if let Some(path) = self.get_file_path(&current.join(".cargo"), "config", true)? {
                 walk(&path)?;
-                stash.insert(path);
+                seen.insert(path);
             }
         }
 
@@ -1594,7 +1594,7 @@ impl GlobalContext {
         // in our history to be sure we pick up that standard location for
         // information.
         if let Some(path) = self.get_file_path(home, "config", true)? {
-            if !stash.contains(&path) {
+            if !seen.contains(&path) {
                 walk(&path)?;
             }
         }

--- a/src/cargo/util/context/mod.rs
+++ b/src/cargo/util/context/mod.rs
@@ -1581,20 +1581,21 @@ impl GlobalContext {
     where
         F: FnMut(&Path) -> CargoResult<()>,
     {
-        let mut seen = HashSet::new();
+        let mut seen_dir = HashSet::new();
 
         for current in paths::ancestors(pwd, self.search_stop_path.as_deref()) {
-            if let Some(path) = self.get_file_path(&current.join(".cargo"), "config", true)? {
+            let config_root = current.join(".cargo");
+            if let Some(path) = self.get_file_path(&config_root, "config", true)? {
                 walk(&path)?;
-                seen.insert(path);
             }
+            seen_dir.insert(config_root);
         }
 
         // Once we're done, also be sure to walk the home directory even if it's not
         // in our history to be sure we pick up that standard location for
         // information.
-        if let Some(path) = self.get_file_path(home, "config", true)? {
-            if !seen.contains(&path) {
+        if !seen_dir.contains(home) {
+            if let Some(path) = self.get_file_path(home, "config", true)? {
                 walk(&path)?;
             }
         }

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -314,8 +314,6 @@ f1 = 1
         .with_stderr_data(str![[r#"
 [WARNING] `[ROOT]/home/.cargo/config` is deprecated in favor of `config.toml`
 [NOTE] if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
-[WARNING] `[ROOT]/home/.cargo/config` is deprecated in favor of `config.toml`
-[NOTE] if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
 
 "#]])
         .run();

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -16,7 +16,7 @@ use cargo::CargoResult;
 use cargo_test_support::compare::assert_e2e;
 use cargo_test_support::prelude::*;
 use cargo_test_support::str;
-use cargo_test_support::{paths, project, symlink_supported, t};
+use cargo_test_support::{paths, project, project_in_home, symlink_supported, t};
 use cargo_util_schemas::manifest::TomlTrimPaths;
 use cargo_util_schemas::manifest::TomlTrimPathsValue;
 use cargo_util_schemas::manifest::{self as cargo_toml, TomlDebugInfo, VecStringOrBool as VSOB};
@@ -297,6 +297,28 @@ f1 = 1
 
 "#]];
     assert_e2e().eq(&output, expected);
+}
+
+#[cargo_test]
+fn home_config_works_without_extension() {
+    write_config_at(
+        paths::cargo_home().join("config"),
+        "\
+[foo]
+f1 = 1
+",
+    );
+    let p = project_in_home("foo").file("src/lib.rs", "").build();
+
+    p.cargo("-vV")
+        .with_stderr_data(str![[r#"
+[WARNING] `[ROOT]/home/.cargo/config` is deprecated in favor of `config.toml`
+[NOTE] if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
+[WARNING] `[ROOT]/home/.cargo/config` is deprecated in favor of `config.toml`
+[NOTE] if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
+
+"#]])
+        .run();
 }
 
 #[cargo_test]


### PR DESCRIPTION
### What does this PR try to resolve?

The core requirements for this bug are
- You have a `$CARGO_HOME/.config`
- Your project is inside of `$HOME`

We have a check to make sure we don't double-walk `$CARGO/config` but
that check is *after* we warn about there being no `.toml` extension.

To fix this, we just need to move that check outside of the file lookup.
This required changing the `seen` check from checking whether walked the
config file to checking if we've walked the config dir.  As we only have
one file per directory, this should work.

Fixes #14560

### How should we test and review this PR?

test commit added the test, fix commit fixed the issue.

### Additional information
