### PR TITLE
perf: Improve quality of completion performance traces

### DIFF
--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -31,9 +31,19 @@ fn main() {
 
     let nightly_features_allowed = matches!(&*features::channel(), "nightly" | "dev");
     if nightly_features_allowed {
+        let args = std::env::args_os();
+        let current_dir = std::env::current_dir().ok();
         let completer =
             clap_complete::CompleteEnv::with_factory(|| cli::cli(&mut gctx)).var("CARGO_COMPLETE");
-        completer.complete();
+        if completer
+            .try_complete(args, current_dir.as_deref())
+            .unwrap_or_else(|e| {
+                let mut shell = Shell::new();
+                cargo::exit_with_error(e.into(), &mut shell)
+            })
+        {
+            return;
+        }
     }
 
     let result = if let Some(lock_addr) = cargo::ops::fix_get_proxy_lock_addr() {

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -31,6 +31,7 @@ fn main() {
 
     let nightly_features_allowed = matches!(&*features::channel(), "nightly" | "dev");
     if nightly_features_allowed {
+        let _span = tracing::span!(tracing::Level::TRACE, "completions").entered();
         let args = std::env::args_os();
         let current_dir = std::env::current_dir().ok();
         let completer =

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -31,9 +31,9 @@ fn main() {
 
     let nightly_features_allowed = matches!(&*features::channel(), "nightly" | "dev");
     if nightly_features_allowed {
-        clap_complete::CompleteEnv::with_factory(|| cli::cli(&mut gctx))
-            .var("CARGO_COMPLETE")
-            .complete();
+        let completer =
+            clap_complete::CompleteEnv::with_factory(|| cli::cli(&mut gctx)).var("CARGO_COMPLETE");
+        completer.complete();
     }
 
     let result = if let Some(lock_addr) = cargo::ops::fix_get_proxy_lock_addr() {


### PR DESCRIPTION
### What does this PR try to resolve?

- `CompleteEnv::complete` calls `std::process::exit`, causing the traces not to be flushed
- Its hard to see where overhead is coming from for completions without tracing it

This was inspired by #14552

### How should we test and review this PR?



### Additional information
