### PR TITLE
[beta-1.83] fix(publish): Downgrade version-exists error to warning on dry-run 

### DIFF
--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -150,6 +150,16 @@ fn duplicate_version() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
+    p.cargo("publish --dry-run")
+        .replace_crates_io(registry_dupl.index_url())
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[UPDATING] crates.io index
+[ERROR] crate foo@0.0.1 already exists on crates.io index
+
+"#]])
+        .run();
+
     p.cargo("publish")
         .replace_crates_io(registry_dupl.index_url())
         .with_status(101)

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -152,10 +152,19 @@ fn duplicate_version() {
 
     p.cargo("publish --dry-run")
         .replace_crates_io(registry_dupl.index_url())
-        .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] crates.io index
-[ERROR] crate foo@0.0.1 already exists on crates.io index
+[WARNING] crate foo@0.0.1 already exists on crates.io index
+[WARNING] manifest has no documentation, homepage or repository.
+See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
+[PACKAGING] foo v0.0.1 ([ROOT]/foo)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[VERIFYING] foo v0.0.1 ([ROOT]/foo)
+[WARNING] no edition set: defaulting to the 2015 edition while the latest is 2021
+[COMPILING] foo v0.0.1 ([ROOT]/foo/target/package/foo-0.0.1)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[UPLOADING] foo v0.0.1 ([ROOT]/foo)
+[WARNING] aborting upload due to dry run
 
 "#]])
         .run();


### PR DESCRIPTION
Beta backports

* #14742

In order to make CI pass, the following PRs are also cherry-picked:

* 
