### PR TITLE
Simplify English used in guide

### DIFF
--- a/src/doc/src/guide/dependencies.md
+++ b/src/doc/src/guide/dependencies.md
@@ -13,7 +13,7 @@ To depend on a library hosted on [crates.io], add it to your `Cargo.toml`.
 
 If your `Cargo.toml` doesn't already have a `[dependencies]` section, add
 that, then list the [crate][def-crate] name and version that you would like to
-use. This example adds a dependency of the `time` crate:
+use. This example adds a dependency on the `time` crate:
 
 ```toml
 [dependencies]
@@ -67,7 +67,7 @@ Our `Cargo.lock` contains the exact information about which revision of all of
 these dependencies we used.
 
 Now, if `regex` gets updated, we will still build with the same revision until
-we choose to `cargo update`.
+we choose to run `cargo update`.
 
 You can now use the `regex` library in `main.rs`.
 

--- a/src/doc/src/guide/why-cargo-exists.md
+++ b/src/doc/src/guide/why-cargo-exists.md
@@ -5,7 +5,7 @@
 In Rust, as you may know, a library or executable program is called a
 [*crate*][def-crate]. Crates are compiled using the Rust compiler,
 `rustc`. When starting with Rust, the first source code most people encounter
-is that of the venerable “hello world” program, which they compile by invoking
+is that of the classic “hello world” program, which they compile by invoking
 `rustc` directly:
 
 ```console
@@ -18,15 +18,15 @@ Note that the above command required that we specify the file name
 explicitly. If we were to directly use `rustc` to compile a different program,
 a different command line invocation would be required. If we needed to specify
 any specific compiler flags or include external dependencies, then the
-needed command would be even more specific (and elaborate).
+needed command would be even more specific (and complex).
 
 Furthermore, most non-trivial programs will likely have dependencies on
 external libraries, and will therefore also depend transitively on *their*
 dependencies. Obtaining the correct versions of all the necessary dependencies
-and keeping them up to date would be laborious and error-prone if done by
+and keeping them up to date would be hard and error-prone if done by
 hand.
 
-Rather than work only with crates and `rustc`, we can avoid the manual tedium
+Rather than work only with crates and `rustc`, we can avoid the difficulties
 involved with performing the above tasks by introducing a higher-level
 ["*package*"][def-package] abstraction and by using a
 [*package manager*][def-package-manager].
@@ -51,9 +51,9 @@ we show later, the same command can be used to build different
 [*artifacts*][def-artifact], regardless of their names. Rather than invoke
 `rustc` directly, we can instead invoke something generic such as `cargo
 build` and let cargo worry about constructing the correct `rustc`
-invocation. Furthermore, Cargo will automatically fetch from a
-[*registry*][def-registry] any dependencies we have defined for our artifact,
-and arrange for them to be incorporated into our build as needed.
+invocation. Furthermore, Cargo will automatically fetch any dependencies
+we have defined for our artifact from a [*registry*][def-registry],
+and arrange for them to be added into our build as needed.
 
 It is only a slight exaggeration to say that once you know how to build one
 Cargo-based project, you know how to build *all* of them.


### PR DESCRIPTION
First draft of trying to simplify the English used in the guide section of the book, as well as normalising between 'you' for the reader and 'we' for the authors
