### PR TITLE
Fix typo in faq.md

### DIFF
--- a/src/doc/src/faq.md
+++ b/src/doc/src/faq.md
@@ -132,7 +132,7 @@ However, this determinism can give a false sense of security because
 `Cargo.lock` does not affect the consumers of your package, only `Cargo.toml` does that.
 For example:
 - [`cargo install`] will select the latest dependencies unless
- `[--locked`](commands/cargo.html#option-cargo---locked) is passed in.
+[`--locked`](commands/cargo.html#option-cargo---locked) is passed in.
 - New dependencies, like those added with [`cargo add`], will be locked to the latest version
 
 The lockfile can also be a source of merge conflicts.


### PR DESCRIPTION
The opening backtick for the code snippet was in the wrong place, causing the URL to not render correctly.

<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

I noticed a typo in the rust docs for Cargo.lock, and realized it was a simple markdown fix. This PR fixes the markdown typo. 

### How should we test and review this PR?

Take a look at the markdown preview for the changed file. 

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
