### PR TITLE
refactor: use `Iterator::is_sorted`

### DIFF
--- a/src/cargo/ops/cargo_add/mod.rs
+++ b/src/cargo/ops/cargo_add/mod.rs
@@ -37,7 +37,6 @@ use crate::util::toml_mut::dependency::MaybeWorkspace;
 use crate::util::toml_mut::dependency::PathSource;
 use crate::util::toml_mut::dependency::Source;
 use crate::util::toml_mut::dependency::WorkspaceSource;
-use crate::util::toml_mut::is_sorted;
 use crate::util::toml_mut::manifest::DepTable;
 use crate::util::toml_mut::manifest::LocalManifest;
 use crate::CargoResult;
@@ -111,10 +110,14 @@ pub fn add(workspace: &Workspace<'_>, options: &AddOptions<'_>) -> CargoResult<(
         .map(TomlItem::as_table)
         .map_or(true, |table_option| {
             table_option.map_or(true, |table| {
-                is_sorted(table.get_values().iter_mut().map(|(key, _)| {
-                    // get_values key paths always have at least one key.
-                    key.remove(0)
-                }))
+                table
+                    .get_values()
+                    .iter_mut()
+                    .map(|(key, _)| {
+                        // get_values key paths always have at least one key.
+                        key.remove(0)
+                    })
+                    .is_sorted()
             })
         });
     for dep in deps {

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -1,7 +1,6 @@
 use crate::core::{Edition, Shell, Workspace};
 use crate::util::errors::CargoResult;
 use crate::util::important_paths::find_root_manifest_for_wd;
-use crate::util::toml_mut::is_sorted;
 use crate::util::{existing_vcs_repo, FossilRepo, GitRepo, HgRepo, PijulRepo};
 use crate::util::{restricted_names, GlobalContext};
 use anyhow::{anyhow, Context as _};
@@ -995,7 +994,7 @@ fn update_manifest_with_new_member(
             }
         }
 
-        let was_sorted = is_sorted(members.iter().map(Value::as_str));
+        let was_sorted = members.iter().map(Value::as_str).is_sorted();
         members.push(display_path);
         if was_sorted {
             members.sort_by(|lhs, rhs| lhs.as_str().cmp(&rhs.as_str()));

--- a/src/cargo/util/toml_mut/dependency.rs
+++ b/src/cargo/util/toml_mut/dependency.rs
@@ -14,7 +14,6 @@ use crate::core::SourceId;
 use crate::core::Summary;
 use crate::core::{Features, GitReference};
 use crate::util::toml::lookup_path_base;
-use crate::util::toml_mut::is_sorted;
 use crate::CargoResult;
 use crate::GlobalContext;
 
@@ -639,7 +638,7 @@ impl Dependency {
                             .collect::<Option<IndexSet<_>>>()
                     })
                     .unwrap_or_default();
-                let is_already_sorted = is_sorted(features.iter());
+                let is_already_sorted = features.iter().is_sorted();
                 features.extend(new_features.iter().map(|s| s.as_str()));
                 let features = if is_already_sorted {
                     features.into_iter().sorted().collect::<toml_edit::Value>()

--- a/src/cargo/util/toml_mut/mod.rs
+++ b/src/cargo/util/toml_mut/mod.rs
@@ -12,19 +12,3 @@
 pub mod dependency;
 pub mod manifest;
 pub mod upgrade;
-
-// Based on Iterator::is_sorted from nightly std; remove in favor of that when stabilized.
-pub fn is_sorted(mut it: impl Iterator<Item = impl PartialOrd>) -> bool {
-    let Some(mut last) = it.next() else {
-        return true;
-    };
-
-    for curr in it {
-        if curr < last {
-            return false;
-        }
-        last = curr;
-    }
-
-    true
-}


### PR DESCRIPTION
<!-- homu-ignore:start -->


### What does this PR try to resolve?

Switching to [`Iterator::is_sorted`](https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.is_sorted).

### How should we test and review this PR?

Should not affect any other things else.

<!-- homu-ignore:end -->
