### PR TITLE
CI: make the `lint-docs` job required

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,7 @@ jobs:
       - clippy
       - msrv
       - docs
+      - lint-docs
       - lockfile
       - resolver
       - rustfmt


### PR DESCRIPTION
Discussed [here](https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/non-gating.20CI.20jobs/near/481347550).

r? @ehuss