### PR TITLE
docs(charter): Declare new Intentional Artifacts as 'small' changes

### DIFF
--- a/src/doc/contrib/src/team.md
+++ b/src/doc/contrib/src/team.md
@@ -135,6 +135,7 @@ The degree of process is correlated with the degree of change being proposed:
     These decisions are usually processed via private channels by the entirety of the team.
   - A change that is a "one-way door".
     That is, something that is difficult to reverse without breaking backwards compatibility.
+  - New or transferred "Intentional Artifact" crates to the team, see also [Rust crate ownership policy](https://forge.rust-lang.org/policies/crate-ownership.html)
 
 - Larger features should usually go through the [RFC process].
   This usually involves first soliciting feedback from the Cargo team and the rest of the community, often via the [Rust Internals] discussion board, [Cargo's issue tracker], and the [Zulip] channel.


### PR DESCRIPTION
### What does this PR try to resolve?

The default stance for new "Intentional Artifact" crates is that an RFC is needed, see [Crate ownership policy](https://forge.rust-lang.org/policies/crate-ownership.html).
However, it gives room for team's to have their charter define the process.  As we don't generally need wide input for these decisions, I'm proposing we treat these as "small" changes and only require an FCP.

### How should we test and review this PR?



### Additional information
