### PR TITLE
rustfix: replace special-case duplicate handling with error

### DIFF
--- a/crates/rustfix/src/error.rs
+++ b/crates/rustfix/src/error.rs
@@ -11,9 +11,15 @@ pub enum Error {
     #[error("invalid range {0:?}, original data is only {1} byte long")]
     DataLengthExceeded(Range<usize>, usize),
 
-    #[non_exhaustive] // There are plans to add fields to this variant at a later time.
+    #[non_exhaustive]
     #[error("cannot replace slice of data that was already replaced")]
-    AlreadyReplaced,
+    AlreadyReplaced {
+        /// The location of the intended replacement.
+        range: Range<usize>,
+        /// Whether the modification exactly matches (both range and data) the one it conflicts with.
+        /// Some clients may wish to simply ignore this condition.
+        is_identical: bool,
+    },
 
     #[error(transparent)]
     Utf8(#[from] std::string::FromUtf8Error),


### PR DESCRIPTION

### What does this PR try to resolve?

This PR changes how conflicts are handled in `rustfix`.

By design, `cargo fix` repeatedly compiles the code, collects suggested changes, and applies changes that don't conflict with one another. Often, conflicts arise because the same suggestion is reported multiple times e.g., due to a macro expansion. There have been previous changes to address that specific case, but following [the PR to add transactional semantics](https://github.com/rust-lang/cargo/pull/14747), it makes sense to change how this is handled.

Specifically, this PR adds details to `Error::AlreadyReplaced` to indicate whether the specific replacement is identical to the one it conflicts with, allowing callers to handle this case, rather than special-casing it within `replace.rs` itself. To that point, this PR changes `fix.rs` and `lib.rs` to handle identical replacements by skipping the conflicting suggestion. This is not exactly identical to their previous behavior: before, it skipped a suggestion if any _solution_ had been applied, whereas this skips it if any _replacement within a solution_ has been applied. While more expansive, this is very much the spirit of the goal described above.

### How should we test and review this PR?

The existing tests have been updated to account for this change.

### Additional information

See: https://github.com/rust-lang/cargo/issues/13027