### PR TITLE
docs: More information on what is and isn't included by cargo package

### DIFF
--- a/src/doc/man/cargo-package.md
+++ b/src/doc/man/cargo-package.md
@@ -32,6 +32,16 @@ stored in the `target/package` directory. This performs the following steps:
     - A `.cargo_vcs_info.json` file is included that contains information
       about the current VCS checkout hash if available, as well as a flag if the
       worktree is dirty.
+    - Symlinks are flattened to their target files.
+    - Subdirectories containing `Cargo.toml` are excluded, as they are assumed
+      to be separate packages.
+    - A `target` directory in the root of the package is excluded.
+    - Files and directories matching the `[include]` and `[exclude]` fields in
+      the manifest are included or excluded. Include patterns can override the
+      following rules.
+    - Files that are ignored by VCS are excluded.
+    - Unix hidden files and directories (starting with `.`) are excluded.
+
 3. Extract the `.crate` file and build it to verify it can build.
     - This will rebuild your package from scratch to ensure that it can be
       built from a pristine state. The `--no-verify` flag can be used to skip

--- a/src/doc/man/cargo-package.md
+++ b/src/doc/man/cargo-package.md
@@ -33,14 +33,8 @@ stored in the `target/package` directory. This performs the following steps:
       about the current VCS checkout hash if available, as well as a flag if the
       worktree is dirty.
     - Symlinks are flattened to their target files.
-    - Subdirectories containing `Cargo.toml` are excluded, as they are assumed
-      to be separate packages.
-    - A `target` directory in the root of the package is excluded.
-    - Files and directories matching the `[include]` and `[exclude]` fields in
-      the manifest are included or excluded. Include patterns can override the
-      following rules.
-    - Files that are ignored by VCS are excluded.
-    - Unix hidden files and directories (starting with `.`) are excluded.
+    - Files and directories are included or excluded based on rules mentioned in
+      [the `[include]` and `[exclude]` fields](../reference/manifest.html#the-exclude-and-include-fields).
 
 3. Extract the `.crate` file and build it to verify it can build.
     - This will rebuild your package from scratch to ensure that it can be

--- a/src/doc/man/generated_txt/cargo-package.txt
+++ b/src/doc/man/generated_txt/cargo-package.txt
@@ -14,11 +14,13 @@ DESCRIPTION
        following steps:
 
        1. Load and check the current workspace, performing some basic checks.
+
           o  Path dependencies are not allowed unless they have a version key.
              Cargo will ignore the path key for dependencies in published
              packages. dev-dependencies do not have this restriction.
 
        2. Create the compressed .crate file.
+
           o  The original Cargo.toml file is rewritten and normalized.
 
           o  [patch], [replace], and [workspace] sections are removed from the
@@ -32,7 +34,23 @@ DESCRIPTION
              about the current VCS checkout hash if available, as well as a
              flag if the worktree is dirty.
 
+          o  Symlinks are flattened to their target files.
+
+          o  Subdirectories containing Cargo.toml are excluded, as they are
+             assumed to be separate packages.
+
+          o  A target directory in the root of the package is excluded.
+
+          o  Files and directories matching the [include] and [exclude] fields
+             in the manifest are included or excluded. Include patterns can
+             override the following rules.
+
+          o  Files that are ignored by VCS are excluded.
+
+          o  Unix hidden files and directories (starting with .) are excluded.
+
        3. Extract the .crate file and build it to verify it can build.
+
           o  This will rebuild your package from scratch to ensure that it can
              be built from a pristine state. The --no-verify flag can be used
              to skip this step.

--- a/src/doc/man/generated_txt/cargo-package.txt
+++ b/src/doc/man/generated_txt/cargo-package.txt
@@ -36,18 +36,9 @@ DESCRIPTION
 
           o  Symlinks are flattened to their target files.
 
-          o  Subdirectories containing Cargo.toml are excluded, as they are
-             assumed to be separate packages.
-
-          o  A target directory in the root of the package is excluded.
-
-          o  Files and directories matching the [include] and [exclude] fields
-             in the manifest are included or excluded. Include patterns can
-             override the following rules.
-
-          o  Files that are ignored by VCS are excluded.
-
-          o  Unix hidden files and directories (starting with .) are excluded.
+          o  Files and directories are included or excluded based on rules
+             mentioned in the [include] and [exclude] fields
+             <https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields>.
 
        3. Extract the .crate file and build it to verify it can build.
 

--- a/src/doc/src/commands/cargo-package.md
+++ b/src/doc/src/commands/cargo-package.md
@@ -28,14 +28,8 @@ stored in the `target/package` directory. This performs the following steps:
       about the current VCS checkout hash if available, as well as a flag if the
       worktree is dirty.
     - Symlinks are flattened to their target files.
-    - Subdirectories containing `Cargo.toml` are excluded, as they are assumed
-      to be separate packages.
-    - A `target` directory in the root of the package is excluded.
-    - Files and directories matching the `[include]` and `[exclude]` fields in
-      the manifest are included or excluded. Include patterns can override the
-      following rules.
-    - Files that are ignored by VCS are excluded.
-    - Unix hidden files and directories (starting with `.`) are excluded.
+    - Files and directories are included or excluded based on rules mentioned in
+      [the `[include]` and `[exclude]` fields](../reference/manifest.html#the-exclude-and-include-fields).
 
 3. Extract the `.crate` file and build it to verify it can build.
     - This will rebuild your package from scratch to ensure that it can be

--- a/src/doc/src/commands/cargo-package.md
+++ b/src/doc/src/commands/cargo-package.md
@@ -27,6 +27,16 @@ stored in the `target/package` directory. This performs the following steps:
     - A `.cargo_vcs_info.json` file is included that contains information
       about the current VCS checkout hash if available, as well as a flag if the
       worktree is dirty.
+    - Symlinks are flattened to their target files.
+    - Subdirectories containing `Cargo.toml` are excluded, as they are assumed
+      to be separate packages.
+    - A `target` directory in the root of the package is excluded.
+    - Files and directories matching the `[include]` and `[exclude]` fields in
+      the manifest are included or excluded. Include patterns can override the
+      following rules.
+    - Files that are ignored by VCS are excluded.
+    - Unix hidden files and directories (starting with `.`) are excluded.
+
 3. Extract the `.crate` file and build it to verify it can build.
     - This will rebuild your package from scratch to ensure that it can be
       built from a pristine state. The `--no-verify` flag can be used to skip

--- a/src/etc/man/cargo-package.1
+++ b/src/etc/man/cargo-package.1
@@ -51,26 +51,8 @@ worktree is dirty.
 .RE
 .sp
 .RS 4
-\h'-04'\(bu\h'+02'Subdirectories containing \fBCargo.toml\fR are excluded, as they are assumed
-to be separate packages.
-.RE
-.sp
-.RS 4
-\h'-04'\(bu\h'+02'A \fBtarget\fR directory in the root of the package is excluded.
-.RE
-.sp
-.RS 4
-\h'-04'\(bu\h'+02'Files and directories matching the \fB[include]\fR and \fB[exclude]\fR fields in
-the manifest are included or excluded. Include patterns can override the
-following rules.
-.RE
-.sp
-.RS 4
-\h'-04'\(bu\h'+02'Files that are ignored by VCS are excluded.
-.RE
-.sp
-.RS 4
-\h'-04'\(bu\h'+02'Unix hidden files and directories (starting with \fB\&.\fR) are excluded.
+\h'-04'\(bu\h'+02'Files and directories are included or excluded based on rules mentioned in
+\fIthe \f(BI[include]\fI and \f(BI[exclude]\fI fields\fR <https://doc.rust\-lang.org/cargo/reference/manifest.html#the\-exclude\-and\-include\-fields>\&.
 .RE
 .RE
 .sp

--- a/src/etc/man/cargo-package.1
+++ b/src/etc/man/cargo-package.1
@@ -45,6 +45,33 @@ packaged lock file if the \fB\-\-locked\fR flag is used.
 about the current VCS checkout hash if available, as well as a flag if the
 worktree is dirty.
 .RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'Symlinks are flattened to their target files.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'Subdirectories containing \fBCargo.toml\fR are excluded, as they are assumed
+to be separate packages.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'A \fBtarget\fR directory in the root of the package is excluded.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'Files and directories matching the \fB[include]\fR and \fB[exclude]\fR fields in
+the manifest are included or excluded. Include patterns can override the
+following rules.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'Files that are ignored by VCS are excluded.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'Unix hidden files and directories (starting with \fB\&.\fR) are excluded.
+.RE
 .RE
 .sp
 .RS 4


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.
-->

### What does this PR try to resolve?

Add more detail to `cargo package` explaining what is and isn't included. 

This doesn't add the feature requested by #11203 (shipping symlinks) but it does at least make it more clear that it's not supported.

### How should we test and review this PR?

Docs only change.

I wrote this by reading [src/cargo/sources/path.rs](https://github.com/rust-lang/cargo/blob/82c489f1c612096c2dffc48a4091d21af4b8e046/src/cargo/sources/path.rs), in addition to my observations of cargo behavior, so it might be helpful for reviewers to check the new docs against the code.
