### PR TITLE
Remove the support for `Cargo.toml` of the cargo-script

### DIFF
--- a/src/bin/cargo/commands/run.rs
+++ b/src/bin/cargo/commands/run.rs
@@ -90,9 +90,7 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
 /// See also `util/toml/mod.rs`s `is_embedded`
 pub fn is_manifest_command(arg: &str) -> bool {
     let path = Path::new(arg);
-    1 < path.components().count()
-        || path.extension() == Some(OsStr::new("rs"))
-        || path.file_name() == Some(OsStr::new("Cargo.toml"))
+    1 < path.components().count() || path.extension() == Some(OsStr::new("rs"))
 }
 
 pub fn exec_manifest_command(gctx: &mut GlobalContext, cmd: &str, args: &[OsString]) -> CliResult {

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -69,28 +69,6 @@ args: []
 }
 
 #[cargo_test]
-fn basic_cargo_toml() {
-    let p = cargo_test_support::project()
-        .file("src/main.rs", ECHO_SCRIPT)
-        .build();
-
-    p.cargo("-Zscript -v Cargo.toml")
-        .masquerade_as_nightly_cargo(&["script"])
-        .with_stdout_data(str![[r#"
-bin: target/debug/foo[EXE]
-args: []
-
-"#]])
-        .with_stderr_data(str![[r#"
-[COMPILING] foo v0.0.1 ([ROOT]/foo)
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `target/debug/foo[EXE]`
-
-"#]])
-        .run();
-}
-
-#[cargo_test]
 fn path_required() {
     let p = cargo_test_support::project()
         .file("echo", ECHO_SCRIPT)


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

ref https://github.com/rust-lang/cargo/issues/12207#issuecomment-2358818671

I had a discussion with @epage two weeks ago, and we decided to defer this feature and remove it now. The reason is that we couldn't always resolve the symbolic link that breaks some use cases, and the use cases of `cargo Cargo.toml` may be rare.

### How should we test and review this PR?

The unit test has been removed.

### Additional information

r? @epage 

<!-- homu-ignore:end -->
