### PR TITLE
Fix panic when running cargo tree on a package with a cross compiled bindep

### DIFF
--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -1568,15 +1568,14 @@ fn artifact_dep_target_specified() {
         .with_status(0)
         .run();
 
-    // TODO: This command currently fails due to a bug in cargo but it should be fixed so that it succeeds in the future.
     p.cargo("tree -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
-        .with_stdout_data("")
-        .with_stderr_data(r#"...
-[..]did not find features for (PackageId { name: "bindep", version: "0.0.0", source: "[..]" }, NormalOrDev) within activated_features:[..]
-...
-"#)
-        .with_status(101)
+        .with_stdout_data(str![[r#"
+foo v0.0.0 ([ROOT]/foo)
+└── bindep v0.0.0 ([ROOT]/foo/bindep)
+
+"#]])
+        .with_status(0)
         .run();
 }
 


### PR DESCRIPTION
### What does this PR try to resolve?

This is an attempt to close out @rukai's [PR](https://github.com/rust-lang/cargo/pull/13207#issue-2056019109) for #12358 and #10593 by adjusting the new integration test and resolving merge conflicts.

I have also separated the changes into atomic commits as per [previous review](https://github.com/rust-lang/cargo/pull/13207#discussion_r1543447659).

### How should we test and review this PR?

The integration test that has been edited here is sufficient, plus the new integration test that confirms a more specific case where `cargo tree` throws an error.

### Additional information

I have confirmed the test `artifact_dep_target_specified` fails on master branch and succeeds on this branch.

The first commit fixes the panic and the integration test. Commits 2 and 3 add other tests that confirm behaviour mentioned in related issues.

Commits:
1. [Fix panic when running cargo tree on a package with a cross compiled bindep](https://github.com/rust-lang/cargo/pull/14593/commits/5c5ea78ecd4d92b04cd4d4f8f867a3dffacf9a79) - fixes some panics and changes the integration test to succeed
2. [test: cargo tree panic on artifact dep target deactivated](https://github.com/rust-lang/cargo/pull/14593/commits/ed294ab4e7743454472b13119e110973ed4c56fd) - adds test to confirm the behaviour for the specific panic from [#10539 (comment)](https://github.com/rust-lang/cargo/issues/10593#issuecomment-1317759526)