### PR TITLE
Don't copy in `From<String> for InternedString`.

### DIFF
--- a/src/cargo/util/interning.rs
+++ b/src/cargo/util/interning.rs
@@ -46,7 +46,14 @@ impl<'a> From<&'a String> for InternedString {
 
 impl From<String> for InternedString {
     fn from(item: String) -> Self {
-        InternedString::new(&item)
+        let mut cache = interned_storage();
+        let s = cache.get(item.as_str()).copied().unwrap_or_else(|| {
+            let s = item.leak();
+            cache.insert(s);
+            s
+        });
+
+        InternedString { inner: s }
     }
 }
 


### PR DESCRIPTION
If we have an owned `String` already, then don't clone it just to internalise it.

### What does this PR try to resolve?

Before, `InternedString::from(String::new("blahblah"))` would take ownership of the `String` but then make and leak a copy (`str.to_string().leak()`) for use in the `interned_storage()`. This change just avoids that copy, which I think was the intention behind the interface and the interning mechanism.

### How should we test and review this PR?

Several existing tests hit this implementation, so I'd expect `cargo test` to suffice for functional correctness. The implementation of `InternedString::new()` (a few lines down) is useful as a reference.

### Additional information

Whilst it looks like an optimisation, I've no particular performance objective here. This was just something I noticed whilst looking around the code.