### PR TITLE
docs(ref): Highleft whats left for msrv-policy

### DIFF
--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -369,6 +369,22 @@ Can be overridden with
 - Setting the dependency's version requirement higher than any version with a compatible `rust-version`
 - Specifying the version to `cargo update` with `--precise`
 
+### Convert `incompatible_toolchain` error into a lint
+
+Unimplemented
+
+### `--update-rust-version` flag for `cargo add`, `cargo update`
+
+Unimplemented
+
+### `package.rust-version = "toolchain"`
+
+Unimplemented
+
+### Update `cargp new` template to set `package.rust-version = "toolchain"`
+
+Unimplemented
+
 ## precise-pre-release
 
 * Tracking Issue: [#13290](https://github.com/rust-lang/cargo/issues/13290)

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -331,6 +331,7 @@ Documentation updates:
 - For workspace's "The `dependencies` table" section, include `public` as an unsupported field for `workspace.dependencies`
 
 ## msrv-policy
+- [RFC: MSRV-aware Resolver](https://rust-lang.github.io/rfcs/3537-msrv-resolver.html)
 - [#9930](https://github.com/rust-lang/cargo/issues/9930) (MSRV-aware resolver)
 
 Catch-all unstable feature for MSRV-aware cargo features under


### PR DESCRIPTION
### What does this PR try to resolve?

While there is a tracking issue for these,
I didn't want to have everything under `msrv-policy` to be stabilized,
making it look like it should be moved to the Stable section of the
page, when there are independently stabilizable pieces missing.


### How should we test and review this PR?


### Additional information

This is prep for stabilizing MSRV-aware resover