### PR TITLE
fix(git): dont fetch tags by default

### DIFF
--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -1193,6 +1193,8 @@ fn fetch_with_cli(
     cmd.arg("fetch");
     if tags {
         cmd.arg("--tags");
+    } else {
+        cmd.arg("--no-tags");
     }
     match gctx.shell().verbosity() {
         Verbosity::Normal => {}

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -2954,7 +2954,7 @@ fn use_the_cli() {
 
     let stderr = str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep1`
-[RUNNING] `git fetch --verbose --force --update-head-ok [..][ROOTURL]/dep1[..] [..]+HEAD:refs/remotes/origin/HEAD[..]`
+[RUNNING] `git fetch --no-tags --verbose --force --update-head-ok [..][ROOTURL]/dep1[..] [..]+HEAD:refs/remotes/origin/HEAD[..]`
 From [ROOTURL]/dep1
  * [new ref] [..] -> origin/HEAD[..]
 [LOCKING] 1 package to latest compatible version


### PR DESCRIPTION
### What does this PR try to resolve?

Change Cargo to pass [`--no-tags`] Git CLI option by default. This aligns with how libgit2 works in Cargo.

Based on the Git official doc,
the flag has been there since at least 2.0.5

[`--no-tags`]: https://git-scm.com/docs/git-fetch/2.0.5#Documentation/git-fetch.txt---no-tags

### How should we test and review this PR?

Not sure if we want a test for this.
`CARGO_NET_GIT_FETCH_WITH_CLI` is barely tested.

### Additional information

Fixes #14687