### PR TITLE
fix(perf): switch global allocator to mimalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,6 +334,7 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "memchr",
+ "mimalloc",
  "opener",
  "openssl",
  "os_info",
@@ -2246,6 +2247,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libnghttp2-sys"
 version = "0.1.10+1.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2360,6 +2371,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ libc = "0.2.155"
 libgit2-sys = "0.17.0"
 libloading = "0.8.5"
 memchr = "2.7.4"
+mimalloc = "0.1.43"
 miow = "0.6.0"
 opener = "0.7.1"
 openssl = "=0.10.57" # See rust-lang/cargo#13546 and openssl/openssl#23376 for pinning
@@ -181,6 +182,7 @@ jobserver.workspace = true
 lazycell.workspace = true
 libgit2-sys.workspace = true
 memchr.workspace = true
+mimalloc = { workspace = true, optional = true }
 opener.workspace = true
 os_info.workspace = true
 pasetors.workspace = true
@@ -260,6 +262,7 @@ test = false
 doc = false
 
 [features]
+mimalloc = ["dep:mimalloc"]
 vendored-openssl = ["openssl/vendored"]
 vendored-libgit2 = ["libgit2-sys/vendored"]
 # This is primarily used by rust-lang/rust distributing cargo the executable.

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -1,5 +1,9 @@
 #![allow(clippy::self_named_module_files)] // false positive in `commands/build.rs`
 
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use cargo::core::features;
 use cargo::core::shell::Shell;
 use cargo::util::network::http::http_handle;


### PR DESCRIPTION
### What does this PR try to resolve?

Follow-up of https://github.com/Eh2406/pubgrub-crates-benchmark/issues/6#issuecomment-2408905423.

This PR uses `mimalloc` as the global allocator for `cargo`. This improves performance of the resolver by reducing allocation and deallocation cost. The performance gains are the same as with `jemalloc`, but `mimalloc` is compatible with Windows. 

Comparison of performance using `solana-core = "=1.0.5"` in `Cargo.toml`:

| allocator  | duration |
|------------|----------|
| system     | 66.3s    |
| jemalloc   | 57.7s    |
| mimalloc   | 58s      |

r? Eh2406