### PR TITLE
Update cc to 1.1.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,12 +497,13 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.6"
+version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
+checksum = "9540e661f81799159abee814118cc139a2004b3a3aa3ea37724a1b66530b90e0"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]


### PR DESCRIPTION
This version of `cc` contains [a fix](https://github.com/rust-lang/cc-rs/releases/tag/cc-v1.1.22) to prevent spurious rebuilds. Hopefully this should help avoid the CI issues rustc has been having.