### PR TITLE
fix(renovate): Switch matchPackageNames to matchDepNames

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -44,7 +44,7 @@
       matchManagers: [
         'custom.regex',
       ],
-      matchPackageNames: [
+      matchDepNames: [
         'MSRV:1',
       ],
       extractVersion: '^(?<version>\\d+\\.\\d+)',  // Drop the patch version
@@ -58,7 +58,7 @@
       matchManagers: [
         'custom.regex',
       ],
-      matchPackageNames: [
+      matchDepNames: [
         'MSRV:3',
       ],
       extractVersion: '^(?<version>\\d+\\.\\d+)',  // Drop the patch version


### PR DESCRIPTION
When talking to @weihanglo about #14703, it was noticed that `renovate` was ignoring `extractVersion` and `schedule` for [`MSRV:1`](https://github.com/rust-lang/cargo/blob/cf53cc54bb593b5ec3dc2be4b1702f50c36d24d5/.github/renovate.json5#L50-L53) and [`MSRV:3`](https://github.com/rust-lang/cargo/blob/cf53cc54bb593b5ec3dc2be4b1702f50c36d24d5/.github/renovate.json5#L64-L67). After a lot of digging into why that was happening, I figured out that it was caused by a [breaking change in `renovate@38`](https://github.com/renovatebot/renovate/releases/tag/38.0.0):
> **package-rules**: `matchPackageNames` and related functions no longer fall back to checking `depName`.

This change caused `renovate` to no longer apply the configuration from `packageRules` to `MSRV:1` and `MSRV:3` as the `customManagers` for both specified [`depNameTemplate`](https://github.com/rust-lang/cargo/blob/cf53cc54bb593b5ec3dc2be4b1702f50c36d24d5/.github/renovate.json5#L23) which is no longer being read.


To fix this issue, I changed `matchPackageNames` to `matchDepNames`, which solved the issue when I was testing locally.