### PR TITLE
test: relax panic output assertion

### DIFF
--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -1891,6 +1891,7 @@ test t1 ... FAILED
 failures:
 
 ---- t1 stdout ----
+...
 thread 't1' panicked at src/lib.rs:8:21:
 assertion `left == right` failed: doit assert failure
   left: 2
@@ -1958,6 +1959,7 @@ Caused by:
   cargo::rerun-if-changed=build.rs
 
   --- stderr
+...
   thread 'main' panicked at helper.rs:1:16:
   Crash!
   [NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
@@ -1977,6 +1979,7 @@ Caused by:
   cargo::rerun-if-changed=build.rs
 
   --- stderr
+...
   thread 'main' panicked at helper.rs:1:16:
   Crash!
   [NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -1327,6 +1327,7 @@ fn reports_unsuccessful_subcommand_result() {
     cargo_process("fail")
         .with_status(101)
         .with_stderr_data(str![[r#"
+...
 thread 'main' panicked at [ROOT]/home/.cargo/registry/src/-[HASH]/cargo-fail-1.0.0/src/main.rs:1:13:
 explicit panic
 [NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/testsuite/jobserver.rs
+++ b/tests/testsuite/jobserver.rs
@@ -232,6 +232,7 @@ this is a runner
         .with_stderr_data(str![[r#"
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `target/debug/cargo-jobserver-check[EXE]`
+...
 thread 'main' panicked at src/main.rs:5:43:
 no jobserver from env: NotPresent
 [NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
@@ -248,9 +249,11 @@ no jobserver from env: NotPresent
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `runner target/debug/cargo-jobserver-check[EXE]`
 this is a runner
+...
 thread 'main' panicked at src/main.rs:5:43:
 no jobserver from env: NotPresent
 [NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+...
 thread 'main' panicked at src/main.rs:6:17:
 assertion failed: status.success()
 [NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
@@ -268,6 +271,7 @@ test test ... FAILED
 failures:
 
 ---- test stdout ----
+...
 thread 'test' panicked at src/lib.rs:4:42:
 no jobserver from env: NotPresent
 [NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
@@ -290,6 +294,7 @@ test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; 
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] unittests src/lib.rs (target/debug/deps/cargo_jobserver_check-[HASH][EXE])
 this is a runner
+...
 thread 'main' panicked at src/main.rs:6:17:
 assertion failed: status.success()
 [NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
@@ -304,6 +309,7 @@ test test ... FAILED
 failures:
 
 ---- test stdout ----
+...
 thread 'test' panicked at src/lib.rs:4:42:
 no jobserver from env: NotPresent
 [NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -516,6 +516,7 @@ test test_hello ... FAILED
 failures:
 
 ---- test_hello stdout ----
+...
 thread 'test_hello' panicked at src/lib.rs:1:27:
 assertion failed: false
 ...


### PR DESCRIPTION
### What does this PR try to resolve?

rust-lang/rust#122565 adds a new line to thread panic output. To make the current test suites works on stable, beta, and nightly, this relaxes the assertion around that by globbing everything.

### How should we test and review this PR?

Switch to rust-lang/rust#122565 and build a stage0 std, then use it to run these Cargo tests.

Linking to stage0 toolchain should work: https://rustc-dev-guide.rust-lang.org/building/how-to-build-and-run.html#creating-a-rustup-toolchain

<!-- homu-ignore:start -->

### Additional information

An extra newline from the beginning of the panic message seems a bit odd to me, though I understand until we find a better approach, it is probably the only way to fix the message interleaved issue.

<!-- homu-ignore:end -->
