### PR TITLE
Always include Cargo.lock in published crates

### DIFF
--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -186,11 +186,6 @@ impl Package {
         }
     }
 
-    /// Returns if package should include `Cargo.lock`.
-    pub fn include_lockfile(&self) -> bool {
-        self.targets().iter().any(|t| t.is_example() || t.is_bin())
-    }
-
     pub fn serialized(
         &self,
         unstable_flags: &CliUnstable,

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -459,17 +459,16 @@ fn build_ar_list(
         ))?;
     }
 
-    if pkg.include_lockfile() {
-        let rel_str = "Cargo.lock";
-        result
-            .entry(UncasedAscii::new(rel_str))
-            .or_insert_with(Vec::new)
-            .push(ArchiveFile {
-                rel_path: PathBuf::from(rel_str),
-                rel_str: rel_str.to_string(),
-                contents: FileContents::Generated(GeneratedFile::Lockfile),
-            });
-    }
+    let rel_str = "Cargo.lock";
+    result
+        .entry(UncasedAscii::new(rel_str))
+        .or_insert_with(Vec::new)
+        .push(ArchiveFile {
+            rel_path: PathBuf::from(rel_str),
+            rel_str: rel_str.to_string(),
+            contents: FileContents::Generated(GeneratedFile::Lockfile),
+        });
+
     if let Some(vcs_info) = vcs_info {
         let rel_str = VCS_INFO_FILE;
         result

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -505,9 +505,7 @@ fn _list_files(pkg: &Package, gctx: &GlobalContext) -> CargoResult<Vec<PathBuf>>
         };
 
         let rel = relative_path.as_os_str();
-        if rel == "Cargo.lock" {
-            return pkg.include_lockfile();
-        } else if rel == "Cargo.toml" {
+        if rel == "Cargo.lock" || rel == "Cargo.toml" {
             return true;
         }
 

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -2271,7 +2271,8 @@ fn publish_artifact_dep() {
         .with_stderr_data(str![[r#"
 [UPDATING] crates.io index
 [PACKAGING] foo v0.1.0 ([ROOT]/foo)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[UPDATING] crates.io index
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] foo v0.1.0 ([ROOT]/foo)
 [UPLOADED] foo v0.1.0 to registry `crates-io`
 [NOTE] waiting for `foo v0.1.0` to be available at registry `crates-io`.
@@ -2331,7 +2332,7 @@ You may press ctrl-c to skip waiting; the crate should be available shortly.
         }
         "#,
         "foo-0.1.0.crate",
-        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs"],
+        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs", "Cargo.lock"],
         [(
             "Cargo.toml",
             str![[r##"

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -637,7 +637,7 @@ fn publish_allowed() {
 [WARNING] manifest has no description, license, license-file, documentation, homepage or repository.
 See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
 [PACKAGING] a v0.0.1 ([ROOT]/foo)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [VERIFYING] a v0.0.1 ([ROOT]/foo)
 [COMPILING] a v0.0.1 ([ROOT]/foo/target/package/a-0.0.1)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/credential_process.rs
+++ b/tests/testsuite/credential_process.rs
@@ -75,7 +75,7 @@ fn publish() {
 [UPDATING] `alternative` index
 {"v":1,"registry":{"index-url":"[..]","name":"alternative","headers":[..]},"kind":"get","operation":"read"}
 [PACKAGING] foo v0.1.0 ([ROOT]/foo)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] foo v0.1.0 ([ROOT]/foo)
 {"v":1,"registry":{"index-url":"[..]","name":"alternative"},"kind":"get","operation":"publish","name":"foo","vers":"0.1.0","cksum":"[..]"}
 [UPLOADED] foo v0.1.0 to registry `alternative`
@@ -528,7 +528,7 @@ fn token_caching() {
     let output = r#"[UPDATING] `alternative` index
 {"v":1,"registry":{"index-url":"[..]","name":"alternative"},"kind":"get","operation":"read"}
 [PACKAGING] foo v0.1.0 ([ROOT]/foo)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] foo v0.1.0 ([ROOT]/foo)
 {"v":1,"registry":{"index-url":"[..]","name":"alternative"},"kind":"get","operation":"publish","name":"foo","vers":"0.1.0","cksum":"[..]"}
 [UPLOADED] foo v0.1.0 to registry `alternative`
@@ -547,7 +547,7 @@ You may press ctrl-c [..]
     let output_non_independent = r#"[UPDATING] `alternative` index
 {"v":1,"registry":{"index-url":"[..]","name":"alternative"},"kind":"get","operation":"read"}
 [PACKAGING] foo v0.1.1 ([ROOT]/foo)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] foo v0.1.1 ([ROOT]/foo)
 {"v":1,"registry":{"index-url":"[..]","name":"alternative"},"kind":"get","operation":"publish","name":"foo","vers":"0.1.1","cksum":"[..]"}
 [UPLOADED] foo v0.1.1 to registry `alternative`

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -1826,7 +1826,7 @@ path = "src/lib.rs"
     validate_crate_contents(
         f,
         "a-0.1.0.crate",
-        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs"],
+        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs", "Cargo.lock"],
         [("Cargo.toml", rewritten_toml)],
     );
 }

--- a/tests/testsuite/features_namespaced.rs
+++ b/tests/testsuite/features_namespaced.rs
@@ -920,7 +920,8 @@ fn publish_no_implicit() {
         .with_stderr_data(str![[r#"
 [UPDATING] crates.io index
 [PACKAGING] foo v0.1.0 ([ROOT]/foo)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[UPDATING] crates.io index
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] foo v0.1.0 ([ROOT]/foo)
 [UPLOADED] foo v0.1.0 to registry `crates-io`
 [NOTE] waiting for `foo v0.1.0` to be available at registry `crates-io`.
@@ -975,7 +976,7 @@ You may press ctrl-c to skip waiting; the crate should be available shortly.
           }
         "#,
         "foo-0.1.0.crate",
-        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs"],
+        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs", "Cargo.lock"],
         [(
             "Cargo.toml",
             str![[r##"
@@ -1060,9 +1061,9 @@ fn publish() {
         .with_stderr_data(str![[r#"
 [UPDATING] crates.io index
 [PACKAGING] foo v0.1.0 ([ROOT]/foo)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
-[VERIFYING] foo v0.1.0 ([ROOT]/foo)
 [UPDATING] crates.io index
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[VERIFYING] foo v0.1.0 ([ROOT]/foo)
 [COMPILING] foo v0.1.0 ([ROOT]/foo/target/package/foo-0.1.0)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] foo v0.1.0 ([ROOT]/foo)
@@ -1112,7 +1113,7 @@ You may press ctrl-c to skip waiting; the crate should be available shortly.
           }
         "#,
         "foo-0.1.0.crate",
-        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs"],
+        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs", "Cargo.lock"],
         [(
             "Cargo.toml",
             str![[r##"

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -2737,6 +2737,7 @@ fn include_overrides_gitignore() {
     p.cargo("package --list --allow-dirty")
         .with_stdout_data(str![[r#"
 .cargo_vcs_info.json
+Cargo.lock
 Cargo.toml
 Cargo.toml.orig
 ignored.txt
@@ -4048,6 +4049,7 @@ fn git_worktree_with_original_repo_renamed() {
         .cwd(&new)
         .with_stdout_data(str![[r#"
 .cargo_vcs_info.json
+Cargo.lock
 Cargo.toml
 Cargo.toml.orig
 README.md
@@ -4116,6 +4118,7 @@ fn git_worktree_with_bare_original_repo() {
         .cwd(wt.path())
         .with_stdout_data(str![[r#"
 .cargo_vcs_info.json
+Cargo.lock
 Cargo.toml
 Cargo.toml.orig
 README.md

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -72,7 +72,13 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
     validate_crate_contents(
         f,
         "foo-0.0.1.crate",
-        &["Cargo.lock", "Cargo.toml", "Cargo.toml.orig", "src/main.rs"],
+        &[
+            "Cargo.lock",
+            "Cargo.toml",
+            "Cargo.toml.orig",
+            "src/main.rs",
+            "Cargo.lock",
+        ],
         (),
     );
 }
@@ -207,10 +213,11 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
 [PACKAGING] a v0.0.1 ([ROOT]/all/a/a)
 [ARCHIVING] .cargo_vcs_info.json
+[ARCHIVING] Cargo.lock
 [ARCHIVING] Cargo.toml
 [ARCHIVING] Cargo.toml.orig
 [ARCHIVING] src/lib.rs
-[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 5 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 
 "#]])
         .run();
@@ -229,6 +236,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
         f,
         "a-0.0.1.crate",
         &[
+            "Cargo.lock",
             "Cargo.toml",
             "Cargo.toml.orig",
             "src/lib.rs",
@@ -1138,6 +1146,7 @@ to proceed despite this and include the uncommitted changes, pass the `--allow-d
         .with_stderr_data("")
         .with_stdout_data(str![[r#"
 .cargo_vcs_info.json
+Cargo.lock
 Cargo.toml
 Cargo.toml.orig
 src/build/mod.rs
@@ -1181,6 +1190,7 @@ fn issue_13695_allow_dirty_vcs_info() {
             "Cargo.toml",
             "Cargo.toml.orig",
             "src/lib.rs",
+            "Cargo.lock",
         ],
         [(
             ".cargo_vcs_info.json",
@@ -1202,6 +1212,7 @@ fn issue_13695_allow_dirty_vcs_info() {
         .with_stderr_data("")
         .with_stdout_data(str![[r#"
 .cargo_vcs_info.json
+Cargo.lock
 Cargo.toml
 Cargo.toml.orig
 src/lib.rs
@@ -1241,6 +1252,7 @@ fn issue_13695_allowing_dirty_vcs_info_but_clean() {
             "Cargo.toml",
             "Cargo.toml.orig",
             "src/lib.rs",
+            "Cargo.lock",
         ],
         [(
             ".cargo_vcs_info.json",
@@ -1282,7 +1294,7 @@ fn issue_14354_allowing_dirty_bare_commit() {
     validate_crate_contents(
         f,
         "foo-0.1.0.crate",
-        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs"],
+        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs", "Cargo.lock"],
         (),
     );
 }
@@ -1456,7 +1468,7 @@ path = "src/lib.rs"
     validate_crate_contents(
         f,
         "bar-0.1.0.crate",
-        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs"],
+        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs", "Cargo.lock"],
         [("Cargo.toml", rewritten_toml)],
     );
 }
@@ -1873,6 +1885,7 @@ fn include_cargo_toml_implicit() {
 
     p.cargo("package --list")
         .with_stdout_data(str![[r#"
+Cargo.lock
 Cargo.toml
 Cargo.toml.orig
 src/lib.rs
@@ -1925,7 +1938,8 @@ fn package_include_ignore_only() {
         r#"["Cargo.toml", "src/abc**", "src/lib.rs"]"#,
         "[]",
         &["src/lib.rs", "src/abc1.rs", "src/abc2.rs", "src/abc/mod.rs"],
-        "Cargo.toml\n\
+        "Cargo.lock\n\
+         Cargo.toml\n\
          Cargo.toml.orig\n\
          src/abc/mod.rs\n\
          src/abc1.rs\n\
@@ -1941,7 +1955,8 @@ fn gitignore_patterns() {
         r#"["Cargo.toml", "foo"]"#, // include
         "[]",
         &["src/lib.rs", "foo", "a/foo", "a/b/foo", "x/foo/y", "bar"],
-        "Cargo.toml\n\
+        "Cargo.lock\n\
+         Cargo.toml\n\
          Cargo.toml.orig\n\
          a/b/foo\n\
          a/foo\n\
@@ -1954,7 +1969,8 @@ fn gitignore_patterns() {
         r#"["Cargo.toml", "/foo"]"#, // include
         "[]",
         &["src/lib.rs", "foo", "a/foo", "a/b/foo", "x/foo/y", "bar"],
-        "Cargo.toml\n\
+        "Cargo.lock\n\
+         Cargo.toml\n\
          Cargo.toml.orig\n\
          foo\n\
          ",
@@ -1964,7 +1980,8 @@ fn gitignore_patterns() {
         "[]",
         r#"["foo/"]"#, // exclude
         &["src/lib.rs", "foo", "a/foo", "x/foo/y", "bar"],
-        "Cargo.toml\n\
+        "Cargo.lock\n\
+         Cargo.toml\n\
          Cargo.toml.orig\n\
          a/foo\n\
          bar\n\
@@ -1988,7 +2005,8 @@ fn gitignore_patterns() {
             "y",
             "z",
         ],
-        "Cargo.toml\n\
+        "Cargo.lock\n\
+         Cargo.toml\n\
          Cargo.toml.orig\n\
          c\n\
          other\n\
@@ -2000,7 +2018,8 @@ fn gitignore_patterns() {
         r#"["Cargo.toml", "**/foo/bar"]"#, // include
         "[]",
         &["src/lib.rs", "a/foo/bar", "foo", "bar"],
-        "Cargo.toml\n\
+        "Cargo.lock\n\
+         Cargo.toml\n\
          Cargo.toml.orig\n\
          a/foo/bar\n\
          ",
@@ -2010,7 +2029,8 @@ fn gitignore_patterns() {
         r#"["Cargo.toml", "foo/**"]"#, // include
         "[]",
         &["src/lib.rs", "a/foo/bar", "foo/x/y/z"],
-        "Cargo.toml\n\
+        "Cargo.lock\n\
+         Cargo.toml\n\
          Cargo.toml.orig\n\
          foo/x/y/z\n\
          ",
@@ -2020,7 +2040,8 @@ fn gitignore_patterns() {
         r#"["Cargo.toml", "a/**/b"]"#, // include
         "[]",
         &["src/lib.rs", "a/b", "a/x/b", "a/x/y/b"],
-        "Cargo.toml\n\
+        "Cargo.lock\n\
+         Cargo.toml\n\
          Cargo.toml.orig\n\
          a/b\n\
          a/x/b\n\
@@ -2036,6 +2057,7 @@ fn gitignore_negate() {
         "[]",
         &["src/lib.rs", "foo.rs", "!important"],
         "!important\n\
+         Cargo.lock\n\
          Cargo.toml\n\
          Cargo.toml.orig\n\
          src/lib.rs\n\
@@ -2050,7 +2072,8 @@ fn gitignore_negate() {
         r#"["Cargo.toml", "src/", "!src/foo.rs"]"#, // include
         "[]",
         &["src/lib.rs", "src/foo.rs"],
-        "Cargo.toml\n\
+        "Cargo.lock\n\
+         Cargo.toml\n\
          Cargo.toml.orig\n\
          src/lib.rs\n\
          ",
@@ -2060,7 +2083,8 @@ fn gitignore_negate() {
         r#"["Cargo.toml", "src/*.rs", "!foo.rs"]"#, // include
         "[]",
         &["src/lib.rs", "foo.rs", "src/foo.rs", "src/bar/foo.rs"],
-        "Cargo.toml\n\
+        "Cargo.lock\n\
+         Cargo.toml\n\
          Cargo.toml.orig\n\
          src/lib.rs\n\
          ",
@@ -2070,7 +2094,8 @@ fn gitignore_negate() {
         "[]",
         r#"["*.rs", "!foo.rs", "\\!important"]"#, // exclude
         &["src/lib.rs", "foo.rs", "!important"],
-        "Cargo.toml\n\
+        "Cargo.lock\n\
+         Cargo.toml\n\
          Cargo.toml.orig\n\
          foo.rs\n\
          ",
@@ -2083,7 +2108,8 @@ fn exclude_dot_files_and_directories_by_default() {
         "[]",
         "[]",
         &["src/lib.rs", ".dotfile", ".dotdir/file"],
-        "Cargo.toml\n\
+        "Cargo.lock\n\
+         Cargo.toml\n\
          Cargo.toml.orig\n\
          src/lib.rs\n\
          ",
@@ -2095,6 +2121,7 @@ fn exclude_dot_files_and_directories_by_default() {
         &["src/lib.rs", ".dotfile", ".dotdir/file"],
         ".dotdir/file\n\
          .dotfile\n\
+         Cargo.lock\n\
          Cargo.toml\n\
          Cargo.toml.orig\n\
          src/lib.rs\n\
@@ -2278,6 +2305,7 @@ fn license_file_implicit_include() {
     p.cargo("package --list")
         .with_stdout_data(str![[r#"
 .cargo_vcs_info.json
+Cargo.lock
 Cargo.toml
 Cargo.toml.orig
 src/lib.rs
@@ -2291,11 +2319,12 @@ subdir/LICENSE
         .with_stderr_data(str![[r#"
 [PACKAGING] foo v1.0.0 ([ROOT]/foo)
 [ARCHIVING] .cargo_vcs_info.json
+[ARCHIVING] Cargo.lock
 [ARCHIVING] Cargo.toml
 [ARCHIVING] Cargo.toml.orig
 [ARCHIVING] src/lib.rs
 [ARCHIVING] subdir/LICENSE
-[PACKAGED] 5 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 6 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 
 "#]])
         .run();
@@ -2305,6 +2334,7 @@ subdir/LICENSE
         "foo-1.0.0.crate",
         &[
             ".cargo_vcs_info.json",
+            "Cargo.lock",
             "Cargo.toml",
             "Cargo.toml.orig",
             "subdir/LICENSE",
@@ -2336,6 +2366,7 @@ fn relative_license_included() {
 
     p.cargo("package --list")
         .with_stdout_data(str![[r#"
+Cargo.lock
 Cargo.toml
 Cargo.toml.orig
 LICENSE
@@ -2348,7 +2379,7 @@ src/lib.rs
     p.cargo("package")
         .with_stderr_data(str![[r#"
 [PACKAGING] foo v1.0.0 ([ROOT]/foo)
-[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 5 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [VERIFYING] foo v1.0.0 ([ROOT]/foo)
 [COMPILING] foo v1.0.0 ([ROOT]/foo/target/package/foo-1.0.0)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2359,7 +2390,13 @@ src/lib.rs
     validate_crate_contents(
         f,
         "foo-1.0.0.crate",
-        &["Cargo.toml", "Cargo.toml.orig", "LICENSE", "src/lib.rs"],
+        &[
+            "Cargo.toml",
+            "Cargo.toml.orig",
+            "LICENSE",
+            "src/lib.rs",
+            "Cargo.lock",
+        ],
         [("LICENSE", "license text")],
     );
     let manifest =
@@ -2393,6 +2430,7 @@ fn relative_license_include_collision() {
 
     p.cargo("package --list")
         .with_stdout_data(str![[r#"
+Cargo.lock
 Cargo.toml
 Cargo.toml.orig
 LICENSE
@@ -2408,7 +2446,7 @@ src/lib.rs
     p.cargo("package").with_stderr_data(str![[r#"
 [WARNING] license-file `../LICENSE` appears to be a path outside of the package, but there is already a file named `LICENSE` in the root of the package. The archived crate will contain the copy in the root of the package. Update the license-file to point to the path relative to the root of the package to remove this warning.
 [PACKAGING] foo v1.0.0 ([ROOT]/foo)
-[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 5 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [VERIFYING] foo v1.0.0 ([ROOT]/foo)
 [COMPILING] foo v1.0.0 ([ROOT]/foo/target/package/foo-1.0.0)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2418,7 +2456,13 @@ src/lib.rs
     validate_crate_contents(
         f,
         "foo-1.0.0.crate",
-        &["Cargo.toml", "Cargo.toml.orig", "LICENSE", "src/lib.rs"],
+        &[
+            "Cargo.toml",
+            "Cargo.toml.orig",
+            "LICENSE",
+            "src/lib.rs",
+            "Cargo.lock",
+        ],
         [("LICENSE", "inner license")],
     );
     let manifest = read_to_string(p.root().join("target/package/foo-1.0.0/Cargo.toml")).unwrap();
@@ -2455,7 +2499,7 @@ fn package_restricted_windows() {
 [WARNING] file src/con.rs is a reserved Windows filename, it will not work on Windows platforms
 [WARNING] file src/aux/mod.rs is a reserved Windows filename, it will not work on Windows platforms
 [PACKAGING] foo v0.1.0 ([ROOT]/foo)
-[PACKAGED] 5 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 6 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [VERIFYING] foo v0.1.0 ([ROOT]/foo)
 [COMPILING] foo v0.1.0 ([ROOT]/foo/target/package/foo-0.1.0)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2484,6 +2528,7 @@ fn finds_git_in_parent() {
     p.cargo("package --list --allow-dirty")
         .with_stdout_data(str![[r#"
 .cargo_vcs_info.json
+Cargo.lock
 Cargo.toml
 Cargo.toml.orig
 ignoreme
@@ -2498,6 +2543,7 @@ src/lib.rs
         .with_stdout_data(str![[r#"
 .cargo_vcs_info.json
 .gitignore
+Cargo.lock
 Cargo.toml
 Cargo.toml.orig
 ignoreme2
@@ -2511,6 +2557,7 @@ src/lib.rs
         .with_stdout_data(str![[r#"
 .cargo_vcs_info.json
 .gitignore
+Cargo.lock
 Cargo.toml
 Cargo.toml.orig
 src/lib.rs
@@ -3052,7 +3099,7 @@ path = "src/lib.rs"
     validate_crate_contents(
         f,
         "bar-0.1.0.crate",
-        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs"],
+        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs", "Cargo.lock"],
         [("Cargo.toml", rewritten_toml)],
     );
 
@@ -3090,7 +3137,7 @@ path = "src/lib.rs"
     validate_crate_contents(
         f,
         "baz-0.1.0.crate",
-        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs"],
+        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs", "Cargo.lock"],
         [("Cargo.toml", rewritten_toml)],
     );
 }
@@ -4036,7 +4083,7 @@ fn discovery_inferred_build_rs_included() {
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [PACKAGING] foo v0.0.1 ([ROOT]/foo)
-[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 5 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [VERIFYING] foo v0.0.1 ([ROOT]/foo)
 [COMPILING] foo v0.0.1 ([ROOT]/foo/target/package/foo-0.0.1)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -4048,7 +4095,13 @@ fn discovery_inferred_build_rs_included() {
     validate_crate_contents(
         f,
         "foo-0.0.1.crate",
-        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs", "build.rs"],
+        &[
+            "Cargo.toml",
+            "Cargo.toml.orig",
+            "src/lib.rs",
+            "build.rs",
+            "Cargo.lock",
+        ],
         [(
             "Cargo.toml",
             str![[r##"
@@ -4118,7 +4171,7 @@ fn discovery_inferred_build_rs_excluded() {
         .with_stderr_data(str![[r#"
 [PACKAGING] foo v0.0.1 ([ROOT]/foo)
 [WARNING] ignoring `package.build` as `build.rs` is not included in the published package
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [VERIFYING] foo v0.0.1 ([ROOT]/foo)
 [COMPILING] foo v0.0.1 ([ROOT]/foo/target/package/foo-0.0.1)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -4130,7 +4183,7 @@ fn discovery_inferred_build_rs_excluded() {
     validate_crate_contents(
         f,
         "foo-0.0.1.crate",
-        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs"],
+        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs", "Cargo.lock"],
         [(
             "Cargo.toml",
             str![[r##"
@@ -4197,7 +4250,7 @@ fn discovery_explicit_build_rs_included() {
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [PACKAGING] foo v0.0.1 ([ROOT]/foo)
-[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 5 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [VERIFYING] foo v0.0.1 ([ROOT]/foo)
 [COMPILING] foo v0.0.1 ([ROOT]/foo/target/package/foo-0.0.1)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -4209,7 +4262,13 @@ fn discovery_explicit_build_rs_included() {
     validate_crate_contents(
         f,
         "foo-0.0.1.crate",
-        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs", "build.rs"],
+        &[
+            "Cargo.toml",
+            "Cargo.toml.orig",
+            "src/lib.rs",
+            "build.rs",
+            "Cargo.lock",
+        ],
         [(
             "Cargo.toml",
             str![[r##"
@@ -4280,7 +4339,7 @@ fn discovery_explicit_build_rs_excluded() {
         .with_stderr_data(str![[r#"
 [PACKAGING] foo v0.0.1 ([ROOT]/foo)
 [WARNING] ignoring `package.build` as `build.rs` is not included in the published package
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [VERIFYING] foo v0.0.1 ([ROOT]/foo)
 [COMPILING] foo v0.0.1 ([ROOT]/foo/target/package/foo-0.0.1)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -4292,7 +4351,7 @@ fn discovery_explicit_build_rs_excluded() {
     validate_crate_contents(
         f,
         "foo-0.0.1.crate",
-        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs"],
+        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs", "Cargo.lock"],
         [(
             "Cargo.toml",
             str![[r##"
@@ -5302,17 +5361,15 @@ fn workspace_with_local_deps() {
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [PACKAGING] level3 v0.0.1 ([ROOT]/foo/level3)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [PACKAGING] level2 v0.0.1 ([ROOT]/foo/level2)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
-[PACKAGING] level1 v0.0.1 ([ROOT]/foo/level1)
 [UPDATING] crates.io index
 [ERROR] failed to prepare local package for uploading
 
 Caused by:
-  no matching package named `level2` found
+  no matching package named `level3` found
   location searched: crates.io index
-  required by package `level1 v0.0.1 ([ROOT]/foo/level1)`
+  required by package `level2 v0.0.1 ([ROOT]/foo/level2)`
 
 "#]])
         .run();
@@ -5329,11 +5386,11 @@ fn workspace_with_local_deps_nightly() {
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [PACKAGING] level3 v0.0.1 ([ROOT]/foo/level3)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [PACKAGING] level2 v0.0.1 ([ROOT]/foo/level2)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
-[PACKAGING] level1 v0.0.1 ([ROOT]/foo/level1)
 [UPDATING] crates.io index
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGING] level1 v0.0.1 ([ROOT]/foo/level1)
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [VERIFYING] level3 v0.0.1 ([ROOT]/foo/level3)
 [COMPILING] level3 v0.0.1 ([ROOT]/foo/target/package/level3-0.0.1)
@@ -5488,15 +5545,13 @@ fn workspace_with_local_deps_packaging_one_fails() {
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [PACKAGING] level1 v0.0.1 ([ROOT]/foo/level1)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
-[VERIFYING] level1 v0.0.1 ([ROOT]/foo/level1)
 [UPDATING] crates.io index
-[ERROR] failed to verify package tarball
+[ERROR] failed to prepare local package for uploading
 
 Caused by:
   no matching package named `level2` found
   location searched: crates.io index
-  required by package `level1 v0.0.1 ([ROOT]/foo/target/package/level1-0.0.1)`
+  required by package `level1 v0.0.1 ([ROOT]/foo/level1)`
 
 "#]])
         .run();
@@ -5515,15 +5570,13 @@ fn workspace_with_local_deps_packaging_one_fails_nightly() {
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [PACKAGING] level1 v0.0.1 ([ROOT]/foo/level1)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
-[VERIFYING] level1 v0.0.1 ([ROOT]/foo/level1)
 [UPDATING] crates.io index
-[ERROR] failed to verify package tarball
+[ERROR] failed to prepare local package for uploading
 
 Caused by:
   no matching package named `level2` found
   location searched: crates.io index
-  required by package `level1 v0.0.1 ([ROOT]/foo/target/package/level1-0.0.1)`
+  required by package `level1 v0.0.1 ([ROOT]/foo/level1)`
 
 "#]])
         .run();
@@ -5664,14 +5717,14 @@ fn workspace_with_local_deps_packaging_one_with_needed_deps() {
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [PACKAGING] level3 v0.0.1 ([ROOT]/foo/level3)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [PACKAGING] level2 v0.0.1 ([ROOT]/foo/level2)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[UPDATING] crates.io index
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [VERIFYING] level3 v0.0.1 ([ROOT]/foo/level3)
 [COMPILING] level3 v0.0.1 ([ROOT]/foo/target/package/level3-0.0.1)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [VERIFYING] level2 v0.0.1 ([ROOT]/foo/level2)
-[UPDATING] crates.io index
 [UNPACKING] level3 v0.0.1 (registry `[ROOT]/foo/target/package/tmp-registry`)
 [COMPILING] level3 v0.0.1
 [COMPILING] level2 v0.0.1 ([ROOT]/foo/target/package/level2-0.0.1)
@@ -5730,6 +5783,7 @@ fn workspace_with_local_deps_list() {
     p.cargo("package --list")
         .replace_crates_io(crates_io.index_url())
         .with_stdout_data(str![[r#"
+Cargo.lock
 Cargo.toml
 Cargo.toml.orig
 src/lib.rs
@@ -5801,7 +5855,7 @@ fn workspace_with_local_deps_index_mismatch() {
     .with_stdout_data("")
     .with_stderr_data(str![[r#"
 [PACKAGING] level2 v0.0.1 ([ROOT]/foo/level2)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [PACKAGING] level1 v0.0.1 ([ROOT]/foo/level1)
 [UPDATING] crates.io index
 [ERROR] failed to prepare local package for uploading
@@ -5871,7 +5925,7 @@ fn workspace_with_local_deps_alternative_index() {
     .with_stdout_data("")
     .with_stderr_data(str![[r#"
 [PACKAGING] level2 v0.0.1 ([ROOT]/foo/level2)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [PACKAGING] level1 v0.0.1 ([ROOT]/foo/level1)
 [UPDATING] `alternative` index
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
@@ -5974,7 +6028,6 @@ fn workspace_with_local_dep_already_published() {
         .with_stderr_data(
             str![[r#"
 [PACKAGING] dep v0.1.0 ([ROOT]/foo/dep)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [PACKAGING] main v0.0.1 ([ROOT]/foo/main)
 [UPDATING] crates.io index
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
@@ -5987,6 +6040,7 @@ fn workspace_with_local_dep_already_published() {
 [COMPILING] dep v0.1.0
 [COMPILING] main v0.0.1 ([ROOT]/foo/target/package/main-0.0.1)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 
 "#]]
             .unordered(),
@@ -6006,7 +6060,6 @@ fn workspace_with_local_dep_already_published_nightly() {
         .with_stderr_data(
             str![[r#"
 [PACKAGING] dep v0.1.0 ([ROOT]/foo/dep)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [PACKAGING] main v0.0.1 ([ROOT]/foo/main)
 [UPDATING] crates.io index
 [ERROR] failed to prepare local package for uploading
@@ -6016,6 +6069,7 @@ Caused by:
 
 Caused by:
   found a package in the remote registry and the local overlay: dep@0.1.0
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 
 "#]]
             .unordered(),
@@ -6077,7 +6131,6 @@ fn workspace_with_local_and_remote_deps() {
         .with_stderr_data(
             str![[r#"
 [PACKAGING] dep v0.1.0 ([ROOT]/foo/dep)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [PACKAGING] main v0.0.1 ([ROOT]/foo/main)
 [UPDATING] crates.io index
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
@@ -6092,6 +6145,7 @@ fn workspace_with_local_and_remote_deps() {
 [COMPILING] dep v0.1.0
 [COMPILING] main v0.0.1 ([ROOT]/foo/target/package/main-0.0.1)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 
 "#]]
             .unordered(),
@@ -6186,7 +6240,7 @@ fn registry_inferred_from_unique_option() {
         .masquerade_as_nightly_cargo(&["package-workspace"])
         .with_stderr_data(str![[r#"
 [PACKAGING] dep v0.1.0 ([ROOT]/foo/dep)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [PACKAGING] main v0.0.1 ([ROOT]/foo/main)
 [UPDATING] `alternative` index
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
@@ -6281,7 +6335,7 @@ The registry `alternative` is not listed in the `package.publish` value in Cargo
     .masquerade_as_nightly_cargo(&["package-workspace"])
     .with_stderr_data(str![[r#"
 [PACKAGING] dep v0.1.0 ([ROOT]/foo/dep)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [PACKAGING] main v0.0.1 ([ROOT]/foo/main)
 [UPDATING] `alternative` index
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
@@ -6354,7 +6408,7 @@ fn registry_inference_ignores_unpublishable() {
         .masquerade_as_nightly_cargo(&["package-workspace"])
         .with_stderr_data(str![[r#"
 [PACKAGING] dep v0.1.0 ([ROOT]/foo/dep)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [PACKAGING] main v0.0.1 ([ROOT]/foo/main)
 [UPDATING] `alternative` index
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
@@ -6375,7 +6429,7 @@ fn registry_inference_ignores_unpublishable() {
         .masquerade_as_nightly_cargo(&["package-workspace"])
         .with_stderr_data(str![[r#"
 [PACKAGING] dep v0.1.0 ([ROOT]/foo/dep)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [PACKAGING] main v0.0.1 ([ROOT]/foo/main)
 [UPDATING] `alternative` index
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
@@ -6456,7 +6510,7 @@ fn registry_not_inferred_because_of_multiple_options() {
         .masquerade_as_nightly_cargo(&["package-workspace"])
         .with_stderr_data(str![[r#"
 [PACKAGING] dep v0.1.0 ([ROOT]/foo/dep)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [PACKAGING] main v0.0.1 ([ROOT]/foo/main)
 [UPDATING] `alternative` index
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
@@ -6539,7 +6593,7 @@ fn registry_not_inferred_because_of_mismatch() {
         .masquerade_as_nightly_cargo(&["package-workspace"])
         .with_stderr_data(str![[r#"
 [PACKAGING] dep v0.1.0 ([ROOT]/foo/dep)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [PACKAGING] main v0.0.1 ([ROOT]/foo/main)
 [UPDATING] `alternative` index
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
@@ -6612,7 +6666,7 @@ fn unpublishable_dependency() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [PACKAGING] dep v0.1.0 ([ROOT]/foo/dep)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [PACKAGING] main v0.0.1 ([ROOT]/foo/main)
 [UPDATING] `alternative` index
 [ERROR] failed to prepare local package for uploading

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -2253,7 +2253,7 @@ fn api_error_json() {
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
 [PACKAGING] foo v0.0.1 ([ROOT]/foo)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
 [ERROR] failed to publish to registry at http://127.0.0.1:[..]/
 
@@ -2301,7 +2301,7 @@ fn api_error_200() {
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
 [PACKAGING] foo v0.0.1 ([ROOT]/foo)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
 [ERROR] failed to publish to registry at http://127.0.0.1:[..]/
 
@@ -2349,7 +2349,7 @@ fn api_error_code() {
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
 [PACKAGING] foo v0.0.1 ([ROOT]/foo)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
 [ERROR] failed to publish to registry at http://127.0.0.1:[..]/
 
@@ -2406,7 +2406,7 @@ fn api_curl_error() {
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
 [PACKAGING] foo v0.0.1 ([ROOT]/foo)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
 [ERROR] failed to publish to registry at http://127.0.0.1:[..]/
 
@@ -2454,7 +2454,7 @@ fn api_other_error() {
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
 [PACKAGING] foo v0.0.1 ([ROOT]/foo)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
 [ERROR] failed to publish to registry at http://127.0.0.1:[..]/
 
@@ -2979,7 +2979,7 @@ fn wait_for_first_publish() {
 [WARNING] manifest has no documentation, homepage or repository.
 See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
 [PACKAGING] delay v0.0.1 ([ROOT]/foo)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] delay v0.0.1 ([ROOT]/foo)
 [UPLOADED] delay v0.0.1 to registry `crates-io`
 [NOTE] waiting for `delay v0.0.1` to be available at registry `crates-io`.
@@ -3072,7 +3072,7 @@ fn wait_for_first_publish_underscore() {
 [WARNING] manifest has no documentation, homepage or repository.
 See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
 [PACKAGING] delay_with_underscore v0.0.1 ([ROOT]/foo)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] delay_with_underscore v0.0.1 ([ROOT]/foo)
 [UPLOADED] delay_with_underscore v0.0.1 to registry `crates-io`
 [NOTE] waiting for `delay_with_underscore v0.0.1` to be available at registry `crates-io`.
@@ -3172,7 +3172,7 @@ fn wait_for_subsequent_publish() {
 [WARNING] manifest has no documentation, homepage or repository.
 See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
 [PACKAGING] delay v0.0.2 ([ROOT]/foo)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] delay v0.0.2 ([ROOT]/foo)
 [UPLOADED] delay v0.0.2 to registry `crates-io`
 [NOTE] waiting for `delay v0.0.2` to be available at registry `crates-io`.
@@ -3290,7 +3290,7 @@ fn timeout_waiting_for_publish() {
 [WARNING] manifest has no documentation, homepage or repository.
 See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
 [PACKAGING] delay v0.0.1 ([ROOT]/foo)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] delay v0.0.1 ([ROOT]/foo)
 [UPLOADED] delay v0.0.1 to registry `crates-io`
 [NOTE] waiting for `delay v0.0.1` to be available at registry `crates-io`.
@@ -3381,7 +3381,7 @@ fn timeout_waiting_for_dependency_publish() {
 [WARNING] manifest has no documentation, homepage or repository.
 See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
 [PACKAGING] dep v0.0.1 ([ROOT]/foo/dep)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [WARNING] manifest has no documentation, homepage or repository.
 See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
 [PACKAGING] main v0.0.1 ([ROOT]/foo/main)
@@ -3427,11 +3427,11 @@ fn package_selection() {
 [WARNING] manifest has no description, license, license-file, documentation, homepage or repository.
 See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
 [PACKAGING] a v0.1.0 ([ROOT]/foo/a)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [WARNING] manifest has no description, license, license-file, documentation, homepage or repository.
 See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
 [PACKAGING] b v0.1.0 ([ROOT]/foo/b)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] a v0.1.0 ([ROOT]/foo/a)
 [WARNING] aborting upload due to dry run
 [UPLOADING] b v0.1.0 ([ROOT]/foo/b)
@@ -3449,11 +3449,11 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [WARNING] manifest has no description, license, license-file, documentation, homepage or repository.
 See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
 [PACKAGING] a v0.1.0 ([ROOT]/foo/a)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [WARNING] manifest has no description, license, license-file, documentation, homepage or repository.
 See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
 [PACKAGING] b v0.1.0 ([ROOT]/foo/b)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] a v0.1.0 ([ROOT]/foo/a)
 [WARNING] aborting upload due to dry run
 [UPLOADING] b v0.1.0 ([ROOT]/foo/b)
@@ -3471,7 +3471,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [WARNING] manifest has no description, license, license-file, documentation, homepage or repository.
 See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
 [PACKAGING] a v0.1.0 ([ROOT]/foo/a)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] a v0.1.0 ([ROOT]/foo/a)
 [WARNING] aborting upload due to dry run
 
@@ -3553,7 +3553,7 @@ fn wait_for_git_publish() {
 [WARNING] manifest has no documentation, homepage or repository.
 See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
 [PACKAGING] delay v0.0.2 ([ROOT]/foo)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] delay v0.0.2 ([ROOT]/foo)
 [UPLOADED] delay v0.0.2 to registry `crates-io`
 [NOTE] waiting for `delay v0.0.2` to be available at registry `crates-io`.
@@ -3746,9 +3746,10 @@ fn workspace_with_local_deps_nightly() {
         .with_stderr_data(str![[r#"
 [UPDATING] crates.io index
 [PACKAGING] level3 v0.0.1 ([ROOT]/foo/level3)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [PACKAGING] level2 v0.0.1 ([ROOT]/foo/level2)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[UPDATING] crates.io index
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [PACKAGING] level1 v0.0.1 ([ROOT]/foo/level1)
 [UPDATING] crates.io index
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
@@ -3854,11 +3855,11 @@ fn workspace_parallel() {
             str![[r#"
 [UPDATING] crates.io index
 [PACKAGING] a v0.0.1 ([ROOT]/foo/a)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [PACKAGING] b v0.0.1 ([ROOT]/foo/b)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [PACKAGING] c v0.0.1 ([ROOT]/foo/c)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [VERIFYING] a v0.0.1 ([ROOT]/foo/a)
 [COMPILING] a v0.0.1 ([ROOT]/foo/target/package/a-0.0.1)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -3885,6 +3886,7 @@ You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] c v0.0.1 at registry `crates-io`
 [UPLOADING] a v0.0.1 ([ROOT]/foo/a)
 [UPLOADING] b v0.0.1 ([ROOT]/foo/b)
+[UPDATING] crates.io index
 
 "#]]
             .unordered(),
@@ -3943,15 +3945,13 @@ fn workspace_missing_dependency() {
         .with_stderr_data(str![[r#"
 [UPDATING] crates.io index
 [PACKAGING] b v0.0.1 ([ROOT]/foo/b)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
-[VERIFYING] b v0.0.1 ([ROOT]/foo/b)
 [UPDATING] crates.io index
-[ERROR] failed to verify package tarball
+[ERROR] failed to prepare local package for uploading
 
 Caused by:
   no matching package named `a` found
   location searched: crates.io index
-  required by package `b v0.0.1 ([ROOT]/foo/target/package/b-0.0.1)`
+  required by package `b v0.0.1 ([ROOT]/foo/b)`
 
 "#]])
         .run();
@@ -3962,7 +3962,7 @@ Caused by:
         .with_stderr_data(str![[r#"
 [UPDATING] crates.io index
 [PACKAGING] a v0.0.1 ([ROOT]/foo/a)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [VERIFYING] a v0.0.1 ([ROOT]/foo/a)
 [COMPILING] a v0.0.1 ([ROOT]/foo/target/package/a-0.0.1)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/publish_lockfile.rs
+++ b/tests/testsuite/publish_lockfile.rs
@@ -150,7 +150,7 @@ src/main.rs
 }
 
 #[cargo_test]
-fn no_lock_file_with_library() {
+fn lock_file_with_library() {
     let p = project()
         .file("Cargo.toml", &pl_manifest("foo", "0.0.1", ""))
         .file("src/lib.rs", "")
@@ -162,7 +162,7 @@ fn no_lock_file_with_library() {
     validate_crate_contents(
         f,
         "foo-0.0.1.crate",
-        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs"],
+        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs", "Cargo.lock"],
         (),
     );
 }

--- a/tests/testsuite/registry_auth.rs
+++ b/tests/testsuite/registry_auth.rs
@@ -562,13 +562,15 @@ fn token_not_logged() {
     assert!(authorizations.iter().all(|line| line.contains("REDACTED")));
     // Total authorizations:
     // 1. Initial config.json
-    // 2. config.json again for verification
-    // 3. /index/3/b/bar
-    // 4. /dl/bar/1.0.0/download
-    // 5. /index/3/f/foo for checking duplicate version
-    // 6. /api/v1/crates/new
-    // 7. config.json for the "wait for publish"
-    // 8. /index/3/f/foo for the "wait for publish"
-    assert_eq!(authorizations.len(), 8);
+    // 2. /index/3/f/foo
+    // 3. config.json again for verification
+    // 4. /index/3/b/bar
+    // 5. config.json again for verification
+    // 6. /index/3/b/bar
+    // 7. /dl/bar/1.0.0/download
+    // 8. /api/v1/crates/new
+    // 9. config.json again for verification
+    // 10. /index/3/f/foo for the "wait for publish"
+    assert_eq!(authorizations.len(), 10);
     assert!(!log.contains("a-unique_token"));
 }

--- a/tests/testsuite/source_replacement.rs
+++ b/tests/testsuite/source_replacement.rs
@@ -211,9 +211,9 @@ fn publish_with_replacement() {
 [WARNING] manifest has no documentation, homepage or repository.
 See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
 [PACKAGING] foo v0.0.1 ([ROOT]/foo)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
-[VERIFYING] foo v0.0.1 ([ROOT]/foo)
 [UPDATING] `alternative` index
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[VERIFYING] foo v0.0.1 ([ROOT]/foo)
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `alternative`)
 [COMPILING] bar v1.0.0

--- a/tests/testsuite/weak_dep_features.rs
+++ b/tests/testsuite/weak_dep_features.rs
@@ -569,9 +569,9 @@ fn publish() {
         .with_stderr_data(str![[r#"
 [UPDATING] crates.io index
 [PACKAGING] foo v0.1.0 ([ROOT]/foo)
-[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
-[VERIFYING] foo v0.1.0 ([ROOT]/foo)
 [UPDATING] crates.io index
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[VERIFYING] foo v0.1.0 ([ROOT]/foo)
 [COMPILING] foo v0.1.0 ([ROOT]/foo/target/package/foo-0.1.0)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] foo v0.1.0 ([ROOT]/foo)
@@ -620,7 +620,7 @@ You may press ctrl-c to skip waiting; the crate should be available shortly.
           }
         "#,
         "foo-0.1.0.crate",
-        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs"],
+        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs", "Cargo.lock"],
         [(
             "Cargo.toml",
             str![[r##"


### PR DESCRIPTION
### What does this PR try to resolve?

Originally it was only included for packages that have executables or examples for `cargo install`, however this causes inconsistencies and is kind of unexpected nowadays, e.g. with cdylib crates.

Including it always only slightly increases the crate size and allows for all crates to know a set of dependency versions that were working, which can make regression tracking easier.

Fixes https://github.com/rust-lang/cargo/issues/13447

### How should we test and review this PR?

The existing tests are covering this change in all kinds of various already, and one test that previously asserted that there is *no* Cargo.lock for library crates was changed to explicitly check for the new behaviour.