### PR TITLE
Enable transfer feature in triagebot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -26,6 +26,8 @@ label = "O-windows"
 
 [shortcut]
 
+[transfer]
+
 [autolabel."S-waiting-on-review"]
 new_pr = true
 


### PR DESCRIPTION
This PR enables the `transfer` feature from triagebot, it permits issue transfers within the org.

Documentation at: https://forge.rust-lang.org/triagebot/transfer.html

It would have been useful in https://github.com/rust-lang/rust/issues/132572#issuecomment-2453566084

r? @ehuss 