### PR TITLE
Implement RFC3695: Allow boolean literals as cfg predicates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
  "cargo-credential-libsecret",
  "cargo-credential-macos-keychain",
  "cargo-credential-wincred",
- "cargo-platform 0.2.0",
+ "cargo-platform 0.3.0",
  "cargo-test-support",
  "cargo-util",
  "cargo-util-schemas",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
 ]
@@ -3371,7 +3371,7 @@ name = "resolver-tests"
 version = "0.0.0"
 dependencies = [
  "cargo",
- "cargo-platform 0.2.0",
+ "cargo-platform 0.3.0",
  "cargo-util",
  "cargo-util-schemas",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ cargo-credential = { version = "0.4.2", path = "credential/cargo-credential" }
 cargo-credential-libsecret = { version = "0.4.13", path = "credential/cargo-credential-libsecret" }
 cargo-credential-macos-keychain = { version = "0.4.13", path = "credential/cargo-credential-macos-keychain" }
 cargo-credential-wincred = { version = "0.4.13", path = "credential/cargo-credential-wincred" }
-cargo-platform = { path = "crates/cargo-platform", version = "0.2.0" }
+cargo-platform = { path = "crates/cargo-platform", version = "0.3.0" }
 cargo-test-macro = { version = "0.4.2", path = "crates/cargo-test-macro" }
 cargo-test-support = { version = "0.7.1", path = "crates/cargo-test-support" }
 cargo-util = { version = "0.2.20", path = "crates/cargo-util" }

--- a/crates/cargo-platform/Cargo.toml
+++ b/crates/cargo-platform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-platform"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/cargo-platform/src/lib.rs
+++ b/crates/cargo-platform/src/lib.rs
@@ -98,6 +98,7 @@ impl Platform {
                         ))
                     },
                 }
+                CfgExpr::True | CfgExpr::False => {},
             }
         }
 
@@ -115,30 +116,18 @@ impl Platform {
                         check_cfg_expr(e, warnings, path);
                     }
                 }
+                CfgExpr::True | CfgExpr::False => {}
                 CfgExpr::Value(ref e) => match e {
                     Cfg::Name(name) | Cfg::KeyPair(name, _) => {
                         if !name.raw && KEYWORDS.contains(&name.as_str()) {
-                            if name.as_str() == "true" || name.as_str() == "false" {
-                                warnings.push(format!(
-                                    "[{}] future-incompatibility: the meaning of `cfg({e})` will change in the future\n \
-                                     | Cargo is erroneously allowing `cfg(true)` and `cfg(false)`, but both forms are interpreted as false unless manually overridden with `--cfg`.\n \
-                                     | In the future these will be built-in defines that will have the corresponding true/false value.\n \
-                                     | It is recommended to avoid using these configs until they are properly supported.\n \
-                                     | See <https://github.com/rust-lang/rust/issues/131204> for more information.\n \
-                                     |\n \
-                                     | help: use raw-idents instead: `cfg(r#{name})`",
-                                    path.display()
-                                ));
-                            } else {
-                                warnings.push(format!(
-                                    "[{}] future-incompatibility: `cfg({e})` is deprecated as `{name}` is a keyword \
-                                     and not an identifier and should not have have been accepted in this position.\n \
-                                     | this was previously accepted by Cargo but is being phased out; it will become a hard error in a future release!\n \
-                                     |\n \
-                                     | help: use raw-idents instead: `cfg(r#{name})`",
-                                     path.display()
-                                ));
-                            }
+                            warnings.push(format!(
+                                "[{}] future-incompatibility: `cfg({e})` is deprecated as `{name}` is a keyword \
+                                 and not an identifier and should not have have been accepted in this position.\n \
+                                 | this was previously accepted by Cargo but is being phased out; it will become a hard error in a future release!\n \
+                                 |\n \
+                                 | help: use raw-idents instead: `cfg(r#{name})`",
+                                 path.display()
+                            ));
                         }
                     }
                 },

--- a/crates/cargo-platform/tests/test_cfg.rs
+++ b/crates/cargo-platform/tests/test_cfg.rs
@@ -39,6 +39,8 @@ macro_rules! e {
     (any($($t:tt),*)) => (CfgExpr::Any(vec![$(e!($t)),*]));
     (all($($t:tt),*)) => (CfgExpr::All(vec![$(e!($t)),*]));
     (not($($t:tt)*)) => (CfgExpr::Not(Box::new(e!($($t)*))));
+    (true) => (CfgExpr::True);
+    (false) => (CfgExpr::False);
     (($($t:tt)*)) => (e!($($t)*));
     ($($t:tt)*) => (CfgExpr::Value(c!($($t)*)));
 }
@@ -121,6 +123,9 @@ fn cfg_expr() {
     good("foo=\"\"", e!(foo = ""));
     good(" foo=\"3\"      ", e!(foo = "3"));
     good("foo = \"3 e\"", e!(foo = "3 e"));
+
+    good("true", e!(true));
+    good("false", e!(false));
 
     good("all()", e!(all()));
     good("all(a)", e!(all(a)));
@@ -249,6 +254,8 @@ fn check_cfg_attributes() {
     ok("windows");
     ok("any(not(unix), windows)");
     ok("foo");
+    ok("true");
+    ok("false");
 
     ok("target_arch = \"abc\"");
     ok("target_feature = \"abc\"");

--- a/tests/testsuite/cfg.rs
+++ b/tests/testsuite/cfg.rs
@@ -545,6 +545,7 @@ fn cfg_raw_idents() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to latest compatible version
+[CHECKING] b v0.0.1 ([ROOT]/foo/b)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -638,21 +639,8 @@ fn cfg_keywords() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] [[ROOT]/foo/Cargo.toml] future-incompatibility: the meaning of `cfg(true)` will change in the future
- | Cargo is erroneously allowing `cfg(true)` and `cfg(false)`, but both forms are interpreted as false unless manually overridden with `--cfg`.
- | In the future these will be built-in defines that will have the corresponding true/false value.
- | It is recommended to avoid using these configs until they are properly supported.
- | See <https://github.com/rust-lang/rust/issues/131204> for more information.
- |
- | [HELP] use raw-idents instead: `cfg(r#true)`
-[WARNING] [.cargo/config.toml] future-incompatibility: the meaning of `cfg(false)` will change in the future
- | Cargo is erroneously allowing `cfg(true)` and `cfg(false)`, but both forms are interpreted as false unless manually overridden with `--cfg`.
- | In the future these will be built-in defines that will have the corresponding true/false value.
- | It is recommended to avoid using these configs until they are properly supported.
- | See <https://github.com/rust-lang/rust/issues/131204> for more information.
- |
- | [HELP] use raw-idents instead: `cfg(r#false)`
 [LOCKING] 1 package to latest compatible version
+[CHECKING] b v0.0.1 ([ROOT]/foo/b)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -687,23 +675,9 @@ fn cfg_booleans() {
         .build();
 
     p.cargo("check")
-        // FIXME: `b` should be compiled
         .with_stderr_data(str![[r#"
-[WARNING] [[ROOT]/foo/Cargo.toml] future-incompatibility: the meaning of `cfg(false)` will change in the future
- | Cargo is erroneously allowing `cfg(true)` and `cfg(false)`, but both forms are interpreted as false unless manually overridden with `--cfg`.
- | In the future these will be built-in defines that will have the corresponding true/false value.
- | It is recommended to avoid using these configs until they are properly supported.
- | See <https://github.com/rust-lang/rust/issues/131204> for more information.
- |
- | [HELP] use raw-idents instead: `cfg(r#false)`
-[WARNING] [[ROOT]/foo/Cargo.toml] future-incompatibility: the meaning of `cfg(true)` will change in the future
- | Cargo is erroneously allowing `cfg(true)` and `cfg(false)`, but both forms are interpreted as false unless manually overridden with `--cfg`.
- | In the future these will be built-in defines that will have the corresponding true/false value.
- | It is recommended to avoid using these configs until they are properly supported.
- | See <https://github.com/rust-lang/rust/issues/131204> for more information.
- |
- | [HELP] use raw-idents instead: `cfg(r#true)`
 [LOCKING] 2 packages to latest compatible versions
+[CHECKING] b v0.0.1 ([ROOT]/foo/b)
 [CHECKING] a v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -735,13 +709,6 @@ fn cfg_booleans_config() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] [.cargo/config.toml] future-incompatibility: the meaning of `cfg(true)` will change in the future
- | Cargo is erroneously allowing `cfg(true)` and `cfg(false)`, but both forms are interpreted as false unless manually overridden with `--cfg`.
- | In the future these will be built-in defines that will have the corresponding true/false value.
- | It is recommended to avoid using these configs until they are properly supported.
- | See <https://github.com/rust-lang/rust/issues/131204> for more information.
- |
- | [HELP] use raw-idents instead: `cfg(r#true)`
 [CHECKING] a v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -772,13 +739,6 @@ fn cfg_booleans_not() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] [[ROOT]/foo/Cargo.toml] future-incompatibility: the meaning of `cfg(false)` will change in the future
- | Cargo is erroneously allowing `cfg(true)` and `cfg(false)`, but both forms are interpreted as false unless manually overridden with `--cfg`.
- | In the future these will be built-in defines that will have the corresponding true/false value.
- | It is recommended to avoid using these configs until they are properly supported.
- | See <https://github.com/rust-lang/rust/issues/131204> for more information.
- |
- | [HELP] use raw-idents instead: `cfg(r#false)`
 [LOCKING] 1 package to latest compatible version
 [CHECKING] b v0.0.1 ([ROOT]/foo/b)
 [CHECKING] a v0.0.1 ([ROOT]/foo)
@@ -810,30 +770,9 @@ fn cfg_booleans_combinators() {
         .build();
 
     p.cargo("check")
-        // FIXME: `b` should be compiled
         .with_stderr_data(str![[r#"
-[WARNING] [[ROOT]/foo/Cargo.toml] future-incompatibility: the meaning of `cfg(true)` will change in the future
- | Cargo is erroneously allowing `cfg(true)` and `cfg(false)`, but both forms are interpreted as false unless manually overridden with `--cfg`.
- | In the future these will be built-in defines that will have the corresponding true/false value.
- | It is recommended to avoid using these configs until they are properly supported.
- | See <https://github.com/rust-lang/rust/issues/131204> for more information.
- |
- | [HELP] use raw-idents instead: `cfg(r#true)`
-[WARNING] [[ROOT]/foo/Cargo.toml] future-incompatibility: the meaning of `cfg(false)` will change in the future
- | Cargo is erroneously allowing `cfg(true)` and `cfg(false)`, but both forms are interpreted as false unless manually overridden with `--cfg`.
- | In the future these will be built-in defines that will have the corresponding true/false value.
- | It is recommended to avoid using these configs until they are properly supported.
- | See <https://github.com/rust-lang/rust/issues/131204> for more information.
- |
- | [HELP] use raw-idents instead: `cfg(r#false)`
-[WARNING] [[ROOT]/foo/Cargo.toml] future-incompatibility: the meaning of `cfg(true)` will change in the future
- | Cargo is erroneously allowing `cfg(true)` and `cfg(false)`, but both forms are interpreted as false unless manually overridden with `--cfg`.
- | In the future these will be built-in defines that will have the corresponding true/false value.
- | It is recommended to avoid using these configs until they are properly supported.
- | See <https://github.com/rust-lang/rust/issues/131204> for more information.
- |
- | [HELP] use raw-idents instead: `cfg(r#true)`
 [LOCKING] 1 package to latest compatible version
+[CHECKING] b v0.0.1 ([ROOT]/foo/b)
 [CHECKING] a v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -868,26 +807,10 @@ fn cfg_booleans_rustflags_no_effect() {
         .build();
 
     p.cargo("check")
-        // FIXME: only `b` should be compiled, the rustflags don't take effect
         .env("RUSTFLAGS", "--cfg false")
         .with_stderr_data(str![[r#"
-[WARNING] [[ROOT]/foo/Cargo.toml] future-incompatibility: the meaning of `cfg(false)` will change in the future
- | Cargo is erroneously allowing `cfg(true)` and `cfg(false)`, but both forms are interpreted as false unless manually overridden with `--cfg`.
- | In the future these will be built-in defines that will have the corresponding true/false value.
- | It is recommended to avoid using these configs until they are properly supported.
- | See <https://github.com/rust-lang/rust/issues/131204> for more information.
- |
- | [HELP] use raw-idents instead: `cfg(r#false)`
-[WARNING] [[ROOT]/foo/Cargo.toml] future-incompatibility: the meaning of `cfg(true)` will change in the future
- | Cargo is erroneously allowing `cfg(true)` and `cfg(false)`, but both forms are interpreted as false unless manually overridden with `--cfg`.
- | In the future these will be built-in defines that will have the corresponding true/false value.
- | It is recommended to avoid using these configs until they are properly supported.
- | See <https://github.com/rust-lang/rust/issues/131204> for more information.
- |
- | [HELP] use raw-idents instead: `cfg(r#true)`
 [LOCKING] 2 packages to latest compatible versions
 [CHECKING] b v0.0.1 ([ROOT]/foo/b)
-[CHECKING] c v0.0.1 ([ROOT]/foo/c)
 [CHECKING] a v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 


### PR DESCRIPTION
### What does this PR try to resolve?

This PR implements https://github.com/rust-lang/rfcs/pull/3695: allow boolean literals as cfg predicates, i.e. `cfg(true)` and `cfg(false)`.

### How should we test and review this PR?

The PR should be reviewed commit by commit and tested by looking at the tests and using `[target.'cfg(<true/false>)']` in `Cargo.toml`/`.cargo/config.toml`.

### Additional information

I had to bump `cargo-platform` to `0.3.0` has we are changing `CfgExpr` enum in a semver incompatible change.

We currently have (thks to https://github.com/rust-lang/cargo/pull/14671) a forward compatibility warning against `cfg(true/false)` as identifiers instead of keywords.

~~I choose a use a `Cargo.toml` feature (for the manifest) as well as a unstable CLI flag for the `.cargo/config.toml` part.~~

~~Given the very small (two occurrences on Github Search) for [`cfg(true)`](https://github.com/search?q=lang%3Atoml+%2F%28%3F-i%29%5C%5Btarget%5C.%5B%27%22%5Dcfg.*true%2F&type=code) and [`cfg(false)`](https://github.com/search?q=lang%3Atoml+%2F%28%3F-i%29%5C%5Btarget%5C.%5B%27%22%5Dcfg.*false%2F&type=code), I choose to gate the feature under a error and not a warning.~~
