### PR TITLE
chore: update handlebars to v6, fix build error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1938,11 +1938,12 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "5.1.2"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d08485b96a0e6393e9e4d1b8d48cf74ad6c063cd905eb33f42c1ce3f0377539b"
+checksum = "fd4ccde012831f9a071a637b0d4e31df31c0f6c525784b35ae76a9ac6bc1e315"
 dependencies = [
  "log",
+ "num-order",
  "pest",
  "pest_derive",
  "serde",
@@ -2460,6 +2461,21 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-modular"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17bb261bf36fa7d83f4c294f834e91256769097b3cb505d44831e0a179ac647f"
+
+[[package]]
+name = "num-order"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537b596b97c40fcf8056d153049eb22f481c17ebce72a513ec9286e4986d1bb6"
+dependencies = [
+ "num-modular",
+]
 
 [[package]]
 name = "num-traits"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ git2 = "0.19.0"
 git2-curl = "0.20.0"
 gix = { version = "0.67.0", default-features = false, features = ["blocking-http-transport-curl", "progress-tree", "parallel", "dirwalk"] }
 glob = "0.3.1"
-handlebars = { version = "5.1.2", features = ["dir_source"] }
+handlebars = { version = "6.0.0", features = ["dir_source"] }
 hex = "0.4.3"
 hmac = "0.12.1"
 home = "0.5.9"

--- a/crates/mdman/src/hbs.rs
+++ b/crates/mdman/src/hbs.rs
@@ -24,11 +24,8 @@ pub fn expand(file: &Path, formatter: FormatterRef<'_>) -> Result<String, Error>
     handlebars.register_decorator("set", Box::new(set_decorator));
     handlebars.register_template_file("template", file)?;
     let includes = file.parent().unwrap().join("includes");
-    let options = DirectorySourceOptions {
-        tpl_extension: ".md".to_string(),
-        hidden: false,
-        temporary: false,
-    };
+    let mut options = DirectorySourceOptions::default();
+    options.tpl_extension = ".md".to_string();
     handlebars.register_templates_directory(includes, options)?;
     let man_name = file
         .file_stem()


### PR DESCRIPTION
`DirectorySourceOptions` is marked as `#[non_exhaustive]`, and only exposes the Default trait, so we need to instantiate a mutable instance using `default()`, and then change `tpl_extension` to the value we want.

Fixes #14764 
