### PR TITLE
Improve resolver speed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,6 +342,7 @@ dependencies = [
  "rand",
  "regex",
  "rusqlite",
+ "rustc-hash 2.0.0",
  "rustfix",
  "same-file",
  "semver",
@@ -3007,6 +3008,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+
+[[package]]
 name = "rustfix"
 version = "0.8.7"
 dependencies = [
@@ -3748,7 +3755,7 @@ dependencies = [
  "log",
  "ordered-float",
  "partial_ref",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "serde",
  "thiserror",
  "varisat-checker",
@@ -3768,7 +3775,7 @@ dependencies = [
  "anyhow",
  "log",
  "partial_ref",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "smallvec",
  "thiserror",
  "varisat-dimacs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ pulldown-cmark = { version = "0.11.0", default-features = false, features = ["ht
 rand = "0.8.5"
 regex = "1.10.5"
 rusqlite = { version = "0.32.0", features = ["bundled"] }
+rustc-hash = "2.0.0"
 rustfix = { version = "0.8.2", path = "crates/rustfix" }
 same-file = "1.0.6"
 security-framework = "2.11.1"
@@ -187,6 +188,7 @@ pathdiff.workspace = true
 rand.workspace = true
 regex.workspace = true
 rusqlite.workspace = true
+rustc-hash.workspace = true
 rustfix.workspace = true
 same-file.workspace = true
 semver.workspace = true

--- a/crates/resolver-tests/src/sat.rs
+++ b/crates/resolver-tests/src/sat.rs
@@ -352,7 +352,7 @@ impl SatResolver {
 
         let mut by_name: HashMap<InternedString, Vec<Summary>> = HashMap::new();
         for pkg in registry {
-            by_name.entry(pkg.name()).or_default().push(pkg.clone())
+            by_name.entry(pkg.name()).or_default().push(pkg.clone());
         }
 
         let mut solver = varisat::Solver::new();

--- a/src/cargo/core/resolver/context.rs
+++ b/src/cargo/core/resolver/context.rs
@@ -19,13 +19,13 @@ pub struct ResolverContext {
     pub age: ContextAge,
     pub activations: Activations,
     /// list the features that are activated for each package
-    pub resolve_features: im_rc::HashMap<PackageId, FeaturesSet>,
+    pub resolve_features: im_rc::HashMap<PackageId, FeaturesSet, rustc_hash::FxBuildHasher>,
     /// get the package that will be linking to a native library by its links attribute
-    pub links: im_rc::HashMap<InternedString, PackageId>,
+    pub links: im_rc::HashMap<InternedString, PackageId, rustc_hash::FxBuildHasher>,
 
     /// a way to look up for a package in activations what packages required it
     /// and all of the exact deps that it fulfilled.
-    pub parents: Graph<PackageId, im_rc::HashSet<Dependency>>,
+    pub parents: Graph<PackageId, im_rc::HashSet<Dependency, rustc_hash::FxBuildHasher>>,
 }
 
 /// When backtracking it can be useful to know how far back to go.
@@ -40,7 +40,9 @@ pub type ContextAge = usize;
 /// semver compatible version of each crate.
 /// This all so stores the `ContextAge`.
 pub type ActivationsKey = (InternedString, SourceId, SemverCompatibility);
-pub type Activations = im_rc::HashMap<ActivationsKey, (Summary, ContextAge)>;
+
+pub type Activations =
+    im_rc::HashMap<ActivationsKey, (Summary, ContextAge), rustc_hash::FxBuildHasher>;
 
 /// A type that represents when cargo treats two Versions as compatible.
 /// Versions `a` and `b` are compatible if their left-most nonzero digit is the
@@ -74,10 +76,10 @@ impl ResolverContext {
     pub fn new() -> ResolverContext {
         ResolverContext {
             age: 0,
-            resolve_features: im_rc::HashMap::new(),
-            links: im_rc::HashMap::new(),
+            resolve_features: im_rc::HashMap::default(),
+            links: im_rc::HashMap::default(),
             parents: Graph::new(),
-            activations: im_rc::HashMap::new(),
+            activations: im_rc::HashMap::default(),
         }
     }
 

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -679,7 +679,7 @@ fn activate(
         Rc::make_mut(
             cx.resolve_features
                 .entry(candidate.package_id())
-                .or_insert_with(Rc::default),
+                .or_default(),
         )
         .extend(used_features);
     }

--- a/src/cargo/util/graph.rs
+++ b/src/cargo/util/graph.rs
@@ -22,7 +22,7 @@ impl<N: Eq + Ord + Clone, E: Default + Clone> Graph<N, E> {
             .entry(node)
             .or_insert_with(im_rc::OrdMap::new)
             .entry(child)
-            .or_insert_with(Default::default)
+            .or_default()
     }
 
     /// Returns the graph obtained by reversing all edges.


### PR DESCRIPTION
### What does this PR try to resolve?

This PR improves the resolver speed after investigations from https://github.com/Eh2406/pubgrub-crates-benchmark/issues/6.

### How should we test and review this PR?

Commit 1 adds a test showing a slow case in the resolver, where resolving time is cubic over the number of versions of a crate. It can be used for benchmarking the resolver.

Comparison of the resolving time with various values of `N=LAST_CRATE_VERSION_COUNT` and `C=TRANSITIVE_CRATES_COUNT`:

|      | N=100 | N=200 | N=400 |
|------|-------|-------|-------|
| C=1  | 0.25s | 0.5s  | 1.4s  |
| C=2  | 7s    | 44s   | 314s  |
| C=3  | 12s   | 77s   | 537s  |
| C=6  | 30s   | 149s  | 1107s |
| C=12 | 99s   | 447s  | 2393s |

Commit 2 replaces the default hasher with the hasher from `rustc-hash`, decreasing resolving time by more than 50%.

Performance comparison with the test from commit 1 by setting `LAST_CRATE_VERSION_COUNT = 100`:
| commit          | duration |
|-----------------|----------|
| master          | 16s      |
| with rustc-hash | 6.7s     |

Firefox profiles, can be read with https://profiler.firefox.com:
[perf.tar.gz](https://github.com/user-attachments/files/17318243/perf.tar.gz)

r? Eh2406