### PR TITLE
fix(toml): Update frontmatter parser for RFC 3503

### DIFF
--- a/src/cargo/util/toml/embedded.rs
+++ b/src/cargo/util/toml/embedded.rs
@@ -267,6 +267,7 @@ fn split_source(input: &str) -> CargoResult<Source<'_>> {
 
 #[cfg(test)]
 mod test_expand {
+    use snapbox::assert_data_eq;
     use snapbox::str;
 
     use super::*;
@@ -284,7 +285,7 @@ mod test_expand {
 
     #[test]
     fn test_default() {
-        snapbox::assert_data_eq!(
+        assert_data_eq!(
             si!(r#"fn main() {}"#),
             str![[r#"
 [[bin]]
@@ -312,7 +313,7 @@ strip = true
 
     #[test]
     fn test_dependencies() {
-        snapbox::assert_data_eq!(
+        assert_data_eq!(
             si!(r#"---cargo
 [dependencies]
 time="0.1.25"
@@ -348,7 +349,7 @@ strip = true
 
     #[test]
     fn test_no_infostring() {
-        snapbox::assert_data_eq!(
+        assert_data_eq!(
             si!(r#"---
 [dependencies]
 time="0.1.25"

--- a/src/cargo/util/toml/embedded.rs
+++ b/src/cargo/util/toml/embedded.rs
@@ -216,10 +216,12 @@ fn split_source(input: &str) -> CargoResult<Source<'_>> {
         }
 
         // No other choice than to consider this a shebang.
-        let (shebang, content) = source
+        let newline_end = source
             .content
-            .split_once('\n')
-            .unwrap_or((source.content, ""));
+            .find('\n')
+            .map(|pos| pos + 1)
+            .unwrap_or(source.content.len());
+        let (shebang, content) = source.content.split_at(newline_end);
         source.shebang = Some(shebang);
         source.content = content;
     }
@@ -394,7 +396,7 @@ time="0.1.25"
 fn main() {}
 "#,
             str![[r##"
-shebang: "#!/usr/bin/env cargo"
+shebang: "#!/usr/bin/env cargo\n"
 info: None
 frontmatter: "[dependencies]\ntime=\"0.1.25\"\n"
 content: "fn main() {}\n"
@@ -408,7 +410,7 @@ content: "fn main() {}\n"
         assert_source(
                 "#!/usr/bin/env cargo\r\n---\r\n[dependencies]\r\ntime=\"0.1.25\"\r\n---\r\nfn main() {}",
             str![[r##"
-shebang: "#!/usr/bin/env cargo\r"
+shebang: "#!/usr/bin/env cargo\r\n"
 info: ""
 frontmatter: "[dependencies]\r\ntime=\"0.1.25\"\r\n"
 content: "fn main() {}"
@@ -433,7 +435,7 @@ time="0.1.25"
 fn main() {}
 "#,
             str![[r##"
-shebang: "#!/usr/bin/env cargo"
+shebang: "#!/usr/bin/env cargo\n"
 info: None
 frontmatter: None
 content: "    \n\n\n---\n[dependencies]\ntime=\"0.1.25\"\n---\n\n\nfn main() {}\n"
@@ -473,7 +475,7 @@ time="0.1.25"
 
 fn main() {}"#,
             str![[r##"
-shebang: "#!/usr/bin/env cargo"
+shebang: "#!/usr/bin/env cargo\n"
 info: None
 frontmatter: "[dependencies]\ntime=\"0.1.25\"\n"
 content: "\nfn main() {}"

--- a/src/cargo/util/toml/embedded.rs
+++ b/src/cargo/util/toml/embedded.rs
@@ -224,13 +224,12 @@ fn split_source(input: &str) -> CargoResult<Source<'_>> {
         source.content = content;
     }
 
-    // Experiment: let us try which char works better
-    let fence_char = '-';
+    const FENCE_CHAR: char = '-';
 
     let fence_end = source
         .content
         .char_indices()
-        .find_map(|(i, c)| (c != fence_char).then_some(i))
+        .find_map(|(i, c)| (c != FENCE_CHAR).then_some(i))
         .unwrap_or(source.content.len());
     let (fence_pattern, rest) = match fence_end {
         0 => {
@@ -238,7 +237,7 @@ fn split_source(input: &str) -> CargoResult<Source<'_>> {
         }
         1 | 2 => {
             anyhow::bail!(
-                "found {fence_end} `{fence_char}` in rust frontmatter, expected at least 3"
+                "found {fence_end} `{FENCE_CHAR}` in rust frontmatter, expected at least 3"
             )
         }
         _ => source.content.split_at(fence_end),

--- a/src/cargo/util/toml/embedded.rs
+++ b/src/cargo/util/toml/embedded.rs
@@ -225,21 +225,23 @@ fn split_source(input: &str) -> CargoResult<Source<'_>> {
     }
 
     // Experiment: let us try which char works better
-    let tick_char = '-';
+    let fence_char = '-';
 
-    let tick_end = source
+    let fence_end = source
         .content
         .char_indices()
-        .find_map(|(i, c)| (c != tick_char).then_some(i))
+        .find_map(|(i, c)| (c != fence_char).then_some(i))
         .unwrap_or(source.content.len());
-    let (fence_pattern, rest) = match tick_end {
+    let (fence_pattern, rest) = match fence_end {
         0 => {
             return Ok(source);
         }
         1 | 2 => {
-            anyhow::bail!("found {tick_end} `{tick_char}` in rust frontmatter, expected at least 3")
+            anyhow::bail!(
+                "found {fence_end} `{fence_char}` in rust frontmatter, expected at least 3"
+            )
         }
-        _ => source.content.split_at(tick_end),
+        _ => source.content.split_at(fence_end),
     };
     let (info, content) = rest.split_once("\n").unwrap_or((rest, ""));
     if !info.is_empty() {

--- a/src/cargo/util/toml/embedded.rs
+++ b/src/cargo/util/toml/embedded.rs
@@ -272,21 +272,20 @@ mod test_expand {
 
     use super::*;
 
-    macro_rules! si {
-        ($i:expr) => {{
-            let shell = crate::Shell::from_write(Box::new(Vec::new()));
-            let cwd = std::env::current_dir().unwrap();
-            let home = home::cargo_home_with_cwd(&cwd).unwrap();
-            let gctx = GlobalContext::new(shell, cwd, home);
-            expand_manifest($i, std::path::Path::new("/home/me/test.rs"), &gctx)
-                .unwrap_or_else(|err| panic!("{}", err))
-        }};
+    #[track_caller]
+    fn expand(source: &str) -> String {
+        let shell = crate::Shell::from_write(Box::new(Vec::new()));
+        let cwd = std::env::current_dir().unwrap();
+        let home = home::cargo_home_with_cwd(&cwd).unwrap();
+        let gctx = GlobalContext::new(shell, cwd, home);
+        expand_manifest(source, std::path::Path::new("/home/me/test.rs"), &gctx)
+            .unwrap_or_else(|err| panic!("{}", err))
     }
 
     #[test]
     fn test_default() {
         assert_data_eq!(
-            si!(r#"fn main() {}"#),
+            expand(r#"fn main() {}"#),
             str![[r#"
 [[bin]]
 name = "test-"
@@ -314,12 +313,14 @@ strip = true
     #[test]
     fn test_dependencies() {
         assert_data_eq!(
-            si!(r#"---cargo
+            expand(
+                r#"---cargo
 [dependencies]
 time="0.1.25"
 ---
 fn main() {}
-"#),
+"#
+            ),
             str![[r#"
 [[bin]]
 name = "test-"
@@ -350,12 +351,14 @@ strip = true
     #[test]
     fn test_no_infostring() {
         assert_data_eq!(
-            si!(r#"---
+            expand(
+                r#"---
 [dependencies]
 time="0.1.25"
 ---
 fn main() {}
-"#),
+"#
+            ),
             str![[r#"
 [[bin]]
 name = "test-"

--- a/src/cargo/util/toml/embedded.rs
+++ b/src/cargo/util/toml/embedded.rs
@@ -245,8 +245,9 @@ fn split_source(input: &str) -> CargoResult<Source<'_>> {
         _ => source.content.split_at(fence_end),
     };
     let (info, content) = rest.split_once("\n").unwrap_or((rest, ""));
+    let info = info.trim_end();
     if !info.is_empty() {
-        source.info = Some(info.trim_end());
+        source.info = Some(info);
     }
     source.content = content;
 
@@ -411,7 +412,7 @@ content: "fn main() {}\n"
                 "#!/usr/bin/env cargo\r\n---\r\n[dependencies]\r\ntime=\"0.1.25\"\r\n---\r\nfn main() {}",
             str![[r##"
 shebang: "#!/usr/bin/env cargo\r\n"
-info: ""
+info: None
 frontmatter: "[dependencies]\r\ntime=\"0.1.25\"\r\n"
 content: "fn main() {}"
 

--- a/src/cargo/util/toml/embedded.rs
+++ b/src/cargo/util/toml/embedded.rs
@@ -245,7 +245,7 @@ fn split_source(input: &str) -> CargoResult<Source<'_>> {
         _ => source.content.split_at(fence_end),
     };
     let (info, content) = rest.split_once("\n").unwrap_or((rest, ""));
-    let info = info.trim_end();
+    let info = info.trim();
     if !info.is_empty() {
         source.info = Some(info);
     }
@@ -378,7 +378,7 @@ fn main() {}
 "#,
             str![[r#"
 shebang: None
-info: " cargo"
+info: "cargo"
 frontmatter: "[dependencies]\ntime=\"0.1.25\"\n"
 content: "fn main() {}\n"
 


### PR DESCRIPTION
### What does this PR try to resolve?

We removed rejected syntax in #13861 haven't update frontmatter parsing to what [RFC 3503](https://rust-lang.github.io/rfcs/3503-frontmatter.html#reference-level-explanation) says.

This adds tests and fixes various cases to ensure we correctly detect the frontmatter and the infostring.

This is part of #12207

### How should we test and review this PR?


### Additional information
