### PR TITLE
refactor(env): remove unnecessary clones

### DIFF
--- a/src/cargo/core/compiler/fingerprint/mod.rs
+++ b/src/cargo/core/compiler/fingerprint/mod.rs
@@ -837,31 +837,26 @@ impl LocalFingerprint {
                 };
                 for (key, previous) in info.env.iter() {
                     let current = if key == CARGO_ENV {
-                        Some(
-                            cargo_exe
-                                .to_str()
-                                .ok_or_else(|| {
-                                    format_err!(
-                                        "cargo exe path {} must be valid UTF-8",
-                                        cargo_exe.display()
-                                    )
-                                })?
-                                .to_string(),
-                        )
+                        Some(cargo_exe.to_str().ok_or_else(|| {
+                            format_err!(
+                                "cargo exe path {} must be valid UTF-8",
+                                cargo_exe.display()
+                            )
+                        })?)
                     } else {
                         if let Some(value) = gctx.env_config()?.get(key) {
-                            value.to_str().and_then(|s| Some(s.to_string()))
+                            value.to_str()
                         } else {
                             gctx.get_env(key).ok()
                         }
                     };
-                    if current == *previous {
+                    if current == previous.as_deref() {
                         continue;
                     }
                     return Ok(Some(StaleItem::ChangedEnv {
                         var: key.clone(),
                         previous: previous.clone(),
-                        current,
+                        current: current.map(Into::into),
                     }));
                 }
                 if *checksum {

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -669,7 +669,7 @@ where
         debug_assert!(res.is_err());
         let mut attempts = vec![String::from("git")];
         if let Ok(s) = gctx.get_env("USER").or_else(|_| gctx.get_env("USERNAME")) {
-            attempts.push(s);
+            attempts.push(s.to_string());
         }
         if let Some(ref s) = cred_helper.username {
             attempts.push(s.clone());

--- a/src/cargo/util/context/mod.rs
+++ b/src/cargo/util/context/mod.rs
@@ -815,7 +815,7 @@ impl GlobalContext {
     /// [`GlobalContext`].
     ///
     /// This can be used similarly to [`std::env::var`].
-    pub fn get_env(&self, key: impl AsRef<OsStr>) -> CargoResult<String> {
+    pub fn get_env(&self, key: impl AsRef<OsStr>) -> CargoResult<&str> {
         self.env.get_env(key)
     }
 
@@ -823,7 +823,7 @@ impl GlobalContext {
     /// [`GlobalContext`].
     ///
     /// This can be used similarly to [`std::env::var_os`].
-    pub fn get_env_os(&self, key: impl AsRef<OsStr>) -> Option<OsString> {
+    pub fn get_env_os(&self, key: impl AsRef<OsStr>) -> Option<&OsStr> {
         self.env.get_env_os(key)
     }
 


### PR DESCRIPTION
### What does this PR try to resolve?

This was found during the review of #14701.

Not every environment variable access requires an owned type.
To be precise, most of our usages don't.

### How should we test and review this PR?

Refactor only. Should not have any change in behavior.

One drawback is that the fn signatures deviate from `std::env::var{_os}`.
