### PR TITLE
test: add support for features in the sat resolver

### DIFF
--- a/crates/resolver-tests/src/lib.rs
+++ b/crates/resolver-tests/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::print_stderr)]
 
 use std::cmp::{max, min};
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt;
 use std::fmt::Write;
 use std::sync::OnceLock;
@@ -10,12 +10,14 @@ use std::time::Instant;
 
 use cargo::core::dependency::DepKind;
 use cargo::core::resolver::{self, ResolveOpts, VersionOrdering, VersionPreferences};
-use cargo::core::Resolve;
+use cargo::core::FeatureMap;
 use cargo::core::ResolveVersion;
 use cargo::core::{Dependency, PackageId, Registry, Summary};
+use cargo::core::{FeatureValue, Resolve};
 use cargo::core::{GitReference, SourceId};
 use cargo::sources::source::QueryKind;
 use cargo::sources::IndexSummary;
+use cargo::util::interning::{InternedString, INTERNED_DEFAULT};
 use cargo::util::{CargoResult, GlobalContext, IntoUrl};
 
 use proptest::collection::{btree_map, vec};
@@ -25,7 +27,12 @@ use proptest::string::string_regex;
 use varisat::ExtendFormula;
 
 pub fn resolve(deps: Vec<Dependency>, registry: &[Summary]) -> CargoResult<Vec<PackageId>> {
-    resolve_with_global_context(deps, registry, &GlobalContext::default().unwrap())
+    Ok(
+        resolve_with_global_context(deps, registry, &GlobalContext::default().unwrap())?
+            .into_iter()
+            .map(|(pkg, _)| pkg)
+            .collect(),
+    )
 }
 
 // Verify that the resolution of cargo resolver can pass the verification of SAT
@@ -33,7 +40,7 @@ pub fn resolve_and_validated(
     deps: Vec<Dependency>,
     registry: &[Summary],
     sat_resolver: &mut SatResolver,
-) -> CargoResult<Vec<PackageId>> {
+) -> CargoResult<Vec<(PackageId, Vec<InternedString>)>> {
     let resolve =
         resolve_with_global_context_raw(deps.clone(), registry, &GlobalContext::default().unwrap());
 
@@ -66,7 +73,7 @@ pub fn resolve_and_validated(
                     }));
                 }
             }
-            let out = resolve.sort();
+            let out = collect_features(&resolve);
             assert_eq!(out.len(), used.len());
 
             if !sat_resolver.sat_is_valid_solution(&out) {
@@ -80,13 +87,21 @@ pub fn resolve_and_validated(
     }
 }
 
+fn collect_features(resolve: &Resolve) -> Vec<(PackageId, Vec<InternedString>)> {
+    resolve
+        .sort()
+        .iter()
+        .map(|&pkg| (pkg, resolve.features(pkg).to_vec()))
+        .collect()
+}
+
 pub fn resolve_with_global_context(
     deps: Vec<Dependency>,
     registry: &[Summary],
     gctx: &GlobalContext,
-) -> CargoResult<Vec<PackageId>> {
+) -> CargoResult<Vec<(PackageId, Vec<InternedString>)>> {
     let resolve = resolve_with_global_context_raw(deps, registry, gctx)?;
-    Ok(resolve.sort())
+    Ok(collect_features(&resolve))
 }
 
 pub fn resolve_with_global_context_raw(
@@ -201,7 +216,7 @@ fn log_bits(x: usize) -> usize {
 // At this point is possible to select every version of every package.
 // So we need to mark certain versions as incompatible with each other.
 // We could add a clause not A, not B for all A and B that are incompatible,
-fn sat_at_most_one(solver: &mut impl varisat::ExtendFormula, vars: &[varisat::Var]) {
+fn sat_at_most_one(solver: &mut varisat::Solver<'_>, vars: &[varisat::Var]) {
     if vars.len() <= 1 {
         return;
     } else if vars.len() == 2 {
@@ -226,48 +241,201 @@ fn sat_at_most_one(solver: &mut impl varisat::ExtendFormula, vars: &[varisat::Va
 }
 
 fn sat_at_most_one_by_key<K: std::hash::Hash + Eq>(
-    cnf: &mut impl varisat::ExtendFormula,
+    solver: &mut varisat::Solver<'_>,
     data: impl Iterator<Item = (K, varisat::Var)>,
 ) -> HashMap<K, Vec<varisat::Var>> {
-    // no two packages with the same links set
+    // no two packages with the same keys set
     let mut by_keys: HashMap<K, Vec<varisat::Var>> = HashMap::new();
     for (p, v) in data {
         by_keys.entry(p).or_default().push(v)
     }
     for key in by_keys.values() {
-        sat_at_most_one(cnf, key);
+        sat_at_most_one(solver, key);
     }
     by_keys
+}
+
+fn find_compatible_dep_summaries_by_name_in_toml(
+    pkg_dependencies: &[Dependency],
+    by_name: &HashMap<InternedString, Vec<Summary>>,
+) -> HashMap<InternedString, Vec<Summary>> {
+    let empty_vec = vec![];
+
+    pkg_dependencies
+        .iter()
+        .map(|dep| {
+            let name_in_toml = dep.name_in_toml();
+
+            let compatible_summaries = by_name
+                .get(&dep.package_name())
+                .unwrap_or(&empty_vec)
+                .iter()
+                .filter(|s| dep.matches_id(s.package_id()))
+                .filter(|s| dep.features().iter().all(|f| s.features().contains_key(f)))
+                .cloned()
+                .collect::<Vec<_>>();
+
+            (name_in_toml, compatible_summaries)
+        })
+        .collect()
+}
+
+fn process_pkg_features(
+    solver: &mut varisat::Solver<'_>,
+    var_for_is_packages_used: &HashMap<PackageId, varisat::Var>,
+    var_for_is_packages_features_used: &HashMap<PackageId, HashMap<InternedString, varisat::Var>>,
+    pkg_feature_var_map: &HashMap<InternedString, varisat::Var>,
+    pkg_features: &FeatureMap,
+    compatible_dep_summaries_by_name_in_toml: &HashMap<InternedString, Vec<Summary>>,
+) {
+    // add clauses for package features
+    for (&feature_name, feature_values) in pkg_features {
+        for feature_value in feature_values {
+            let pkg_feature_var = pkg_feature_var_map[&feature_name];
+
+            match *feature_value {
+                FeatureValue::Feature(other_feature_name) => {
+                    solver.add_clause(&[
+                        pkg_feature_var.negative(),
+                        pkg_feature_var_map[&other_feature_name].positive(),
+                    ]);
+                }
+                FeatureValue::Dep { dep_name } => {
+                    let dep_clause = compatible_dep_summaries_by_name_in_toml[&dep_name]
+                        .iter()
+                        .map(|dep| var_for_is_packages_used[&dep.package_id()].positive())
+                        .chain([pkg_feature_var.negative()])
+                        .collect::<Vec<_>>();
+
+                    solver.add_clause(&dep_clause);
+                }
+                FeatureValue::DepFeature {
+                    dep_name,
+                    dep_feature: dep_feature_name,
+                    weak,
+                } => {
+                    for dep in &compatible_dep_summaries_by_name_in_toml[&dep_name] {
+                        let dep_var = var_for_is_packages_used[&dep.package_id()];
+                        let dep_feature_var =
+                            var_for_is_packages_features_used[&dep.package_id()][&dep_feature_name];
+
+                        solver.add_clause(&[
+                            pkg_feature_var.negative(),
+                            dep_var.negative(),
+                            dep_feature_var.positive(),
+                        ]);
+                    }
+
+                    if !weak {
+                        let dep_clause = compatible_dep_summaries_by_name_in_toml[&dep_name]
+                            .iter()
+                            .map(|dep| var_for_is_packages_used[&dep.package_id()].positive())
+                            .chain([pkg_feature_var.negative()])
+                            .collect::<Vec<_>>();
+
+                        solver.add_clause(&dep_clause);
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn process_pkg_dependencies(
+    solver: &mut varisat::Solver<'_>,
+    var_for_is_packages_used: &HashMap<PackageId, varisat::Var>,
+    var_for_is_packages_features_used: &HashMap<PackageId, HashMap<InternedString, varisat::Var>>,
+    pkg_var: varisat::Var,
+    pkg_dependencies: &[Dependency],
+    compatible_dep_summaries_by_name_in_toml: &HashMap<InternedString, Vec<Summary>>,
+) {
+    for dep in pkg_dependencies {
+        let compatible_dep_summaries =
+            &compatible_dep_summaries_by_name_in_toml[&dep.name_in_toml()];
+
+        // add clauses for package dependency features
+        for dep_summary in compatible_dep_summaries {
+            let dep_package_id = dep_summary.package_id();
+
+            let default_feature = if dep.uses_default_features()
+                && dep_summary.features().contains_key(&*INTERNED_DEFAULT)
+            {
+                Some(&INTERNED_DEFAULT)
+            } else {
+                None
+            };
+
+            for &feature_name in default_feature.into_iter().chain(dep.features()) {
+                solver.add_clause(&[
+                    pkg_var.negative(),
+                    var_for_is_packages_used[&dep_package_id].negative(),
+                    var_for_is_packages_features_used[&dep_package_id][&feature_name].positive(),
+                ]);
+            }
+        }
+
+        // active packages need to activate each of their non-optional dependencies
+        if !dep.is_optional() {
+            let dep_clause = compatible_dep_summaries
+                .iter()
+                .map(|d| var_for_is_packages_used[&d.package_id()].positive())
+                .chain([pkg_var.negative()])
+                .collect::<Vec<_>>();
+
+            solver.add_clause(&dep_clause);
+        }
+    }
 }
 
 /// Resolution can be reduced to the SAT problem. So this is an alternative implementation
 /// of the resolver that uses a SAT library for the hard work. This is intended to be easy to read,
 /// as compared to the real resolver.
 ///
-/// For the subset of functionality that are currently made by `registry_strategy` this will,
-/// find a valid resolution if one exists. The big thing that the real resolver does,
-/// that this one does not do is work with features and optional dependencies.
+/// For the subset of functionality that are currently made by `registry_strategy`,
+/// this will find a valid resolution if one exists.
 ///
 /// The SAT library does not optimize for the newer version,
 /// so the selected packages may not match the real resolver.
 pub struct SatResolver {
     solver: varisat::Solver<'static>,
+    old_root_vars: Vec<varisat::Var>,
     var_for_is_packages_used: HashMap<PackageId, varisat::Var>,
-    by_name: HashMap<&'static str, Vec<PackageId>>,
+    var_for_is_packages_features_used: HashMap<PackageId, HashMap<InternedString, varisat::Var>>,
+    by_name: HashMap<InternedString, Vec<Summary>>,
 }
 
 impl SatResolver {
     pub fn new(registry: &[Summary]) -> Self {
-        let mut cnf = varisat::CnfFormula::new();
+        let mut solver = varisat::Solver::new();
+
         // That represents each package version which is set to "true" if the packages in the lock file and "false" if it is unused.
-        let var_for_is_packages_used: HashMap<PackageId, varisat::Var> = registry
+        let var_for_is_packages_used = registry
             .iter()
-            .map(|s| (s.package_id(), cnf.new_var()))
-            .collect();
+            .map(|s| (s.package_id(), solver.new_var()))
+            .collect::<HashMap<_, _>>();
+
+        // That represents each feature of each package version, which is set to "true" if the package feature is used.
+        let var_for_is_packages_features_used = registry
+            .iter()
+            .map(|s| {
+                (
+                    s.package_id(),
+                    (s.features().keys().map(|&f| (f, solver.new_var()))).collect(),
+                )
+            })
+            .collect::<HashMap<_, HashMap<_, _>>>();
+
+        // if a package feature is used, then the package is used
+        for (package, pkg_feature_var_map) in &var_for_is_packages_features_used {
+            for (_, package_feature_var) in pkg_feature_var_map {
+                let package_var = var_for_is_packages_used[package];
+                solver.add_clause(&[package_feature_var.negative(), package_var.positive()]);
+            }
+        }
 
         // no two packages with the same links set
         sat_at_most_one_by_key(
-            &mut cnf,
+            &mut solver,
             registry
                 .iter()
                 .map(|s| (s.links(), var_for_is_packages_used[&s.package_id()]))
@@ -276,47 +444,46 @@ impl SatResolver {
 
         // no two semver compatible versions of the same package
         sat_at_most_one_by_key(
-            &mut cnf,
+            &mut solver,
             var_for_is_packages_used
                 .iter()
                 .map(|(p, &v)| (p.as_activations_key(), v)),
         );
 
-        let mut by_name: HashMap<&'static str, Vec<PackageId>> = HashMap::new();
+        let mut by_name: HashMap<InternedString, Vec<Summary>> = HashMap::new();
 
-        for p in registry.iter() {
-            by_name
-                .entry(p.name().as_str())
-                .or_default()
-                .push(p.package_id())
+        for p in registry {
+            by_name.entry(p.name()).or_default().push(p.clone())
         }
 
-        let empty_vec = vec![];
+        for pkg in registry {
+            let pkg_id = pkg.package_id();
+            let pkg_dependencies = pkg.dependencies();
+            let pkg_features = pkg.features();
 
-        // Now different versions can conflict, but dependencies might not be selected.
-        // So we need to add clauses that ensure that if a package is selected for each dependency a version
-        // that satisfies that dependency is selected.
-        //
-        // active packages need each of there `deps` to be satisfied
-        for p in registry.iter() {
-            for dep in p.dependencies() {
-                let mut matches: Vec<varisat::Lit> = by_name
-                    .get(dep.package_name().as_str())
-                    .unwrap_or(&empty_vec)
-                    .iter()
-                    .filter(|&p| dep.matches_id(*p))
-                    .map(|p| var_for_is_packages_used[&p].positive())
-                    .collect();
-                // ^ the `dep` is satisfied or `p` is not active
-                matches.push(var_for_is_packages_used[&p.package_id()].negative());
-                cnf.add_clause(&matches);
-            }
+            let compatible_dep_summaries_by_name_in_toml =
+                find_compatible_dep_summaries_by_name_in_toml(pkg_dependencies, &by_name);
+
+            process_pkg_features(
+                &mut solver,
+                &var_for_is_packages_used,
+                &var_for_is_packages_features_used,
+                &var_for_is_packages_features_used[&pkg_id],
+                pkg_features,
+                &compatible_dep_summaries_by_name_in_toml,
+            );
+
+            process_pkg_dependencies(
+                &mut solver,
+                &var_for_is_packages_used,
+                &var_for_is_packages_features_used,
+                var_for_is_packages_used[&pkg_id],
+                pkg_dependencies,
+                &compatible_dep_summaries_by_name_in_toml,
+            );
         }
 
-        let mut solver = varisat::Solver::new();
-        solver.add_formula(&cnf);
-
-        // We dont need to `solve` now. We know that "use nothing" will satisfy all the clauses so far.
+        // We don't need to `solve` now. We know that "use nothing" will satisfy all the clauses so far.
         // But things run faster if we let it spend some time figuring out how the constraints interact before we add assumptions.
         solver
             .solve()
@@ -324,60 +491,80 @@ impl SatResolver {
 
         SatResolver {
             solver,
+            old_root_vars: Vec::new(),
             var_for_is_packages_used,
+            var_for_is_packages_features_used,
             by_name,
         }
     }
 
     pub fn sat_resolve(&mut self, root_dependencies: &[Dependency]) -> bool {
-        let mut assumption = vec![];
-        let mut this_call = None;
+        let SatResolver {
+            solver,
+            old_root_vars,
+            var_for_is_packages_used,
+            var_for_is_packages_features_used,
+            by_name,
+        } = self;
 
-        // the starting `deps` need to be satisfied
-        for dep in root_dependencies {
-            let empty_vec = vec![];
-            let matches: Vec<varisat::Lit> = self
-                .by_name
-                .get(dep.package_name().as_str())
-                .unwrap_or(&empty_vec)
-                .iter()
-                .filter(|&p| dep.matches_id(*p))
-                .map(|p| self.var_for_is_packages_used[p].positive())
-                .collect();
-            if matches.is_empty() {
-                return false;
-            } else if matches.len() == 1 {
-                assumption.extend_from_slice(&matches)
-            } else {
-                if this_call.is_none() {
-                    let new_var = self.solver.new_var();
-                    this_call = Some(new_var);
-                    assumption.push(new_var.positive());
-                }
-                let mut matches = matches;
-                matches.push(this_call.unwrap().negative());
-                self.solver.add_clause(&matches);
-            }
-        }
+        let root_var = solver.new_var();
 
-        self.solver.assume(&assumption);
+        // root package is always used
+        // root vars from previous runs are deactivated
+        let assumption = old_root_vars
+            .iter()
+            .map(|v| v.negative())
+            .chain([root_var.positive()])
+            .collect::<Vec<_>>();
 
-        self.solver
+        old_root_vars.push(root_var);
+
+        let compatible_dep_summaries_by_name_in_toml =
+            find_compatible_dep_summaries_by_name_in_toml(root_dependencies, &by_name);
+
+        process_pkg_dependencies(
+            solver,
+            var_for_is_packages_used,
+            var_for_is_packages_features_used,
+            root_var,
+            root_dependencies,
+            &compatible_dep_summaries_by_name_in_toml,
+        );
+
+        solver.assume(&assumption);
+
+        solver
             .solve()
             .expect("docs say it can't error in default config")
     }
 
-    pub fn sat_is_valid_solution(&mut self, pids: &[PackageId]) -> bool {
-        for p in pids {
-            if p.name().as_str() != "root" && !self.var_for_is_packages_used.contains_key(p) {
+    pub fn sat_is_valid_solution(&mut self, pkgs: &[(PackageId, Vec<InternedString>)]) -> bool {
+        let contains_pkg = |pkg| pkgs.iter().any(|(p, _)| p == pkg);
+        let contains_pkg_feature =
+            |pkg, f| pkgs.iter().any(|(p, flist)| p == pkg && flist.contains(f));
+
+        for (p, _) in pkgs {
+            if p.name() != "root" && !self.var_for_is_packages_used.contains_key(p) {
                 return false;
             }
         }
-        let assumption: Vec<_> = self
-            .var_for_is_packages_used
-            .iter()
-            .map(|(p, v)| v.lit(pids.contains(p)))
-            .collect();
+
+        // root vars from previous runs are deactivated
+        let assumption = (self.old_root_vars.iter().map(|v| v.negative()))
+            .chain(
+                self.var_for_is_packages_used
+                    .iter()
+                    .map(|(p, v)| v.lit(contains_pkg(p))),
+            )
+            .chain(
+                self.var_for_is_packages_features_used
+                    .iter()
+                    .flat_map(|(p, fmap)| {
+                        fmap.iter()
+                            .map(move |(f, v)| v.lit(contains_pkg_feature(p, f)))
+                    }),
+            )
+            .collect::<Vec<_>>();
 
         self.solver.assume(&assumption);
 
@@ -393,13 +580,32 @@ impl SatResolver {
                 .filter(|l| l.is_positive())
                 .map(|l| l.var())
                 .collect();
-            let mut out = String::new();
-            out.push_str("used:\n");
-            for (p, v) in self.var_for_is_packages_used.iter() {
+
+            let mut used_packages = BTreeMap::<PackageId, BTreeSet<InternedString>>::new();
+            for (&p, v) in self.var_for_is_packages_used.iter() {
                 if lits.contains(v) {
-                    writeln!(&mut out, "    {}", p).unwrap();
+                    used_packages.entry(p).or_default();
                 }
             }
+            for (&p, map) in &self.var_for_is_packages_features_used {
+                for (&f, v) in map {
+                    if lits.contains(v) {
+                        used_packages
+                            .get_mut(&p)
+                            .expect("the feature is activated without the package being activated")
+                            .insert(f);
+                    }
+                }
+            }
+
+            let mut out = String::from("used:\n");
+            for (package, feature_names) in used_packages {
+                writeln!(&mut out, "  {package}").unwrap();
+                for feature_name in feature_names {
+                    writeln!(&mut out, "    + {feature_name}").unwrap();
+                }
+            }
+
             out
         })
     }

--- a/crates/resolver-tests/tests/resolve.rs
+++ b/crates/resolver-tests/tests/resolve.rs
@@ -8,7 +8,7 @@ use cargo_util::is_ci;
 use resolver_tests::{
     assert_contains, assert_same, dep, dep_kind, dep_loc, dep_req, loc_names, names, pkg, pkg_id,
     pkg_loc, registry, registry_strategy, remove_dep, resolve, resolve_and_validated,
-    resolve_with_global_context, PrettyPrintRegistry, SatResolve, ToDep, ToPkgId,
+    resolve_with_global_context, PrettyPrintRegistry, SatResolver, ToDep, ToPkgId,
 };
 
 use proptest::prelude::*;
@@ -40,15 +40,15 @@ proptest! {
         PrettyPrintRegistry(input) in registry_strategy(50, 20, 60)
     )  {
         let reg = registry(input.clone());
-        let sat_resolve = SatResolve::new(&reg);
-        // there is only a small chance that any one
-        // crate will be interesting.
+        let mut sat_resolver = SatResolver::new(&reg);
+
+        // There is only a small chance that a crate will be interesting.
         // So we try some of the most complicated.
         for this in input.iter().rev().take(20) {
             let _ = resolve_and_validated(
                 vec![dep_req(&this.name(), &format!("={}", this.version()))],
                 &reg,
-                Some(sat_resolve.clone()),
+                &mut sat_resolver,
             );
         }
     }
@@ -75,23 +75,15 @@ proptest! {
             .unwrap();
 
         let reg = registry(input.clone());
-        // there is only a small chance that any one
-        // crate will be interesting.
+
+        // There is only a small chance that a crate will be interesting.
         // So we try some of the most complicated.
         for this in input.iter().rev().take(10) {
-            // minimal-versions change what order the candidates
-            // are tried but not the existence of a solution
-            let res = resolve(
-                vec![dep_req(&this.name(), &format!("={}", this.version()))],
-                &reg,
-            );
+            let deps = vec![dep_req(&this.name(), &format!("={}", this.version()))];
+            let res = resolve(deps.clone(), &reg);
+            let mres = resolve_with_global_context(deps, &reg, &gctx);
 
-            let mres = resolve_with_global_context(
-                vec![dep_req(&this.name(), &format!("={}", this.version()))],
-                &reg,
-                &gctx,
-            );
-
+            // `minimal-versions` changes what order the candidates are tried but not the existence of a solution.
             prop_assert_eq!(
                 res.is_ok(),
                 mres.is_ok(),
@@ -124,23 +116,16 @@ proptest! {
             .unwrap();
 
         let reg = registry(input.clone());
-        // there is only a small chance that any one
-        // crate will be interesting.
+
+        // There is only a small chance that a crate will be interesting.
         // So we try some of the most complicated.
         for this in input.iter().rev().take(10) {
-            // direct-minimal-versions reduces the number of available solutions, so we verify that
-            // we do not come up with solutions maximal versions does not
-            let res = resolve(
-                vec![dep_req(&this.name(), &format!("={}", this.version()))],
-                &reg,
-            );
+            let deps = vec![dep_req(&this.name(), &format!("={}", this.version()))];
+            let res = resolve(deps.clone(), &reg);
+            let mres = resolve_with_global_context(deps, &reg, &gctx);
 
-            let mres = resolve_with_global_context(
-                vec![dep_req(&this.name(), &format!("={}", this.version()))],
-                &reg,
-                &gctx,
-            );
-
+            // `direct-minimal-versions` reduces the number of available solutions,
+            //  so we verify that we do not come up with solutions not seen in `maximal-versions`.
             if res.is_err() {
                 prop_assert!(
                     mres.is_err(),
@@ -179,8 +164,8 @@ proptest! {
             }
         }
         let removed_reg = registry(removed_input);
-        // there is only a small chance that any one
-        // crate will be interesting.
+
+        // There is only a small chance that a crate will be interesting.
         // So we try some of the most complicated.
         for this in input.iter().rev().take(10) {
             if resolve(
@@ -207,8 +192,8 @@ proptest! {
         indexes_to_unpublish in prop::collection::vec(any::<prop::sample::Index>(), ..10)
     )  {
         let reg = registry(input.clone());
-        // there is only a small chance that any one
-        // crate will be interesting.
+
+        // There is only a small chance that a crate will be interesting.
         // So we try some of the most complicated.
         for this in input.iter().rev().take(10) {
             let res = resolve(
@@ -225,6 +210,7 @@ proptest! {
                         .cloned()
                         .filter(|x| !r.contains(&x.package_id()))
                         .collect();
+
                     if !not_selected.is_empty() {
                         let indexes_to_unpublish: Vec<_> = indexes_to_unpublish.iter().map(|x| x.get(&not_selected)).collect();
 
@@ -659,8 +645,8 @@ fn resolving_with_constrained_sibling_backtrack_parent() {
         let vsn = format!("1.0.{}", i);
         reglist.push(
             pkg!(("bar", vsn.clone()) => [dep_req("backtrack_trap1", "1.0.2"),
-                                                   dep_req("backtrack_trap2", "1.0.2"),
-                                                   dep_req("constrained", "1.0.1")]),
+                                          dep_req("backtrack_trap2", "1.0.2"),
+                                          dep_req("constrained", "1.0.1")]),
         );
         reglist.push(pkg!(("backtrack_trap1", vsn.clone())));
         reglist.push(pkg!(("backtrack_trap2", vsn.clone())));
@@ -1227,7 +1213,8 @@ fn off_by_one_bug() {
     ];
 
     let reg = registry(input);
-    let _ = resolve_and_validated(vec![dep("f")], &reg, None);
+    let mut sat_resolver = SatResolver::new(&reg);
+    let _ = resolve_and_validated(vec![dep("f")], &reg, &mut sat_resolver);
 }
 
 #[test]
@@ -1267,7 +1254,8 @@ fn conflict_store_bug() {
     ];
 
     let reg = registry(input);
-    let _ = resolve_and_validated(vec![dep("j")], &reg, None);
+    let mut sat_resolver = SatResolver::new(&reg);
+    let _ = resolve_and_validated(vec![dep("j")], &reg, &mut sat_resolver);
 }
 
 #[test]
@@ -1295,7 +1283,8 @@ fn conflict_store_more_then_one_match() {
         ]),
     ];
     let reg = registry(input);
-    let _ = resolve_and_validated(vec![dep("nA")], &reg, None);
+    let mut sat_resolver = SatResolver::new(&reg);
+    let _ = resolve_and_validated(vec![dep("nA")], &reg, &mut sat_resolver);
 }
 
 #[test]
@@ -1304,7 +1293,7 @@ fn bad_lockfile_from_8249() {
         pkg!(("a-sys", "0.2.0")),
         pkg!(("a-sys", "0.1.0")),
         pkg!(("b", "0.1.0") => [
-            dep_req("a-sys", "0.1"), // should be optional: true, but not deeded for now
+            dep_req("a-sys", "0.1"), // should be optional: true, but not needed for now
         ]),
         pkg!(("c", "1.0.0") => [
             dep_req("b", "=0.1.0"),
@@ -1320,7 +1309,8 @@ fn bad_lockfile_from_8249() {
         ]),
     ];
     let reg = registry(input);
-    let _ = resolve_and_validated(vec![dep("foo")], &reg, None);
+    let mut sat_resolver = SatResolver::new(&reg);
+    let _ = resolve_and_validated(vec![dep("foo")], &reg, &mut sat_resolver);
 }
 
 #[test]

--- a/src/cargo/core/summary.rs
+++ b/src/cargo/core/summary.rs
@@ -216,6 +216,7 @@ fn build_feature_map(
         .flatten()
         .filter_map(|fv| fv.explicit_dep_name())
         .collect();
+
     for dep in dependencies {
         if !dep.is_optional() {
             continue;
@@ -242,7 +243,7 @@ fn build_feature_map(
                         if !is_any_dep {
                             bail!(
                                 "feature `{feature}` includes `{fv}` which is neither a dependency \
-                                 nor another feature"                              
+                                 nor another feature"
                               );
                         }
                         if is_optional_dep {


### PR DESCRIPTION
### What does this PR try to resolve?

This PR implements the first step of https://github.com/rust-lang/cargo/pull/11938#issuecomment-1868426431.

### How should we test and review this PR?

The first commit does some refactorings, and the second commit updates the SAT resolver.

List of boolean variables in the SAT resolver:
* One variable representing the activation of each registry package.
* One variable representing the activation of each feature of a given registry package.
* In the `sat_resolve()` method, we create an additional representing the activation of the root package.

List of clauses in the SAT resolver:
* If a package feature is activated, then the package should be activated.
* No two packages with the same links set.
* No two semver compatible versions of the same package.
* For each package:
    - For each feature:
        - If the package feature is activated and it depends of another feature of the same package, then it is also activated.
        - If the package feature is activated and it depends of a dependency, then at least one of the compatible dependency package should be activated.
        - If the package feature is activated and it depends of a feature of a dependency, then the feature of a compatible dependency package should be activated only if the compatible dependency package is activated. If this is not a weak dependency feature, then at least one of the compatible dependency package should be activated.
    - For each dependency, if the package is activated and if the dependency is non-optional or has been activated, then at least one of the compatible dependency package and its required features should be activated.
* The root package has the same dependency clauses but has no features.

List of assumptions in the SAT resolver:
* The root package is activated.
* Old root packages from previous calls to `sat_resolve()` are deactivated. This is necessary since the proptest call `sat_resolve()` several times with a different root package using the same SAT resolver, and clauses relative to the root package are not removable.
