### PR TITLE
fix(registry): make sure to process a download after it has completed

### DIFF
--- a/src/cargo/sources/registry/http_remote.rs
+++ b/src/cargo/sources/registry/http_remote.rs
@@ -796,15 +796,15 @@ impl<'gctx> RegistryData for HttpRegistry<'gctx> {
         self.downloads.blocking_calls += 1;
 
         loop {
-            self.handle_completed_downloads()?;
-            self.add_sleepers()?;
-
             let remaining_in_multi = tls::set(&self.downloads, || {
                 self.multi
                     .perform()
                     .context("failed to perform http requests")
             })?;
             trace!(target: "network", "{} transfers remaining", remaining_in_multi);
+
+            self.handle_completed_downloads()?;
+            self.add_sleepers()?;
 
             if remaining_in_multi + self.downloads.sleeping.len() as u32 == 0 {
                 return Ok(());


### PR DESCRIPTION
### What does this PR try to resolve?

This PR solves the bug found in https://github.com/Eh2406/pubgrub-crates-benchmark/issues/6#issuecomment-2406197867.

With this PR we can avoid refetching the same dependency multiple times because a finished download was not processed before returning from the `block_until_ready()` method. It also improves the resolving speed since `activate_deps_loop()` is called less times overall.
