### PR TITLE
docs(test):  Document Execs assertions based on port effort 

### DIFF
--- a/crates/cargo-test-support/src/compare.rs
+++ b/crates/cargo-test-support/src/compare.rs
@@ -458,13 +458,13 @@ fn normalize_expected(content: &str, redactions: &snapbox::Redactions) -> String
 }
 
 /// A single line string that supports `[..]` wildcard matching.
-pub(crate) struct WildStr<'a> {
+struct WildStr<'a> {
     has_meta: bool,
     line: &'a str,
 }
 
 impl<'a> WildStr<'a> {
-    pub fn new(line: &'a str) -> WildStr<'a> {
+    fn new(line: &'a str) -> WildStr<'a> {
         WildStr {
             has_meta: line.contains("[..]"),
             line,

--- a/crates/cargo-test-support/src/compare.rs
+++ b/crates/cargo-test-support/src/compare.rs
@@ -331,27 +331,6 @@ static E2E_LITERAL_REDACTIONS: &[(&str, &str)] = &[
     ("[OPENING]", "     Opening"),
 ];
 
-/// Normalizes the output so that it can be compared against the expected value.
-fn normalize_actual(content: &str, redactions: &snapbox::Redactions) -> String {
-    use snapbox::filter::Filter as _;
-    let content = snapbox::filter::FilterPaths.filter(content.into_data());
-    let content = snapbox::filter::FilterNewlines.filter(content);
-    let content = content.render().expect("came in as a String");
-    let content = redactions.redact(&content);
-    content
-}
-
-/// Normalizes the expected string so that it can be compared against the actual output.
-fn normalize_expected(content: &str, redactions: &snapbox::Redactions) -> String {
-    use snapbox::filter::Filter as _;
-    let content = snapbox::filter::FilterPaths.filter(content.into_data());
-    let content = snapbox::filter::FilterNewlines.filter(content);
-    // Remove any conditionally absent redactions like `[EXE]`
-    let content = content.render().expect("came in as a String");
-    let content = redactions.clear_unused(&content);
-    content.into_owned()
-}
-
 /// Checks that the given string contains the given contiguous lines
 /// somewhere.
 ///
@@ -455,6 +434,27 @@ pub(crate) fn match_with_without(
             itertools::join(matches, "\n")
         ),
     }
+}
+
+/// Normalizes the output so that it can be compared against the expected value.
+fn normalize_actual(content: &str, redactions: &snapbox::Redactions) -> String {
+    use snapbox::filter::Filter as _;
+    let content = snapbox::filter::FilterPaths.filter(content.into_data());
+    let content = snapbox::filter::FilterNewlines.filter(content);
+    let content = content.render().expect("came in as a String");
+    let content = redactions.redact(&content);
+    content
+}
+
+/// Normalizes the expected string so that it can be compared against the actual output.
+fn normalize_expected(content: &str, redactions: &snapbox::Redactions) -> String {
+    use snapbox::filter::Filter as _;
+    let content = snapbox::filter::FilterPaths.filter(content.into_data());
+    let content = snapbox::filter::FilterNewlines.filter(content);
+    // Remove any conditionally absent redactions like `[EXE]`
+    let content = content.render().expect("came in as a String");
+    let content = redactions.clear_unused(&content);
+    content.into_owned()
 }
 
 /// A single line string that supports `[..]` wildcard matching.

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -816,7 +816,6 @@ impl Execs {
     /// - `expected` can end up being ambiguous, causing the assertion to succeed when it should fail
     ///
     /// </div>
-    #[deprecated(note = "replaced with `Execs::with_stdout_data(expected)`")]
     pub fn with_stdout_contains<S: ToString>(&mut self, expected: S) -> &mut Self {
         self.expect_stdout_contains.push(expected.to_string());
         self
@@ -834,7 +833,6 @@ impl Execs {
     /// - `expected` can end up being ambiguous, causing the assertion to succeed when it should fail
     ///
     /// </div>
-    #[deprecated(note = "replaced with `Execs::with_stderr_data(expected)`")]
     pub fn with_stderr_contains<S: ToString>(&mut self, expected: S) -> &mut Self {
         self.expect_stderr_contains.push(expected.to_string());
         self
@@ -857,7 +855,6 @@ impl Execs {
     /// [`Execs::with_stdout_contains`].
     ///
     /// </div>
-    #[deprecated]
     pub fn with_stdout_does_not_contain<S: ToString>(&mut self, expected: S) -> &mut Self {
         self.expect_stdout_not_contains.push(expected.to_string());
         self
@@ -879,7 +876,6 @@ impl Execs {
     /// with [`Execs::with_stderr_line_without`].
     ///
     /// </div>
-    #[deprecated]
     pub fn with_stderr_does_not_contain<S: ToString>(&mut self, expected: S) -> &mut Self {
         self.expect_stderr_not_contains.push(expected.to_string());
         self
@@ -916,7 +912,6 @@ impl Execs {
     /// This will check that a build line includes `-C opt-level=3` but does
     /// not contain `-C debuginfo` or `-C incremental`.
     ///
-    #[deprecated]
     pub fn with_stderr_line_without<S: ToString>(
         &mut self,
         with: &[S],

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -667,6 +667,57 @@ impl Execs {
     /// Verifies that stdout is equal to the given lines.
     ///
     /// See [`compare::assert_e2e`] for assertion details.
+    ///
+    /// <div class="warning">
+    ///
+    /// Prefer passing in [`str!`] for `expected` to get snapshot updating.
+    ///
+    /// If `format!` is needed for content that changes from run to run that you don't care about,
+    /// consider whether you could have [`compare::assert_e2e`] redact the content.
+    /// If nothing else, a wildcard (`[..]`, `...`) may be useful.
+    ///
+    /// However, `""` may be preferred for intentionally empty output so people don't accidentally
+    /// bless a change.
+    ///
+    /// </div>
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use cargo_test_support::prelude::*;
+    /// use cargo_test_support::str;
+    /// use cargo_test_support::execs;
+    ///
+    /// execs().with_stdout_data(str![r#"
+    /// Hello world!
+    /// "#]);
+    /// ```
+    ///
+    /// Non-deterministic compiler output
+    /// ```no_run
+    /// use cargo_test_support::prelude::*;
+    /// use cargo_test_support::str;
+    /// use cargo_test_support::execs;
+    ///
+    /// execs().with_stdout_data(str![r#"
+    /// [COMPILING] foo
+    /// [COMPILING] bar
+    /// "#].unordered());
+    /// ```
+    ///
+    /// jsonlines
+    /// ```no_run
+    /// use cargo_test_support::prelude::*;
+    /// use cargo_test_support::str;
+    /// use cargo_test_support::execs;
+    ///
+    /// execs().with_stdout_data(str![r#"
+    /// [
+    ///   {},
+    ///   {}
+    /// ]
+    /// "#].is_json().against_jsonlines());
+    /// ```
     pub fn with_stdout_data(&mut self, expected: impl snapbox::IntoData) -> &mut Self {
         self.expect_stdout_data = Some(expected.into_data());
         self
@@ -675,6 +726,57 @@ impl Execs {
     /// Verifies that stderr is equal to the given lines.
     ///
     /// See [`compare::assert_e2e`] for assertion details.
+    ///
+    /// <div class="warning">
+    ///
+    /// Prefer passing in [`str!`] for `expected` to get snapshot updating.
+    ///
+    /// If `format!` is needed for content that changes from run to run that you don't care about,
+    /// consider whether you could have [`compare::assert_e2e`] redact the content.
+    /// If nothing else, a wildcard (`[..]`, `...`) may be useful.
+    ///
+    /// However, `""` may be preferred for intentionally empty output so people don't accidentally
+    /// bless a change.
+    ///
+    /// </div>
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use cargo_test_support::prelude::*;
+    /// use cargo_test_support::str;
+    /// use cargo_test_support::execs;
+    ///
+    /// execs().with_stderr_data(str![r#"
+    /// Hello world!
+    /// "#]);
+    /// ```
+    ///
+    /// Non-deterministic compiler output
+    /// ```no_run
+    /// use cargo_test_support::prelude::*;
+    /// use cargo_test_support::str;
+    /// use cargo_test_support::execs;
+    ///
+    /// execs().with_stderr_data(str![r#"
+    /// [COMPILING] foo
+    /// [COMPILING] bar
+    /// "#].unordered());
+    /// ```
+    ///
+    /// jsonlines
+    /// ```no_run
+    /// use cargo_test_support::prelude::*;
+    /// use cargo_test_support::str;
+    /// use cargo_test_support::execs;
+    ///
+    /// execs().with_stderr_data(str![r#"
+    /// [
+    ///   {},
+    ///   {}
+    /// ]
+    /// "#].is_json().against_jsonlines());
+    /// ```
     pub fn with_stderr_data(&mut self, expected: impl snapbox::IntoData) -> &mut Self {
         self.expect_stderr_data = Some(expected.into_data());
         self
@@ -706,6 +808,14 @@ impl Execs {
     /// its output.
     ///
     /// See [`compare`] for supported patterns.
+    ///
+    /// <div class="warning">
+    ///
+    /// Prefer [`Execs::with_stdout_data`] where possible.
+    /// - `expected` cannot be snapshotted
+    /// - `expected` can end up being ambiguous, causing the assertion to succeed when it should fail
+    ///
+    /// </div>
     #[deprecated(note = "replaced with `Execs::with_stdout_data(expected)`")]
     pub fn with_stdout_contains<S: ToString>(&mut self, expected: S) -> &mut Self {
         self.expect_stdout_contains.push(expected.to_string());
@@ -716,6 +826,14 @@ impl Execs {
     /// its output.
     ///
     /// See [`compare`] for supported patterns.
+    ///
+    /// <div class="warning">
+    ///
+    /// Prefer [`Execs::with_stderr_data`] where possible.
+    /// - `expected` cannot be snapshotted
+    /// - `expected` can end up being ambiguous, causing the assertion to succeed when it should fail
+    ///
+    /// </div>
     #[deprecated(note = "replaced with `Execs::with_stderr_data(expected)`")]
     pub fn with_stderr_contains<S: ToString>(&mut self, expected: S) -> &mut Self {
         self.expect_stderr_contains.push(expected.to_string());
@@ -727,6 +845,18 @@ impl Execs {
     /// See [`compare`] for supported patterns.
     ///
     /// See note on [`Self::with_stderr_does_not_contain`].
+    ///
+    /// <div class="warning">
+    ///
+    /// Prefer [`Execs::with_stdout_data`] where possible.
+    /// - `expected` cannot be snapshotted
+    /// - The absence of `expected` can either mean success or that the string being looked for
+    ///   changed.
+    ///
+    /// To mitigate this, consider matching this up with
+    /// [`Execs::with_stdout_contains`].
+    ///
+    /// </div>
     #[deprecated]
     pub fn with_stdout_does_not_contain<S: ToString>(&mut self, expected: S) -> &mut Self {
         self.expect_stdout_not_contains.push(expected.to_string());
@@ -737,11 +867,18 @@ impl Execs {
     ///
     /// See [`compare`] for supported patterns.
     ///
-    /// Care should be taken when using this method because there is a
-    /// limitless number of possible things that *won't* appear. A typo means
-    /// your test will pass without verifying the correct behavior. If
-    /// possible, write the test first so that it fails, and then implement
-    /// your fix/feature to make it pass.
+    /// <div class="warning">
+    ///
+    /// Prefer [`Execs::with_stdout_data`] where possible.
+    /// - `expected` cannot be snapshotted
+    /// - The absence of `expected` can either mean success or that the string being looked for
+    ///   changed.
+    ///
+    /// To mitigate this, consider either matching this up with
+    /// [`Execs::with_stdout_contains`] or replace it
+    /// with [`Execs::with_stderr_line_without`].
+    ///
+    /// </div>
     #[deprecated]
     pub fn with_stderr_does_not_contain<S: ToString>(&mut self, expected: S) -> &mut Self {
         self.expect_stderr_not_contains.push(expected.to_string());
@@ -751,7 +888,18 @@ impl Execs {
     /// Verify that a particular line appears in stderr with and without the
     /// given substrings. Exactly one line must match.
     ///
-    /// The substrings are matched as `contains`. Example:
+    /// The substrings are matched as `contains`.
+    ///
+    /// <div class="warning">
+    ///
+    /// Prefer [`Execs::with_stdout_data`] where possible.
+    /// - `with` cannot be snapshotted
+    /// - The absence of `without`` can either mean success or that the string being looked for
+    ///   changed.
+    ///
+    /// </div>
+    ///
+    /// # Example
     ///
     /// ```no_run
     /// use cargo_test_support::execs;
@@ -768,8 +916,6 @@ impl Execs {
     /// This will check that a build line includes `-C opt-level=3` but does
     /// not contain `-C debuginfo` or `-C incremental`.
     ///
-    /// Be careful writing the `without` fragments, see note in
-    /// `with_stderr_does_not_contain`.
     #[deprecated]
     pub fn with_stderr_line_without<S: ToString>(
         &mut self,

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -687,7 +687,6 @@ fn build_script_with_bin_artifact_and_lib_false() {
         )
         .build();
 
-    #[expect(deprecated)]
     p.cargo("build -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
@@ -731,7 +730,6 @@ fn lib_with_bin_artifact_and_lib_false() {
         )
         .build();
 
-    #[expect(deprecated)]
     p.cargo("build -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
@@ -1117,7 +1115,6 @@ fn build_script_deps_adopt_specified_target_unconditionally() {
         .file("bar/src/lib.rs", "pub fn doit() {}")
         .build();
 
-    #[expect(deprecated)]
     p.cargo("check -v -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_does_not_contain(
@@ -1233,7 +1230,6 @@ fn non_build_script_deps_adopt_specified_target_unconditionally() {
         .file("bar/src/lib.rs", "pub fn doit() {}")
         .build();
 
-    #[expect(deprecated)]
     p.cargo("check -v -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_contains(
@@ -1378,7 +1374,6 @@ fn build_script_deps_adopts_target_platform_if_target_equals_target() {
         .build();
 
     let alternate_target = cross_compile::alternate();
-    #[expect(deprecated)]
     p.cargo("check -v -Z bindeps --target")
         .arg(alternate_target)
         .masquerade_as_nightly_cargo(&["bindeps"])

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -132,7 +132,6 @@ fn cargo_compile_incremental() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn incremental_profile() {
     let p = project()
@@ -176,7 +175,6 @@ fn incremental_profile() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn incremental_config() {
     let p = project()
@@ -5180,7 +5178,6 @@ WRAPPER CALLED: rustc --crate-name foo [..]
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn rustc_wrapper_queries() {
     // Check that the invocations querying rustc for information are done with the wrapper.
@@ -5920,7 +5917,6 @@ fn build_filter_infer_profile() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn targets_selected_default() {
     let p = project().file("src/main.rs", "fn main() {}").build();
@@ -6874,7 +6870,6 @@ Caused by:
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn build_script_o0_default() {
     let p = project()
@@ -6887,7 +6882,6 @@ fn build_script_o0_default() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn build_script_o0_default_even_with_release() {
     let p = project()

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -3779,7 +3779,6 @@ fn custom_target_dir() {
     p.cargo("build -v").run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn panic_abort_with_build_scripts() {
     let p = project()

--- a/tests/testsuite/build_script_extra_link_arg.rs
+++ b/tests/testsuite/build_script_extra_link_arg.rs
@@ -233,7 +233,6 @@ the future. For more information, see <https://github.com/rust-lang/cargo/issues
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn link_arg_transitive_not_allowed() {
     // Verify that transitive dependencies don't pass link args.

--- a/tests/testsuite/cache_messages.rs
+++ b/tests/testsuite/cache_messages.rs
@@ -527,7 +527,6 @@ WRAPPER CALLED: rustc [..]
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn wacky_hashless_fingerprint() {
     // On Windows, executables don't have hashes. This checks for a bad

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -137,7 +137,6 @@ fn list_command_looks_at_path_case_mismatch() {
     );
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn list_command_handles_known_external_commands() {
     let p = project()

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -406,7 +406,6 @@ fn check_all() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn check_all_exclude() {
     let p = project()
@@ -433,7 +432,6 @@ fn check_all_exclude() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn check_all_exclude_glob() {
     let p = project()
@@ -491,7 +489,6 @@ fn check_virtual_all_implied() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn check_virtual_manifest_one_project() {
     let p = project()
@@ -518,7 +515,6 @@ fn check_virtual_manifest_one_project() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn check_virtual_manifest_glob() {
     let p = project()
@@ -559,7 +555,6 @@ fn exclude_warns_on_non_existing_package() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn targets_selected_default() {
     let foo = project()
@@ -633,7 +628,6 @@ error[E0425]: cannot find value `badtext` in this scope
         .run();
 }
 
-#[expect(deprecated)]
 // Verify what is checked with various command-line filters.
 #[cargo_test]
 fn check_filters() {
@@ -1000,7 +994,6 @@ WRAPPER CALLED: rustc --crate-name foo [..]
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn rustc_workspace_wrapper_respects_primary_units() {
     let p = project()
@@ -1024,7 +1017,6 @@ fn rustc_workspace_wrapper_respects_primary_units() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn rustc_workspace_wrapper_excludes_published_deps() {
     let p = project()

--- a/tests/testsuite/check_cfg.rs
+++ b/tests/testsuite/check_cfg.rs
@@ -30,7 +30,6 @@ macro_rules! x {
     }};
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn features() {
     let p = project()
@@ -56,7 +55,6 @@ fn features() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn features_with_deps() {
     let p = project()
@@ -87,7 +85,6 @@ fn features_with_deps() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn features_with_opt_deps() {
     let p = project()
@@ -119,7 +116,6 @@ fn features_with_opt_deps() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn features_with_namespaced_features() {
     let p = project()
@@ -150,7 +146,6 @@ fn features_with_namespaced_features() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn features_fingerprint() {
     let p = project()
@@ -228,7 +223,6 @@ fn features_fingerprint() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn well_known_names_values() {
     let p = project()
@@ -242,7 +236,6 @@ fn well_known_names_values() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn features_test() {
     let p = project()
@@ -268,7 +261,6 @@ fn features_test() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn features_doctest() {
     let p = project()
@@ -297,7 +289,6 @@ fn features_doctest() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn well_known_names_values_test() {
     let p = project()
@@ -311,7 +302,6 @@ fn well_known_names_values_test() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn well_known_names_values_doctest() {
     let p = project()
@@ -327,7 +317,6 @@ fn well_known_names_values_doctest() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn features_doc() {
     let p = project()
@@ -354,7 +343,6 @@ fn features_doc() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn build_script_feedback() {
     let p = project()
@@ -382,7 +370,6 @@ fn build_script_feedback() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn build_script_doc() {
     let p = project()
@@ -421,7 +408,6 @@ fn build_script_doc() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn build_script_override() {
     let target = cargo_test_support::rustc_host();
@@ -531,7 +517,6 @@ test [..] ... ok
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn config_simple() {
     let p = project()
@@ -557,7 +542,6 @@ fn config_simple() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn config_workspace() {
     let p = project()
@@ -599,7 +583,6 @@ fn config_workspace() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn config_workspace_not_inherited() {
     let p = project()
@@ -631,7 +614,6 @@ fn config_workspace_not_inherited() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn config_invalid_position() {
     let p = project()
@@ -746,7 +728,6 @@ Caused by:
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn config_and_features() {
     let p = project()
@@ -836,7 +817,6 @@ fn config_with_cargo_test() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn config_and_build_script() {
     let p = project()
@@ -866,7 +846,6 @@ fn config_and_build_script() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn config_features_and_build_script() {
     let p = project()
@@ -902,7 +881,6 @@ fn config_features_and_build_script() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn config_fingerprint() {
     let p = project()

--- a/tests/testsuite/collisions.rs
+++ b/tests/testsuite/collisions.rs
@@ -226,7 +226,6 @@ fn collision_doc_multiple_versions() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn collision_doc_host_target_feature_split() {
     // Same dependency built twice due to different features.

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -1149,7 +1149,6 @@ it is false
         .exists());
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn proc_macro_ws() {
     // Checks for bug with proc-macro in a workspace with dependency (shouldn't panic).

--- a/tests/testsuite/fetch.rs
+++ b/tests/testsuite/fetch.rs
@@ -67,7 +67,6 @@ fn fetch_all_platform_dependencies_when_no_target_is_given() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn fetch_platform_specific_dependencies() {
     if cross_compile::disabled() {

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -869,7 +869,6 @@ fn prepare_for_already_on_latest_unstable() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn prepare_for_already_on_latest_stable() {
     // Stable counterpart of prepare_for_already_on_latest_unstable.
@@ -1393,7 +1392,6 @@ fn fix_in_existing_repo_weird_ignore() {
     p.cargo("fix").cwd("src").run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn fix_color_message() {
     // Check that color appears in diagnostics.
@@ -1688,7 +1686,6 @@ Original diagnostics will follow.
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn fix_with_run_cargo_in_proc_macros() {
     let p = project()

--- a/tests/testsuite/future_incompat_report.rs
+++ b/tests/testsuite/future_incompat_report.rs
@@ -93,7 +93,6 @@ fn test_zero_future_incompat() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test(
     nightly,
     reason = "-Zfuture-incompat-test requires nightly (permanently)"
@@ -163,7 +162,6 @@ frequency = 'never'
     }
 }
 
-#[expect(deprecated)]
 #[cargo_test(
     nightly,
     reason = "-Zfuture-incompat-test requires nightly (permanently)"
@@ -316,7 +314,6 @@ The package `second-dep v0.0.2` currently triggers the following future incompat
     assert_eq!(lines.next(), None);
 }
 
-#[expect(deprecated)]
 #[cargo_test(
     nightly,
     reason = "-Zfuture-incompat-test requires nightly (permanently)"

--- a/tests/testsuite/git_auth.rs
+++ b/tests/testsuite/git_auth.rs
@@ -346,7 +346,6 @@ Caused by:
     t.join().ok().unwrap();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn net_err_suggests_fetch_with_cli() {
     let p = project()

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -1432,7 +1432,6 @@ fn use_path_workspace() {
     assert_eq!(lock, lock2, "different lockfiles");
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn path_install_workspace_root_despite_default_members() {
     let p = project()
@@ -1479,7 +1478,6 @@ fn path_install_workspace_root_despite_default_members() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn git_install_workspace_root_despite_default_members() {
     let p = git::repo(&paths::root().join("foo"))
@@ -2082,7 +2080,6 @@ fn install_path_config() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn install_version_req() {
     // Try using a few versionreq styles.

--- a/tests/testsuite/lto.rs
+++ b/tests/testsuite/lto.rs
@@ -132,7 +132,6 @@ fn build_dep_not_ltod() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn complicated() {
     Package::new("dep-shared", "0.0.1")

--- a/tests/testsuite/message_format.rs
+++ b/tests/testsuite/message_format.rs
@@ -46,7 +46,6 @@ fn double_json_works() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn cargo_renders() {
     let p = project()
@@ -113,7 +112,6 @@ error[E0601]: `main` function not found in crate `foo`
 }
 
 #[cargo_test]
-#[expect(deprecated)]
 fn cargo_renders_ansi() {
     let p = project()
         .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))

--- a/tests/testsuite/metabuild.rs
+++ b/tests/testsuite/metabuild.rs
@@ -162,7 +162,6 @@ Caused by:
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn metabuild_optional_dep() {
     let p = project()
@@ -244,7 +243,6 @@ fn metabuild_lib_name() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn metabuild_fresh() {
     if is_coarse_mtime() {
@@ -378,7 +376,6 @@ fn metabuild_override() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn metabuild_workspace() {
     let p = project()

--- a/tests/testsuite/offline.rs
+++ b/tests/testsuite/offline.rs
@@ -9,7 +9,6 @@ use cargo_test_support::{
     str, Execs,
 };
 
-#[expect(deprecated)]
 #[cargo_test]
 fn offline_unused_target_dep() {
     // --offline with a target dependency that is not used and not downloaded.
@@ -45,7 +44,6 @@ fn offline_unused_target_dep() {
     p.cargo("check --offline").run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn offline_missing_optional() {
     Package::new("opt_dep", "1.0.0").publish();

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -628,7 +628,6 @@ fn package_git_submodule() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 /// Tests if a symlink to a git submodule is properly handled.
 ///

--- a/tests/testsuite/package_features.rs
+++ b/tests/testsuite/package_features.rs
@@ -426,7 +426,6 @@ feature set
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn virtual_member_slash() {
     // member slash feature syntax

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -316,7 +316,6 @@ fn profile_config_override_precedence() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn profile_config_no_warn_unknown_override() {
     let p = project()
@@ -487,7 +486,6 @@ fn named_env_profile() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn test_with_dev_profile() {
     // The `test` profile inherits from `dev` for both local crates and

--- a/tests/testsuite/profile_overrides.rs
+++ b/tests/testsuite/profile_overrides.rs
@@ -420,7 +420,6 @@ fn profile_override_spec() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn override_proc_macro() {
     Package::new("shared", "1.0.0").publish();

--- a/tests/testsuite/profile_targets.rs
+++ b/tests/testsuite/profile_targets.rs
@@ -77,7 +77,6 @@ fn all_target_project() -> Project {
         .build()
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn profile_selection_build() {
     let p = all_target_project();
@@ -158,7 +157,6 @@ fn profile_selection_build_release() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn profile_selection_build_all_targets() {
     let p = all_target_project();

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -91,7 +91,6 @@ fn release_profile_default_to_object() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test(nightly, reason = "-Zremap-path-scope is unstable")]
 fn one_option() {
     let build = |option| {
@@ -388,7 +387,6 @@ bar-0.0.1/src/lib.rs
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test(nightly, reason = "-Zremap-path-scope is unstable")]
 fn diagnostics_works() {
     Package::new("bar", "0.0.1")

--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -439,7 +439,6 @@ fn panic_unwind_does_not_build_twice() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn debug_0_report() {
     // The finished line handles 0 correctly.
@@ -584,7 +583,6 @@ fn strip_accepts_true_to_strip_symbols() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn strip_accepts_false_to_disable_strip() {
     let p = project()
@@ -670,7 +668,6 @@ fn strip_debuginfo_without_debug() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn do_not_strip_debuginfo_with_requested_debug() {
     let p = project()
@@ -834,7 +831,6 @@ Caused by:
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn debug_options_valid() {
     let build = |option| {

--- a/tests/testsuite/progress.rs
+++ b/tests/testsuite/progress.rs
@@ -125,7 +125,6 @@ fn always_shows_progress() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn never_progress() {
     const N: usize = 3;

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -1385,7 +1385,6 @@ You may press ctrl-c to skip waiting; the crate should be available shortly.
     );
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn publish_checks_for_token_before_verify() {
     let registry = registry::RegistryBuilder::new()

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -437,7 +437,6 @@ fn build_only_bar_dependency() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn targets_selected_default() {
     let p = project().file("src/main.rs", "fn main() {}").build();
@@ -589,7 +588,6 @@ fn rustc_with_other_profile() {
     p.cargo("rustc --profile test").run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn rustc_fingerprint() {
     // Verify that the fingerprint includes the rustc args.

--- a/tests/testsuite/rustc_info_cache.rs
+++ b/tests/testsuite/rustc_info_cache.rs
@@ -10,7 +10,6 @@ const MISS: &str = "[..] rustc info cache miss[..]";
 const HIT: &str = "[..]rustc info cache hit[..]";
 const UPDATE: &str = "[..]updated rustc info cache[..]";
 
-#[expect(deprecated)]
 #[cargo_test]
 fn rustc_info_cache() {
     let p = project()
@@ -106,7 +105,6 @@ fn rustc_info_cache() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn rustc_info_cache_with_wrappers() {
     let wrapper_project = project()

--- a/tests/testsuite/rustdoc_extern_html.rs
+++ b/tests/testsuite/rustdoc_extern_html.rs
@@ -33,7 +33,6 @@ fn basic_project() -> Project {
         .build()
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn ignores_on_stable() {
     // Requires -Zrustdoc-map to use.
@@ -61,7 +60,6 @@ fn simple() {
     assert!(myfun.contains(r#"href="https://docs.rs/bar/1.0.0/bar/struct.Straw.html""#));
 }
 
-#[expect(deprecated)]
 #[ignore = "Broken, temporarily disabled until https://github.com/rust-lang/rust/pull/82776 is resolved."]
 #[cargo_test]
 // #[cargo_test(nightly, reason = "--extern-html-root-url is unstable")]
@@ -451,7 +449,6 @@ fn alt_sparse_registry() {
     assert!(gold.contains(r#"href="https://docs.rs/grimm/1.0.0/grimm/struct.Gold.html""#));
 }
 
-#[expect(deprecated)]
 #[cargo_test(nightly, reason = "--extern-html-root-url is unstable")]
 fn same_deps_multi_occurrence_in_dep_tree() {
     // rust-lang/cargo#13543

--- a/tests/testsuite/search.rs
+++ b/tests/testsuite/search.rs
@@ -178,7 +178,6 @@ fn ignore_quiet() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn colored_results() {
     let registry = setup().build();

--- a/tests/testsuite/standard_lib.rs
+++ b/tests/testsuite/standard_lib.rs
@@ -348,7 +348,6 @@ fn simple_bin_std() {
     p.cargo("run -v").build_std(&setup).target_host().run();
 }
 
-#[expect(deprecated)]
 #[cargo_test(build_std_mock)]
 fn lib_nostd() {
     let setup = setup();
@@ -661,7 +660,6 @@ fn ignores_incremental() {
         .starts_with("foo-"));
 }
 
-#[expect(deprecated)]
 #[cargo_test(build_std_mock)]
 fn cargo_config_injects_compiler_builtins() {
     let setup = setup();
@@ -760,7 +758,6 @@ fn proc_macro_only() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test(build_std_mock)]
 fn fetch() {
     let setup = setup();

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -1809,7 +1809,6 @@ test test_in_bench ... ok
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn test_run_implicit_example_target() {
     let prj = project()
@@ -1897,7 +1896,6 @@ fn test_run_implicit_example_target() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn test_filtered_excludes_compiling_examples() {
     let p = project()
@@ -3596,7 +3594,6 @@ test b ... ok
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn test_virtual_manifest_one_project() {
     let p = project()
@@ -3619,7 +3616,6 @@ fn test_virtual_manifest_one_project() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn test_virtual_manifest_glob() {
     let p = project()
@@ -3872,7 +3868,6 @@ fn doctest_and_registry() {
     p.cargo("test --workspace -v").run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn cargo_test_env() {
     let src = format!(
@@ -4567,7 +4562,6 @@ fn doctest_skip_staticlib() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn can_not_mix_doc_tests_and_regular_tests() {
     let p = project()
@@ -5419,7 +5413,6 @@ Caused by:
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn nonzero_exit_status() {
     // Tests for nonzero exit codes from tests.

--- a/tests/testsuite/warn_on_failure.rs
+++ b/tests/testsuite/warn_on_failure.rs
@@ -77,7 +77,6 @@ fn no_warning_on_success() {
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn no_warning_on_bin_failure() {
     make_lib("");
@@ -101,7 +100,6 @@ error[E0425]: cannot find function `hi` in this scope
         .run();
 }
 
-#[expect(deprecated)]
 #[cargo_test]
 fn warning_on_lib_failure() {
     make_lib("err()");


### PR DESCRIPTION
### What does this PR try to resolve?

Closes #14039

A lot of this was pulled from #14039, common assertions people need to write, and from seeing people not noticing features that exist.

I'm leaving behind the `contains` assertions, rather than finding a way to make them work with snapbox.  Thankfully, snapbox is designed to let people build their own thing (see #14790).  I considered reusing snapbox's `[..]` matches but the code here is pretty minimal, the logic is similar enough, and I don't have a great abstraction for snapbox for it.  If there was more of a need, I'd make something work in snapbox.  As such, the `contains` assertions are no longer deprecated.

While doing this last pass through, I did some polish on the code as well.

### How should we test and review this PR?



### Additional information

