### PR TITLE
test: Update some emaining unordered tests to snapbox

### DIFF
--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -1,5 +1,6 @@
 //! Tests for the `cargo clean` command.
 
+use cargo_test_support::compare::assert_e2e;
 use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
 use cargo_test_support::str;
@@ -824,7 +825,6 @@ fn clean_spec_reserved() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn clean_dry_run() {
     // Basic `clean --dry-run` test.
@@ -866,11 +866,14 @@ fn clean_dry_run() {
     // Verify it didn't delete anything.
     let after = p.build_dir().ls_r();
     assert_eq!(before, after);
-    let expected = itertools::join(before.iter().map(|p| p.to_str().unwrap()), "\n");
+    let mut expected = itertools::join(before.iter().map(|p| p.to_str().unwrap()), "\n");
+    expected.push_str("\n");
+    let expected = snapbox::filter::normalize_paths(&expected);
+    let expected = assert_e2e().redactions().redact(&expected);
     eprintln!("{expected}");
     // Verify the verbose output.
     p.cargo("clean --dry-run -v")
-        .with_stdout_unordered(expected)
+        .with_stdout_data(expected.unordered())
         .with_stderr_data(str![[r#"
 [SUMMARY] [FILE_NUM] files, [FILE_SIZE]B total
 [WARNING] no files deleted due to --dry-run

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -1616,21 +1616,21 @@ fn reuse_panic_pm() {
 
     // bar is built once without panic (for proc-macro) and once with (for the
     // normal dependency).
-    // TODO: Migrating to Snapbox might cause flakyness here. See https://github.com/rust-lang/cargo/pull/14161/files#r1660071433
-    #[expect(deprecated)]
     p.cargo("build -v")
-            .with_stderr_unordered(
-                "\
+        .with_stderr_data(
+            str![[r#"
 [LOCKING] 2 packages to latest compatible versions
-[COMPILING] bar [..]
-[RUNNING] `rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]
-[RUNNING] `rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort[..]-C debuginfo=2 [..]
-[COMPILING] somepm [..]
+[COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
+[RUNNING] `rustc --crate-name bar [..] -C panic=abort [..]
+[RUNNING] `rustc --crate-name bar [..]
+[COMPILING] somepm v0.0.1 ([ROOT]/foo/somepm)
 [RUNNING] `rustc --crate-name somepm [..]
-[COMPILING] foo [..]
-[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]-C panic=abort[..]
-[FINISHED] [..]
-",
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..] -C panic=abort [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]]
+            .unordered(),
         )
         .run();
 }

--- a/tests/testsuite/freshness_checksum.rs
+++ b/tests/testsuite/freshness_checksum.rs
@@ -1639,22 +1639,22 @@ fn reuse_panic_pm() {
 
     // bar is built once without panic (for proc-macro) and once with (for the
     // normal dependency).
-    // TODO: Migrating to Snapbox might cause flakyness here. See https://github.com/rust-lang/cargo/pull/14161/files#r1660071433
-    #[expect(deprecated)]
     p.cargo("build -Zchecksum-freshness -v")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
-            .with_stderr_unordered(
-                "\
+        .with_stderr_data(
+            str![[r#"
 [LOCKING] 2 packages to latest compatible versions
-[COMPILING] bar [..]
-[RUNNING] `rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]
-[RUNNING] `rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort[..]-C debuginfo=2 [..]
-[COMPILING] somepm [..]
+[COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
+[RUNNING] `rustc --crate-name bar [..] -C panic=abort [..]
+[RUNNING] `rustc --crate-name bar [..]
+[COMPILING] somepm v0.0.1 ([ROOT]/foo/somepm)
 [RUNNING] `rustc --crate-name somepm [..]
-[COMPILING] foo [..]
-[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]-C panic=abort[..]
-[FINISHED] [..]
-",
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..] -C panic=abort [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]]
+            .unordered(),
         )
         .run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?

This is part of #14039

This leaves `global_cache_tracker.rs` as it requires some more thinking.

As for the flakiness in `freshness.rs`  that was seen in #14161, `compare.rs` would prioritize expected lines according to their length (assuming its more specific).  Currently, snapbox prioritizes according to the line order.  So we just need to put the proc-macro line before the other one to ensure it gets precedence.

### How should we test and review this PR?



### Additional information

