### PR TITLE
Help with [patch.crates.io]

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1920,8 +1920,13 @@ fn patch(
                 .or_else(|_| toml_url.into_url())
                 .with_context(|| {
                     format!(
-                        "[patch] entry `{}` should be a URL or registry name",
-                        toml_url
+                        "[patch] entry `{}` should be a URL or registry name{}",
+                        toml_url,
+                        if toml_url == "crates" {
+                            "\nFor crates.io, use [patch.crates-io] (with a dash)"
+                        } else {
+                            ""
+                        }
                     )
                 })?,
         };


### PR DESCRIPTION
This catches a syntactical mistake in TOML that's easy to make by patching `[patch.crates.io]` instead of `[patch.crates-io]`.


```diff
 error: failed to parse manifest at `Cargo.toml`
 
 Caused by:
   [patch] entry `crates` should be a URL or registry name
+  For crates.io, use [patch.crates-io] (with a dash)
 
 Caused by:
   invalid url `crates`: relative URL without a base
 ```
