### PR TITLE
chore: switch to ECR Public from Docker Hub

### DIFF
--- a/crates/cargo-test-support/containers/apache/Dockerfile
+++ b/crates/cargo-test-support/containers/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM httpd:2.4-alpine
+FROM public.ecr.aws/docker/library/httpd:2.4-alpine
 
 RUN apk add --no-cache git git-daemon openssl
 

--- a/crates/cargo-test-support/containers/sshd/Dockerfile
+++ b/crates/cargo-test-support/containers/sshd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20
+FROM public.ecr.aws/docker/library/alpine:3.20
 
 RUN apk add --no-cache openssh git
 RUN ssh-keygen -A


### PR DESCRIPTION
### What does this PR try to resolve?

We're hitting this hard.

```
[internal] load metadata for docker.io/library/httpd:2.4-alpine
ERROR: failed to copy: httpReadSeeker:
failed open: unexpected status code https://registry-1.docker.io/v2/library/httpd/manifests/sha256:66c49302c02430619abb84240a438bcfc083015661009fcaaeaac931450f62cd:
  429 Too Many Requests - Server message: toomanyrequests:
You have reached your pull rate limit.
You may increase the limit by authenticating and upgrading:
https://www.docker.com/increase-rate-limit
```

And the rate limit seems quite easy to hit.

> The rate limits of 100 container image requests per six hours for
> anonymous usage, > and 200 container image requests per six hours
> for free Docker accounts are now in effect. Image requests exceeding
> these limits will be denied until the six hour window elapses.

This PR switches to Amazon ECR public, and alternative image registry,
to unblock us from the rate limit of the official Docker registry.

Both of the two images are verified and uploaded by Docker

* https://gallery.ecr.aws/docker/library/alpine
* https://gallery.ecr.aws/docker/library/httpd

See also https://gallery.ecr.aws/