### PR TITLE
Add future-incompat warning against keywords in cfgs and add raw-idents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ dependencies = [
  "cargo-credential-libsecret",
  "cargo-credential-macos-keychain",
  "cargo-credential-wincred",
- "cargo-platform 0.1.9",
+ "cargo-platform 0.2.0",
  "cargo-test-support",
  "cargo-util",
  "cargo-util-schemas",
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "serde",
 ]
@@ -3026,7 +3026,7 @@ name = "resolver-tests"
 version = "0.0.0"
 dependencies = [
  "cargo",
- "cargo-platform 0.1.9",
+ "cargo-platform 0.2.0",
  "cargo-util",
  "cargo-util-schemas",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ cargo-credential = { version = "0.4.2", path = "credential/cargo-credential" }
 cargo-credential-libsecret = { version = "0.4.7", path = "credential/cargo-credential-libsecret" }
 cargo-credential-macos-keychain = { version = "0.4.7", path = "credential/cargo-credential-macos-keychain" }
 cargo-credential-wincred = { version = "0.4.7", path = "credential/cargo-credential-wincred" }
-cargo-platform = { path = "crates/cargo-platform", version = "0.1.5" }
+cargo-platform = { path = "crates/cargo-platform", version = "0.2.0" }
 cargo-test-macro = { version = "0.3.0", path = "crates/cargo-test-macro" }
 cargo-test-support = { version = "0.6.0", path = "crates/cargo-test-support" }
 cargo-util = { version = "0.2.14", path = "crates/cargo-util" }

--- a/crates/cargo-platform/Cargo.toml
+++ b/crates/cargo-platform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-platform"
-version = "0.1.9"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/cargo-platform/src/cfg.rs
+++ b/crates/cargo-platform/src/cfg.rs
@@ -31,6 +31,14 @@ enum Token<'a> {
     String(&'a str),
 }
 
+/// The list of keywords.
+///
+/// We should consider all the keywords, but some are conditional on
+/// the edition so for now we just consider true/false.
+///
+/// <https://doc.rust-lang.org/reference/keywords.html>
+pub(crate) const KEYWORDS: &[&str; 2] = &["true", "false"];
+
 #[derive(Clone)]
 struct Tokenizer<'a> {
     s: iter::Peekable<str::CharIndices<'a>>,

--- a/crates/cargo-platform/src/cfg.rs
+++ b/crates/cargo-platform/src/cfg.rs
@@ -1,5 +1,6 @@
 use crate::error::{ParseError, ParseErrorKind::*};
 use std::fmt;
+use std::hash::{Hash, Hasher};
 use std::iter;
 use std::str::{self, FromStr};
 
@@ -16,16 +17,28 @@ pub enum CfgExpr {
 #[derive(Eq, PartialEq, Hash, Ord, PartialOrd, Clone, Debug)]
 pub enum Cfg {
     /// A named cfg value, like `unix`.
-    Name(String),
+    Name(Ident),
     /// A key/value cfg pair, like `target_os = "linux"`.
-    KeyPair(String, String),
+    KeyPair(Ident, String),
+}
+
+/// A identifier
+#[derive(Eq, Ord, PartialOrd, Clone, Debug)]
+pub struct Ident {
+    /// The identifier
+    pub name: String,
+    /// Is this a raw ident: `r#async`
+    ///
+    /// It's mainly used for display and doesn't take
+    /// part in the hash or equality (`foo` == `r#foo`).
+    pub raw: bool,
 }
 
 #[derive(PartialEq)]
 enum Token<'a> {
     LeftParen,
     RightParen,
-    Ident(&'a str),
+    Ident(bool, &'a str),
     Comma,
     Equals,
     String(&'a str),
@@ -47,6 +60,45 @@ struct Tokenizer<'a> {
 
 struct Parser<'a> {
     t: Tokenizer<'a>,
+}
+
+impl Ident {
+    pub fn as_str(&self) -> &str {
+        &self.name
+    }
+}
+
+impl Hash for Ident {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+    }
+}
+
+impl PartialEq<str> for Ident {
+    fn eq(&self, other: &str) -> bool {
+        self.name == other
+    }
+}
+
+impl PartialEq<&str> for Ident {
+    fn eq(&self, other: &&str) -> bool {
+        self.name == *other
+    }
+}
+
+impl PartialEq<Ident> for Ident {
+    fn eq(&self, other: &Ident) -> bool {
+        self.name == other.name
+    }
+}
+
+impl fmt::Display for Ident {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.raw {
+            f.write_str("r#")?;
+        }
+        f.write_str(&*self.name)
+    }
 }
 
 impl FromStr for Cfg {
@@ -152,7 +204,8 @@ impl<'a> Parser<'a> {
 
     fn expr(&mut self) -> Result<CfgExpr, ParseError> {
         match self.peek() {
-            Some(Ok(Token::Ident(op @ "all"))) | Some(Ok(Token::Ident(op @ "any"))) => {
+            Some(Ok(Token::Ident(false, op @ "all")))
+            | Some(Ok(Token::Ident(false, op @ "any"))) => {
                 self.t.next();
                 let mut e = Vec::new();
                 self.eat(&Token::LeftParen)?;
@@ -169,7 +222,7 @@ impl<'a> Parser<'a> {
                     Ok(CfgExpr::Any(e))
                 }
             }
-            Some(Ok(Token::Ident("not"))) => {
+            Some(Ok(Token::Ident(false, "not"))) => {
                 self.t.next();
                 self.eat(&Token::LeftParen)?;
                 let e = self.expr()?;
@@ -187,7 +240,7 @@ impl<'a> Parser<'a> {
 
     fn cfg(&mut self) -> Result<Cfg, ParseError> {
         match self.t.next() {
-            Some(Ok(Token::Ident(name))) => {
+            Some(Ok(Token::Ident(raw, name))) => {
                 let e = if self.r#try(&Token::Equals) {
                     let val = match self.t.next() {
                         Some(Ok(Token::String(s))) => s,
@@ -205,9 +258,18 @@ impl<'a> Parser<'a> {
                             return Err(ParseError::new(self.t.orig, IncompleteExpr("a string")))
                         }
                     };
-                    Cfg::KeyPair(name.to_string(), val.to_string())
+                    Cfg::KeyPair(
+                        Ident {
+                            name: name.to_string(),
+                            raw,
+                        },
+                        val.to_string(),
+                    )
                 } else {
-                    Cfg::Name(name.to_string())
+                    Cfg::Name(Ident {
+                        name: name.to_string(),
+                        raw,
+                    })
                 };
                 Ok(e)
             }
@@ -287,14 +349,44 @@ impl<'a> Iterator for Tokenizer<'a> {
                     return Some(Err(ParseError::new(self.orig, UnterminatedString)));
                 }
                 Some((start, ch)) if is_ident_start(ch) => {
+                    let (start, raw) = if ch == 'r' {
+                        if let Some(&(_pos, '#')) = self.s.peek() {
+                            // starts with `r#` is a raw ident
+                            self.s.next();
+                            if let Some((start, ch)) = self.s.next() {
+                                if is_ident_start(ch) {
+                                    (start, true)
+                                } else {
+                                    // not a starting ident character
+                                    return Some(Err(ParseError::new(
+                                        self.orig,
+                                        UnexpectedChar(ch),
+                                    )));
+                                }
+                            } else {
+                                // not followed by a ident, error out
+                                return Some(Err(ParseError::new(
+                                    self.orig,
+                                    IncompleteExpr("identifier"),
+                                )));
+                            }
+                        } else {
+                            // starts with `r` but not does continue with `#`
+                            // cannot be a raw ident
+                            (start, false)
+                        }
+                    } else {
+                        // do not start with `r`, cannot be a raw ident
+                        (start, false)
+                    };
                     while let Some(&(end, ch)) = self.s.peek() {
                         if !is_ident_rest(ch) {
-                            return Some(Ok(Token::Ident(&self.orig[start..end])));
+                            return Some(Ok(Token::Ident(raw, &self.orig[start..end])));
                         } else {
                             self.s.next();
                         }
                     }
-                    return Some(Ok(Token::Ident(&self.orig[start..])));
+                    return Some(Ok(Token::Ident(raw, &self.orig[start..])));
                 }
                 Some((_, ch)) => {
                     return Some(Err(ParseError::new(self.orig, UnexpectedChar(ch))));

--- a/crates/cargo-platform/src/lib.rs
+++ b/crates/cargo-platform/src/lib.rs
@@ -18,7 +18,7 @@ mod cfg;
 mod error;
 
 use cfg::KEYWORDS;
-pub use cfg::{Cfg, CfgExpr};
+pub use cfg::{Cfg, CfgExpr, Ident};
 pub use error::{ParseError, ParseErrorKind};
 
 /// Platform definition.

--- a/crates/cargo-platform/src/lib.rs
+++ b/crates/cargo-platform/src/lib.rs
@@ -11,12 +11,13 @@
 //!
 //! [`Platform`]: enum.Platform.html
 
-use std::fmt;
 use std::str::FromStr;
+use std::{fmt, path::Path};
 
 mod cfg;
 mod error;
 
+use cfg::KEYWORDS;
 pub use cfg::{Cfg, CfgExpr};
 pub use error::{ParseError, ParseErrorKind};
 
@@ -102,6 +103,46 @@ impl Platform {
 
         if let Platform::Cfg(cfg) = self {
             check_cfg_expr(cfg, warnings);
+        }
+    }
+
+    pub fn check_cfg_keywords(&self, warnings: &mut Vec<String>, path: &Path) {
+        fn check_cfg_expr(expr: &CfgExpr, warnings: &mut Vec<String>, path: &Path) {
+            match *expr {
+                CfgExpr::Not(ref e) => check_cfg_expr(e, warnings, path),
+                CfgExpr::All(ref e) | CfgExpr::Any(ref e) => {
+                    for e in e {
+                        check_cfg_expr(e, warnings, path);
+                    }
+                }
+                CfgExpr::Value(ref e) => match e {
+                    Cfg::Name(name) | Cfg::KeyPair(name, _) => {
+                        if KEYWORDS.contains(&name.as_str()) {
+                            if name.as_str() == "true" || name.as_str() == "false" {
+                                warnings.push(format!(
+                                    "[{}] future-incompatibility: the meaning of `cfg({e})` will change in the future\n \
+                                     | Cargo is erroneously allowing `cfg(true)` and `cfg(false)`, but both forms are interpreted as false unless manually overridden with `--cfg`.\n \
+                                     | In the future these will be built-in defines that will have the corresponding true/false value.\n \
+                                     | It is recommended to avoid using these configs until they are properly supported.\n \
+                                     | See <https://github.com/rust-lang/rust/issues/131204> for more information.",
+                                    path.display()
+                                ));
+                            } else {
+                                warnings.push(format!(
+                                    "[{}] future-incompatibility: `cfg({e})` is deprecated as `{name}` is a keyword \
+                                     and not an identifier and should not have have been accepted in this position.\n \
+                                     | this was previously accepted by Cargo but is being phased out; it will become a hard error in a future release!",
+                                     path.display()
+                                ));
+                            }
+                        }
+                    }
+                },
+            }
+        }
+
+        if let Platform::Cfg(cfg) = self {
+            check_cfg_expr(cfg, warnings, path);
         }
     }
 }

--- a/crates/cargo-platform/src/lib.rs
+++ b/crates/cargo-platform/src/lib.rs
@@ -117,21 +117,25 @@ impl Platform {
                 }
                 CfgExpr::Value(ref e) => match e {
                     Cfg::Name(name) | Cfg::KeyPair(name, _) => {
-                        if KEYWORDS.contains(&name.as_str()) {
+                        if !name.raw && KEYWORDS.contains(&name.as_str()) {
                             if name.as_str() == "true" || name.as_str() == "false" {
                                 warnings.push(format!(
                                     "[{}] future-incompatibility: the meaning of `cfg({e})` will change in the future\n \
                                      | Cargo is erroneously allowing `cfg(true)` and `cfg(false)`, but both forms are interpreted as false unless manually overridden with `--cfg`.\n \
                                      | In the future these will be built-in defines that will have the corresponding true/false value.\n \
                                      | It is recommended to avoid using these configs until they are properly supported.\n \
-                                     | See <https://github.com/rust-lang/rust/issues/131204> for more information.",
+                                     | See <https://github.com/rust-lang/rust/issues/131204> for more information.\n \
+                                     |\n \
+                                     | help: use raw-idents instead: `cfg(r#{name})`",
                                     path.display()
                                 ));
                             } else {
                                 warnings.push(format!(
                                     "[{}] future-incompatibility: `cfg({e})` is deprecated as `{name}` is a keyword \
                                      and not an identifier and should not have have been accepted in this position.\n \
-                                     | this was previously accepted by Cargo but is being phased out; it will become a hard error in a future release!",
+                                     | this was previously accepted by Cargo but is being phased out; it will become a hard error in a future release!\n \
+                                     |\n \
+                                     | help: use raw-idents instead: `cfg(r#{name})`",
                                      path.display()
                                 ));
                             }

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -353,7 +353,9 @@ fn build_work(build_runner: &mut BuildRunner<'_, '_>, unit: &Unit) -> CargoResul
             // That is because Cargo queries rustc without any profile settings.
             continue;
         }
-        let k = format!("CARGO_CFG_{}", super::envify(&k));
+        // FIXME: We should handle raw-idents somehow instead of predenting they
+        // don't exist here
+        let k = format!("CARGO_CFG_{}", super::envify(k.as_str()));
         cmd.env(&k, v.join(","));
     }
 

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1314,6 +1314,7 @@ pub fn to_real_manifest(
     for (name, platform) in original_toml.target.iter().flatten() {
         let platform_kind: Platform = name.parse()?;
         platform_kind.check_cfg_attributes(warnings);
+        platform_kind.check_cfg_keywords(warnings, manifest_file);
         let platform_kind = Some(platform_kind);
         validate_dependencies(
             platform.dependencies.as_ref(),

--- a/tests/testsuite/cfg.rs
+++ b/tests/testsuite/cfg.rs
@@ -521,3 +521,38 @@ error[E0463]: can't find crate for `bar`
 "#]])
         .run();
 }
+
+#[cargo_test]
+fn cfg_keywords() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2015"
+
+                [target.'cfg(any(async, fn, const, return, true))'.dependencies]
+                b = { path = "b/" }
+            "#,
+        )
+        .file(
+            ".cargo/config.toml",
+            r#"
+                [target."cfg(any(for, match, extern, crate, false))"]
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file("b/Cargo.toml", &basic_manifest("b", "0.0.1"))
+        .file("b/src/lib.rs", "pub fn foo() {}")
+        .build();
+
+    p.cargo("check")
+        .with_stderr_data(str![[r#"
+[LOCKING] 1 package to latest compatible version
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+...
+"#]])
+        .run();
+}

--- a/tests/testsuite/cfg.rs
+++ b/tests/testsuite/cfg.rs
@@ -543,12 +543,15 @@ fn cfg_raw_idents() {
         .build();
 
     p.cargo("check")
-        .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
-
-Caused by:
-  failed to parse `any(r#true, r#all, r#target_os = "<>")` as a cfg expression: unexpected character `#` in cfg, expected parens, a comma, an identifier, or a string
+[WARNING] [[ROOT]/foo/Cargo.toml] future-incompatibility: the meaning of `cfg(r#true)` will change in the future
+ | Cargo is erroneously allowing `cfg(true)` and `cfg(false)`, but both forms are interpreted as false unless manually overridden with `--cfg`.
+ | In the future these will be built-in defines that will have the corresponding true/false value.
+ | It is recommended to avoid using these configs until they are properly supported.
+ | See <https://github.com/rust-lang/rust/issues/131204> for more information.
+[LOCKING] 1 package to latest compatible version
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
         .run();
@@ -577,7 +580,7 @@ fn cfg_raw_idents_empty() {
 [ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
 
 Caused by:
-  failed to parse `r#)` as a cfg expression: unexpected content `#)` found after cfg expression
+  failed to parse `r#)` as a cfg expression: unexpected character `)` in cfg, expected parens, a comma, an identifier, or a string
 
 "#]])
         .run();
@@ -606,7 +609,7 @@ fn cfg_raw_idents_not_really() {
 [ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
 
 Caused by:
-  failed to parse `r#11)` as a cfg expression: unexpected content `#11)` found after cfg expression
+  failed to parse `r#11)` as a cfg expression: unexpected character `1` in cfg, expected parens, a comma, an identifier, or a string
 
 "#]])
         .run();

--- a/tests/testsuite/cfg.rs
+++ b/tests/testsuite/cfg.rs
@@ -523,6 +523,96 @@ error[E0463]: can't find crate for `bar`
 }
 
 #[cargo_test]
+fn cfg_raw_idents() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2015"
+
+                [target.'cfg(any(r#true, r#all, r#target_os = "<>"))'.dependencies]
+                b = { path = "b/" }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file("b/Cargo.toml", &basic_manifest("b", "0.0.1"))
+        .file("b/src/lib.rs", "pub fn foo() {}")
+        .build();
+
+    p.cargo("check")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
+
+Caused by:
+  failed to parse `any(r#true, r#all, r#target_os = "<>")` as a cfg expression: unexpected character `#` in cfg, expected parens, a comma, an identifier, or a string
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn cfg_raw_idents_empty() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2015"
+
+                [target.'cfg(r#))'.dependencies]
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
+
+Caused by:
+  failed to parse `r#)` as a cfg expression: unexpected content `#)` found after cfg expression
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn cfg_raw_idents_not_really() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2015"
+
+                [target.'cfg(r#11))'.dependencies]
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
+
+Caused by:
+  failed to parse `r#11)` as a cfg expression: unexpected content `#11)` found after cfg expression
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn cfg_keywords() {
     let p = project()
         .file(

--- a/tests/testsuite/cfg.rs
+++ b/tests/testsuite/cfg.rs
@@ -544,11 +544,6 @@ fn cfg_raw_idents() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] [[ROOT]/foo/Cargo.toml] future-incompatibility: the meaning of `cfg(r#true)` will change in the future
- | Cargo is erroneously allowing `cfg(true)` and `cfg(false)`, but both forms are interpreted as false unless manually overridden with `--cfg`.
- | In the future these will be built-in defines that will have the corresponding true/false value.
- | It is recommended to avoid using these configs until they are properly supported.
- | See <https://github.com/rust-lang/rust/issues/131204> for more information.
 [LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -648,11 +643,15 @@ fn cfg_keywords() {
  | In the future these will be built-in defines that will have the corresponding true/false value.
  | It is recommended to avoid using these configs until they are properly supported.
  | See <https://github.com/rust-lang/rust/issues/131204> for more information.
+ |
+ | [HELP] use raw-idents instead: `cfg(r#true)`
 [WARNING] [.cargo/config.toml] future-incompatibility: the meaning of `cfg(false)` will change in the future
  | Cargo is erroneously allowing `cfg(true)` and `cfg(false)`, but both forms are interpreted as false unless manually overridden with `--cfg`.
  | In the future these will be built-in defines that will have the corresponding true/false value.
  | It is recommended to avoid using these configs until they are properly supported.
  | See <https://github.com/rust-lang/rust/issues/131204> for more information.
+ |
+ | [HELP] use raw-idents instead: `cfg(r#false)`
 [LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/cfg.rs
+++ b/tests/testsuite/cfg.rs
@@ -550,9 +550,20 @@ fn cfg_keywords() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
+[WARNING] [[ROOT]/foo/Cargo.toml] future-incompatibility: the meaning of `cfg(true)` will change in the future
+ | Cargo is erroneously allowing `cfg(true)` and `cfg(false)`, but both forms are interpreted as false unless manually overridden with `--cfg`.
+ | In the future these will be built-in defines that will have the corresponding true/false value.
+ | It is recommended to avoid using these configs until they are properly supported.
+ | See <https://github.com/rust-lang/rust/issues/131204> for more information.
+[WARNING] [.cargo/config.toml] future-incompatibility: the meaning of `cfg(false)` will change in the future
+ | Cargo is erroneously allowing `cfg(true)` and `cfg(false)`, but both forms are interpreted as false unless manually overridden with `--cfg`.
+ | In the future these will be built-in defines that will have the corresponding true/false value.
+ | It is recommended to avoid using these configs until they are properly supported.
+ | See <https://github.com/rust-lang/rust/issues/131204> for more information.
 [LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
-...
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
 "#]])
         .run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?

This PR tries to address this thread https://github.com/rust-lang/cargo/pull/14649#discussion_r1790468829 in #14649 regarding `cfg(true)`/`cfg(false)` (and keywords more generally) which are wrongly accepted[^1] as ident.

To address this, this PR does two things:
 1. it introduce a future-incompatibility warning against those (wrongly) accepted keywords as ident
 2. it add parsing for raw-idents (`r#true`) add suggest-it in the warning

### How should we test and review this PR?

This PR should be reviewed commit-by-commit.
Tests are included in preliminary commits. 

### Additional information

I added a new struct for representing `Ident`s which is rawness aware.
Which implied updating `cargo-platform` to `0.2.0` due to the API changes.

r? @epage

[^1]: https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=ccfb9c894dbf14e791c8ae7e4798efd0