### PR TITLE
 fix source replacement for deps

### DIFF
--- a/src/cargo/sources/replaced.rs
+++ b/src/cargo/sources/replaced.rs
@@ -73,7 +73,7 @@ impl<'gctx> Source for ReplacedSource<'gctx> {
 
         self.inner
             .query(&dep, kind, &mut |summary| {
-                f(summary.map_summary(|s| s.map_source(replace_with, to_replace)))
+                f(summary.map_summary(|s| s.map_source(to_replace, replace_with)))
             })
             .map_err(|e| {
                 if self.is_builtin_replacement() {

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -439,7 +439,7 @@ fn alt_registry_and_crates_io_deps() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] crates_io_dep v0.0.1 (registry `dummy-registry`)
 [DOWNLOADED] alt_reg_dep v0.1.0 (registry `alternative`)
-[CHECKING] crates_io_dep v0.0.1
+[CHECKING] crates_io_dep v0.0.1 (registry `dummy-registry`)
 [CHECKING] alt_reg_dep v0.1.0 (registry `alternative`)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1105,7 +1105,7 @@ fn alt_reg_metadata() {
       "edition": "2015",
       "features": {},
       "homepage": null,
-      "id": "registry+https://github.com/rust-lang/crates.io-index#bar@0.0.1",
+      "id": "registry+[ROOTURL]/registry#bar@0.0.1",
       "keywords": [],
       "license": null,
       "license_file": null,
@@ -1117,7 +1117,7 @@ fn alt_reg_metadata() {
       "readme": null,
       "repository": null,
       "rust_version": null,
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
+      "source": "registry+[ROOTURL]/registry",
       "targets": [
         {
           "crate_types": [
@@ -1225,7 +1225,7 @@ fn alt_reg_metadata() {
       "edition": "2015",
       "features": {},
       "homepage": null,
-      "id": "registry+https://github.com/rust-lang/crates.io-index#iodep@0.0.1",
+      "id": "registry+[ROOTURL]/registry#iodep@0.0.1",
       "keywords": [],
       "license": null,
       "license_file": null,
@@ -1237,7 +1237,7 @@ fn alt_reg_metadata() {
       "readme": null,
       "repository": null,
       "rust_version": null,
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
+      "source": "registry+[ROOTURL]/registry",
       "targets": [
         {
           "crate_types": [
@@ -1261,7 +1261,7 @@ fn alt_reg_metadata() {
     "nodes": [
       {
         "dependencies": [
-          "registry+https://github.com/rust-lang/crates.io-index#bar@0.0.1"
+          "registry+[ROOTURL]/registry#bar@0.0.1"
         ],
         "deps": [
           {
@@ -1272,7 +1272,7 @@ fn alt_reg_metadata() {
               }
             ],
             "name": "bar",
-            "pkg": "registry+https://github.com/rust-lang/crates.io-index#bar@0.0.1"
+            "pkg": "registry+[ROOTURL]/registry#bar@0.0.1"
           }
         ],
         "features": [],
@@ -1288,12 +1288,12 @@ fn alt_reg_metadata() {
         "dependencies": [],
         "deps": [],
         "features": [],
-        "id": "registry+https://github.com/rust-lang/crates.io-index#bar@0.0.1"
+        "id": "registry+[ROOTURL]/registry#bar@0.0.1"
       },
       {
         "dependencies": [
           "registry+[ROOTURL]/alternative-registry#altdep@0.0.1",
-          "registry+https://github.com/rust-lang/crates.io-index#iodep@0.0.1"
+          "registry+[ROOTURL]/registry#iodep@0.0.1"
         ],
         "deps": [
           {
@@ -1314,7 +1314,7 @@ fn alt_reg_metadata() {
               }
             ],
             "name": "iodep",
-            "pkg": "registry+https://github.com/rust-lang/crates.io-index#iodep@0.0.1"
+            "pkg": "registry+[ROOTURL]/registry#iodep@0.0.1"
           }
         ],
         "features": [],
@@ -1337,7 +1337,7 @@ fn alt_reg_metadata() {
           }
         ],
         "features": [],
-        "id": "registry+https://github.com/rust-lang/crates.io-index#iodep@0.0.1"
+        "id": "registry+[ROOTURL]/registry#iodep@0.0.1"
       }
     ],
     "root": "path+[ROOTURL]/foo#0.0.1"


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.
-->

### What does this PR try to resolve?
**one line** change to set the package source to be the actual registry when source replacement is used.

Example of this issue is demonstrated as:
 https://github.com/zhangweikop/cargo-dep-source-replace-issue
#### Details:

1.  The current dep resolve fail with *"conflict error"* when the resolve loop encounters the following items:
> a. packageX (that contains native link) whose registry has been explicitly specified as the source Y 
> b. the same package X whose source has been replaced by sourceY.

Such case are not uncommon in company with multiple teams where various teams may use:
For crate1:  its Cargo.toml has `packageX = { version = "1.2.3", registry = "SourceY" }`
For crate2: its Cargo.toml has `packageX = { version = "1.2.33" }` (with source replacement  "SourceY")
Also, packageX have some (transitive) dependency which has native links.
Now if a developer creates crate3 which depends on crate1&crate2. It would encounter failure.


Example of error is shown in the background. 
2. This new change will let the resolve process treat "same" dep package same and get rid of this "native link" conflict error.

3. This change should only affect the resolve process.
     The existing source download function has handled the source replacement properly.
     This change doesn't affect behavior of how the crate is packaged and published. 

4. ([wip] A bunch of tests output still need to be updated) 

#### Background:
Our company uses a private "registry" called "external" for the "crates-io". 
And when develop crate, we add the source replacement like the following to ".cargo/config.toml "
```
[source.crates-io]
replace-with = 'external'
```
It normally works well. However, it sometimes complains as:
```
failed to select a version for `wasm-bindgen-shared`.
    ... required by package `wasm-bindgen-macro-support v0.2.40`
    ... which satisfies dependency `wasm-bindgen-macro-support = "=0.2.40"` of package `wasm-bindgen-macro v0.2.40`
    ... which satisfies dependency `wasm-bindgen-macro = "=0.2.40"` of package `wasm-bindgen v0.2.40`
    ... which satisfies dependency `wasm-bindgen = "^0.2.23"` of package `js-sys v0.3.0`
    ... which satisfies dependency `js-sys = "^0.3"` of package `chrono v0.4.20`
    ... which satisfies dependency `chrono_0_4 = "^0.4.20"` of package `serde_with v3.3.0`
..
versions that meet the requirements `=0.2.40` are: 0.2.40

the package `wasm-bindgen-shared` links to the native library `wasm_bindgen`, but it conflicts with a previous package which links to `wasm_bindgen` as well:
package `wasm-bindgen-shared v0.2.95 (registry `external`)`
    ... which satisfies dependency `wasm-bindgen-shared = "=0.2.95"` (locked to 0.2.95) of package `wasm-bindgen-macro-support v0.2.95 (registry `external`)`
    ... which satisfies dependency `wasm-bindgen-macro-support = "=0.2.95"` (locked to 0.2.95) of package `wasm-bindgen-macro v0.2.95 (registry `external`)`
    ... which satisfies dependency `wasm-bindgen-macro = "=0.2.95"` (locked to 0.2.95) of package `wasm-bindgen v0.2.95 (registry `external`)`
    ... which satisfies dependency `wasm-bindgen = "^0.2.89"` (locked to 0.2.95) of package `reqwest v0.12.8 (registry `external`)`
    ... ..
```
It's sort of annoying because we don't even use any Wasm in our crates at all. The dependency system perform some check the , if two **different** [package ids link to](https://github.com/rust-lang/cargo/blob/master/src/cargo/core/resolver/mod.rs#L768) same native library, then resolve fails. But actually, all the packages are downloaded from the same source which is "external".
When I was trying to figure out what lead to: `Package(wasm-bindgen-shared, source="default crate-io") ! = Package(wasm-bindgen-shared, source="external")` . 
I notice "possible mistaken usage" of  `.map_source` in `sources/replaced.rs`.  
From the meaning, the dependency info from source which may be empty (treated as crates-io) should be explicitly set as the active source? 


### How should we test and review this PR?
Test building my crate using this new cargo fix. And it works.
 
I picked a few test and update it. It seems the new test output makes more sense?
 For example :`testsuite/alt_registry.rs` 

Considering this replace block in [test setup](https://github.com/rust-lang/cargo/blob/master/crates/cargo-test-support/src/registry.rs#L443C25-L443C56): the output should not show `github.com/rust-lang/crates.io-index`.

### Additional information
Would like to hear more opinions about this PR. 
If the fix makes sense, I would go ahead to fix other unit tests.


