### PR TITLE
feat(rustdoc): diplay env vars in extra verbose mode 

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -199,7 +199,10 @@ impl<'gctx> Compilation<'gctx> {
         unit: &Unit,
         script_meta: Option<Metadata>,
     ) -> CargoResult<ProcessBuilder> {
-        let rustdoc = ProcessBuilder::new(&*self.gctx.rustdoc()?);
+        let mut rustdoc = ProcessBuilder::new(&*self.gctx.rustdoc()?);
+        if self.gctx.extra_verbose() {
+            rustdoc.display_env_vars();
+        }
         let cmd = fill_rustc_tool_env(rustdoc, unit);
         let mut cmd = self.fill_env(cmd, &unit.pkg, script_meta, unit.kind, ToolKind::Rustdoc)?;
         cmd.retry_with_argfile(true);

--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -129,19 +129,9 @@ pub struct Compilation<'gctx> {
 
 impl<'gctx> Compilation<'gctx> {
     pub fn new<'a>(bcx: &BuildContext<'a, 'gctx>) -> CargoResult<Compilation<'gctx>> {
-        let mut rustc = bcx.rustc().process();
-        let mut primary_rustc_process = bcx.build_config.primary_unit_rustc.clone();
-        let mut rustc_workspace_wrapper_process = bcx.rustc().workspace_process();
-
-        if bcx.gctx.extra_verbose() {
-            rustc.display_env_vars();
-            rustc_workspace_wrapper_process.display_env_vars();
-
-            if let Some(rustc) = primary_rustc_process.as_mut() {
-                rustc.display_env_vars();
-            }
-        }
-
+        let rustc_process = bcx.rustc().process();
+        let primary_rustc_process = bcx.build_config.primary_unit_rustc.clone();
+        let rustc_workspace_wrapper_process = bcx.rustc().workspace_process();
         Ok(Compilation {
             native_dirs: BTreeSet::new(),
             root_output: HashMap::new(),
@@ -155,7 +145,7 @@ impl<'gctx> Compilation<'gctx> {
             to_doc_test: Vec::new(),
             gctx: bcx.gctx,
             host: bcx.host_triple().to_string(),
-            rustc_process: rustc,
+            rustc_process,
             rustc_workspace_wrapper_process,
             primary_rustc_process,
             target_runners: bcx
@@ -189,14 +179,16 @@ impl<'gctx> Compilation<'gctx> {
         is_primary: bool,
         is_workspace: bool,
     ) -> CargoResult<ProcessBuilder> {
-        let rustc = if is_primary && self.primary_rustc_process.is_some() {
+        let mut rustc = if is_primary && self.primary_rustc_process.is_some() {
             self.primary_rustc_process.clone().unwrap()
         } else if is_workspace {
             self.rustc_workspace_wrapper_process.clone()
         } else {
             self.rustc_process.clone()
         };
-
+        if self.gctx.extra_verbose() {
+            rustc.display_env_vars();
+        }
         let cmd = fill_rustc_tool_env(rustc, unit);
         self.fill_env(cmd, &unit.pkg, None, unit.kind, ToolKind::Rustc)
     }

--- a/tests/testsuite/profile_targets.rs
+++ b/tests/testsuite/profile_targets.rs
@@ -715,7 +715,7 @@ fn profile_selection_doc() {
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [DOCUMENTING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]`
-[RUNNING] `rustdoc [..]--crate-name bar bar/src/lib.rs [..]
+[RUNNING] `[..] rustdoc [..]--crate-name bar bar/src/lib.rs [..]
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]metadata -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]`
 [COMPILING] bdep v0.0.1 ([ROOT]/foo/bdep)
 [RUNNING] `[..] rustc --crate-name bdep --edition=2015 bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]`
@@ -724,7 +724,7 @@ fn profile_selection_doc() {
 [RUNNING] `[..][ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo src/lib.rs [..]
+[RUNNING] `[..] rustdoc [..]--crate-name foo src/lib.rs [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 


### PR DESCRIPTION
### What does this PR try to resolve?

This was found when doing #14811.

Other counterparts display environment variables,
but rustdoc does not.
This patch makes rustdoc follow suit.


### How should we test and review this PR?

Run `cargo doc -vv` 
