### PR TITLE
Fix `cargo:version_number` - has only one `:`

### DIFF
--- a/src/doc/src/reference/build-script-examples.md
+++ b/src/doc/src/reference/build-script-examples.md
@@ -440,7 +440,7 @@ script looks something [like
 this](https://github.com/sfackler/rust-openssl/blob/dc72a8e2c429e46c275e528b61a733a66e7877fc/openssl-sys/build/main.rs#L216):
 
 ```rust,ignore
-println!("cargo::version_number={:x}", openssl_version);
+println!("cargo:version_number={openssl_version:x}");
 ```
 
 This instruction causes the `DEP_OPENSSL_VERSION_NUMBER` environment variable

--- a/src/doc/src/reference/build-script-examples.md
+++ b/src/doc/src/reference/build-script-examples.md
@@ -440,7 +440,7 @@ script looks something [like
 this](https://github.com/sfackler/rust-openssl/blob/dc72a8e2c429e46c275e528b61a733a66e7877fc/openssl-sys/build/main.rs#L216):
 
 ```rust,ignore
-println!("cargo:version_number={openssl_version:x}");
+println!("cargo::metadata=version_number={openssl_version:x}");
 ```
 
 This instruction causes the `DEP_OPENSSL_VERSION_NUMBER` environment variable


### PR DESCRIPTION
See [openssl code](https://github.com/sfackler/rust-openssl/blob/8d60e211460122768a1deab0549e35577a52dbeb/openssl-sys/build/main.rs#L392) -- it uses a single colon. Also inlined arg into format to make it a bit more consice.

```rust
let openssl_version = openssl_version.unwrap();
println!("cargo:version_number={:x}", openssl_version);
if openssl_version >= 0x4_00_00_00_0 {
...
```
