### PR TITLE
fix: add source replacement info when no matching package found

### DIFF
--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -353,7 +353,13 @@ pub(super) fn activation_error(
             ));
             msg.push('\n');
         }
-        msg.push_str(&format!("location searched: {}\n", dep.source_id()));
+
+        let mut location_searched_msg = registry.describe_source(dep.source_id());
+        if location_searched_msg.is_empty() {
+            location_searched_msg = format!("{}", dep.source_id());
+        }
+
+        msg.push_str(&format!("location searched: {}\n", location_searched_msg));
         msg.push_str("required by ");
         msg.push_str(&describe_path_in_context(
             resolver_ctx,

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -6043,7 +6043,7 @@ fn avoid_dev_deps() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [ERROR] no matching package named `baz` found
-location searched: registry `crates-io`
+location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `bar v0.1.0 ([ROOT]/foo)`
 
 "#]])

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -199,7 +199,7 @@ Caused by:
   no matching package found
   searched package name: `baz`
   perhaps you meant:      bar or foo
-  location searched: registry `crates-io`
+  location searched: directory source `[ROOT]/index` (which is replacing registry `crates-io`)
   required by package `bar v0.1.0`
 
 "#]])
@@ -283,7 +283,7 @@ fn not_there() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] no matching package named `bar` found
-location searched: registry `crates-io`
+location searched: directory source `[ROOT]/index` (which is replacing registry `crates-io`)
 required by package `foo v0.1.0 ([ROOT]/foo)`
 
 "#]])

--- a/tests/testsuite/local_registry.rs
+++ b/tests/testsuite/local_registry.rs
@@ -101,7 +101,7 @@ fn not_found() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] no matching package named `baz` found
-location searched: registry `crates-io`
+location searched: `[ROOT]/registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.0.1 ([ROOT]/foo)`
 
 "#]])

--- a/tests/testsuite/offline.rs
+++ b/tests/testsuite/offline.rs
@@ -184,7 +184,7 @@ fn cargo_compile_offline_not_try_update() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] no matching package named `not_cached_dep` found
-location searched: registry `crates-io`
+location searched: crates.io index
 required by package `bar v0.1.0 ([ROOT]/bar)`
 As a reminder, you're using offline mode (--offline) which can sometimes cause surprising resolution failures, if this error is too confusing you may wish to retry without the offline flag.
 
@@ -195,7 +195,7 @@ As a reminder, you're using offline mode (--offline) which can sometimes cause s
     p.change_file(".cargo/config.toml", "net.offline = true");
     p.cargo("check").with_status(101).with_stderr_data(str![[r#"
 [ERROR] no matching package named `not_cached_dep` found
-location searched: registry `crates-io`
+location searched: crates.io index
 required by package `bar v0.1.0 ([ROOT]/bar)`
 As a reminder, you're using offline mode (--offline) which can sometimes cause surprising resolution failures, if this error is too confusing you may wish to retry without the offline flag.
 
@@ -383,18 +383,16 @@ fn update_offline_not_cached() {
         )
         .file("src/main.rs", "fn main() {}")
         .build();
+
     p.cargo("update --offline")
         .with_status(101)
-        .with_stderr_data(
-            "\
+        .with_stderr_data(str![["
 [ERROR] no matching package named `bar` found
-location searched: registry `crates-io`
+location searched: [..]
 required by package `foo v0.0.1 ([ROOT]/foo)`
-As a reminder, you're using offline mode (--offline) which can sometimes cause \
-surprising resolution failures, if this error is too confusing you may wish to \
-retry without the offline flag.
-",
-        )
+As a reminder, you're using offline mode (--offline) which can sometimes cause surprising resolution failures, if this error is too confusing you may wish to retry without the offline flag.
+
+"]])
         .run();
 }
 
@@ -756,7 +754,7 @@ fn main(){
         .with_stderr_data(
             str![[r#"
 [ERROR] no matching package named `present_dep` found
-location searched: registry `crates-io`
+location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.1.0 ([ROOT]/foo)`
 As a reminder, you're using offline mode (--offline) which can sometimes cause surprising resolution failures, if this error is too confusing you may wish to retry without the offline flag.
 

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -5312,7 +5312,7 @@ fn workspace_with_local_deps() {
 
 Caused by:
   no matching package named `level2` found
-  location searched: registry `crates-io`
+  location searched: crates.io index
   required by package `level1 v0.0.1 ([ROOT]/foo/level1)`
 
 "#]])
@@ -5496,7 +5496,7 @@ fn workspace_with_local_deps_packaging_one_fails() {
 
 Caused by:
   no matching package named `level2` found
-  location searched: registry `crates-io`
+  location searched: crates.io index
   required by package `level1 v0.0.1 ([ROOT]/foo/target/package/level1-0.0.1)`
 
 "#]])
@@ -5523,7 +5523,7 @@ fn workspace_with_local_deps_packaging_one_fails_nightly() {
 
 Caused by:
   no matching package named `level2` found
-  location searched: registry `crates-io`
+  location searched: crates.io index
   required by package `level1 v0.0.1 ([ROOT]/foo/target/package/level1-0.0.1)`
 
 "#]])
@@ -5589,7 +5589,7 @@ fn workspace_with_local_deps_packaging_one_bin_fails() {
 
 Caused by:
   no matching package named `level2` found
-  location searched: registry `crates-io`
+  location searched: crates.io index
   required by package `level1 v0.0.1 ([ROOT]/foo/level1)`
 
 "#]])
@@ -5809,7 +5809,7 @@ fn workspace_with_local_deps_index_mismatch() {
 
 Caused by:
   no matching package named `level2` found
-  location searched: registry `crates-io`
+  location searched: crates.io index
   required by package `level1 v0.0.1 ([ROOT]/foo/level1)`
 
 "#]])
@@ -6620,7 +6620,7 @@ fn unpublishable_dependency() {
 
 Caused by:
   no matching package named `dep` found
-  location searched: registry `alternative`
+  location searched: `alternative` index
   required by package `main v0.0.1 ([ROOT]/foo/main)`
 
 "#]])

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -3932,7 +3932,7 @@ fn workspace_missing_dependency() {
 
 Caused by:
   no matching package named `a` found
-  location searched: registry `crates-io`
+  location searched: crates.io index
   required by package `b v0.0.1 ([ROOT]/foo/target/package/b-0.0.1)`
 
 "#]])

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -167,7 +167,7 @@ fn nonexistent_http() {
     nonexistent(str![[r#"
 [UPDATING] `dummy-registry` index
 [ERROR] no matching package named `nonexistent` found
-location searched: registry `crates-io`
+location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.0.1 ([ROOT]/foo)`
 
 "#]]);
@@ -178,7 +178,7 @@ fn nonexistent_git() {
     nonexistent(str![[r#"
 [UPDATING] `dummy-registry` index
 [ERROR] no matching package named `nonexistent` found
-location searched: registry `crates-io`
+location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.0.1 ([ROOT]/foo)`
 
 "#]]);
@@ -218,7 +218,7 @@ fn wrong_case_http() {
 [ERROR] no matching package found
 searched package name: `Init`
 perhaps you meant:      init
-location searched: registry `crates-io`
+location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.0.1 ([ROOT]/foo)`
 
 "#]]);
@@ -231,7 +231,7 @@ fn wrong_case_git() {
 [ERROR] no matching package found
 searched package name: `Init`
 perhaps you meant:      init
-location searched: registry `crates-io`
+location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.0.1 ([ROOT]/foo)`
 
 "#]]);
@@ -272,7 +272,7 @@ fn mis_hyphenated_http() {
 [ERROR] no matching package found
 searched package name: `mis_hyphenated`
 perhaps you meant:      mis-hyphenated
-location searched: registry `crates-io`
+location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.0.1 ([ROOT]/foo)`
 
 "#]]);
@@ -285,7 +285,7 @@ fn mis_hyphenated_git() {
 [ERROR] no matching package found
 searched package name: `mis_hyphenated`
 perhaps you meant:      mis-hyphenated
-location searched: registry `crates-io`
+location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.0.1 ([ROOT]/foo)`
 
 "#]]);
@@ -468,7 +468,7 @@ fn update_registry_http() {
         str![[r#"
 [UPDATING] `dummy-registry` index
 [ERROR] no matching package named `notyet` found
-location searched: registry `crates-io`
+location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.0.1 ([ROOT]/foo)`
 
 "#]],
@@ -491,7 +491,7 @@ fn update_registry_git() {
         str![[r#"
 [UPDATING] `dummy-registry` index
 [ERROR] no matching package named `notyet` found
-location searched: registry `crates-io`
+location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.0.1 ([ROOT]/foo)`
 
 "#]],
@@ -551,7 +551,7 @@ fn package_with_path_deps_http() {
 
 Caused by:
   no matching package named `notyet` found
-  location searched: registry `crates-io`
+  location searched: `dummy-registry` index (which is replacing registry `crates-io`)
   required by package `foo v0.0.1 ([ROOT]/foo)`
 
 "#]],
@@ -580,7 +580,7 @@ fn package_with_path_deps_git() {
 
 Caused by:
   no matching package named `notyet` found
-  location searched: registry `crates-io`
+  location searched: `dummy-registry` index (which is replacing registry `crates-io`)
   required by package `foo v0.0.1 ([ROOT]/foo)`
 
 "#]],
@@ -925,7 +925,7 @@ fn yanks_in_lockfiles_are_ok_http() {
         str![[r#"
 [UPDATING] `dummy-registry` index
 [ERROR] no matching package named `bar` found
-location searched: registry `crates-io`
+location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.0.1 ([ROOT]/foo)`
 
 "#]],
@@ -942,7 +942,7 @@ fn yanks_in_lockfiles_are_ok_git() {
         str![[r#"
 [UPDATING] `dummy-registry` index
 [ERROR] no matching package named `bar` found
-location searched: registry `crates-io`
+location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.0.1 ([ROOT]/foo)`
 
 "#]],
@@ -994,7 +994,7 @@ fn yanks_in_lockfiles_are_ok_for_other_update_http() {
         str![[r#"
 [UPDATING] `dummy-registry` index
 [ERROR] no matching package named `bar` found
-location searched: registry `crates-io`
+location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.0.1 ([ROOT]/foo)`
 
 "#]],
@@ -1017,7 +1017,7 @@ fn yanks_in_lockfiles_are_ok_for_other_update_git() {
         str![[r#"
 [UPDATING] `dummy-registry` index
 [ERROR] no matching package named `bar` found
-location searched: registry `crates-io`
+location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.0.1 ([ROOT]/foo)`
 
 "#]],
@@ -3226,7 +3226,7 @@ fn unknown_index_version_error() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [ERROR] no matching package named `bar` found
-location searched: registry `crates-io`
+location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.1.0 ([ROOT]/foo)`
 
 "#]])
@@ -3769,7 +3769,7 @@ foo v0.1.0 ([ROOT]/foo)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [ERROR] no matching package named `bar` found
-location searched: registry `crates-io`
+location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.1.0 ([ROOT]/foo)`
 
 "#]])
@@ -3863,7 +3863,7 @@ fn not_found_permutations() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [ERROR] no matching package named `a-b_c` found
-location searched: registry `crates-io`
+location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.0.1 ([ROOT]/foo)`
 
 "#]])

--- a/tests/testsuite/source_replacement.rs
+++ b/tests/testsuite/source_replacement.rs
@@ -320,7 +320,7 @@ fn source_replacement_with_no_package_in_directoy() {
         r#"
             [source.crates-io]
             replace-with = "vendored-sources"
-    
+
             [source.vendored-sources]
             directory = "vendor"
         "#
@@ -331,7 +331,7 @@ fn source_replacement_with_no_package_in_directoy() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] no matching package named `bar` found
-location searched: registry `crates-io`
+location searched: directory source `[ROOT]/vendor` (which is replacing registry `crates-io`)
 required by package `foo v0.1.0 ([ROOT]/foo)`
 
 "#]])

--- a/tests/testsuite/source_replacement.rs
+++ b/tests/testsuite/source_replacement.rs
@@ -294,3 +294,46 @@ fn source_replacement_with_registry_url() {
 "#]])
         .run();
 }
+
+#[cargo_test]
+fn source_replacement_with_no_package_in_directoy() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                bar = { version = "^0.8.9" }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    let root = paths::root();
+    t!(fs::create_dir(&root.join("vendor")));
+
+    let crates_io = setup_replacement(&format!(
+        r#"
+            [source.crates-io]
+            replace-with = "vendored-sources"
+    
+            [source.vendored-sources]
+            directory = "vendor"
+        "#
+    ));
+
+    p.cargo("build")
+        .replace_crates_io(crates_io.index_url())
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] no matching package named `bar` found
+location searched: registry `crates-io`
+required by package `foo v0.1.0 ([ROOT]/foo)`
+
+"#]])
+        .run();
+}

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -456,7 +456,7 @@ perhaps a crate was updated and forgotten to be re-vendored?
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [ERROR] no matching package named `serde` found
-location searched: registry `crates-io`
+location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `bar v0.0.1 ([ROOT]/foo)`
 
 "#]])
@@ -997,7 +997,7 @@ Caused by:
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [ERROR] no matching package named `bar` found
-location searched: registry `crates-io`
+location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.1.0 ([ROOT]/foo)`
 
 "#]])
@@ -1017,7 +1017,7 @@ required by package `foo v0.1.0 ([ROOT]/foo)`
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [ERROR] no matching package named `bar` found
-location searched: registry `crates-io`
+location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.1.0 ([ROOT]/foo)`
 
 "#]])


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes #14697 

I updated error message in `resolver/errors` with [Registry::describe_source](https://doc.rust-lang.org/nightly/nightly-rustc/cargo/core/registry/trait.Registry.html#tymethod.describe_source)

- Use message from `Registry::describe_source` as default message
- If the message is empty, use `SourceId` message

and I also updated related test cases.

### How should we test and review this PR?

1. Run following test cases:

- resolver-tests
- source_replacement
- build
- directory
- local_registry
- offline
- package
- publish
- registry
- update

2. Run [cargo-bug.zip](https://github.com/user-attachments/files/17493272/cargo-bug.zip)

- Unpack the zip archive
- Run `cargo build` in the root

following message should be seen:
```
error: no matching package named `ahasha` found
location searched: directory source `/home/foo/Desktop/cargo-bug/vendor` (which is replacing registry `crates-io`)
required by package `example v0.1.0 (/home/foo/Desktop/cargo-bug)`
```