### PR TITLE
fix(test): Make redactions consistent with snapbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "escargot"
-version = "0.5.11"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eb5f6eeda986377996e9ed570cbc20cc16d30440696f82f129c863e4e3e83"
+checksum = "05a3ac187a16b5382fef8c69fd1bad123c67b7cf3932240a2d43dcdd32cded88"
 dependencies = [
  "log",
  "once_cell",
@@ -3375,9 +3375,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "snapbox"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba434818a8a9b1b106404288d6bd75a94348aae8fc9a518b211b609a36a54bc"
+checksum = "1373ce406dfad473059bbc31d807715642182bbc952a811952b58d1c9e41dcfa"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ sha2 = "0.10.8"
 shell-escape = "0.1.5"
 similar = "2.6.0"
 supports-hyperlinks = "3.0.0"
-snapbox = { version = "0.6.18", features = ["diff", "dir", "term-svg", "regex", "json"] }
+snapbox = { version = "0.6.20", features = ["diff", "dir", "term-svg", "regex", "json"] }
 tar = { version = "0.4.42", default-features = false }
 tempfile = "3.10.1"
 thiserror = "1.0.63"

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -820,10 +820,6 @@ impl Execs {
         self
     }
 
-    fn get_cwd(&self) -> Option<&Path> {
-        self.process_builder.as_ref().and_then(|p| p.get_cwd())
-    }
-
     pub fn env<T: AsRef<OsStr>>(&mut self, key: &str, val: T) -> &mut Self {
         if let Some(ref mut p) = self.process_builder {
             p.env(key, val);
@@ -1021,7 +1017,6 @@ impl Execs {
         self.verify_checks_output(stdout, stderr);
         let stdout = std::str::from_utf8(stdout).expect("stdout is not utf8");
         let stderr = std::str::from_utf8(stderr).expect("stderr is not utf8");
-        let cwd = self.get_cwd();
 
         match self.expect_exit_code {
             None => {}
@@ -1054,19 +1049,19 @@ impl Execs {
             }
         }
         for expect in self.expect_stdout_contains.iter() {
-            compare::match_contains(expect, stdout, cwd)?;
+            compare::match_contains(expect, stdout, self.assert.redactions())?;
         }
         for expect in self.expect_stderr_contains.iter() {
-            compare::match_contains(expect, stderr, cwd)?;
+            compare::match_contains(expect, stderr, self.assert.redactions())?;
         }
         for expect in self.expect_stdout_not_contains.iter() {
-            compare::match_does_not_contain(expect, stdout, cwd)?;
+            compare::match_does_not_contain(expect, stdout, self.assert.redactions())?;
         }
         for expect in self.expect_stderr_not_contains.iter() {
-            compare::match_does_not_contain(expect, stderr, cwd)?;
+            compare::match_does_not_contain(expect, stderr, self.assert.redactions())?;
         }
         for (with, without) in self.expect_stderr_with_without.iter() {
-            compare::match_with_without(stderr, with, without, cwd)?;
+            compare::match_with_without(stderr, with, without, self.assert.redactions())?;
         }
         Ok(())
     }

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -1120,23 +1120,19 @@ fn build_script_deps_adopt_specified_target_unconditionally() {
     #[expect(deprecated)]
     p.cargo("check -v -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
-        .with_stderr_does_not_contain(format!(
-            "[RUNNING] `rustc --crate-name build_script_build --edition=2015 build.rs [..]--target {} [..]",
-            target
-        ))
+        .with_stderr_does_not_contain(
+            "[RUNNING] `rustc --crate-name build_script_build --edition=2015 build.rs [..]--target [ALT_TARGET] [..]",
+        )
         .with_stderr_contains("[RUNNING] `rustc --crate-name build_script_build --edition=2015 build.rs [..]")
-        .with_stderr_contains(format!(
-            "[RUNNING] `rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--target {} [..]",
-            target
-        ))
-        .with_stderr_contains(format!(
-            "[RUNNING] `rustc --crate-name bar --edition=2015 bar/src/main.rs [..]--target {} [..]",
-            target
-        ))
-        .with_stderr_does_not_contain(format!(
-            "[RUNNING] `rustc --crate-name foo [..]--target {} [..]",
-            target
-        ))
+        .with_stderr_contains(
+            "[RUNNING] `rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--target [ALT_TARGET] [..]",
+        )
+        .with_stderr_contains(
+            "[RUNNING] `rustc --crate-name bar --edition=2015 bar/src/main.rs [..]--target [ALT_TARGET] [..]",
+        )
+        .with_stderr_does_not_contain(
+            "[RUNNING] `rustc --crate-name foo [..]--target [ALT_TARGET] [..]",
+        )
         .with_stderr_contains("[RUNNING] `rustc --crate-name foo [..]")
         .run();
 }
@@ -1240,18 +1236,15 @@ fn non_build_script_deps_adopt_specified_target_unconditionally() {
     #[expect(deprecated)]
     p.cargo("check -v -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
-        .with_stderr_contains(format!(
-            "[RUNNING] `rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--target {} [..]",
-            target
-        ))
-        .with_stderr_contains(format!(
-            "[RUNNING] `rustc --crate-name bar --edition=2015 bar/src/main.rs [..]--target {} [..]",
-            target
-        ))
-        .with_stderr_does_not_contain(format!(
-            "[RUNNING] `rustc --crate-name foo [..]--target {} [..]",
-            target
-        ))
+        .with_stderr_contains(
+            "[RUNNING] `rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--target [ALT_TARGET] [..]",
+        )
+        .with_stderr_contains(
+            "[RUNNING] `rustc --crate-name bar --edition=2015 bar/src/main.rs [..]--target [ALT_TARGET] [..]",
+        )
+        .with_stderr_does_not_contain(
+            "[RUNNING] `rustc --crate-name foo [..]--target [ALT_TARGET] [..]",
+        )
         .with_stderr_contains("[RUNNING] `rustc --crate-name foo [..]")
         .run();
 }
@@ -1389,23 +1382,19 @@ fn build_script_deps_adopts_target_platform_if_target_equals_target() {
     p.cargo("check -v -Z bindeps --target")
         .arg(alternate_target)
         .masquerade_as_nightly_cargo(&["bindeps"])
-        .with_stderr_does_not_contain(format!(
-            "[RUNNING] `rustc --crate-name build_script_build --edition=2015 build.rs [..]--target {} [..]",
-            alternate_target
-        ))
+        .with_stderr_does_not_contain(
+            "[RUNNING] `rustc --crate-name build_script_build --edition=2015 build.rs [..]--target [ALT_TARGET] [..]",
+        )
         .with_stderr_contains("[RUNNING] `rustc --crate-name build_script_build --edition=2015 build.rs [..]")
-        .with_stderr_contains(format!(
-            "[RUNNING] `rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--target {} [..]",
-            alternate_target
-        ))
-        .with_stderr_contains(format!(
-            "[RUNNING] `rustc --crate-name bar --edition=2015 bar/src/main.rs [..]--target {} [..]",
-            alternate_target
-        ))
-        .with_stderr_contains(format!(
-            "[RUNNING] `rustc --crate-name foo [..]--target {} [..]",
-            alternate_target
-        ))
+        .with_stderr_contains(
+            "[RUNNING] `rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--target [ALT_TARGET] [..]",
+        )
+        .with_stderr_contains(
+            "[RUNNING] `rustc --crate-name bar --edition=2015 bar/src/main.rs [..]--target [ALT_TARGET] [..]",
+        )
+        .with_stderr_contains(
+            "[RUNNING] `rustc --crate-name foo [..]--target [ALT_TARGET] [..]",
+        )
         .run();
 }
 

--- a/tests/testsuite/check_cfg.rs
+++ b/tests/testsuite/check_cfg.rs
@@ -945,7 +945,7 @@ fn config_fingerprint() {
 
     p.cargo("check -v")
         // we check that the fingerprint is indeed dirty
-        .with_stderr_contains("[..]Dirty[..]the profile configuration changed")
+        .with_stderr_contains("[..][DIRTY][..]the profile configuration changed")
         // that cause rustc to be called again with the new check-cfg args
         .with_stderr_contains(x!("rustc" => "cfg" of "bar"))
         .with_stderr_contains(x!("rustc" => "cfg" of "foo"))

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -3893,9 +3893,14 @@ fn cargo_test_env() {
         .file("src/lib.rs", &src)
         .build();
 
-    let cargo = cargo_exe().canonicalize().unwrap();
+    let cargo = cargo_exe()
+        .canonicalize()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .replace(std::env::consts::EXE_SUFFIX, "[EXE]");
     p.cargo("test --lib -- --nocapture")
-        .with_stderr_contains(cargo.to_str().unwrap())
+        .with_stderr_contains(cargo)
         .with_stdout_data(str![[r#"
 ...
 test env_test ... ok
@@ -3908,11 +3913,14 @@ test env_test ... ok
         .unwrap()
         .canonicalize()
         .unwrap();
-    let rustc = rustc.to_str().unwrap();
+    let stderr_rustc = rustc
+        .to_str()
+        .unwrap()
+        .replace(std::env::consts::EXE_SUFFIX, "[EXE]");
     p.cargo("test --lib -- --nocapture")
         // we use rustc since $CARGO is only used if it points to a path that exists
         .env(cargo::CARGO_ENV, rustc)
-        .with_stderr_contains(rustc)
+        .with_stderr_contains(stderr_rustc)
         .with_stdout_data(str![[r#"
 ...
 test env_test ... ok


### PR DESCRIPTION
### What does this PR try to resolve?

I'm unsure how we should be replacing these use cases, so I'm exploring keeping them but making them use snapbox under the hood. Part of the intent of snapbox is that it provides you the building blocks to make what you need.

If we go this route, we'll still need to un-deprecate and document the assertions.

If we don't go this route, the tests are now more aligned with where they'll eventually be anyways.

Part of #14039

### How should we test and review this PR?



### Additional information

