### PR TITLE
fix: correct error count for `cargo check --message-format json`

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1867,10 +1867,19 @@ fn on_stderr_line_inner(
 
     #[derive(serde::Deserialize)]
     struct CompilerMessage {
+        message: String,
         level: String,
     }
-    if let Ok(message) = serde_json::from_str::<CompilerMessage>(compiler_message.get()) {
-        count_diagnostic(&message.level, options);
+
+    if let Ok(msg) = serde_json::from_str::<CompilerMessage>(compiler_message.get()) {
+        if msg.message.starts_with("aborting due to")
+            || msg.message.ends_with("warning emitted")
+            || msg.message.ends_with("warnings emitted")
+        {
+            // Skip this line; we'll print our own summary at the end.
+            return Ok(true);
+        }
+        count_diagnostic(&msg.level, options);
     }
 
     let msg = machine_message::FromCompiler {

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -95,7 +95,7 @@ fn cargo_fail_with_no_stderr() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
-[ERROR] could not compile `foo` (bin "foo") due to 2 previous errors
+[ERROR] could not compile `foo` (bin "foo") due to 1 previous error
 
 "#]])
         .run();

--- a/tests/testsuite/pkgid.rs
+++ b/tests/testsuite/pkgid.rs
@@ -330,12 +330,6 @@ fn pkgid_json_message_metadata_consistency() {
   {
     "manifest_path": "[ROOT]/foo/Cargo.toml",
     "package_id": "path+[ROOTURL]/foo#0.5.0",
-    "reason": "compiler-message",
-    "...": "{...}"
-  },
-  {
-    "manifest_path": "[ROOT]/foo/Cargo.toml",
-    "package_id": "path+[ROOTURL]/foo#0.5.0",
     "reason": "compiler-artifact",
     "...": "{...}"
   },


### PR DESCRIPTION
Hi! This is my first time contributing to Cargo. If there is anything that I need to do, please let me know!
(I'm not sure whether the commit message is aligned with the Cargo's convention. If it doesn't, I'm willing to modify it!)

This PR resolves the issue with incorrect error count and ensures warnings are correctly displayed when using `cargo check --message-format json`.

Fixes #14472
