### PR TITLE
test(install): Verify 2024 edition / resolver=3 doesn't affect resolution

### DIFF
--- a/crates/cargo-test-support/src/registry.rs
+++ b/crates/cargo-test-support/src/registry.rs
@@ -571,6 +571,7 @@ pub struct Package {
     local: bool,
     alternative: bool,
     invalid_json: bool,
+    edition: Option<String>,
     resolver: Option<String>,
     proc_macro: bool,
     links: Option<String>,
@@ -1251,6 +1252,7 @@ impl Package {
             local: false,
             alternative: false,
             invalid_json: false,
+            edition: None,
             resolver: None,
             proc_macro: false,
             links: None,
@@ -1384,6 +1386,12 @@ impl Package {
     /// Specifies whether or not the package is "yanked".
     pub fn yanked(&mut self, yanked: bool) -> &mut Package {
         self.yanked = yanked;
+        self
+    }
+
+    /// Specifies `package.edition`
+    pub fn edition(&mut self, edition: &str) -> &mut Package {
+        self.edition = Some(edition.to_owned());
         self
     }
 
@@ -1579,6 +1587,10 @@ impl Package {
 
         if let Some(version) = &self.rust_version {
             manifest.push_str(&format!("rust-version = \"{}\"\n", version));
+        }
+
+        if let Some(edition) = &self.edition {
+            manifest.push_str(&format!("edition = \"{}\"\n", edition));
         }
 
         if let Some(resolver) = &self.resolver {

--- a/crates/cargo-test-support/src/registry.rs
+++ b/crates/cargo-test-support/src/registry.rs
@@ -571,6 +571,7 @@ pub struct Package {
     local: bool,
     alternative: bool,
     invalid_json: bool,
+    resolver: Option<String>,
     proc_macro: bool,
     links: Option<String>,
     rust_version: Option<String>,
@@ -1250,6 +1251,7 @@ impl Package {
             local: false,
             alternative: false,
             invalid_json: false,
+            resolver: None,
             proc_macro: false,
             links: None,
             rust_version: None,
@@ -1382,6 +1384,12 @@ impl Package {
     /// Specifies whether or not the package is "yanked".
     pub fn yanked(&mut self, yanked: bool) -> &mut Package {
         self.yanked = yanked;
+        self
+    }
+
+    /// Specifies `package.resolver`
+    pub fn resolver(&mut self, resolver: &str) -> &mut Package {
+        self.resolver = Some(resolver.to_owned());
         self
     }
 
@@ -1570,7 +1578,11 @@ impl Package {
         ));
 
         if let Some(version) = &self.rust_version {
-            manifest.push_str(&format!("rust-version = \"{}\"", version));
+            manifest.push_str(&format!("rust-version = \"{}\"\n", version));
+        }
+
+        if let Some(resolver) = &self.resolver {
+            manifest.push_str(&format!("resolver = \"{}\"\n", resolver));
         }
 
         if !self.features.is_empty() {

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -998,6 +998,46 @@ fn cargo_install_ignores_resolver_v3_msrv_change() {
         .run();
 }
 
+#[cargo_test(nightly, reason = "edition2024 in rustc is unstable")]
+fn cargo_install_ignores_edition_2024_msrv_change() {
+    Package::new("dep", "1.0.0")
+        .rust_version("1.50")
+        .file("src/lib.rs", "fn hello() {}")
+        .publish();
+    Package::new("dep", "1.1.0")
+        .rust_version("1.70")
+        .file("src/lib.rs", "fn hello() {}")
+        .publish();
+    Package::new("foo", "0.0.1")
+        .rust_version("1.60")
+        .cargo_feature("edition2024")
+        .edition("2024")
+        .file("src/main.rs", "fn main() {}")
+        .dep("dep", "1")
+        .publish();
+
+    cargo_process("install foo")
+        .arg("-Zmsrv-policy")
+        .masquerade_as_nightly_cargo(&["edition2024", "msrv-policy"])
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
+[INSTALLING] foo v0.0.1
+[LOCKING] 1 package to latest compatible version
+[DOWNLOADING] crates ...
+[DOWNLOADED] dep v1.1.0 (registry `dummy-registry`)
+[COMPILING] dep v1.1.0
+[COMPILING] foo v0.0.1
+[FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
+[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
+[INSTALLED] package `foo v0.0.1` (executable `foo[EXE]`)
+[WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
+
+"#]])
+        .run();
+}
+
 #[cargo_test]
 fn report_rust_versions() {
     Package::new("dep-only-low-compatible", "1.55.0")

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -958,6 +958,46 @@ fn cargo_install_ignores_msrv_config() {
         .run();
 }
 
+#[cargo_test(nightly, reason = "edition2024 in rustc is unstable")]
+fn cargo_install_ignores_resolver_v3_msrv_change() {
+    Package::new("dep", "1.0.0")
+        .rust_version("1.50")
+        .file("src/lib.rs", "fn hello() {}")
+        .publish();
+    Package::new("dep", "1.1.0")
+        .rust_version("1.70")
+        .file("src/lib.rs", "fn hello() {}")
+        .publish();
+    Package::new("foo", "0.0.1")
+        .rust_version("1.60")
+        .cargo_feature("edition2024")
+        .resolver("3")
+        .file("src/main.rs", "fn main() {}")
+        .dep("dep", "1")
+        .publish();
+
+    cargo_process("install foo")
+        .arg("-Zmsrv-policy")
+        .masquerade_as_nightly_cargo(&["edition2024", "msrv-policy"])
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
+[INSTALLING] foo v0.0.1
+[LOCKING] 1 package to latest compatible version
+[DOWNLOADING] crates ...
+[DOWNLOADED] dep v1.1.0 (registry `dummy-registry`)
+[COMPILING] dep v1.1.0
+[COMPILING] foo v0.0.1
+[FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
+[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
+[INSTALLED] package `foo v0.0.1` (executable `foo[EXE]`)
+[WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
+
+"#]])
+        .run();
+}
+
 #[cargo_test]
 fn report_rust_versions() {
     Package::new("dep-only-low-compatible", "1.55.0")


### PR DESCRIPTION
### What does this PR try to resolve?

I was worried there might be bugs related to this.  With this out of the way, I think we'll be ready to stabilize `resolver = "3"`.

### How should we test and review this PR?

### Additional information
