### PR TITLE
test: relax compiler panic assertions

### DIFF
--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -290,10 +290,10 @@ fn remap_path_scope() {
 [FINISHED] `release` profile [optimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `target/[HOST_TARGET]/release/foo`
 [..]thread '[..]' panicked at [..]src/main.rs:3:[..]:
-remap to /rustc/<hash>
-             at /rustc/[..]/library/std/src/[..]
-             at ./src/main.rs:3:[..]
-             at /rustc/[..]/library/core/src/[..]
+[..]remap to /rustc/<hash>[..]
+[..]at /rustc/[..]/library/std/src/[..]
+[..]at ./src/main.rs:3:[..]
+[..]at /rustc/[..]/library/core/src/[..]
 ...
 "#]]
             .unordered(),

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -151,7 +151,7 @@ fn check_with_invalid_target_triple() {
 Caused by:
   process didn't exit successfully: `rustc - --crate-name ___ --print=file-names --target unknown-target-triple [..]` ([EXIT_STATUS]: 1)
   --- stderr
-  [ERROR] Error loading target specification: Could not find specification for target "unknown-target-triple". Run `rustc --print target-list` for a list of built-in targets
+...
 
 
 "#]])
@@ -1571,13 +1571,11 @@ fn artifact_dep_target_specified() {
     // TODO: This command currently fails due to a bug in cargo but it should be fixed so that it succeeds in the future.
     p.cargo("tree -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
-        .with_stdout_data(str![[""]])
-        .with_stderr_data(str![[r#"
-thread 'main' panicked at src/cargo/[..]:
-activated_features for invalid package: features did not find PackageId { name: "bindep", version: "0.0.0", source: "[..]" } NormalOrDev
-[NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-
-"#]])
+        .with_stdout_data("")
+        .with_stderr_data(r#"...
+[..]activated_features for invalid package: features did not find PackageId { name: "bindep", version: "0.0.0", source: "[..]" } NormalOrDev[..]
+...
+"#)
         .with_status(101)
         .run();
 }
@@ -3246,7 +3244,7 @@ Caused by:
 Caused by:
   process didn't exit successfully: `rustc [..] ([EXIT_STATUS]: 1)
   --- stderr
-  [ERROR] Error loading target specification: Could not find specification for target "custom-target". Run `rustc --print target-list` for a list of built-in targets
+...
 
 
 "#]])

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -364,7 +364,7 @@ fn cargo_bench_failing_test() {
 
             #[bench]
             fn bench_hello(_b: &mut test::Bencher) {
-                assert_eq!(hello(), "nope")
+                assert_eq!(hello(), "nope", "NOPE!")
             }
             "#,
         )
@@ -389,28 +389,7 @@ hello
 [ERROR] bench failed, to rerun pass `--bin foo`
 
 "#]])
-        .with_stdout_data(str![[r#"
-
-running 1 test
-test bench_hello ... FAILED
-
-failures:
-
----- bench_hello stdout ----
-thread 'main' panicked at src/main.rs:15:17:
-assertion `left == right` failed
-  left: "hello"
- right: "nope"
-[NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-
-
-failures:
-    bench_hello
-
-test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in [ELAPSED]s
-
-
-"#]])
+        .with_stdout_data("...\n[..]NOPE![..]\n...")
         .with_status(101)
         .run();
 }
@@ -1439,7 +1418,7 @@ fn test_bench_no_fail_fast() {
 
             #[bench]
             fn bench_nope(_b: &mut test::Bencher) {
-                assert_eq!("nope", hello())
+                assert_eq!("nope", hello(), "NOPE!")
             }
             "#,
         )
@@ -1449,7 +1428,7 @@ fn test_bench_no_fail_fast() {
                 #![feature(test)]
                 extern crate test;
                 #[bench]
-                fn b1_fail(_b: &mut test::Bencher) { assert_eq!(1, 2); }
+                fn b1_fail(_b: &mut test::Bencher) { assert_eq!(1, 2, "ONE=TWO"); }
             "#,
         )
         .build();
@@ -1468,48 +1447,15 @@ fn test_bench_no_fail_fast() {
     `--bench b1`
 
 "#]])
-        .with_stdout_data(str![[r#"
-
-running 2 tests
-test bench_hello ... bench:           [AVG_ELAPSED] ns/iter (+/- [JITTER])
-test bench_nope  ... FAILED
-
-failures:
-
----- bench_nope stdout ----
-thread 'main' panicked at src/main.rs:20:17:
-assertion `left == right` failed
-  left: "nope"
- right: "hello"
-[NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-
-
-failures:
-    bench_nope
-
-test result: FAILED. 0 passed; 1 failed; 0 ignored; 1 measured; 0 filtered out; finished in [ELAPSED]s
-
-
-running 1 test
-test b1_fail ... FAILED
-
-failures:
-
----- b1_fail stdout ----
-thread 'main' panicked at benches/b1.rs:5:54:
-assertion `left == right` failed
-  left: 1
- right: 2
-[NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-
-
-failures:
-    b1_fail
-
-test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in [ELAPSED]s
-
-
-"#]])
+        .with_stdout_data(
+            r#"
+...
+[..]NOPE![..]
+...
+[..]ONE=TWO[..]
+...
+"#,
+        )
         .run();
 }
 

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -1120,11 +1120,7 @@ it is true
     // Make sure the test is fallible.
     p.cargo("test --doc")
         .with_status(101)
-        .with_stdout_data(str![[r#"
-...
-assertion `left == right` failed: common is wrong
-...
-"#]])
+        .with_stdout_data("...\n[..]common is wrong[..]\n...")
         .run();
     p.cargo("test --doc").env("TEST_EXPECTS_ENABLED", "1").run();
     p.cargo("doc").run();

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -1883,29 +1883,7 @@ fn dirty_both_lib_and_test() {
     // 2 != 1
     p.cargo("test --lib")
         .with_status(101)
-        .with_stdout_data(str![[r#"
-
-running 1 test
-test t1 ... FAILED
-
-failures:
-
----- t1 stdout ----
-...
-thread 't1' panicked at src/lib.rs:8:21:
-assertion `left == right` failed: doit assert failure
-  left: 2
- right: 1
-[NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-
-
-failures:
-    t1
-
-test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in [ELAPSED]s
-
-
-"#]])
+        .with_stdout_data("...\n[..]doit assert failure[..]\n...")
         .run();
 
     if is_coarse_mtime() {
@@ -1949,42 +1927,12 @@ fn script_fails_stay_dirty() {
     }
     p.change_file("helper.rs", r#"pub fn doit() {panic!("Crash!");}"#);
     p.cargo("build")
-        .with_stderr_data(str![[r#"
-[COMPILING] foo v0.0.1 ([ROOT]/foo)
-[ERROR] failed to run custom build command for `foo v0.0.1 ([ROOT]/foo)`
-
-Caused by:
-  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build` ([EXIT_STATUS]: 101)
-  --- stdout
-  cargo::rerun-if-changed=build.rs
-
-  --- stderr
-...
-  thread 'main' panicked at helper.rs:1:16:
-  Crash!
-  [NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-
-"#]])
+        .with_stderr_data("...\n[..]Crash![..]\n...")
         .with_status(101)
         .run();
     // There was a bug where this second call would be "fresh".
     p.cargo("build")
-        .with_stderr_data(str![[r#"
-[COMPILING] foo v0.0.1 ([ROOT]/foo)
-[ERROR] failed to run custom build command for `foo v0.0.1 ([ROOT]/foo)`
-
-Caused by:
-  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build` ([EXIT_STATUS]: 101)
-  --- stdout
-  cargo::rerun-if-changed=build.rs
-
-  --- stderr
-...
-  thread 'main' panicked at helper.rs:1:16:
-  Crash!
-  [NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-
-"#]])
+        .with_stderr_data("...\n[..]Crash![..]\n...")
         .with_status(101)
         .run();
 }

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -1314,7 +1314,7 @@ fn do_not_rebuilds_on_local_install() {
 #[cargo_test]
 fn reports_unsuccessful_subcommand_result() {
     Package::new("cargo-fail", "1.0.0")
-        .file("src/main.rs", "fn main() { panic!(); }")
+        .file("src/main.rs", r#"fn main() { panic!("EXPLICIT PANIC!"); }"#)
         .publish();
     cargo_process("install cargo-fail").run();
     cargo_process("--list")
@@ -1326,13 +1326,7 @@ fn reports_unsuccessful_subcommand_result() {
         .run();
     cargo_process("fail")
         .with_status(101)
-        .with_stderr_data(str![[r#"
-...
-thread 'main' panicked at [ROOT]/home/.cargo/registry/src/-[HASH]/cargo-fail-1.0.0/src/main.rs:1:13:
-explicit panic
-[NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-
-"#]])
+        .with_stderr_data("...\n[..]EXPLICIT PANIC![..]\n...")
         .run();
 }
 

--- a/tests/testsuite/jobserver.rs
+++ b/tests/testsuite/jobserver.rs
@@ -233,9 +233,7 @@ this is a runner
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `target/debug/cargo-jobserver-check[EXE]`
 ...
-thread 'main' panicked at src/main.rs:5:43:
-no jobserver from env: NotPresent
-[NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+[..]no jobserver from env[..]
 ...
 
 "#]])
@@ -250,40 +248,14 @@ no jobserver from env: NotPresent
 [RUNNING] `runner target/debug/cargo-jobserver-check[EXE]`
 this is a runner
 ...
-thread 'main' panicked at src/main.rs:5:43:
-no jobserver from env: NotPresent
-[NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-...
-thread 'main' panicked at src/main.rs:6:17:
-assertion failed: status.success()
-[NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+[..]no jobserver from env[..]
 ...
 
 "#]])
         .run();
     p.cargo("test -j2")
         .with_status(101)
-        .with_stdout_data(str![[r#"
-
-running 1 test
-test test ... FAILED
-
-failures:
-
----- test stdout ----
-...
-thread 'test' panicked at src/lib.rs:4:42:
-no jobserver from env: NotPresent
-[NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-
-
-failures:
-    test
-
-test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in [ELAPSED]s
-
-
-"#]])
+        .with_stdout_data("...\n[..]no jobserver from env[..]\n...")
         .run();
     p.cargo("test -j2")
         .env("PATH", path)
@@ -295,33 +267,9 @@ test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; 
 [RUNNING] unittests src/lib.rs (target/debug/deps/cargo_jobserver_check-[HASH][EXE])
 this is a runner
 ...
-thread 'main' panicked at src/main.rs:6:17:
-assertion failed: status.success()
-[NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-[ERROR] test failed, to rerun pass `--lib`
 
 "#]])
-        .with_stdout_data(str![[r#"
-
-running 1 test
-test test ... FAILED
-
-failures:
-
----- test stdout ----
-...
-thread 'test' panicked at src/lib.rs:4:42:
-no jobserver from env: NotPresent
-[NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-
-
-failures:
-    test
-
-test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in [ELAPSED]s
-
-
-"#]])
+        .with_stdout_data("...\n[..]no jobserver from env[..]\n...")
         .run();
 }
 

--- a/tests/testsuite/rustflags.rs
+++ b/tests/testsuite/rustflags.rs
@@ -967,7 +967,7 @@ fn build_rustflags_for_build_scripts() {
         .file(
             "build.rs",
             r#"
-                fn main() { assert!(cfg!(foo)); }
+                fn main() { assert!(cfg!(foo), "CFG FOO!"); }
             "#,
         )
         .file(
@@ -986,12 +986,7 @@ fn build_rustflags_for_build_scripts() {
     p.cargo("check --target")
         .arg(host)
         .with_status(101)
-        .with_stderr_data(str![[r#"
-...
-  assertion failed: cfg!(foo)
-  [NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-
-"#]])
+        .with_stderr_data("...\n[..]CFG FOO![..]\n...")
         .run();
 
     // Enabling -Ztarget-applies-to-host should not make a difference without the config setting
@@ -1004,12 +999,7 @@ fn build_rustflags_for_build_scripts() {
         .masquerade_as_nightly_cargo(&["target-applies-to-host"])
         .arg("-Ztarget-applies-to-host")
         .with_status(101)
-        .with_stderr_data(str![[r#"
-...
-  assertion failed: cfg!(foo)
-  [NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-
-"#]])
+        .with_stderr_data("...\n[..]CFG FOO![..]\n...")
         .run();
 
     // When set to false though, the "proper" behavior where host artifacts _only_ pick up on
@@ -1027,24 +1017,14 @@ fn build_rustflags_for_build_scripts() {
         .masquerade_as_nightly_cargo(&["target-applies-to-host"])
         .arg("-Ztarget-applies-to-host")
         .with_status(101)
-        .with_stderr_data(str![[r#"
-...
-  assertion failed: cfg!(foo)
-  [NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-
-"#]])
+        .with_stderr_data("...\n[..]CFG FOO![..]\n...")
         .run();
     p.cargo("check --target")
         .arg(host)
         .masquerade_as_nightly_cargo(&["target-applies-to-host"])
         .arg("-Ztarget-applies-to-host")
         .with_status(101)
-        .with_stderr_data(str![[r#"
-...
-  assertion failed: cfg!(foo)
-  [NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-
-"#]])
+        .with_stderr_data("...\n[..]CFG FOO![..]\n...")
         .run();
 }
 

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -396,7 +396,7 @@ fn cargo_test_failing_test_in_bin() {
 
             #[test]
             fn test_hello() {
-                assert_eq!(hello(), "nope")
+                assert_eq!(hello(), "nope", "NOPE!")
             }
             "#,
         )
@@ -420,24 +420,7 @@ hello
 [ERROR] test failed, to rerun pass `--bin foo`
 
 "#]])
-        .with_stdout_data(
-            str![[r#"
-running 1 test
-test test_hello ... FAILED
-
-failures:
-
----- test_hello stdout ----
-thread 'test_hello' panicked at src/main.rs:12:17:
-assertion `left == right` failed
-  left: "hello"
- right: "nope"
-failures:
-    test_hello
-...
-"#]]
-            .unordered(),
-        )
+        .with_stdout_data("...\n[..]NOPE![..]\n...")
         .with_status(101)
         .run();
 }
@@ -449,7 +432,7 @@ fn cargo_test_failing_test_in_test() {
         .file("src/main.rs", r#"pub fn main() { println!("hello"); }"#)
         .file(
             "tests/footest.rs",
-            "#[test] fn test_hello() { assert!(false) }",
+            r#"#[test] fn test_hello() { assert!(false, "FALSE!") }"#,
         )
         .build();
 
@@ -476,17 +459,13 @@ hello
             str![[r#"
 ...
 running 0 tests
+...
 running 1 test
 test test_hello ... FAILED
-
-failures:
-
----- test_hello stdout ----
-thread 'test_hello' panicked at tests/footest.rs:1:27:
-assertion failed: false
-failures:
-    test_hello
 ...
+[..]FALSE![..]
+...
+
 "#]]
             .unordered(),
         )
@@ -498,7 +477,10 @@ failures:
 fn cargo_test_failing_test_in_lib() {
     let p = project()
         .file("Cargo.toml", &basic_lib_manifest("foo"))
-        .file("src/lib.rs", "#[test] fn test_hello() { assert!(false) }")
+        .file(
+            "src/lib.rs",
+            r#"#[test] fn test_hello() { assert!(false, "FALSE!") }"#,
+        )
         .build();
 
     p.cargo("test")
@@ -512,16 +494,8 @@ fn cargo_test_failing_test_in_lib() {
         .with_stdout_data(str![[r#"
 ...
 test test_hello ... FAILED
-
-failures:
-
----- test_hello stdout ----
 ...
-thread 'test_hello' panicked at src/lib.rs:1:27:
-assertion failed: false
-...
-failures:
-    test_hello
+[..]FALSE![..]
 ...
 "#]])
         .with_status(101)
@@ -5528,7 +5502,7 @@ Caused by:
             "test exited abnormally; to see the full output pass --nocapture to the harness.",
         )
         .with_stderr_data(str![[r#"
-thread 't' panicked at tests/t1.rs:3:26:
+[..]thread [..]panicked [..] tests/t1.rs[..]
 [NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 Caused by:
   process didn't exit successfully: `[ROOT]/foo/target/debug/deps/t2-[HASH][EXE] --nocapture` ([EXIT_STATUS]: 4)

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -5497,7 +5497,6 @@ Caused by:
         .run();
 
     p.cargo("test --no-fail-fast -- --nocapture")
-        .env_remove("RUST_BACKTRACE")
         .with_stderr_does_not_contain(
             "test exited abnormally; to see the full output pass --nocapture to the harness.",
         )


### PR DESCRIPTION
### What does this PR try to resolve?

Minimize the panic output assertion per request from <https://github.com/rust-lang/cargo/pull/14602#issuecomment-2378205191>.

Instead of snapshotting the entire panic message, 
here we only check the precense of our custom messaage.

### How should we test and review this PR?

Test suite passes.
