### PR TITLE
fix: env table config can't trigger rebuild with `rerun-if-env-changed`.

### DIFF
--- a/tests/testsuite/build_script_env.rs
+++ b/tests/testsuite/build_script_env.rs
@@ -415,6 +415,7 @@ fn rerun_if_env_is_exsited_config() {
 
     p.cargo(r#"check --config 'env.FOO="bar"'"#)
         .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -445,6 +446,7 @@ fn rerun_if_env_newly_added_in_config() {
 
     p.cargo(r#"check --config 'env.FOO="foo"'"#)
         .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])

--- a/tests/testsuite/build_script_env.rs
+++ b/tests/testsuite/build_script_env.rs
@@ -383,3 +383,70 @@ fn rustc_cfg_with_and_without_value() {
     );
     check.run();
 }
+
+#[cargo_test]
+fn rerun_if_env_is_exsited_config() {
+    let p = project()
+        .file("src/main.rs", "fn main() {}")
+        .file(
+            "build.rs",
+            r#"
+            fn main() {
+                println!("cargo::rerun-if-env-changed=FOO");
+            }
+        "#,
+        )
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [env]
+            FOO = "foo"
+            "#,
+        )
+        .build();
+
+    p.cargo("check")
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+
+    p.cargo(r#"check --config 'env.FOO="bar"'"#)
+        .with_stderr_data(str![[r#"
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn rerun_if_env_newly_added_in_config() {
+    let p = project()
+        .file("src/main.rs", "fn main() {}")
+        .file(
+            "build.rs",
+            r#"
+            fn main() {
+                println!("cargo::rerun-if-env-changed=FOO");
+            }
+        "#,
+        )
+        .build();
+
+    p.cargo("check")
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+
+    p.cargo(r#"check --config 'env.FOO="foo"'"#)
+        .with_stderr_data(str![[r#"
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}


### PR DESCRIPTION
### What does this PR try to resolve?

As #10358 said, `When a build.rs script emits cargo:rerun-if-env-changed, it is not re-run when the value of the specified variable is changed via the env configuration.`  

Fixes #10358 

### How should we test and review this PR?
Add test bofore fixing to reflect the issue, the next commit fixed it.

### Additional information

The PR is a sucessor of https://github.com/rust-lang/cargo/pull/14058, so the previous dicussion can be refer to it.