### PR TITLE
Added unstable-schema generation for Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ dependencies = [
  "humantime",
  "ignore",
  "im-rc",
- "indexmap",
+ "indexmap 2.3.0",
  "itertools 0.13.0",
  "jobserver",
  "lazycell",
@@ -492,10 +492,12 @@ dependencies = [
 name = "cargo-util-schemas"
 version = "0.7.1"
 dependencies = [
+ "schemars",
  "semver",
  "serde",
  "serde-untagged",
  "serde-value",
+ "serde_json",
  "snapbox",
  "thiserror",
  "toml",
@@ -901,6 +903,12 @@ name = "dunce"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "ecdsa"
@@ -1466,7 +1474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddf80e16f3c19ac06ce415a38b8591993d3f73aede049cb561becb5b3a8e242"
 dependencies = [
  "gix-hash",
- "hashbrown",
+ "hashbrown 0.14.5",
  "parking_lot",
 ]
 
@@ -1502,7 +1510,7 @@ dependencies = [
  "gix-traverse",
  "gix-utils",
  "gix-validate",
- "hashbrown",
+ "hashbrown 0.14.5",
  "itoa 1.0.11",
  "libc",
  "memmap2",
@@ -1961,6 +1969,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -1975,7 +1989,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692eaaf7f7607518dd3cef090f1474b61edc5301d8012f09579920df68b725ee"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2090,12 +2104,23 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -3078,6 +3103,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+dependencies = [
+ "dyn-clone",
+ "indexmap 1.9.3",
+ "schemars_derive",
+ "semver",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.72",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3171,6 +3222,17 @@ name = "serde_derive"
 version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3557,7 +3619,7 @@ version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
- "indexmap",
+ "indexmap 2.3.0",
  "serde",
  "serde_spanned",
  "toml_datetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ rusqlite = { version = "0.32.0", features = ["bundled"] }
 rustc-hash = "2.0.0"
 rustfix = { version = "0.8.2", path = "crates/rustfix" }
 same-file = "1.0.6"
+schemars = "0.8.21"
 security-framework = "2.11.1"
 semver = { version = "1.0.23", features = ["serde"] }
 serde = "1.0.204"

--- a/crates/cargo-util-schemas/Cargo.toml
+++ b/crates/cargo-util-schemas/Cargo.toml
@@ -9,8 +9,10 @@ repository.workspace = true
 description = "Deserialization schemas for Cargo"
 
 [dependencies]
+schemars = { workspace = true, features = ["preserve_order","semver"], optional = true }
 semver.workspace = true
 serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, optional = true }
 serde-untagged.workspace = true
 serde-value.workspace = true
 thiserror.workspace = true
@@ -23,3 +25,6 @@ workspace = true
 
 [dev-dependencies]
 snapbox.workspace = true
+
+[features]
+unstable-schema = ["dep:schemars", "dep:serde_json"]

--- a/crates/cargo-util-schemas/manifest.schema.json
+++ b/crates/cargo-util-schemas/manifest.schema.json
@@ -1,0 +1,1485 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "TomlManifest",
+  "description": "This type is used to deserialize `Cargo.toml` files.",
+  "type": "object",
+  "properties": {
+    "cargo-features": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "package": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TomlPackage"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "project": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TomlPackage"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "profile": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TomlProfiles"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "lib": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TomlTarget"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "bin": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/TomlTarget"
+      }
+    },
+    "example": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/TomlTarget"
+      }
+    },
+    "test": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/TomlTarget"
+      }
+    },
+    "bench": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/TomlTarget"
+      }
+    },
+    "dependencies": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": {
+        "$ref": "#/definitions/InheritableDependency"
+      }
+    },
+    "dev-dependencies": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": {
+        "$ref": "#/definitions/InheritableDependency"
+      }
+    },
+    "dev_dependencies": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": {
+        "$ref": "#/definitions/InheritableDependency"
+      }
+    },
+    "build-dependencies": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": {
+        "$ref": "#/definitions/InheritableDependency"
+      }
+    },
+    "build_dependencies": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": {
+        "$ref": "#/definitions/InheritableDependency"
+      }
+    },
+    "features": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "target": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": {
+        "$ref": "#/definitions/TomlPlatform"
+      }
+    },
+    "replace": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": {
+        "$ref": "#/definitions/TomlDependency_for_String"
+      }
+    },
+    "patch": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/definitions/TomlDependency_for_String"
+        }
+      }
+    },
+    "workspace": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TomlWorkspace"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "badges": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      }
+    },
+    "lints": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/InheritableLints"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "definitions": {
+    "TomlPackage": {
+      "description": "Represents the `package`/`project` sections of a `Cargo.toml`./n/nNote that the order of the fields matters, since this is the order they are serialized to a TOML file. For example, you cannot have values after the field `metadata`, since it is a table and values cannot appear after tables.",
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "edition": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/InheritableField_for_String"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "rust-version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/InheritableField_for_Version"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "authors": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/InheritableField_for_Array_of_String"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "build": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrBool"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "metabuild": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "default-target": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "forced-target": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "links": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "exclude": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/InheritableField_for_Array_of_String"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "include": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/InheritableField_for_Array_of_String"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "publish": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/InheritableField_for_VecStringOrBool"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "workspace": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "im-a-teapot": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "autolib": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "autobins": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "autoexamples": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "autotests": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "autobenches": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "default-run": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "description": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/InheritableField_for_String"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "homepage": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/InheritableField_for_String"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "documentation": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/InheritableField_for_String"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readme": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/InheritableField_for_StringOrBool"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "keywords": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/InheritableField_for_Array_of_String"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "categories": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/InheritableField_for_Array_of_String"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "license": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/InheritableField_for_String"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "license-file": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/InheritableField_for_String"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "repository": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/InheritableField_for_String"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "resolver": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "metadata": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TomlValue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "InheritableField_for_String": {
+      "description": "An enum that allows for inheriting keys from a workspace in a Cargo.toml.",
+      "anyOf": [
+        {
+          "description": "The type that is used when not inheriting from a workspace.",
+          "type": "string"
+        },
+        {
+          "description": "The type when inheriting from a workspace.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TomlInheritedField"
+            }
+          ]
+        }
+      ]
+    },
+    "TomlInheritedField": {
+      "type": "object",
+      "required": [
+        "workspace"
+      ],
+      "properties": {
+        "workspace": {
+          "$ref": "#/definitions/WorkspaceValue"
+        }
+      }
+    },
+    "WorkspaceValue": {
+      "type": "null"
+    },
+    "InheritableField_for_Version": {
+      "description": "An enum that allows for inheriting keys from a workspace in a Cargo.toml.",
+      "anyOf": [
+        {
+          "description": "The type that is used when not inheriting from a workspace.",
+          "type": "string",
+          "pattern": "^(0|[1-9]//d*)//.(0|[1-9]//d*)//.(0|[1-9]//d*)(?:-((?:0|[1-9]//d*|//d*[a-zA-Z-][0-9a-zA-Z-]*)(?://.(?:0|[1-9]//d*|//d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?://+([0-9a-zA-Z-]+(?://.[0-9a-zA-Z-]+)*))?$"
+        },
+        {
+          "description": "The type when inheriting from a workspace.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TomlInheritedField"
+            }
+          ]
+        }
+      ]
+    },
+    "InheritableField_for_Array_of_String": {
+      "description": "An enum that allows for inheriting keys from a workspace in a Cargo.toml.",
+      "anyOf": [
+        {
+          "description": "The type that is used when not inheriting from a workspace.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "description": "The type when inheriting from a workspace.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TomlInheritedField"
+            }
+          ]
+        }
+      ]
+    },
+    "StringOrBool": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
+    },
+    "StringOrVec": {
+      "description": "A StringOrVec can be parsed from either a TOML string or array, but is always stored as a vector.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "InheritableField_for_VecStringOrBool": {
+      "description": "An enum that allows for inheriting keys from a workspace in a Cargo.toml.",
+      "anyOf": [
+        {
+          "description": "The type that is used when not inheriting from a workspace.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/VecStringOrBool"
+            }
+          ]
+        },
+        {
+          "description": "The type when inheriting from a workspace.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TomlInheritedField"
+            }
+          ]
+        }
+      ]
+    },
+    "VecStringOrBool": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "boolean"
+        }
+      ]
+    },
+    "InheritableField_for_StringOrBool": {
+      "description": "An enum that allows for inheriting keys from a workspace in a Cargo.toml.",
+      "anyOf": [
+        {
+          "description": "The type that is used when not inheriting from a workspace.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StringOrBool"
+            }
+          ]
+        },
+        {
+          "description": "The type when inheriting from a workspace.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TomlInheritedField"
+            }
+          ]
+        }
+      ]
+    },
+    "TomlValue": {
+      "type": "object",
+      "properties": {
+        "string": {
+          "type": "string"
+        },
+        "integer": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "float": {
+          "type": "number",
+          "format": "double"
+        },
+        "boolean": {
+          "type": "boolean"
+        },
+        "datetime": {
+          "type": "string"
+        },
+        "array": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TomlValue"
+          }
+        },
+        "table": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/TomlValue"
+          }
+        }
+      }
+    },
+    "TomlProfiles": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/TomlProfile"
+      }
+    },
+    "TomlProfile": {
+      "type": "object",
+      "properties": {
+        "opt-level": {
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TomlOptLevel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "lto": {
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrBool"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "codegen-backend": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "codegen-units": {
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "debug": {
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TomlDebugInfo"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "split-debuginfo": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "debug-assertions": {
+          "default": null,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "rpath": {
+          "default": null,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "panic": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "overflow-checks": {
+          "default": null,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "incremental": {
+          "default": null,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "dir-name": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "inherits": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "strip": {
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrBool"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "rustflags": {
+          "default": null,
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "package": {
+          "default": null,
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/definitions/TomlProfile"
+          }
+        },
+        "build-override": {
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TomlProfile"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "trim-paths": {
+          "description": "Unstable feature `-Ztrim-paths`.",
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TomlTrimPaths"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "TomlOptLevel": {
+      "type": "string"
+    },
+    "TomlDebugInfo": {
+      "type": "string",
+      "enum": [
+        "None",
+        "LineDirectivesOnly",
+        "LineTablesOnly",
+        "Limited",
+        "Full"
+      ]
+    },
+    "TomlTrimPaths": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TomlTrimPathsValue"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "TomlTrimPathsValue": {
+      "type": "string",
+      "enum": [
+        "diagnostics",
+        "macro",
+        "object"
+      ]
+    },
+    "TomlTarget": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "crate-type": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "crate_type": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "filename": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "test": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "doctest": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "bench": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "doc": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "doc-scrape-examples": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "proc-macro": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "proc_macro": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "harness": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "required-features": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "edition": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "InheritableDependency": {
+      "anyOf": [
+        {
+          "description": "The type that is used when not inheriting from a workspace.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TomlDependency_for_String"
+            }
+          ]
+        },
+        {
+          "description": "The type when inheriting from a workspace.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TomlInheritedDependency"
+            }
+          ]
+        }
+      ]
+    },
+    "TomlDependency_for_String": {
+      "anyOf": [
+        {
+          "description": "In the simple format, only a version is specified, eg. `package = /"<version>/"`",
+          "type": "string"
+        },
+        {
+          "description": "The simple format is equivalent to a detailed dependency specifying only a version, eg. `package = { version = /"<version>/" }`",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TomlDetailedDependency_for_String"
+            }
+          ]
+        }
+      ]
+    },
+    "TomlDetailedDependency_for_String": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "registry": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "registry-index": {
+          "description": "The URL of the `registry` field. This is an internal implementation detail. When Cargo creates a package, it replaces `registry` with `registry-index` so that the manifest contains the correct URL. All users won't have the same registry names configured, so Cargo can't rely on just the name for crates published by other users.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "base": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "git": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "branch": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tag": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "rev": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "features": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "optional": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "default-features": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "default_features": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "package": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "public": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "artifact": {
+          "description": "One or more of `bin`, `cdylib`, `staticlib`, `bin:<name>`.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "lib": {
+          "description": "If set, the artifact should also be a dependency",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "target": {
+          "description": "A platform name, like `x86_64-apple-darwin`",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "TomlInheritedDependency": {
+      "type": "object",
+      "required": [
+        "workspace"
+      ],
+      "properties": {
+        "workspace": {
+          "type": "boolean"
+        },
+        "features": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "default-features": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "default_features": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "optional": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "public": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      }
+    },
+    "TomlPlatform": {
+      "description": "Corresponds to a `target` entry, but `TomlTarget` is already used.",
+      "type": "object",
+      "properties": {
+        "dependencies": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/definitions/InheritableDependency"
+          }
+        },
+        "build-dependencies": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/definitions/InheritableDependency"
+          }
+        },
+        "build_dependencies": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/definitions/InheritableDependency"
+          }
+        },
+        "dev-dependencies": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/definitions/InheritableDependency"
+          }
+        },
+        "dev_dependencies": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/definitions/InheritableDependency"
+          }
+        }
+      }
+    },
+    "TomlWorkspace": {
+      "type": "object",
+      "properties": {
+        "members": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "exclude": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "default-members": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "resolver": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "metadata": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TomlValue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "package": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/InheritablePackage"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependencies": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/definitions/TomlDependency_for_String"
+          }
+        },
+        "lints": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/definitions/TomlLint"
+            }
+          }
+        }
+      }
+    },
+    "InheritablePackage": {
+      "description": "A group of fields that are inheritable by members of the workspace",
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^(0|[1-9]//d*)//.(0|[1-9]//d*)//.(0|[1-9]//d*)(?:-((?:0|[1-9]//d*|//d*[a-zA-Z-][0-9a-zA-Z-]*)(?://.(?:0|[1-9]//d*|//d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?://+([0-9a-zA-Z-]+(?://.[0-9a-zA-Z-]+)*))?$"
+        },
+        "authors": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "homepage": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "documentation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "readme": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrBool"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "keywords": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "categories": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "license": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "license-file": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "repository": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "publish": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/VecStringOrBool"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "edition": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "badges": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        },
+        "exclude": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "include": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "rust-version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "TomlLint": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TomlLintLevel"
+        },
+        {
+          "$ref": "#/definitions/TomlLintConfig"
+        }
+      ]
+    },
+    "TomlLintLevel": {
+      "type": "string",
+      "enum": [
+        "forbid",
+        "deny",
+        "warn",
+        "allow"
+      ]
+    },
+    "TomlLintConfig": {
+      "type": "object",
+      "required": [
+        "level"
+      ],
+      "properties": {
+        "level": {
+          "$ref": "#/definitions/TomlLintLevel"
+        },
+        "priority": {
+          "default": 0,
+          "type": "integer",
+          "format": "int8"
+        }
+      }
+    },
+    "InheritableLints": {
+      "type": "object",
+      "required": [
+        "workspace"
+      ],
+      "properties": {
+        "workspace": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/crates/cargo-util-schemas/src/lib.rs
+++ b/crates/cargo-util-schemas/src/lib.rs
@@ -10,5 +10,7 @@
 
 pub mod core;
 pub mod manifest;
+#[cfg(feature = "unstable-schema")]
+pub mod schema;
 
 mod restricted_names;

--- a/crates/cargo-util-schemas/src/schema.rs
+++ b/crates/cargo-util-schemas/src/schema.rs
@@ -1,0 +1,54 @@
+use schemars::JsonSchema;
+
+use serde::{Deserialize, Serialize};
+
+use std::collections::HashMap;
+use std::string::String;
+
+use toml::Value as TomlValue;
+
+#[derive(Serialize, Deserialize)]
+pub struct TomlValueWrapper(pub TomlValue);
+
+impl JsonSchema for TomlValueWrapper {
+    fn schema_name() -> String {
+        "TomlValue".to_string()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        use schemars::schema::*;
+
+        SchemaObject {
+            instance_type: Some(InstanceType::Object.into()),
+            object: Some(Box::new(ObjectValidation {
+                properties: [
+                    (
+                        "string".to_string(),
+                        gen.subschema_for::<std::string::String>(),
+                    ),
+                    ("integer".to_string(), gen.subschema_for::<i64>()),
+                    ("float".to_string(), gen.subschema_for::<f64>()),
+                    ("boolean".to_string(), gen.subschema_for::<bool>()),
+                    (
+                        "datetime".to_string(),
+                        gen.subschema_for::<std::string::String>(),
+                    ), // Assuming datetime is represented as a string
+                    (
+                        "array".to_string(),
+                        gen.subschema_for::<Vec<TomlValueWrapper>>(),
+                    ),
+                    (
+                        "table".to_string(),
+                        gen.subschema_for::<HashMap<std::string::String, TomlValueWrapper>>(),
+                    ),
+                ]
+                .iter()
+                .cloned()
+                .collect(),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }
+        .into()
+    }
+}


### PR DESCRIPTION
### What does this PR try to resolve?

Added unstable-schema feature that generates JsonSchema for Cargo.toml

See #12883
finished first step of [plan](https://github.com/rust-lang/cargo/issues/12883#issuecomment-2407648385)

### Information
In cargo-util-schemas,  run cargo test --feature unstable-schema  . If there have been any changes to manifest.schema.json, rerun with env variable SNAPSHOTS=overwrite  and it will update them.

### How should we test and review this PR?
In cargo-util-schemas run cargo test --features unstable-schema and it will generate manifest.schema.json



