### PR TITLE
test(rustfix): switch to a simpler case for dedup-suggestions

### DIFF
--- a/crates/rustfix/tests/everything/dedup-suggestions.fixed.rs
+++ b/crates/rustfix/tests/everything/dedup-suggestions.fixed.rs
@@ -1,17 +1,11 @@
-// This fixes rust-lang/rust#123304.
-// If that lint stops emitting duplicate suggestions,
-// we might need to find a substitution.
-#![warn(unsafe_op_in_unsafe_fn)]
-
+// See <https://github.com/rust-lang/cargo/issues/13027>
 macro_rules! foo {
-    ($x:ident) => {
-        pub unsafe fn $x() { unsafe {
-            let _ = String::new().as_mut_vec();
-        }}
+    () => {
+        let _ = &1;
     };
 }
 
 fn main() {
-    foo!(a);
-    foo!(b);
+    foo!();
+    foo!();
 }

--- a/crates/rustfix/tests/everything/dedup-suggestions.json
+++ b/crates/rustfix/tests/everything/dedup-suggestions.json
@@ -1,5 +1,323 @@
-{"$message_type":"diagnostic","message":"call to unsafe function `std::string::String::as_mut_vec` is unsafe and requires unsafe block (error E0133)","code":{"code":"unsafe_op_in_unsafe_fn","explanation":null},"level":"warning","spans":[{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":254,"byte_end":280,"line_start":9,"line_end":9,"column_start":21,"column_end":47,"is_primary":true,"text":[{"text":"            let _ = String::new().as_mut_vec();","highlight_start":21,"highlight_end":47}],"label":"call to unsafe function","suggested_replacement":null,"suggestion_applicability":null,"expansion":{"span":{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":318,"byte_end":325,"line_start":15,"line_end":15,"column_start":5,"column_end":12,"is_primary":false,"text":[{"text":"    foo!(a);","highlight_start":5,"highlight_end":12}],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":null},"macro_decl_name":"foo!","def_site_span":{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":166,"byte_end":182,"line_start":6,"line_end":6,"column_start":1,"column_end":17,"is_primary":false,"text":[{"text":"macro_rules! foo {","highlight_start":1,"highlight_end":17}],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":null}}}],"children":[{"message":"for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>","code":null,"level":"note","spans":[],"children":[],"rendered":null},{"message":"consult the function's documentation for information on how to avoid undefined behavior","code":null,"level":"note","spans":[],"children":[],"rendered":null},{"message":"an unsafe function restricts its caller, but its body is safe by default","code":null,"level":"note","spans":[{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":213,"byte_end":231,"line_start":8,"line_end":8,"column_start":9,"column_end":27,"is_primary":true,"text":[{"text":"        pub unsafe fn $x() {","highlight_start":9,"highlight_end":27}],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":{"span":{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":318,"byte_end":325,"line_start":15,"line_end":15,"column_start":5,"column_end":12,"is_primary":false,"text":[{"text":"    foo!(a);","highlight_start":5,"highlight_end":12}],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":null},"macro_decl_name":"foo!","def_site_span":{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":166,"byte_end":182,"line_start":6,"line_end":6,"column_start":1,"column_end":17,"is_primary":false,"text":[{"text":"macro_rules! foo {","highlight_start":1,"highlight_end":17}],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":null}}}],"children":[],"rendered":null},{"message":"the lint level is defined here","code":null,"level":"note","spans":[{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":140,"byte_end":162,"line_start":4,"line_end":4,"column_start":9,"column_end":31,"is_primary":true,"text":[{"text":"#![warn(unsafe_op_in_unsafe_fn)]","highlight_start":9,"highlight_end":31}],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":null}],"children":[],"rendered":null},{"message":"consider wrapping the function body in an unsafe block","code":null,"level":"help","spans":[{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":232,"byte_end":232,"line_start":8,"line_end":8,"column_start":28,"column_end":28,"is_primary":true,"text":[{"text":"        pub unsafe fn $x() {","highlight_start":28,"highlight_end":28}],"label":null,"suggested_replacement":"{ unsafe ","suggestion_applicability":"MachineApplicable","expansion":{"span":{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":318,"byte_end":325,"line_start":15,"line_end":15,"column_start":5,"column_end":12,"is_primary":false,"text":[{"text":"    foo!(a);","highlight_start":5,"highlight_end":12}],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":null},"macro_decl_name":"foo!","def_site_span":{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":166,"byte_end":182,"line_start":6,"line_end":6,"column_start":1,"column_end":17,"is_primary":false,"text":[{"text":"macro_rules! foo {","highlight_start":1,"highlight_end":17}],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":null}}},{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":291,"byte_end":291,"line_start":10,"line_end":10,"column_start":10,"column_end":10,"is_primary":true,"text":[{"text":"        }","highlight_start":10,"highlight_end":10}],"label":null,"suggested_replacement":"}","suggestion_applicability":"MachineApplicable","expansion":{"span":{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":318,"byte_end":325,"line_start":15,"line_end":15,"column_start":5,"column_end":12,"is_primary":false,"text":[{"text":"    foo!(a);","highlight_start":5,"highlight_end":12}],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":null},"macro_decl_name":"foo!","def_site_span":{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":166,"byte_end":182,"line_start":6,"line_end":6,"column_start":1,"column_end":17,"is_primary":false,"text":[{"text":"macro_rules! foo {","highlight_start":1,"highlight_end":17}],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":null}}}],"children":[],"rendered":null}],"rendered":"warning: call to unsafe function `std::string::String::as_mut_vec` is unsafe and requires unsafe block (error E0133)\n  --> ./tests/everything/dedup-suggestions.rs:9:21\n   |\n9  |             let _ = String::new().as_mut_vec();\n   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function\n...\n15 |     foo!(a);\n   |     ------- in this macro invocation\n   |\n   = note: for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>\n   = note: consult the function's documentation for information on how to avoid undefined behavior\nnote: an unsafe function restricts its caller, but its body is safe by default\n  --> ./tests/everything/dedup-suggestions.rs:8:9\n   |\n8  |         pub unsafe fn $x() {\n   |         ^^^^^^^^^^^^^^^^^^\n...\n15 |     foo!(a);\n   |     ------- in this macro invocation\nnote: the lint level is defined here\n  --> ./tests/everything/dedup-suggestions.rs:4:9\n   |\n4  | #![warn(unsafe_op_in_unsafe_fn)]\n   |         ^^^^^^^^^^^^^^^^^^^^^^\n   = note: this warning originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)\n\n"}
-{"$message_type":"diagnostic","message":"call to unsafe function `std::string::String::as_mut_vec` is unsafe and requires unsafe block (error E0133)","code":{"code":"unsafe_op_in_unsafe_fn","explanation":null},"level":"warning","spans":[{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":254,"byte_end":280,"line_start":9,"line_end":9,"column_start":21,"column_end":47,"is_primary":true,"text":[{"text":"            let _ = String::new().as_mut_vec();","highlight_start":21,"highlight_end":47}],"label":"call to unsafe function","suggested_replacement":null,"suggestion_applicability":null,"expansion":{"span":{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":331,"byte_end":338,"line_start":16,"line_end":16,"column_start":5,"column_end":12,"is_primary":false,"text":[{"text":"    foo!(b);","highlight_start":5,"highlight_end":12}],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":null},"macro_decl_name":"foo!","def_site_span":{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":166,"byte_end":182,"line_start":6,"line_end":6,"column_start":1,"column_end":17,"is_primary":false,"text":[{"text":"macro_rules! foo {","highlight_start":1,"highlight_end":17}],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":null}}}],"children":[{"message":"for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>","code":null,"level":"note","spans":[],"children":[],"rendered":null},{"message":"consult the function's documentation for information on how to avoid undefined behavior","code":null,"level":"note","spans":[],"children":[],"rendered":null},{"message":"an unsafe function restricts its caller, but its body is safe by default","code":null,"level":"note","spans":[{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":213,"byte_end":231,"line_start":8,"line_end":8,"column_start":9,"column_end":27,"is_primary":true,"text":[{"text":"        pub unsafe fn $x() {","highlight_start":9,"highlight_end":27}],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":{"span":{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":331,"byte_end":338,"line_start":16,"line_end":16,"column_start":5,"column_end":12,"is_primary":false,"text":[{"text":"    foo!(b);","highlight_start":5,"highlight_end":12}],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":null},"macro_decl_name":"foo!","def_site_span":{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":166,"byte_end":182,"line_start":6,"line_end":6,"column_start":1,"column_end":17,"is_primary":false,"text":[{"text":"macro_rules! foo {","highlight_start":1,"highlight_end":17}],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":null}}}],"children":[],"rendered":null},{"message":"consider wrapping the function body in an unsafe block","code":null,"level":"help","spans":[{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":232,"byte_end":232,"line_start":8,"line_end":8,"column_start":28,"column_end":28,"is_primary":true,"text":[{"text":"        pub unsafe fn $x() {","highlight_start":28,"highlight_end":28}],"label":null,"suggested_replacement":"{ unsafe ","suggestion_applicability":"MachineApplicable","expansion":{"span":{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":331,"byte_end":338,"line_start":16,"line_end":16,"column_start":5,"column_end":12,"is_primary":false,"text":[{"text":"    foo!(b);","highlight_start":5,"highlight_end":12}],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":null},"macro_decl_name":"foo!","def_site_span":{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":166,"byte_end":182,"line_start":6,"line_end":6,"column_start":1,"column_end":17,"is_primary":false,"text":[{"text":"macro_rules! foo {","highlight_start":1,"highlight_end":17}],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":null}}},{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":291,"byte_end":291,"line_start":10,"line_end":10,"column_start":10,"column_end":10,"is_primary":true,"text":[{"text":"        }","highlight_start":10,"highlight_end":10}],"label":null,"suggested_replacement":"}","suggestion_applicability":"MachineApplicable","expansion":{"span":{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":331,"byte_end":338,"line_start":16,"line_end":16,"column_start":5,"column_end":12,"is_primary":false,"text":[{"text":"    foo!(b);","highlight_start":5,"highlight_end":12}],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":null},"macro_decl_name":"foo!","def_site_span":{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":166,"byte_end":182,"line_start":6,"line_end":6,"column_start":1,"column_end":17,"is_primary":false,"text":[{"text":"macro_rules! foo {","highlight_start":1,"highlight_end":17}],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":null}}}],"children":[],"rendered":null}],"rendered":"warning: call to unsafe function `std::string::String::as_mut_vec` is unsafe and requires unsafe block (error E0133)\n  --> ./tests/everything/dedup-suggestions.rs:9:21\n   |\n9  |             let _ = String::new().as_mut_vec();\n   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function\n...\n16 |     foo!(b);\n   |     ------- in this macro invocation\n   |\n   = note: for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>\n   = note: consult the function's documentation for information on how to avoid undefined behavior\nnote: an unsafe function restricts its caller, but its body is safe by default\n  --> ./tests/everything/dedup-suggestions.rs:8:9\n   |\n8  |         pub unsafe fn $x() {\n   |         ^^^^^^^^^^^^^^^^^^\n...\n16 |     foo!(b);\n   |     ------- in this macro invocation\n   = note: this warning originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)\n\n"}
-{"$message_type":"diagnostic","message":"function `a` is never used","code":{"code":"dead_code","explanation":null},"level":"warning","spans":[{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":323,"byte_end":324,"line_start":15,"line_end":15,"column_start":10,"column_end":11,"is_primary":true,"text":[{"text":"    foo!(a);","highlight_start":10,"highlight_end":11}],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":{"span":{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":318,"byte_end":325,"line_start":15,"line_end":15,"column_start":5,"column_end":12,"is_primary":false,"text":[{"text":"    foo!(a);","highlight_start":5,"highlight_end":12}],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":null},"macro_decl_name":"foo!","def_site_span":{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":166,"byte_end":182,"line_start":6,"line_end":6,"column_start":1,"column_end":17,"is_primary":false,"text":[{"text":"macro_rules! foo {","highlight_start":1,"highlight_end":17}],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":null}}}],"children":[{"message":"`#[warn(dead_code)]` on by default","code":null,"level":"note","spans":[],"children":[],"rendered":null}],"rendered":"warning: function `a` is never used\n  --> ./tests/everything/dedup-suggestions.rs:15:10\n   |\n15 |     foo!(a);\n   |          ^\n   |\n   = note: `#[warn(dead_code)]` on by default\n   = note: this warning originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)\n\n"}
-{"$message_type":"diagnostic","message":"function `b` is never used","code":{"code":"dead_code","explanation":null},"level":"warning","spans":[{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":336,"byte_end":337,"line_start":16,"line_end":16,"column_start":10,"column_end":11,"is_primary":true,"text":[{"text":"    foo!(b);","highlight_start":10,"highlight_end":11}],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":{"span":{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":331,"byte_end":338,"line_start":16,"line_end":16,"column_start":5,"column_end":12,"is_primary":false,"text":[{"text":"    foo!(b);","highlight_start":5,"highlight_end":12}],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":null},"macro_decl_name":"foo!","def_site_span":{"file_name":"./tests/everything/dedup-suggestions.rs","byte_start":166,"byte_end":182,"line_start":6,"line_end":6,"column_start":1,"column_end":17,"is_primary":false,"text":[{"text":"macro_rules! foo {","highlight_start":1,"highlight_end":17}],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":null}}}],"children":[],"rendered":"warning: function `b` is never used\n  --> ./tests/everything/dedup-suggestions.rs:16:10\n   |\n16 |     foo!(b);\n   |          ^\n   |\n   = note: this warning originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)\n\n"}
-{"$message_type":"diagnostic","message":"4 warnings emitted","code":null,"level":"warning","spans":[],"children":[],"rendered":"warning: 4 warnings emitted\n\n"}
+{
+  "$message_type": "diagnostic",
+  "message": "unused borrow that must be used",
+  "code": {
+    "code": "unused_must_use",
+    "explanation": null
+  },
+  "level": "warning",
+  "spans": [
+    {
+      "file_name": "./tests/everything/dedup-insert-only-replacements.rs",
+      "byte_start": 96,
+      "byte_end": 98,
+      "line_start": 4,
+      "line_end": 4,
+      "column_start": 9,
+      "column_end": 11,
+      "is_primary": true,
+      "text": [
+        {
+          "text": "        &1;",
+          "highlight_start": 9,
+          "highlight_end": 11
+        }
+      ],
+      "label": "the borrow produces a value",
+      "suggested_replacement": null,
+      "suggestion_applicability": null,
+      "expansion": {
+        "span": {
+          "file_name": "./tests/everything/dedup-insert-only-replacements.rs",
+          "byte_start": 126,
+          "byte_end": 132,
+          "line_start": 9,
+          "line_end": 9,
+          "column_start": 5,
+          "column_end": 11,
+          "is_primary": false,
+          "text": [
+            {
+              "text": "    foo!();",
+              "highlight_start": 5,
+              "highlight_end": 11
+            }
+          ],
+          "label": null,
+          "suggested_replacement": null,
+          "suggestion_applicability": null,
+          "expansion": null
+        },
+        "macro_decl_name": "foo!",
+        "def_site_span": {
+          "file_name": "./tests/everything/dedup-insert-only-replacements.rs",
+          "byte_start": 57,
+          "byte_end": 73,
+          "line_start": 2,
+          "line_end": 2,
+          "column_start": 1,
+          "column_end": 17,
+          "is_primary": false,
+          "text": [
+            {
+              "text": "macro_rules! foo {",
+              "highlight_start": 1,
+              "highlight_end": 17
+            }
+          ],
+          "label": null,
+          "suggested_replacement": null,
+          "suggestion_applicability": null,
+          "expansion": null
+        }
+      }
+    }
+  ],
+  "children": [
+    {
+      "message": "`#[warn(unused_must_use)]` on by default",
+      "code": null,
+      "level": "note",
+      "spans": [],
+      "children": [],
+      "rendered": null
+    },
+    {
+      "message": "use `let _ = ...` to ignore the resulting value",
+      "code": null,
+      "level": "help",
+      "spans": [
+        {
+          "file_name": "./tests/everything/dedup-insert-only-replacements.rs",
+          "byte_start": 96,
+          "byte_end": 96,
+          "line_start": 4,
+          "line_end": 4,
+          "column_start": 9,
+          "column_end": 9,
+          "is_primary": true,
+          "text": [
+            {
+              "text": "        &1;",
+              "highlight_start": 9,
+              "highlight_end": 9
+            }
+          ],
+          "label": null,
+          "suggested_replacement": "let _ = ",
+          "suggestion_applicability": "MaybeIncorrect",
+          "expansion": {
+            "span": {
+              "file_name": "./tests/everything/dedup-insert-only-replacements.rs",
+              "byte_start": 126,
+              "byte_end": 132,
+              "line_start": 9,
+              "line_end": 9,
+              "column_start": 5,
+              "column_end": 11,
+              "is_primary": false,
+              "text": [
+                {
+                  "text": "    foo!();",
+                  "highlight_start": 5,
+                  "highlight_end": 11
+                }
+              ],
+              "label": null,
+              "suggested_replacement": null,
+              "suggestion_applicability": null,
+              "expansion": null
+            },
+            "macro_decl_name": "foo!",
+            "def_site_span": {
+              "file_name": "./tests/everything/dedup-insert-only-replacements.rs",
+              "byte_start": 57,
+              "byte_end": 73,
+              "line_start": 2,
+              "line_end": 2,
+              "column_start": 1,
+              "column_end": 17,
+              "is_primary": false,
+              "text": [
+                {
+                  "text": "macro_rules! foo {",
+                  "highlight_start": 1,
+                  "highlight_end": 17
+                }
+              ],
+              "label": null,
+              "suggested_replacement": null,
+              "suggestion_applicability": null,
+              "expansion": null
+            }
+          }
+        }
+      ],
+      "children": [],
+      "rendered": null
+    }
+  ],
+  "rendered": "warning: unused borrow that must be used\n --> ./tests/everything/dedup-insert-only-replacements.rs:4:9\n  |\n4 |         &1;\n  |         ^^ the borrow produces a value\n...\n9 |     foo!();\n  |     ------ in this macro invocation\n  |\n  = note: `#[warn(unused_must_use)]` on by default\n  = note: this warning originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)\nhelp: use `let _ = ...` to ignore the resulting value\n  |\n4 |         let _ = &1;\n  |         +++++++\n\n"
+}
+{
+  "$message_type": "diagnostic",
+  "message": "unused borrow that must be used",
+  "code": {
+    "code": "unused_must_use",
+    "explanation": null
+  },
+  "level": "warning",
+  "spans": [
+    {
+      "file_name": "./tests/everything/dedup-insert-only-replacements.rs",
+      "byte_start": 96,
+      "byte_end": 98,
+      "line_start": 4,
+      "line_end": 4,
+      "column_start": 9,
+      "column_end": 11,
+      "is_primary": true,
+      "text": [
+        {
+          "text": "        &1;",
+          "highlight_start": 9,
+          "highlight_end": 11
+        }
+      ],
+      "label": "the borrow produces a value",
+      "suggested_replacement": null,
+      "suggestion_applicability": null,
+      "expansion": {
+        "span": {
+          "file_name": "./tests/everything/dedup-insert-only-replacements.rs",
+          "byte_start": 138,
+          "byte_end": 144,
+          "line_start": 10,
+          "line_end": 10,
+          "column_start": 5,
+          "column_end": 11,
+          "is_primary": false,
+          "text": [
+            {
+              "text": "    foo!();",
+              "highlight_start": 5,
+              "highlight_end": 11
+            }
+          ],
+          "label": null,
+          "suggested_replacement": null,
+          "suggestion_applicability": null,
+          "expansion": null
+        },
+        "macro_decl_name": "foo!",
+        "def_site_span": {
+          "file_name": "./tests/everything/dedup-insert-only-replacements.rs",
+          "byte_start": 57,
+          "byte_end": 73,
+          "line_start": 2,
+          "line_end": 2,
+          "column_start": 1,
+          "column_end": 17,
+          "is_primary": false,
+          "text": [
+            {
+              "text": "macro_rules! foo {",
+              "highlight_start": 1,
+              "highlight_end": 17
+            }
+          ],
+          "label": null,
+          "suggested_replacement": null,
+          "suggestion_applicability": null,
+          "expansion": null
+        }
+      }
+    }
+  ],
+  "children": [
+    {
+      "message": "use `let _ = ...` to ignore the resulting value",
+      "code": null,
+      "level": "help",
+      "spans": [
+        {
+          "file_name": "./tests/everything/dedup-insert-only-replacements.rs",
+          "byte_start": 96,
+          "byte_end": 96,
+          "line_start": 4,
+          "line_end": 4,
+          "column_start": 9,
+          "column_end": 9,
+          "is_primary": true,
+          "text": [
+            {
+              "text": "        &1;",
+              "highlight_start": 9,
+              "highlight_end": 9
+            }
+          ],
+          "label": null,
+          "suggested_replacement": "let _ = ",
+          "suggestion_applicability": "MaybeIncorrect",
+          "expansion": {
+            "span": {
+              "file_name": "./tests/everything/dedup-insert-only-replacements.rs",
+              "byte_start": 138,
+              "byte_end": 144,
+              "line_start": 10,
+              "line_end": 10,
+              "column_start": 5,
+              "column_end": 11,
+              "is_primary": false,
+              "text": [
+                {
+                  "text": "    foo!();",
+                  "highlight_start": 5,
+                  "highlight_end": 11
+                }
+              ],
+              "label": null,
+              "suggested_replacement": null,
+              "suggestion_applicability": null,
+              "expansion": null
+            },
+            "macro_decl_name": "foo!",
+            "def_site_span": {
+              "file_name": "./tests/everything/dedup-insert-only-replacements.rs",
+              "byte_start": 57,
+              "byte_end": 73,
+              "line_start": 2,
+              "line_end": 2,
+              "column_start": 1,
+              "column_end": 17,
+              "is_primary": false,
+              "text": [
+                {
+                  "text": "macro_rules! foo {",
+                  "highlight_start": 1,
+                  "highlight_end": 17
+                }
+              ],
+              "label": null,
+              "suggested_replacement": null,
+              "suggestion_applicability": null,
+              "expansion": null
+            }
+          }
+        }
+      ],
+      "children": [],
+      "rendered": null
+    }
+  ],
+  "rendered": "warning: unused borrow that must be used\n  --> ./tests/everything/dedup-insert-only-replacements.rs:4:9\n   |\n4  |         &1;\n   |         ^^ the borrow produces a value\n...\n10 |     foo!();\n   |     ------ in this macro invocation\n   |\n   = note: this warning originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)\nhelp: use `let _ = ...` to ignore the resulting value\n   |\n4  |         let _ = &1;\n   |         +++++++\n\n"
+}
+{
+  "$message_type": "diagnostic",
+  "message": "2 warnings emitted",
+  "code": null,
+  "level": "warning",
+  "spans": [],
+  "children": [],
+  "rendered": "warning: 2 warnings emitted\n\n"
+}

--- a/crates/rustfix/tests/everything/dedup-suggestions.rs
+++ b/crates/rustfix/tests/everything/dedup-suggestions.rs
@@ -1,17 +1,11 @@
-// This fixes rust-lang/rust#123304.
-// If that lint stops emitting duplicate suggestions,
-// we might need to find a substitution.
-#![warn(unsafe_op_in_unsafe_fn)]
-
+// See <https://github.com/rust-lang/cargo/issues/13027>
 macro_rules! foo {
-    ($x:ident) => {
-        pub unsafe fn $x() {
-            let _ = String::new().as_mut_vec();
-        }
+    () => {
+        &1;
     };
 }
 
 fn main() {
-    foo!(a);
-    foo!(b);
+    foo!();
+    foo!();
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

This case also emits insert-only suggestions (span start == end),
and doesn't rely on any lint behavior.

See also

* https://github.com/rust-lang/cargo/pull/13728
* https://github.com/rust-lang/cargo/issues/13027

### How should we test and review this PR?

Revert the change in <https://github.com/rust-lang/cargo/commit/95edc06e5bcfca0ca5e6c09d8843be8b60488165> and see it if it actually emits duplicate suggestions.

Closes #13027
<!-- homu-ignore:end -->
