### PR TITLE
fix(cargo-rustc): give trailing flags higher precedence on nightly

### DIFF
--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -795,3 +795,67 @@ windows
         )
         .run();
 }
+
+#[cargo_test]
+fn precedence() {
+    // Ensure that the precedence of cargo-rustc is only lower than RUSTFLAGS,
+    // but higher than most flags set by cargo.
+    //
+    // See rust-lang/cargo#14346
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            edition = "2021"
+
+            [lints.rust]
+            unexpected_cfgs = "allow"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("rustc --release -v -- --cfg cargo_rustc -C strip=symbols")
+        .env("RUSTFLAGS", "--cfg from_rustflags")
+        .with_stderr_data(
+            str![[r#"
+[COMPILING] foo v0.0.0 ([ROOT]/foo)
+[RUNNING] `rustc [..]--cfg cargo_rustc -C strip=symbols [..]-C strip=debuginfo [..]--cfg from_rustflags`
+[FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
+
+"#]]
+        )
+        .run();
+
+    // Ensure the short-live env var to work
+    p.cargo("clean").run();
+    p.cargo("rustc --release -v -- --cfg cargo_rustc -C strip=symbols")
+        .env("RUSTFLAGS", "--cfg from_rustflags")
+        .env("__CARGO_RUSTC_ORIG_ARGS_PRIO", "1")
+        .masquerade_as_nightly_cargo(&["cargo-rustc-precedence"])
+        .with_stderr_data(
+            str![[r#"
+[COMPILING] foo v0.0.0 ([ROOT]/foo)
+[RUNNING] `rustc [..]--cfg cargo_rustc -C strip=symbols [..]-C strip=debuginfo [..]--cfg from_rustflags`
+[FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
+
+"#]]
+        )
+        .run();
+
+    // Ensure non-nightly to work as before
+    p.cargo("clean").run();
+    p.cargo("rustc --release -v -- --cfg cargo_rustc -C strip=symbols")
+        .env("RUSTFLAGS", "--cfg from_rustflags")
+        .with_stderr_data(
+            str![[r#"
+[COMPILING] foo v0.0.0 ([ROOT]/foo)
+[RUNNING] `rustc [..]--cfg cargo_rustc -C strip=symbols [..]-C strip=debuginfo [..]--cfg from_rustflags`
+[FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
+
+"#]]
+        )
+        .run();
+}

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -819,14 +819,13 @@ fn precedence() {
 
     p.cargo("rustc --release -v -- --cfg cargo_rustc -C strip=symbols")
         .env("RUSTFLAGS", "--cfg from_rustflags")
-        .with_stderr_data(
-            str![[r#"
+        .masquerade_as_nightly_cargo(&["cargo-rustc-precedence"])
+        .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustc [..]--cfg cargo_rustc -C strip=symbols [..]-C strip=debuginfo [..]--cfg from_rustflags`
+[RUNNING] `rustc [..]-C strip=debuginfo [..]--cfg cargo_rustc -C strip=symbols --cfg from_rustflags`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 
-"#]]
-        )
+"#]])
         .run();
 
     // Ensure the short-live env var to work


### PR DESCRIPTION
### What does this PR try to resolve?

Previously `cargo rustc -- <flags>` got a lower precedence than
some of the flags set by cargo internal.
This is a bit unintuitive as Cargo generally treats user-provided
CLI flags with the highest priority.

This commit changes `cargo rustc -- <flags>` to a higher precedence:
higher than most of flags set by Cargo, and only lower than
`build.rustflags` family.




### How should we test and review this PR?

Unsure if this affects people's workflow, so this behavior is only
enabled on nightly for collectin feedback. A environment variable
`__CARGO_RUSTC_ORIG_ARGS_PRIO=1` is provided for users to opt-out.
If everything goes well, the nightly gate will be removed after a
few of releases.

### Additional information

See discussion on https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/rustflags.20precendence.20of.20.60cargo.20rustc.60

Fixes #14346
