### PR TITLE
Fix building count off-by-one error

### DIFF
--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -887,7 +887,7 @@ impl<'gctx> DrainState<'gctx> {
             .map(|u| self.name_for_progress(u))
             .collect::<Vec<_>>();
         let _ = self.progress.tick_now(
-            self.finished,
+            self.finished + 1,
             self.total_units,
             &format!(": {}", active_names.join(", ")),
         );


### PR DESCRIPTION
When building a project, the count of the current `Building` item is always one less than it should be.
'Building' implies the current item being built.
One would expect the **last** item being built to be for example 330/330 and NOT 329/330

This is because we are currently calculating the `finished / total`
Instead we should be calculating `current / total`
The current will always be 1 more than the finished up until the last item.

### Before
note `20/21`

![cargo_old1](https://github.com/user-attachments/assets/d39eeb58-0921-4ae3-8906-9d9c6551f80d)

### After
note `21/21`

![cargo_new1](https://github.com/user-attachments/assets/97dafd68-cc59-4710-ba61-795d8c86c90b)

