### PR TITLE
Use the replacement source instead of the original source when generating `-C metadata` and `-C extra-filename`

### DIFF
--- a/src/cargo/core/compiler/build_runner/compilation_files.rs
+++ b/src/cargo/core/compiler/build_runner/compilation_files.rs
@@ -585,6 +585,7 @@ fn compute_metadata(
     // to pull crates from anywhere without worrying about conflicts.
     unit.pkg
         .package_id()
+        .with_source_id(unit.replaced_source)
         .stable_hash(bcx.ws.root())
         .hash(&mut hasher);
 

--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -162,6 +162,7 @@ pub fn generate_std_roots(
             );
             list.push(interner.intern(
                 pkg,
+                pkg.package_id().source_id(),
                 lib,
                 profile,
                 *kind,

--- a/src/cargo/core/compiler/unit.rs
+++ b/src/cargo/core/compiler/unit.rs
@@ -4,7 +4,7 @@ use crate::core::compiler::unit_dependencies::IsArtifact;
 use crate::core::compiler::{CompileKind, CompileMode, CompileTarget, CrateType};
 use crate::core::manifest::{Target, TargetKind};
 use crate::core::profiles::Profile;
-use crate::core::Package;
+use crate::core::{Package, SourceId};
 use crate::util::hex::short_hash;
 use crate::util::interning::InternedString;
 use crate::util::GlobalContext;
@@ -42,6 +42,7 @@ pub struct UnitInner {
     /// Information about available targets, which files to include/exclude, etc. Basically stuff in
     /// `Cargo.toml`.
     pub pkg: Package,
+    pub replaced_source: SourceId,
     /// Information about the specific target to build, out of the possible targets in `pkg`. Not
     /// to be confused with *target-triple* (or *target architecture* ...), the target arch for a
     /// build.
@@ -226,6 +227,7 @@ impl UnitInterner {
     pub fn intern(
         &self,
         pkg: &Package,
+        replaced_source: SourceId,
         target: &Target,
         profile: Profile,
         kind: CompileKind,
@@ -262,6 +264,7 @@ impl UnitInterner {
         };
         let inner = self.intern_inner(&UnitInner {
             pkg: pkg.clone(),
+            replaced_source,
             target,
             profile,
             kind,

--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -848,8 +848,17 @@ fn new_unit_dep_with_profile(
         _ => None,
     };
     let features = state.activated_features(pkg.package_id(), features_for);
+
+    let replaced_source = state
+        .package_set
+        .sources()
+        .get(pkg.package_id().source_id())
+        .unwrap()
+        .replaced_source_id();
+
     let unit = state.interner.intern(
         pkg,
+        replaced_source,
         target,
         profile,
         kind,

--- a/src/cargo/ops/cargo_compile/mod.rs
+++ b/src/cargo/ops/cargo_compile/mod.rs
@@ -695,6 +695,7 @@ fn traverse_and_share(
         canonical_profile.debuginfo = canonical_debuginfo;
         let unit_probe = interner.intern(
             &unit.pkg,
+            unit.replaced_source,
             &unit.target,
             canonical_profile,
             to_host.unwrap(),
@@ -723,6 +724,7 @@ fn traverse_and_share(
 
     let new_unit = interner.intern(
         &unit.pkg,
+        unit.replaced_source,
         &unit.target,
         profile,
         canonical_kind,
@@ -887,6 +889,7 @@ fn override_rustc_crate_types(
         target.set_kind(f(crate_types));
         interner.intern(
             &unit.pkg,
+            unit.replaced_source,
             &target,
             unit.profile.clone(),
             unit.kind,

--- a/src/cargo/ops/cargo_compile/unit_generator.rs
+++ b/src/cargo/ops/cargo_compile/unit_generator.rs
@@ -166,6 +166,7 @@ impl<'a> UnitGenerator<'a, '_> {
                 let kind = kind.for_target(target);
                 self.interner.intern(
                     pkg,
+                    pkg.package_id().source_id(),
                     target,
                     profile,
                     kind,
@@ -671,6 +672,7 @@ Rustdoc did not scrape the following examples because they require dev-dependenc
                 }
                 None => Vec::new(),
             };
+
             if target.is_lib() || unavailable_features.is_empty() {
                 units.extend(self.new_units(pkg, target, mode));
             } else if requires_features {


### PR DESCRIPTION
### What does this PR try to resolve?

This commit fixes an issue when replacing two different sources with the same local one (for example using `cargo vendor`), where `rustc` errs saying that two types "defined at the same place in the same file" are "different".

See #14821.

### How should we test and review this PR?

Use the steps described in #14821.

### Additional information

This is really useful in the context of private registries and vendored dependencies.