### PR TITLE
Enable LTO for profile.release and profile.bench in new packages

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -784,6 +784,9 @@ fn mk(gctx: &GlobalContext, opts: &MkOptions<'_>) -> CargoResult<()> {
         manifest["profile.release"]["lto"] = toml_edit::value(true);
     }
 
+    manifest["profile.bench"] = toml_edit::Item::Table(toml_edit::Table::new());
+    manifest["profile.bench"]["lto"] = toml_edit::value(true);
+
     // Calculate what `[lib]` and `[[bin]]`s we need to append to `Cargo.toml`.
     for i in &opts.source_files {
         if i.bin {

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -779,6 +779,11 @@ fn mk(gctx: &GlobalContext, opts: &MkOptions<'_>) -> CargoResult<()> {
     let dep_table = toml_edit::Table::default();
     manifest["dependencies"] = toml_edit::Item::Table(dep_table);
 
+    if opts.source_files.iter().any(|i| i.bin) {
+        manifest["profile.release"] = toml_edit::Item::Table(toml_edit::Table::new());
+        manifest["profile.release"]["lto"] = toml_edit::value(true);
+    }
+
     // Calculate what `[lib]` and `[[bin]]`s we need to append to `Cargo.toml`.
     for i in &opts.source_files {
         if i.bin {

--- a/tests/testsuite/cargo_init/auto_git/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/auto_git/out/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_init/bin_already_exists_explicit/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/bin_already_exists_explicit/out/Cargo.toml
@@ -4,3 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+["profile.release"]
+lto = true
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_init/bin_already_exists_explicit_nosrc/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/bin_already_exists_explicit_nosrc/out/Cargo.toml
@@ -5,6 +5,12 @@ edition = "2021"
 
 [dependencies]
 
+["profile.release"]
+lto = true
+
+["profile.bench"]
+lto = true
+
 [[bin]]
 name = "case"
 path = "main.rs"

--- a/tests/testsuite/cargo_init/bin_already_exists_implicit/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/bin_already_exists_implicit/out/Cargo.toml
@@ -4,3 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+["profile.release"]
+lto = true
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_init/bin_already_exists_implicit_namenosrc/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/bin_already_exists_implicit_namenosrc/out/Cargo.toml
@@ -5,6 +5,12 @@ edition = "2021"
 
 [dependencies]
 
+["profile.release"]
+lto = true
+
+["profile.bench"]
+lto = true
+
 [[bin]]
 name = "case"
 path = "case.rs"

--- a/tests/testsuite/cargo_init/bin_already_exists_implicit_namesrc/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/bin_already_exists_implicit_namesrc/out/Cargo.toml
@@ -5,6 +5,12 @@ edition = "2021"
 
 [dependencies]
 
+["profile.release"]
+lto = true
+
+["profile.bench"]
+lto = true
+
 [[bin]]
 name = "case"
 path = "src/case.rs"

--- a/tests/testsuite/cargo_init/bin_already_exists_implicit_nosrc/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/bin_already_exists_implicit_nosrc/out/Cargo.toml
@@ -5,6 +5,12 @@ edition = "2021"
 
 [dependencies]
 
+["profile.release"]
+lto = true
+
+["profile.bench"]
+lto = true
+
 [[bin]]
 name = "case"
 path = "main.rs"

--- a/tests/testsuite/cargo_init/creates_binary_when_both_binlib_present/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/creates_binary_when_both_binlib_present/out/Cargo.toml
@@ -5,6 +5,12 @@ edition = "2021"
 
 [dependencies]
 
+["profile.release"]
+lto = true
+
+["profile.bench"]
+lto = true
+
 [[bin]]
 name = "case"
 path = "case.rs"

--- a/tests/testsuite/cargo_init/creates_binary_when_instructed_and_has_lib_file/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/creates_binary_when_instructed_and_has_lib_file/out/Cargo.toml
@@ -5,6 +5,12 @@ edition = "2021"
 
 [dependencies]
 
+["profile.release"]
+lto = true
+
+["profile.bench"]
+lto = true
+
 [[bin]]
 name = "case"
 path = "case.rs"

--- a/tests/testsuite/cargo_init/creates_library_when_instructed_and_has_bin_file/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/creates_library_when_instructed_and_has_bin_file/out/Cargo.toml
@@ -5,5 +5,8 @@ edition = "2021"
 
 [dependencies]
 
+["profile.bench"]
+lto = true
+
 [lib]
 path = "case.rs"

--- a/tests/testsuite/cargo_init/explicit_bin_with_git/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/explicit_bin_with_git/out/Cargo.toml
@@ -4,3 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+["profile.release"]
+lto = true
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_init/formats_source/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/formats_source/out/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_init/fossil_autodetect/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/fossil_autodetect/out/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_init/git_autodetect/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/git_autodetect/out/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_init/git_ignore_exists_no_conflicting_entries/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/git_ignore_exists_no_conflicting_entries/out/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2015"
 
 [dependencies]
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_init/ignores_failure_to_format_source/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/ignores_failure_to_format_source/out/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_init/inferred_bin_with_git/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/inferred_bin_with_git/out/Cargo.toml
@@ -5,6 +5,12 @@ edition = "2021"
 
 [dependencies]
 
+["profile.release"]
+lto = true
+
+["profile.bench"]
+lto = true
+
 [[bin]]
 name = "case"
 path = "main.rs"

--- a/tests/testsuite/cargo_init/inferred_lib_with_git/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/inferred_lib_with_git/out/Cargo.toml
@@ -5,5 +5,8 @@ edition = "2021"
 
 [dependencies]
 
+["profile.bench"]
+lto = true
+
 [lib]
 path = "lib.rs"

--- a/tests/testsuite/cargo_init/inherit_workspace_package_table/out/crates/foo/Cargo.toml
+++ b/tests/testsuite/cargo_init/inherit_workspace_package_table/out/crates/foo/Cargo.toml
@@ -17,3 +17,9 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
+
+["profile.release"]
+lto = true
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_init/lib_already_exists_nosrc/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/lib_already_exists_nosrc/out/Cargo.toml
@@ -5,5 +5,8 @@ edition = "2021"
 
 [dependencies]
 
+["profile.bench"]
+lto = true
+
 [lib]
 path = "lib.rs"

--- a/tests/testsuite/cargo_init/lib_already_exists_src/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/lib_already_exists_src/out/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_init/mercurial_autodetect/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/mercurial_autodetect/out/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_init/path_contains_separator/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/path_contains_separator/out/Cargo.toml
@@ -4,3 +4,9 @@ version = "0.1.0"
 edition = "2015"
 
 [dependencies]
+
+["profile.release"]
+lto = true
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_init/pijul_autodetect/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/pijul_autodetect/out/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_init/simple_bin/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/simple_bin/out/Cargo.toml
@@ -4,3 +4,9 @@ version = "0.1.0"
 edition = "2015"
 
 [dependencies]
+
+["profile.release"]
+lto = true
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_init/simple_git/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/simple_git/out/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_init/simple_git_ignore_exists/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/simple_git_ignore_exists/out/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2015"
 
 [dependencies]
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_init/simple_hg/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/simple_hg/out/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_init/simple_hg_ignore_exists/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/simple_hg_ignore_exists/out/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_init/simple_lib/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/simple_lib/out/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2015"
 
 [dependencies]
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_init/with_argument/out/foo/Cargo.toml
+++ b/tests/testsuite/cargo_init/with_argument/out/foo/Cargo.toml
@@ -4,3 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+["profile.release"]
+lto = true
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_init/workspace_add_member/out/crates/foo/Cargo.toml
+++ b/tests/testsuite/cargo_init/workspace_add_member/out/crates/foo/Cargo.toml
@@ -4,3 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+["profile.release"]
+lto = true
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_new/add_members_to_non_workspace/out/bar/Cargo.toml
+++ b/tests/testsuite/cargo_new/add_members_to_non_workspace/out/bar/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_new/add_members_to_workspace_format_previous_items/out/crates/foo/Cargo.toml
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_format_previous_items/out/crates/foo/Cargo.toml
@@ -5,3 +5,9 @@ edition = "2021"
 authors.workspace = true
 
 [dependencies]
+
+["profile.release"]
+lto = true
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_new/add_members_to_workspace_format_sorted/out/crates/foo/Cargo.toml
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_format_sorted/out/crates/foo/Cargo.toml
@@ -4,3 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+["profile.release"]
+lto = true
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_new/add_members_to_workspace_with_absolute_package_path/out/crates/foo/Cargo.toml
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_with_absolute_package_path/out/crates/foo/Cargo.toml
@@ -4,3 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+["profile.release"]
+lto = true
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_new/add_members_to_workspace_with_empty_members/out/crates/foo/Cargo.toml
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_with_empty_members/out/crates/foo/Cargo.toml
@@ -4,3 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+["profile.release"]
+lto = true
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_new/add_members_to_workspace_with_exclude_list/out/crates/foo/Cargo.toml
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_with_exclude_list/out/crates/foo/Cargo.toml
@@ -4,3 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+["profile.release"]
+lto = true
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_new/add_members_to_workspace_with_members_glob/out/crates/foo/Cargo.toml
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_with_members_glob/out/crates/foo/Cargo.toml
@@ -4,3 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+["profile.release"]
+lto = true
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_new/add_members_to_workspace_without_members/out/bar/Cargo.toml
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_without_members/out/bar/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_new/ignore_current_dir_workspace/out/out-of-workspace/Cargo.toml
+++ b/tests/testsuite/cargo_new/ignore_current_dir_workspace/out/out-of-workspace/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_new/inherit_workspace_lints/out/crates/foo/Cargo.toml
+++ b/tests/testsuite/cargo_new/inherit_workspace_lints/out/crates/foo/Cargo.toml
@@ -5,5 +5,11 @@ edition = "2021"
 
 [dependencies]
 
+["profile.release"]
+lto = true
+
+["profile.bench"]
+lto = true
+
 [lints]
 workspace = true

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table/out/crates/foo/Cargo.toml
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table/out/crates/foo/Cargo.toml
@@ -17,3 +17,9 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
+
+["profile.release"]
+lto = true
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table_with_edition/out/crates/foo/Cargo.toml
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table_with_edition/out/crates/foo/Cargo.toml
@@ -17,3 +17,9 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
+
+["profile.release"]
+lto = true
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table_with_registry/out/crates/foo/Cargo.toml
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table_with_registry/out/crates/foo/Cargo.toml
@@ -17,3 +17,9 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
+
+["profile.release"]
+lto = true
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table_without_version/out/crates/foo/Cargo.toml
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table_without_version/out/crates/foo/Cargo.toml
@@ -17,3 +17,9 @@ publish.workspace = true
 repository.workspace = true
 
 [dependencies]
+
+["profile.release"]
+lto = true
+
+["profile.bench"]
+lto = true

--- a/tests/testsuite/cargo_new/not_inherit_workspace_package_table_if_not_members/out/bar/Cargo.toml
+++ b/tests/testsuite/cargo_new/not_inherit_workspace_package_table_if_not_members/out/bar/Cargo.toml
@@ -4,3 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+["profile.release"]
+lto = true
+
+["profile.bench"]
+lto = true


### PR DESCRIPTION
Hi!

This PR enables fat Link-Time Optimization (LTO) by default for new packages which are started via `cargo init` command. To speed-up development cycle, LTO is enabled only for performance-related build types (`release`, `bench`). For library targets, only `bench` profile gets enabled LTO.

The main advantage is that new projects will no longer need to enable LTO manually. This means users will benefit from binaries that are a bit more optimized for both size and speed just from the start of their projects. Since projects are generally small in the early stages, this change should not significantly impact compilation time or memory usage — these issues usually arise only in the compilation with LTO of really large projects.

This PR does not affect existing packages. I've test these changes via `cargo test` command or more precisely:
```bash
cargo test --test testsuite -- cargo_init::
cargo test --test testsuite -- cargo_new::
```
because only these tests were affected by my changes.

Hope these changes will be merged and all Rust community gets faster packages from scratch :) 