### PR TITLE
fix(env): dont track envs set by cargo in dep-info file 

### DIFF
--- a/crates/cargo-util/src/paths.rs
+++ b/crates/cargo-util/src/paths.rs
@@ -35,7 +35,7 @@ pub fn join_paths<T: AsRef<OsStr>>(paths: &[T], env: &str) -> Result<OsString> {
 
 /// Returns the name of the environment variable used for searching for
 /// dynamic libraries.
-pub fn dylib_path_envvar() -> &'static str {
+pub const fn dylib_path_envvar() -> &'static str {
     if cfg!(windows) {
         "PATH"
     } else if cfg!(target_os = "macos") {

--- a/src/cargo/core/compiler/fingerprint/dep_info.rs
+++ b/src/cargo/core/compiler/fingerprint/dep_info.rs
@@ -19,6 +19,7 @@ use cargo_util::paths;
 use cargo_util::ProcessBuilder;
 use cargo_util::Sha256;
 
+use crate::core::compiler::is_env_set_by_cargo;
 use crate::CargoResult;
 use crate::CARGO_ENV;
 
@@ -334,7 +335,13 @@ pub fn translate_dep_info(
     //
     // For cargo#13280, We trace env vars that are defined in the `[env]` config table.
     on_disk_info.env.retain(|(key, _)| {
-        env_config.contains_key(key) || !rustc_cmd.get_envs().contains_key(key) || key == CARGO_ENV
+        if env_config.contains_key(key) && !is_env_set_by_cargo(key) {
+            return true;
+        }
+        if !rustc_cmd.get_envs().contains_key(key) {
+            return true;
+        }
+        key == CARGO_ENV
     });
 
     let serialize_path = |file| {

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -74,6 +74,7 @@ pub use self::build_context::{
 };
 use self::build_plan::BuildPlan;
 pub use self::build_runner::{BuildRunner, Metadata, UnitHash};
+pub(crate) use self::compilation::is_env_set_by_cargo;
 pub use self::compilation::{Compilation, Doctest, UnitOutput};
 pub use self::compile_kind::{CompileKind, CompileTarget};
 pub use self::crate_type::CrateType;
@@ -331,6 +332,10 @@ fn rustc(
         output_options.show_diagnostics = false;
     }
     let env_config = Arc::clone(build_runner.bcx.gctx.env_config()?);
+
+    #[cfg(debug_assertions)]
+    compilation::assert_only_envs_set_by_cargo(rustc.get_envs().keys(), &env_config);
+
     return Ok(Work::new(move |state| {
         // Artifacts are in a different location than typical units,
         // hence we must assure the crate- and target-dependent

--- a/tests/testsuite/cargo_env_config.rs
+++ b/tests/testsuite/cargo_env_config.rs
@@ -490,7 +490,6 @@ foo
 
 "#]])
         .with_stderr_data(str![[r#"
-[COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `target/debug/foo[EXE]`
 


### PR DESCRIPTION
### What does this PR try to resolve?

Don't track environment variables set by Cargo[1] in Cargo's dep-info file.

This patch is quite hacky since the "set-by-Cargo" env vars are
hardcoded. However, not all environment variables set by Cargo are
statically known. To prevent the actual environment variables applied to
rustc invocation get out of sync from what we hard-code, a debug time
assertion is put to help discover missing environment variables earlier.

Fixes #14798

### How should we test and review this PR?

A new test is added to show no rebuild triggered.

Try adding a random new env [here][2] and see if a debug build fails.

[1]: https://doc.rust-lang.org/nightly/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
[2]: https://github.com/rust-lang/cargo/blob/2e7fc43158d9621dccb4012756a5ad3efba849e9/src/cargo/core/compiler/compilation.rs?plain=1#L399

