### PR TITLE
cargo test --help: clarify --tests and --benches

### DIFF
--- a/src/bin/cargo/commands/bench.rs
+++ b/src/bin/cargo/commands/bench.rs
@@ -36,9 +36,9 @@ pub fn cli() -> Command {
             "Benchmark only the specified example",
             "Benchmark all examples",
             "Benchmark only the specified test target",
-            "Benchmark all test targets",
+            "Benchmark all targets that have `test = true` set",
             "Benchmark only the specified bench target",
-            "Benchmark all bench targets",
+            "Benchmark all targets that have `bench = true` set",
             "Benchmark all targets",
         )
         .arg_features()

--- a/src/bin/cargo/commands/build.rs
+++ b/src/bin/cargo/commands/build.rs
@@ -22,9 +22,9 @@ pub fn cli() -> Command {
             "Build only the specified example",
             "Build all examples",
             "Build only the specified test target",
-            "Build all test targets",
+            "Build all targets that have `test = true` set",
             "Build only the specified bench target",
-            "Build all bench targets",
+            "Build all targets that have `bench = true` set",
             "Build all targets",
         )
         .arg_features()

--- a/src/bin/cargo/commands/check.rs
+++ b/src/bin/cargo/commands/check.rs
@@ -22,9 +22,9 @@ pub fn cli() -> Command {
             "Check only the specified example",
             "Check all examples",
             "Check only the specified test target",
-            "Check all test targets",
+            "Check all targets that have `test = true` set",
             "Check only the specified bench target",
-            "Check all bench targets",
+            "Check all targets that have `bench = true` set",
             "Check all targets",
         )
         .arg_features()

--- a/src/bin/cargo/commands/fix.rs
+++ b/src/bin/cargo/commands/fix.rs
@@ -41,9 +41,9 @@ pub fn cli() -> Command {
             "Fix only the specified example",
             "Fix all examples",
             "Fix only the specified test target",
-            "Fix all test targets",
+            "Fix all targets that have `test = true` set",
             "Fix only the specified bench target",
-            "Fix all bench targets",
+            "Fix all targets that have `bench = true` set",
             "Fix all targets (default)",
         )
         .arg_features()

--- a/src/bin/cargo/commands/rustc.rs
+++ b/src/bin/cargo/commands/rustc.rs
@@ -38,9 +38,9 @@ pub fn cli() -> Command {
             "Build only the specified example",
             "Build all examples",
             "Build only the specified test target",
-            "Build all test targets",
+            "Build all targets that have `test = true` set",
             "Build only the specified bench target",
-            "Build all bench targets",
+            "Build all targets that have `bench = true` set",
             "Build all targets",
         )
         .arg_features()

--- a/src/bin/cargo/commands/rustdoc.rs
+++ b/src/bin/cargo/commands/rustdoc.rs
@@ -26,9 +26,9 @@ pub fn cli() -> Command {
             "Build only the specified example",
             "Build all examples",
             "Build only the specified test target",
-            "Build all test targets",
+            "Build all targets that have `test = true` set",
             "Build only the specified bench target",
-            "Build all bench targets",
+            "Build all targets that have `bench = true` set",
             "Build all targets",
         )
         .arg_features()

--- a/src/bin/cargo/commands/test.rs
+++ b/src/bin/cargo/commands/test.rs
@@ -41,9 +41,9 @@ pub fn cli() -> Command {
             "Test only the specified example",
             "Test all examples",
             "Test only the specified test target",
-            "Test all test targets",
+            "Test all targets that have `test = true` set",
             "Test only the specified bench target",
-            "Test all bench targets",
+            "Test all targets that have `bench = true` set",
             "Test all targets (does not include doctests)",
         )
         .arg(

--- a/src/doc/man/generated_txt/cargo-bench.txt
+++ b/src/doc/man/generated_txt/cargo-bench.txt
@@ -172,11 +172,11 @@ OPTIONS
            multiple times and supports common Unix glob patterns.
 
        --tests
-           Benchmark all targets in test mode that have the test = true
-           manifest flag set. By default this includes the library and binaries
-           built as unittests, and integration tests. Be aware that this will
-           also build any required dependencies, so the lib target may be built
-           twice (once as a unittest, and once as a dependency for binaries,
+           Benchmark all targets that have the test = true manifest flag set.
+           By default this includes the library and binaries built as
+           unittests, and integration tests. Be aware that this will also build
+           any required dependencies, so the lib target may be built twice
+           (once as a unittest, and once as a dependency for binaries,
            integration tests, etc.). Targets may be enabled or disabled by
            setting the test flag in the manifest settings for the target.
 
@@ -185,11 +185,11 @@ OPTIONS
            multiple times and supports common Unix glob patterns.
 
        --benches
-           Benchmark all targets in benchmark mode that have the bench = true
-           manifest flag set. By default this includes the library and binaries
-           built as benchmarks, and bench targets. Be aware that this will also
-           build any required dependencies, so the lib target may be built
-           twice (once as a benchmark, and once as a dependency for binaries,
+           Benchmark all targets that have the bench = true manifest flag set.
+           By default this includes the library and binaries built as
+           benchmarks, and bench targets. Be aware that this will also build
+           any required dependencies, so the lib target may be built twice
+           (once as a benchmark, and once as a dependency for binaries,
            benchmarks, etc.). Targets may be enabled or disabled by setting the
            bench flag in the manifest settings for the target.
 

--- a/src/doc/man/generated_txt/cargo-build.txt
+++ b/src/doc/man/generated_txt/cargo-build.txt
@@ -89,26 +89,26 @@ OPTIONS
            multiple times and supports common Unix glob patterns.
 
        --tests
-           Build all targets in test mode that have the test = true manifest
-           flag set. By default this includes the library and binaries built as
-           unittests, and integration tests. Be aware that this will also build
-           any required dependencies, so the lib target may be built twice
-           (once as a unittest, and once as a dependency for binaries,
-           integration tests, etc.). Targets may be enabled or disabled by
-           setting the test flag in the manifest settings for the target.
+           Build all targets that have the test = true manifest flag set. By
+           default this includes the library and binaries built as unittests,
+           and integration tests. Be aware that this will also build any
+           required dependencies, so the lib target may be built twice (once as
+           a unittest, and once as a dependency for binaries, integration
+           tests, etc.). Targets may be enabled or disabled by setting the test
+           flag in the manifest settings for the target.
 
        --bench name…
            Build the specified benchmark. This flag may be specified multiple
            times and supports common Unix glob patterns.
 
        --benches
-           Build all targets in benchmark mode that have the bench = true
-           manifest flag set. By default this includes the library and binaries
-           built as benchmarks, and bench targets. Be aware that this will also
-           build any required dependencies, so the lib target may be built
-           twice (once as a benchmark, and once as a dependency for binaries,
-           benchmarks, etc.). Targets may be enabled or disabled by setting the
-           bench flag in the manifest settings for the target.
+           Build all targets that have the bench = true manifest flag set. By
+           default this includes the library and binaries built as benchmarks,
+           and bench targets. Be aware that this will also build any required
+           dependencies, so the lib target may be built twice (once as a
+           benchmark, and once as a dependency for binaries, benchmarks, etc.).
+           Targets may be enabled or disabled by setting the bench flag in the
+           manifest settings for the target.
 
        --all-targets
            Build all targets. This is equivalent to specifying --lib --bins

--- a/src/doc/man/generated_txt/cargo-check.txt
+++ b/src/doc/man/generated_txt/cargo-check.txt
@@ -86,26 +86,26 @@ OPTIONS
            multiple times and supports common Unix glob patterns.
 
        --tests
-           Check all targets in test mode that have the test = true manifest
-           flag set. By default this includes the library and binaries built as
-           unittests, and integration tests. Be aware that this will also build
-           any required dependencies, so the lib target may be built twice
-           (once as a unittest, and once as a dependency for binaries,
-           integration tests, etc.). Targets may be enabled or disabled by
-           setting the test flag in the manifest settings for the target.
+           Check all targets that have the test = true manifest flag set. By
+           default this includes the library and binaries built as unittests,
+           and integration tests. Be aware that this will also build any
+           required dependencies, so the lib target may be built twice (once as
+           a unittest, and once as a dependency for binaries, integration
+           tests, etc.). Targets may be enabled or disabled by setting the test
+           flag in the manifest settings for the target.
 
        --bench name…
            Check the specified benchmark. This flag may be specified multiple
            times and supports common Unix glob patterns.
 
        --benches
-           Check all targets in benchmark mode that have the bench = true
-           manifest flag set. By default this includes the library and binaries
-           built as benchmarks, and bench targets. Be aware that this will also
-           build any required dependencies, so the lib target may be built
-           twice (once as a benchmark, and once as a dependency for binaries,
-           benchmarks, etc.). Targets may be enabled or disabled by setting the
-           bench flag in the manifest settings for the target.
+           Check all targets that have the bench = true manifest flag set. By
+           default this includes the library and binaries built as benchmarks,
+           and bench targets. Be aware that this will also build any required
+           dependencies, so the lib target may be built twice (once as a
+           benchmark, and once as a dependency for binaries, benchmarks, etc.).
+           Targets may be enabled or disabled by setting the bench flag in the
+           manifest settings for the target.
 
        --all-targets
            Check all targets. This is equivalent to specifying --lib --bins

--- a/src/doc/man/generated_txt/cargo-fix.txt
+++ b/src/doc/man/generated_txt/cargo-fix.txt
@@ -159,26 +159,26 @@ OPTIONS
            multiple times and supports common Unix glob patterns.
 
        --tests
-           Fix all targets in test mode that have the test = true manifest flag
-           set. By default this includes the library and binaries built as
-           unittests, and integration tests. Be aware that this will also build
-           any required dependencies, so the lib target may be built twice
-           (once as a unittest, and once as a dependency for binaries,
-           integration tests, etc.). Targets may be enabled or disabled by
-           setting the test flag in the manifest settings for the target.
+           Fix all targets that have the test = true manifest flag set. By
+           default this includes the library and binaries built as unittests,
+           and integration tests. Be aware that this will also build any
+           required dependencies, so the lib target may be built twice (once as
+           a unittest, and once as a dependency for binaries, integration
+           tests, etc.). Targets may be enabled or disabled by setting the test
+           flag in the manifest settings for the target.
 
        --bench name…
            Fix the specified benchmark. This flag may be specified multiple
            times and supports common Unix glob patterns.
 
        --benches
-           Fix all targets in benchmark mode that have the bench = true
-           manifest flag set. By default this includes the library and binaries
-           built as benchmarks, and bench targets. Be aware that this will also
-           build any required dependencies, so the lib target may be built
-           twice (once as a benchmark, and once as a dependency for binaries,
-           benchmarks, etc.). Targets may be enabled or disabled by setting the
-           bench flag in the manifest settings for the target.
+           Fix all targets that have the bench = true manifest flag set. By
+           default this includes the library and binaries built as benchmarks,
+           and bench targets. Be aware that this will also build any required
+           dependencies, so the lib target may be built twice (once as a
+           benchmark, and once as a dependency for binaries, benchmarks, etc.).
+           Targets may be enabled or disabled by setting the bench flag in the
+           manifest settings for the target.
 
        --all-targets
            Fix all targets. This is equivalent to specifying --lib --bins

--- a/src/doc/man/generated_txt/cargo-rustc.txt
+++ b/src/doc/man/generated_txt/cargo-rustc.txt
@@ -80,26 +80,26 @@ OPTIONS
            multiple times and supports common Unix glob patterns.
 
        --tests
-           Build all targets in test mode that have the test = true manifest
-           flag set. By default this includes the library and binaries built as
-           unittests, and integration tests. Be aware that this will also build
-           any required dependencies, so the lib target may be built twice
-           (once as a unittest, and once as a dependency for binaries,
-           integration tests, etc.). Targets may be enabled or disabled by
-           setting the test flag in the manifest settings for the target.
+           Build all targets that have the test = true manifest flag set. By
+           default this includes the library and binaries built as unittests,
+           and integration tests. Be aware that this will also build any
+           required dependencies, so the lib target may be built twice (once as
+           a unittest, and once as a dependency for binaries, integration
+           tests, etc.). Targets may be enabled or disabled by setting the test
+           flag in the manifest settings for the target.
 
        --bench name…
            Build the specified benchmark. This flag may be specified multiple
            times and supports common Unix glob patterns.
 
        --benches
-           Build all targets in benchmark mode that have the bench = true
-           manifest flag set. By default this includes the library and binaries
-           built as benchmarks, and bench targets. Be aware that this will also
-           build any required dependencies, so the lib target may be built
-           twice (once as a benchmark, and once as a dependency for binaries,
-           benchmarks, etc.). Targets may be enabled or disabled by setting the
-           bench flag in the manifest settings for the target.
+           Build all targets that have the bench = true manifest flag set. By
+           default this includes the library and binaries built as benchmarks,
+           and bench targets. Be aware that this will also build any required
+           dependencies, so the lib target may be built twice (once as a
+           benchmark, and once as a dependency for binaries, benchmarks, etc.).
+           Targets may be enabled or disabled by setting the bench flag in the
+           manifest settings for the target.
 
        --all-targets
            Build all targets. This is equivalent to specifying --lib --bins

--- a/src/doc/man/generated_txt/cargo-rustdoc.txt
+++ b/src/doc/man/generated_txt/cargo-rustdoc.txt
@@ -80,24 +80,24 @@ OPTIONS
            multiple times and supports common Unix glob patterns.
 
        --tests
-           Document all targets in test mode that have the test = true manifest
-           flag set. By default this includes the library and binaries built as
-           unittests, and integration tests. Be aware that this will also build
-           any required dependencies, so the lib target may be built twice
-           (once as a unittest, and once as a dependency for binaries,
-           integration tests, etc.). Targets may be enabled or disabled by
-           setting the test flag in the manifest settings for the target.
+           Document all targets that have the test = true manifest flag set. By
+           default this includes the library and binaries built as unittests,
+           and integration tests. Be aware that this will also build any
+           required dependencies, so the lib target may be built twice (once as
+           a unittest, and once as a dependency for binaries, integration
+           tests, etc.). Targets may be enabled or disabled by setting the test
+           flag in the manifest settings for the target.
 
        --bench name…
            Document the specified benchmark. This flag may be specified
            multiple times and supports common Unix glob patterns.
 
        --benches
-           Document all targets in benchmark mode that have the bench = true
-           manifest flag set. By default this includes the library and binaries
-           built as benchmarks, and bench targets. Be aware that this will also
-           build any required dependencies, so the lib target may be built
-           twice (once as a benchmark, and once as a dependency for binaries,
+           Document all targets that have the bench = true manifest flag set.
+           By default this includes the library and binaries built as
+           benchmarks, and bench targets. Be aware that this will also build
+           any required dependencies, so the lib target may be built twice
+           (once as a benchmark, and once as a dependency for binaries,
            benchmarks, etc.). Targets may be enabled or disabled by setting the
            bench flag in the manifest settings for the target.
 

--- a/src/doc/man/generated_txt/cargo-test.txt
+++ b/src/doc/man/generated_txt/cargo-test.txt
@@ -190,26 +190,26 @@ OPTIONS
            multiple times and supports common Unix glob patterns.
 
        --tests
-           Test all targets in test mode that have the test = true manifest
-           flag set. By default this includes the library and binaries built as
-           unittests, and integration tests. Be aware that this will also build
-           any required dependencies, so the lib target may be built twice
-           (once as a unittest, and once as a dependency for binaries,
-           integration tests, etc.). Targets may be enabled or disabled by
-           setting the test flag in the manifest settings for the target.
+           Test all targets that have the test = true manifest flag set. By
+           default this includes the library and binaries built as unittests,
+           and integration tests. Be aware that this will also build any
+           required dependencies, so the lib target may be built twice (once as
+           a unittest, and once as a dependency for binaries, integration
+           tests, etc.). Targets may be enabled or disabled by setting the test
+           flag in the manifest settings for the target.
 
        --bench name…
            Test the specified benchmark. This flag may be specified multiple
            times and supports common Unix glob patterns.
 
        --benches
-           Test all targets in benchmark mode that have the bench = true
-           manifest flag set. By default this includes the library and binaries
-           built as benchmarks, and bench targets. Be aware that this will also
-           build any required dependencies, so the lib target may be built
-           twice (once as a benchmark, and once as a dependency for binaries,
-           benchmarks, etc.). Targets may be enabled or disabled by setting the
-           bench flag in the manifest settings for the target.
+           Test all targets that have the bench = true manifest flag set. By
+           default this includes the library and binaries built as benchmarks,
+           and bench targets. Be aware that this will also build any required
+           dependencies, so the lib target may be built twice (once as a
+           benchmark, and once as a dependency for binaries, benchmarks, etc.).
+           Targets may be enabled or disabled by setting the bench flag in the
+           manifest settings for the target.
 
        --all-targets
            Test all targets. This is equivalent to specifying --lib --bins

--- a/src/doc/man/includes/options-targets.md
+++ b/src/doc/man/includes/options-targets.md
@@ -25,7 +25,7 @@ multiple times and supports common Unix glob patterns.
 {{/option}}
 
 {{#option "`--tests`" }}
-{{actionverb}} all targets in test mode that have the `test = true` manifest
+{{actionverb}} all targets that have the `test = true` manifest
 flag set. By default this includes the library and binaries built as
 unittests, and integration tests. Be aware that this will also build any
 required dependencies, so the lib target may be built twice (once as a
@@ -40,7 +40,7 @@ times and supports common Unix glob patterns.
 {{/option}}
 
 {{#option "`--benches`" }}
-{{actionverb}} all targets in benchmark mode that have the `bench = true`
+{{actionverb}} all targets that have the `bench = true`
 manifest flag set. By default this includes the library and binaries built
 as benchmarks, and bench targets. Be aware that this will also build any
 required dependencies, so the lib target may be built twice (once as a

--- a/src/doc/src/commands/cargo-bench.md
+++ b/src/doc/src/commands/cargo-bench.md
@@ -193,7 +193,7 @@ multiple times and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-bench---tests"><a class="option-anchor" href="#option-cargo-bench---tests"></a><code>--tests</code></dt>
-<dd class="option-desc">Benchmark all targets in test mode that have the <code>test = true</code> manifest
+<dd class="option-desc">Benchmark all targets that have the <code>test = true</code> manifest
 flag set. By default this includes the library and binaries built as
 unittests, and integration tests. Be aware that this will also build any
 required dependencies, so the lib target may be built twice (once as a
@@ -208,7 +208,7 @@ times and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-bench---benches"><a class="option-anchor" href="#option-cargo-bench---benches"></a><code>--benches</code></dt>
-<dd class="option-desc">Benchmark all targets in benchmark mode that have the <code>bench = true</code>
+<dd class="option-desc">Benchmark all targets that have the <code>bench = true</code>
 manifest flag set. By default this includes the library and binaries built
 as benchmarks, and bench targets. Be aware that this will also build any
 required dependencies, so the lib target may be built twice (once as a

--- a/src/doc/src/commands/cargo-build.md
+++ b/src/doc/src/commands/cargo-build.md
@@ -108,7 +108,7 @@ multiple times and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-build---tests"><a class="option-anchor" href="#option-cargo-build---tests"></a><code>--tests</code></dt>
-<dd class="option-desc">Build all targets in test mode that have the <code>test = true</code> manifest
+<dd class="option-desc">Build all targets that have the <code>test = true</code> manifest
 flag set. By default this includes the library and binaries built as
 unittests, and integration tests. Be aware that this will also build any
 required dependencies, so the lib target may be built twice (once as a
@@ -123,7 +123,7 @@ times and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-build---benches"><a class="option-anchor" href="#option-cargo-build---benches"></a><code>--benches</code></dt>
-<dd class="option-desc">Build all targets in benchmark mode that have the <code>bench = true</code>
+<dd class="option-desc">Build all targets that have the <code>bench = true</code>
 manifest flag set. By default this includes the library and binaries built
 as benchmarks, and bench targets. Be aware that this will also build any
 required dependencies, so the lib target may be built twice (once as a

--- a/src/doc/src/commands/cargo-check.md
+++ b/src/doc/src/commands/cargo-check.md
@@ -104,7 +104,7 @@ multiple times and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-check---tests"><a class="option-anchor" href="#option-cargo-check---tests"></a><code>--tests</code></dt>
-<dd class="option-desc">Check all targets in test mode that have the <code>test = true</code> manifest
+<dd class="option-desc">Check all targets that have the <code>test = true</code> manifest
 flag set. By default this includes the library and binaries built as
 unittests, and integration tests. Be aware that this will also build any
 required dependencies, so the lib target may be built twice (once as a
@@ -119,7 +119,7 @@ times and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-check---benches"><a class="option-anchor" href="#option-cargo-check---benches"></a><code>--benches</code></dt>
-<dd class="option-desc">Check all targets in benchmark mode that have the <code>bench = true</code>
+<dd class="option-desc">Check all targets that have the <code>bench = true</code>
 manifest flag set. By default this includes the library and binaries built
 as benchmarks, and bench targets. Be aware that this will also build any
 required dependencies, so the lib target may be built twice (once as a

--- a/src/doc/src/commands/cargo-fix.md
+++ b/src/doc/src/commands/cargo-fix.md
@@ -184,7 +184,7 @@ multiple times and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-fix---tests"><a class="option-anchor" href="#option-cargo-fix---tests"></a><code>--tests</code></dt>
-<dd class="option-desc">Fix all targets in test mode that have the <code>test = true</code> manifest
+<dd class="option-desc">Fix all targets that have the <code>test = true</code> manifest
 flag set. By default this includes the library and binaries built as
 unittests, and integration tests. Be aware that this will also build any
 required dependencies, so the lib target may be built twice (once as a
@@ -199,7 +199,7 @@ times and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-fix---benches"><a class="option-anchor" href="#option-cargo-fix---benches"></a><code>--benches</code></dt>
-<dd class="option-desc">Fix all targets in benchmark mode that have the <code>bench = true</code>
+<dd class="option-desc">Fix all targets that have the <code>bench = true</code>
 manifest flag set. By default this includes the library and binaries built
 as benchmarks, and bench targets. Be aware that this will also build any
 required dependencies, so the lib target may be built twice (once as a

--- a/src/doc/src/commands/cargo-rustc.md
+++ b/src/doc/src/commands/cargo-rustc.md
@@ -97,7 +97,7 @@ multiple times and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-rustc---tests"><a class="option-anchor" href="#option-cargo-rustc---tests"></a><code>--tests</code></dt>
-<dd class="option-desc">Build all targets in test mode that have the <code>test = true</code> manifest
+<dd class="option-desc">Build all targets that have the <code>test = true</code> manifest
 flag set. By default this includes the library and binaries built as
 unittests, and integration tests. Be aware that this will also build any
 required dependencies, so the lib target may be built twice (once as a
@@ -112,7 +112,7 @@ times and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-rustc---benches"><a class="option-anchor" href="#option-cargo-rustc---benches"></a><code>--benches</code></dt>
-<dd class="option-desc">Build all targets in benchmark mode that have the <code>bench = true</code>
+<dd class="option-desc">Build all targets that have the <code>bench = true</code>
 manifest flag set. By default this includes the library and binaries built
 as benchmarks, and bench targets. Be aware that this will also build any
 required dependencies, so the lib target may be built twice (once as a

--- a/src/doc/src/commands/cargo-rustdoc.md
+++ b/src/doc/src/commands/cargo-rustdoc.md
@@ -103,7 +103,7 @@ multiple times and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-rustdoc---tests"><a class="option-anchor" href="#option-cargo-rustdoc---tests"></a><code>--tests</code></dt>
-<dd class="option-desc">Document all targets in test mode that have the <code>test = true</code> manifest
+<dd class="option-desc">Document all targets that have the <code>test = true</code> manifest
 flag set. By default this includes the library and binaries built as
 unittests, and integration tests. Be aware that this will also build any
 required dependencies, so the lib target may be built twice (once as a
@@ -118,7 +118,7 @@ times and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-rustdoc---benches"><a class="option-anchor" href="#option-cargo-rustdoc---benches"></a><code>--benches</code></dt>
-<dd class="option-desc">Document all targets in benchmark mode that have the <code>bench = true</code>
+<dd class="option-desc">Document all targets that have the <code>bench = true</code>
 manifest flag set. By default this includes the library and binaries built
 as benchmarks, and bench targets. Be aware that this will also build any
 required dependencies, so the lib target may be built twice (once as a

--- a/src/doc/src/commands/cargo-test.md
+++ b/src/doc/src/commands/cargo-test.md
@@ -206,7 +206,7 @@ multiple times and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-test---tests"><a class="option-anchor" href="#option-cargo-test---tests"></a><code>--tests</code></dt>
-<dd class="option-desc">Test all targets in test mode that have the <code>test = true</code> manifest
+<dd class="option-desc">Test all targets that have the <code>test = true</code> manifest
 flag set. By default this includes the library and binaries built as
 unittests, and integration tests. Be aware that this will also build any
 required dependencies, so the lib target may be built twice (once as a
@@ -221,7 +221,7 @@ times and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-test---benches"><a class="option-anchor" href="#option-cargo-test---benches"></a><code>--benches</code></dt>
-<dd class="option-desc">Test all targets in benchmark mode that have the <code>bench = true</code>
+<dd class="option-desc">Test all targets that have the <code>bench = true</code>
 manifest flag set. By default this includes the library and binaries built
 as benchmarks, and bench targets. Be aware that this will also build any
 required dependencies, so the lib target may be built twice (once as a

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -208,7 +208,7 @@ multiple times and supports common Unix glob patterns.
 .sp
 \fB\-\-tests\fR
 .RS 4
-Benchmark all targets in test mode that have the \fBtest = true\fR manifest
+Benchmark all targets that have the \fBtest = true\fR manifest
 flag set. By default this includes the library and binaries built as
 unittests, and integration tests. Be aware that this will also build any
 required dependencies, so the lib target may be built twice (once as a
@@ -225,7 +225,7 @@ times and supports common Unix glob patterns.
 .sp
 \fB\-\-benches\fR
 .RS 4
-Benchmark all targets in benchmark mode that have the \fBbench = true\fR
+Benchmark all targets that have the \fBbench = true\fR
 manifest flag set. By default this includes the library and binaries built
 as benchmarks, and bench targets. Be aware that this will also build any
 required dependencies, so the lib target may be built twice (once as a

--- a/src/etc/man/cargo-build.1
+++ b/src/etc/man/cargo-build.1
@@ -107,7 +107,7 @@ multiple times and supports common Unix glob patterns.
 .sp
 \fB\-\-tests\fR
 .RS 4
-Build all targets in test mode that have the \fBtest = true\fR manifest
+Build all targets that have the \fBtest = true\fR manifest
 flag set. By default this includes the library and binaries built as
 unittests, and integration tests. Be aware that this will also build any
 required dependencies, so the lib target may be built twice (once as a
@@ -124,7 +124,7 @@ times and supports common Unix glob patterns.
 .sp
 \fB\-\-benches\fR
 .RS 4
-Build all targets in benchmark mode that have the \fBbench = true\fR
+Build all targets that have the \fBbench = true\fR
 manifest flag set. By default this includes the library and binaries built
 as benchmarks, and bench targets. Be aware that this will also build any
 required dependencies, so the lib target may be built twice (once as a

--- a/src/etc/man/cargo-check.1
+++ b/src/etc/man/cargo-check.1
@@ -103,7 +103,7 @@ multiple times and supports common Unix glob patterns.
 .sp
 \fB\-\-tests\fR
 .RS 4
-Check all targets in test mode that have the \fBtest = true\fR manifest
+Check all targets that have the \fBtest = true\fR manifest
 flag set. By default this includes the library and binaries built as
 unittests, and integration tests. Be aware that this will also build any
 required dependencies, so the lib target may be built twice (once as a
@@ -120,7 +120,7 @@ times and supports common Unix glob patterns.
 .sp
 \fB\-\-benches\fR
 .RS 4
-Check all targets in benchmark mode that have the \fBbench = true\fR
+Check all targets that have the \fBbench = true\fR
 manifest flag set. By default this includes the library and binaries built
 as benchmarks, and bench targets. Be aware that this will also build any
 required dependencies, so the lib target may be built twice (once as a

--- a/src/etc/man/cargo-fix.1
+++ b/src/etc/man/cargo-fix.1
@@ -198,7 +198,7 @@ multiple times and supports common Unix glob patterns.
 .sp
 \fB\-\-tests\fR
 .RS 4
-Fix all targets in test mode that have the \fBtest = true\fR manifest
+Fix all targets that have the \fBtest = true\fR manifest
 flag set. By default this includes the library and binaries built as
 unittests, and integration tests. Be aware that this will also build any
 required dependencies, so the lib target may be built twice (once as a
@@ -215,7 +215,7 @@ times and supports common Unix glob patterns.
 .sp
 \fB\-\-benches\fR
 .RS 4
-Fix all targets in benchmark mode that have the \fBbench = true\fR
+Fix all targets that have the \fBbench = true\fR
 manifest flag set. By default this includes the library and binaries built
 as benchmarks, and bench targets. Be aware that this will also build any
 required dependencies, so the lib target may be built twice (once as a

--- a/src/etc/man/cargo-rustc.1
+++ b/src/etc/man/cargo-rustc.1
@@ -93,7 +93,7 @@ multiple times and supports common Unix glob patterns.
 .sp
 \fB\-\-tests\fR
 .RS 4
-Build all targets in test mode that have the \fBtest = true\fR manifest
+Build all targets that have the \fBtest = true\fR manifest
 flag set. By default this includes the library and binaries built as
 unittests, and integration tests. Be aware that this will also build any
 required dependencies, so the lib target may be built twice (once as a
@@ -110,7 +110,7 @@ times and supports common Unix glob patterns.
 .sp
 \fB\-\-benches\fR
 .RS 4
-Build all targets in benchmark mode that have the \fBbench = true\fR
+Build all targets that have the \fBbench = true\fR
 manifest flag set. By default this includes the library and binaries built
 as benchmarks, and bench targets. Be aware that this will also build any
 required dependencies, so the lib target may be built twice (once as a

--- a/src/etc/man/cargo-rustdoc.1
+++ b/src/etc/man/cargo-rustdoc.1
@@ -95,7 +95,7 @@ multiple times and supports common Unix glob patterns.
 .sp
 \fB\-\-tests\fR
 .RS 4
-Document all targets in test mode that have the \fBtest = true\fR manifest
+Document all targets that have the \fBtest = true\fR manifest
 flag set. By default this includes the library and binaries built as
 unittests, and integration tests. Be aware that this will also build any
 required dependencies, so the lib target may be built twice (once as a
@@ -112,7 +112,7 @@ times and supports common Unix glob patterns.
 .sp
 \fB\-\-benches\fR
 .RS 4
-Document all targets in benchmark mode that have the \fBbench = true\fR
+Document all targets that have the \fBbench = true\fR
 manifest flag set. By default this includes the library and binaries built
 as benchmarks, and bench targets. Be aware that this will also build any
 required dependencies, so the lib target may be built twice (once as a

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -222,7 +222,7 @@ multiple times and supports common Unix glob patterns.
 .sp
 \fB\-\-tests\fR
 .RS 4
-Test all targets in test mode that have the \fBtest = true\fR manifest
+Test all targets that have the \fBtest = true\fR manifest
 flag set. By default this includes the library and binaries built as
 unittests, and integration tests. Be aware that this will also build any
 required dependencies, so the lib target may be built twice (once as a
@@ -239,7 +239,7 @@ times and supports common Unix glob patterns.
 .sp
 \fB\-\-benches\fR
 .RS 4
-Test all targets in benchmark mode that have the \fBbench = true\fR
+Test all targets that have the \fBbench = true\fR
 manifest flag set. By default this includes the library and binaries built
 as benchmarks, and bench targets. Be aware that this will also build any
 required dependencies, so the lib target may be built twice (once as a

--- a/tests/testsuite/cargo_bench/help/stdout.term.svg
+++ b/tests/testsuite/cargo_bench/help/stdout.term.svg
@@ -83,11 +83,11 @@
 </tspan>
     <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Benchmark only the specified example</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-cyan bold">--tests</tspan><tspan>             Benchmark all test targets</tspan>
+    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-cyan bold">--tests</tspan><tspan>             Benchmark all targets that have `test = true` set</tspan>
 </tspan>
     <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-cyan bold">--test</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>     Benchmark only the specified test target</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--benches</tspan><tspan>           Benchmark all bench targets</tspan>
+    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--benches</tspan><tspan>           Benchmark all targets that have `bench = true` set</tspan>
 </tspan>
     <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-cyan bold">--bench</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>    Benchmark only the specified bench target</tspan>
 </tspan>

--- a/tests/testsuite/cargo_build/help/stdout.term.svg
+++ b/tests/testsuite/cargo_build/help/stdout.term.svg
@@ -73,11 +73,11 @@
 </tspan>
     <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Build only the specified example</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--tests</tspan><tspan>             Build all test targets</tspan>
+    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--tests</tspan><tspan>             Build all targets that have `test = true` set</tspan>
 </tspan>
     <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-cyan bold">--test</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>     Build only the specified test target</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-cyan bold">--benches</tspan><tspan>           Build all bench targets</tspan>
+    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-cyan bold">--benches</tspan><tspan>           Build all targets that have `bench = true` set</tspan>
 </tspan>
     <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-cyan bold">--bench</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>    Build only the specified bench target</tspan>
 </tspan>

--- a/tests/testsuite/cargo_check/help/stdout.term.svg
+++ b/tests/testsuite/cargo_check/help/stdout.term.svg
@@ -73,11 +73,11 @@
 </tspan>
     <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Check only the specified example</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--tests</tspan><tspan>             Check all test targets</tspan>
+    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--tests</tspan><tspan>             Check all targets that have `test = true` set</tspan>
 </tspan>
     <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-cyan bold">--test</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>     Check only the specified test target</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-cyan bold">--benches</tspan><tspan>           Check all bench targets</tspan>
+    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-cyan bold">--benches</tspan><tspan>           Check all targets that have `bench = true` set</tspan>
 </tspan>
     <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-cyan bold">--bench</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>    Check only the specified bench target</tspan>
 </tspan>

--- a/tests/testsuite/cargo_fix/help/stdout.term.svg
+++ b/tests/testsuite/cargo_fix/help/stdout.term.svg
@@ -83,11 +83,11 @@
 </tspan>
     <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Fix only the specified example</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-cyan bold">--tests</tspan><tspan>             Fix all test targets</tspan>
+    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-cyan bold">--tests</tspan><tspan>             Fix all targets that have `test = true` set</tspan>
 </tspan>
     <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-cyan bold">--test</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>     Fix only the specified test target</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--benches</tspan><tspan>           Fix all bench targets</tspan>
+    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--benches</tspan><tspan>           Fix all targets that have `bench = true` set</tspan>
 </tspan>
     <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-cyan bold">--bench</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>    Fix only the specified bench target</tspan>
 </tspan>

--- a/tests/testsuite/cargo_rustc/help/stdout.term.svg
+++ b/tests/testsuite/cargo_rustc/help/stdout.term.svg
@@ -77,11 +77,11 @@
 </tspan>
     <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Build only the specified example</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-cyan bold">--tests</tspan><tspan>             Build all test targets</tspan>
+    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-cyan bold">--tests</tspan><tspan>             Build all targets that have `test = true` set</tspan>
 </tspan>
     <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-cyan bold">--test</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>     Build only the specified test target</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-cyan bold">--benches</tspan><tspan>           Build all bench targets</tspan>
+    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-cyan bold">--benches</tspan><tspan>           Build all targets that have `bench = true` set</tspan>
 </tspan>
     <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-cyan bold">--bench</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>    Build only the specified bench target</tspan>
 </tspan>

--- a/tests/testsuite/cargo_rustdoc/help/stdout.term.svg
+++ b/tests/testsuite/cargo_rustdoc/help/stdout.term.svg
@@ -75,11 +75,11 @@
 </tspan>
     <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Build only the specified example</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-cyan bold">--tests</tspan><tspan>             Build all test targets</tspan>
+    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-cyan bold">--tests</tspan><tspan>             Build all targets that have `test = true` set</tspan>
 </tspan>
     <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-cyan bold">--test</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>     Build only the specified test target</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-cyan bold">--benches</tspan><tspan>           Build all bench targets</tspan>
+    <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-cyan bold">--benches</tspan><tspan>           Build all targets that have `bench = true` set</tspan>
 </tspan>
     <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-cyan bold">--bench</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>    Build only the specified bench target</tspan>
 </tspan>

--- a/tests/testsuite/cargo_test/help/stdout.term.svg
+++ b/tests/testsuite/cargo_test/help/stdout.term.svg
@@ -85,11 +85,11 @@
 </tspan>
     <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Test only the specified example</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-cyan bold">--tests</tspan><tspan>             Test all test targets</tspan>
+    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-cyan bold">--tests</tspan><tspan>             Test all targets that have `test = true` set</tspan>
 </tspan>
     <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--test</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>     Test only the specified test target</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-cyan bold">--benches</tspan><tspan>           Test all bench targets</tspan>
+    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-cyan bold">--benches</tspan><tspan>           Test all targets that have `bench = true` set</tspan>
 </tspan>
     <tspan x="10px" y="676px"><tspan>      </tspan><tspan class="fg-cyan bold">--bench</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>    Test only the specified bench target</tspan>
 </tspan>


### PR DESCRIPTION
This tries to reduce the confusion expressed in https://github.com/rust-lang/cargo/issues/10936.

I am not sure what it means to "test a target in benchmark mode", this is copied verbatim from `cargo help test`.