### PR TITLE
feat: Stabilize MSRV-aware resolver config

### DIFF
--- a/src/bin/cargo/commands/generate_lockfile.rs
+++ b/src/bin/cargo/commands/generate_lockfile.rs
@@ -8,23 +8,13 @@ pub fn cli() -> Command {
         .arg_silent_suggestion()
         .arg_manifest_path()
         .arg_lockfile_path()
-        .arg_ignore_rust_version_with_help(
-            "Ignore `rust-version` specification in packages (unstable)",
-        )
+        .arg_ignore_rust_version_with_help("Ignore `rust-version` specification in packages")
         .after_help(color_print::cstr!(
             "Run `<cyan,bold>cargo help generate-lockfile</>` for more detailed information.\n"
         ))
 }
 
 pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
-    if args.honor_rust_version().is_some() {
-        gctx.cli_unstable().fail_if_stable_opt_custom_z(
-            "--ignore-rust-version",
-            9930,
-            "msrv-policy",
-            gctx.cli_unstable().msrv_policy,
-        )?;
-    }
     let ws = args.workspace(gctx)?;
     ops::generate_lockfile(&ws)?;
     Ok(())

--- a/src/bin/cargo/commands/update.rs
+++ b/src/bin/cargo/commands/update.rs
@@ -53,24 +53,13 @@ pub fn cli() -> Command {
         )
         .arg_manifest_path()
         .arg_lockfile_path()
-        .arg_ignore_rust_version_with_help(
-            "Ignore `rust-version` specification in packages (unstable)",
-        )
+        .arg_ignore_rust_version_with_help("Ignore `rust-version` specification in packages")
         .after_help(color_print::cstr!(
             "Run `<cyan,bold>cargo help update</>` for more detailed information.\n"
         ))
 }
 
 pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
-    if args.honor_rust_version().is_some() {
-        gctx.cli_unstable().fail_if_stable_opt_custom_z(
-            "--ignore-rust-version",
-            9930,
-            "msrv-policy",
-            gctx.cli_unstable().msrv_policy,
-        )?;
-    }
-
     let mut ws = args.workspace(gctx)?;
 
     if args.is_present_with_zero_values("package") {

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -306,31 +306,12 @@ impl<'gctx> Workspace<'gctx> {
                 }
             }
         }
-        match self.gctx().get::<CargoResolverConfig>("resolver") {
-            Ok(CargoResolverConfig {
-                incompatible_rust_versions: Some(incompatible_rust_versions),
-            }) => {
-                if self.gctx().cli_unstable().msrv_policy {
-                    self.resolve_honors_rust_version =
-                        incompatible_rust_versions == IncompatibleRustVersions::Fallback;
-                } else {
-                    self.gctx()
-                        .shell()
-                        .warn("ignoring `resolver` config table without `-Zmsrv-policy`")?;
-                }
-            }
-            Ok(CargoResolverConfig {
-                incompatible_rust_versions: None,
-            }) => {}
-            Err(err) => {
-                if self.gctx().cli_unstable().msrv_policy {
-                    return Err(err);
-                } else {
-                    self.gctx()
-                        .shell()
-                        .warn("ignoring `resolver` config table without `-Zmsrv-policy`")?;
-                }
-            }
+        if let CargoResolverConfig {
+            incompatible_rust_versions: Some(incompatible_rust_versions),
+        } = self.gctx().get::<CargoResolverConfig>("resolver")?
+        {
+            self.resolve_honors_rust_version =
+                incompatible_rust_versions == IncompatibleRustVersions::Fallback;
         }
 
         Ok(())

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -143,6 +143,9 @@ rpath = false            # Sets the rpath linking option.
 [profile.<name>.package.<name>]  # Override profile for a package.
 # Same keys for a normal profile (minus `panic`, `lto`, and `rpath`).
 
+[resolver]
+incompatible-rust-versions = "allow"  # Specifies how resolver reacts to these
+
 [registries.<name>]  # registries other than crates.io
 index = "…"          # URL of the registry index
 token = "…"          # authentication token for the registry
@@ -972,6 +975,30 @@ See [rpath](profiles.md#rpath).
 
 See [strip](profiles.md#strip).
 
+### `[resolver]`
+
+The `[resolver]` table overrides [dependency resolution behavior](resolver.md) for local development (e.g. excludes `cargo install`).
+
+#### `resolver.incompatible-rust-versions`
+* Type: string
+* Default: `"allow"`
+* Environment: `CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS`
+
+When resolving which version of a dependency to use, select how versions with incompatible `package.rust-version`s are treated.
+Values include:
+- `allow`: treat `rust-version`-incompatible versions like any other version
+- `fallback`: only consider `rust-version`-incompatible versions if no other version matched
+
+Can be overridden with
+- `--ignore-rust-version` CLI option
+- Setting the dependency's version requirement higher than any version with a compatible `rust-version`
+- Specifying the version to `cargo update` with `--precise`
+
+See the [resolver](resolver.md#rust-version) chapter for more details.
+
+> **MSRV:**
+> - `allow` is supported on any version
+> - `fallback` is respected as of 1.84
 
 ### `[registries]`
 

--- a/src/doc/src/reference/rust-version.md
+++ b/src/doc/src/reference/rust-version.md
@@ -29,6 +29,8 @@ benchmarks, etc.
 `cargo add` will auto-select the dependency's version requirement to be the latest version compatible with your `rust-version`.
 If that isn't the latest version, `cargo add` will inform users so they can make the choice on whether to keep it or update your `rust-version`.
 
+The [resolver](resolver.md#rust-version) may take Rust version into account when picking dependencies.
+
 Other tools may also take advantage of it, like `cargo clippy`'s
 [`incompatible_msrv` lint](https://rust-lang.github.io/rust-clippy/stable/index.html#/incompatible_msrv).
 
@@ -130,6 +132,10 @@ potentially limiting access to features of the shared dependency for the workspa
 
 To allow users to patch a dependency on one of your workspace members,
 every package in the workspace would need to be loadable in the oldest Rust version supported by the workspace.
+
+When using [`incompatible-rust-versions = "fallback"`](config.md#resolverincompatible-rust-versions),
+the Rust version of one package can affect dependency versions selected for another package with a different Rust version.
+See the [resolver](resolver.md#rust-version) chapter for more details.
 
 ### One or More Policies
 

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -351,31 +351,7 @@ This was stabilized in 1.79 in [#13608](https://github.com/rust-lang/cargo/pull/
 
 ### MSRV-aware resolver
 
-`-Zmsrv-policy` allows access to an MSRV-aware resolver which can be enabled with:
-- `resolver.incompatible-rust-versions` config field
-- `workspace.resolver = "3"` / `package.resolver = "3"`
-- `package.edition = "2024"` (only in workspace root)
-
-The resolver will prefer dependencies with a `package.rust-version` that is the same or older than your project's MSRV.
-As the resolver is unable to determine which workspace members will eventually
-depend on a package when it is being selected, we prioritize versions based on
-how many workspace member MSRVs they are compatible with.
-If there is no MSRV set then your toolchain version will be used, allowing it to pick up the toolchain version from pinned in rustup (e.g. `rust-toolchain.toml`).
-
-#### `resolver.incompatible-rust-versions`
-* Type: string
-* Default: `"allow"`
-* Environment: `CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS`
-
-When resolving a version for a dependency, select how versions with incompatible `package.rust-version`s are treated.
-Values include:
-- `allow`: treat `rust-version`-incompatible versions like any other version
-- `fallback`: only consider `rust-version`-incompatible versions if no other version matched
-
-Can be overridden with
-- `--ignore-rust-version` CLI option
-- Setting the dependency's version requirement higher than any version with a compatible `rust-version`
-- Specifying the version to `cargo update` with `--precise`
+This was stabilized in 1.83 in [#14639](https://github.com/rust-lang/cargo/pull/14639).
 
 ### Convert `incompatible_toolchain` error into a lint
 

--- a/tests/testsuite/cargo_add/rust_version_ignore/mod.rs
+++ b/tests/testsuite/cargo_add/rust_version_ignore/mod.rs
@@ -20,13 +20,11 @@ fn case() {
     let cwd = &project_root;
 
     snapbox::cmd::Command::cargo_ui()
-        .arg("-Zmsrv-policy")
         .arg("add")
         .arg("--ignore-rust-version")
         .arg_line("rust-version-user")
         .current_dir(cwd)
         .env("CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS", "fallback")
-        .masquerade_as_nightly_cargo(&["msrv-policy"])
         .assert()
         .code(0)
         .stdout_eq(str![""])

--- a/tests/testsuite/cargo_add/rust_version_incompatible/mod.rs
+++ b/tests/testsuite/cargo_add/rust_version_incompatible/mod.rs
@@ -23,12 +23,10 @@ fn case() {
     let cwd = &project_root;
 
     snapbox::cmd::Command::cargo_ui()
-        .arg("-Zmsrv-policy")
         .arg("add")
         .arg_line("rust-version-user")
         .current_dir(cwd)
         .env("CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS", "fallback")
-        .masquerade_as_nightly_cargo(&["msrv-policy"])
         .assert()
         .failure()
         .stdout_eq(str![""])

--- a/tests/testsuite/cargo_add/rust_version_latest/mod.rs
+++ b/tests/testsuite/cargo_add/rust_version_latest/mod.rs
@@ -20,12 +20,10 @@ fn case() {
     let cwd = &project_root;
 
     snapbox::cmd::Command::cargo_ui()
-        .arg("-Zmsrv-policy")
         .arg("add")
         .arg_line("rust-version-user")
         .current_dir(cwd)
         .env("CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS", "fallback")
-        .masquerade_as_nightly_cargo(&["msrv-policy"])
         .assert()
         .success()
         .stdout_eq(str![""])

--- a/tests/testsuite/cargo_add/rust_version_older/mod.rs
+++ b/tests/testsuite/cargo_add/rust_version_older/mod.rs
@@ -20,12 +20,10 @@ fn case() {
     let cwd = &project_root;
 
     snapbox::cmd::Command::cargo_ui()
-        .arg("-Zmsrv-policy")
         .arg("add")
         .arg_line("rust-version-user")
         .current_dir(cwd)
         .env("CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS", "fallback")
-        .masquerade_as_nightly_cargo(&["msrv-policy"])
         .assert()
         .success()
         .stdout_eq(str![""])

--- a/tests/testsuite/cargo_add/rustc_ignore/mod.rs
+++ b/tests/testsuite/cargo_add/rustc_ignore/mod.rs
@@ -23,13 +23,11 @@ fn case() {
     let cwd = &project_root;
 
     snapbox::cmd::Command::cargo_ui()
-        .arg("-Zmsrv-policy")
         .arg("add")
         .arg("--ignore-rust-version")
         .arg_line("rust-version-user")
         .current_dir(cwd)
         .env("CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS", "fallback")
-        .masquerade_as_nightly_cargo(&["msrv-policy"])
         .assert()
         .code(0)
         .stdout_eq(str![""])

--- a/tests/testsuite/cargo_add/rustc_incompatible/mod.rs
+++ b/tests/testsuite/cargo_add/rustc_incompatible/mod.rs
@@ -17,12 +17,10 @@ fn case() {
     let cwd = &project_root;
 
     snapbox::cmd::Command::cargo_ui()
-        .arg("-Zmsrv-policy")
         .arg("add")
         .arg_line("rust-version-user")
         .current_dir(cwd)
         .env("CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS", "fallback")
-        .masquerade_as_nightly_cargo(&["msrv-policy"])
         .assert()
         .failure()
         .stdout_eq(str![""])

--- a/tests/testsuite/cargo_add/rustc_latest/mod.rs
+++ b/tests/testsuite/cargo_add/rustc_latest/mod.rs
@@ -23,12 +23,10 @@ fn case() {
     let cwd = &project_root;
 
     snapbox::cmd::Command::cargo_ui()
-        .arg("-Zmsrv-policy")
         .arg("add")
         .arg_line("rust-version-user")
         .current_dir(cwd)
         .env("CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS", "fallback")
-        .masquerade_as_nightly_cargo(&["msrv-policy"])
         .assert()
         .success()
         .stdout_eq(str![""])

--- a/tests/testsuite/cargo_add/rustc_older/mod.rs
+++ b/tests/testsuite/cargo_add/rustc_older/mod.rs
@@ -23,12 +23,10 @@ fn case() {
     let cwd = &project_root;
 
     snapbox::cmd::Command::cargo_ui()
-        .arg("-Zmsrv-policy")
         .arg("add")
         .arg_line("rust-version-user")
         .current_dir(cwd)
         .env("CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS", "fallback")
-        .masquerade_as_nightly_cargo(&["msrv-policy"])
         .assert()
         .success()
         .stdout_eq(str![""])

--- a/tests/testsuite/cargo_generate_lockfile/help/stdout.term.svg
+++ b/tests/testsuite/cargo_generate_lockfile/help/stdout.term.svg
@@ -51,7 +51,7 @@
 </tspan>
     <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages (unstable)</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
 </tspan>
     <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>

--- a/tests/testsuite/cargo_update/help/stdout.term.svg
+++ b/tests/testsuite/cargo_update/help/stdout.term.svg
@@ -67,7 +67,7 @@
 </tspan>
     <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages (unstable)</tspan>
+    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
 </tspan>
     <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>


### PR DESCRIPTION
### What does this PR try to resolve?

This includes
- `cargo generate-lockfile --ignore-rust-version`
- `cargo update --ignore-rust-version`

This does not include
- `edition = "2024"`
- `resolver = "3"`

This is part of #9930

### How should we test and review this PR?


### Additional information

This is stacked on top of #14636.  The commits for this PR start with the commit with a title that matches the PR title.

[FCP](https://github.com/rust-lang/cargo/pull/14639#issuecomment-2392172716)