### PR TITLE
fix(fingerprint): Don't throwaway the cache on RUSTFLAGS changes 

### DIFF
--- a/src/cargo/core/compiler/build_runner/compilation_files.rs
+++ b/src/cargo/core/compiler/build_runner/compilation_files.rs
@@ -593,6 +593,7 @@ fn compute_metadata(
         .iter()
         .map(|dep| *metadata_of(&dep.unit, build_runner, metas))
         .collect::<Vec<_>>();
+    let use_extra_filename = use_extra_filename(bcx, unit);
 
     let mut hasher = StableHasher::new();
 
@@ -685,9 +686,11 @@ fn compute_metadata(
     dep_hashes.sort();
     dep_hashes.hash(&mut hasher);
 
+    let meta_hash = UnitHash(hasher.finish());
+
     Metadata {
-        meta_hash: UnitHash(hasher.finish()),
-        use_extra_filename: use_extra_filename(bcx, unit),
+        meta_hash,
+        use_extra_filename,
     }
 }
 

--- a/src/cargo/core/compiler/build_runner/compilation_files.rs
+++ b/src/cargo/core/compiler/build_runner/compilation_files.rs
@@ -700,6 +700,18 @@ fn compute_metadata(
         .collect::<Vec<_>>();
     dep_c_extra_filename_hashes.sort();
     dep_c_extra_filename_hashes.hash(&mut c_extra_filename_hasher);
+    // Avoid trashing the caches on RUSTFLAGS changing via `c_extra_filename`
+    //
+    // Limited to `c_extra_filename` to help with reproducible build / PGO issues.
+    build_runner
+        .bcx
+        .extra_args_for(unit)
+        .hash(&mut c_extra_filename_hasher);
+    if unit.mode.is_doc() || unit.mode.is_doc_scrape() {
+        unit.rustdocflags.hash(&mut c_extra_filename_hasher);
+    } else {
+        unit.rustflags.hash(&mut c_extra_filename_hasher);
+    }
 
     let c_metadata = UnitHash(c_metadata_hasher.finish());
     let c_extra_filename = UnitHash(c_extra_filename_hasher.finish());

--- a/src/cargo/core/compiler/build_runner/compilation_files.rs
+++ b/src/cargo/core/compiler/build_runner/compilation_files.rs
@@ -609,14 +609,6 @@ fn compute_metadata(
     // when changing feature sets each lib is separately cached.
     unit.features.hash(&mut hasher);
 
-    // Mix in the target-metadata of all the dependencies of this target.
-    let mut dep_hashes = deps_metadata
-        .iter()
-        .map(|m| m.meta_hash)
-        .collect::<Vec<_>>();
-    dep_hashes.sort();
-    dep_hashes.hash(&mut hasher);
-
     // Throw in the profile we're compiling with. This helps caching
     // `panic=abort` and `panic=unwind` artifacts, additionally with various
     // settings like debuginfo and whatnot.
@@ -684,6 +676,14 @@ fn compute_metadata(
                 != unit.links_overrides;
         target_configs_are_different.hash(&mut hasher);
     }
+
+    // Mix in the target-metadata of all the dependencies of this target.
+    let mut dep_hashes = deps_metadata
+        .iter()
+        .map(|m| m.meta_hash)
+        .collect::<Vec<_>>();
+    dep_hashes.sort();
+    dep_hashes.hash(&mut hasher);
 
     Metadata {
         meta_hash: UnitHash(hasher.finish()),

--- a/src/cargo/core/compiler/fingerprint/mod.rs
+++ b/src/cargo/core/compiler/fingerprint/mod.rs
@@ -47,46 +47,48 @@
 //! reliable and reproducible builds at the cost of being complex, slow, and
 //! platform-dependent.
 //!
-//! ## Fingerprints and Metadata
+//! ## Fingerprints and [`UnitHash`]s
 //!
-//! The [`Metadata`] hash is a hash added to the output filenames to isolate
-//! each unit. See its documentationfor more details.
+//! [`Metadata`] tracks several [`UnitHash`]s, including
+//! [`Metadata::unit_id`], [`Metadata::c_metadata`], and [`Metadata::c_extra_filename`].
+//! See its documentation for more details.
+//!
 //! NOTE: Not all output files are isolated via filename hashes (like dylibs).
 //! The fingerprint directory uses a hash, but sometimes units share the same
 //! fingerprint directory (when they don't have Metadata) so care should be
 //! taken to handle this!
 //!
-//! Fingerprints and Metadata are similar, and track some of the same things.
-//! The Metadata contains information that is required to keep Units separate.
+//! Fingerprints and [`UnitHash`]s are similar, and track some of the same things.
+//! [`UnitHash`]s contains information that is required to keep Units separate.
 //! The Fingerprint includes additional information that should cause a
 //! recompile, but it is desired to reuse the same filenames. A comparison
 //! of what is tracked:
 //!
-//! Value                                      | Fingerprint | Metadata
-//! -------------------------------------------|-------------|----------
-//! rustc                                      | ✓           | ✓
-//! [`Profile`]                                | ✓           | ✓
-//! `cargo rustc` extra args                   | ✓           |
-//! [`CompileMode`]                            | ✓           | ✓
-//! Target Name                                | ✓           | ✓
-//! `TargetKind` (bin/lib/etc.)                | ✓           | ✓
-//! Enabled Features                           | ✓           | ✓
-//! Declared Features                          | ✓           |
-//! Immediate dependency’s hashes              | ✓[^1]       | ✓
-//! [`CompileKind`] (host/target)              | ✓           | ✓
-//! `__CARGO_DEFAULT_LIB_METADATA`[^4]         |             | ✓
-//! `package_id`                               |             | ✓
-//! authors, description, homepage, repo       | ✓           |
-//! Target src path relative to ws             | ✓           |
-//! Target flags (test/bench/for_host/edition) | ✓           |
-//! -C incremental=… flag                      | ✓           |
-//! mtime of sources                           | ✓[^3]       |
-//! RUSTFLAGS/RUSTDOCFLAGS                     | ✓           |
-//! [`Lto`] flags                              | ✓           | ✓
-//! config settings[^5]                        | ✓           |
-//! `is_std`                                   |             | ✓
-//! `[lints]` table[^6]                        | ✓           |
-//! `[lints.rust.unexpected_cfgs.check-cfg]`   | ✓           |
+//! Value                                      | Fingerprint | `Metadata::unit_id` | `Metadata::c_metadata` | `Metadata::c_extra_filename`
+//! -------------------------------------------|-------------|---------------------|------------------------|----------
+//! rustc                                      | ✓           | ✓                   | ✓                      | ✓
+//! [`Profile`]                                | ✓           | ✓                   | ✓                      | ✓
+//! `cargo rustc` extra args                   | ✓           |                     |                        |
+//! [`CompileMode`]                            | ✓           | ✓                   | ✓                      | ✓
+//! Target Name                                | ✓           | ✓                   | ✓                      | ✓
+//! `TargetKind` (bin/lib/etc.)                | ✓           | ✓                   | ✓                      | ✓
+//! Enabled Features                           | ✓           | ✓                   | ✓                      | ✓
+//! Declared Features                          | ✓           |                     |                        |
+//! Immediate dependency’s hashes              | ✓[^1]       | ✓                   | ✓                      | ✓
+//! [`CompileKind`] (host/target)              | ✓           | ✓                   | ✓                      | ✓
+//! `__CARGO_DEFAULT_LIB_METADATA`[^4]         |             | ✓                   | ✓                      | ✓
+//! `package_id`                               |             | ✓                   | ✓                      | ✓
+//! authors, description, homepage, repo       | ✓           |                     |                        |
+//! Target src path relative to ws             | ✓           |                     |                        |
+//! Target flags (test/bench/for_host/edition) | ✓           |                     |                        |
+//! -C incremental=… flag                      | ✓           |                     |                        |
+//! mtime of sources                           | ✓[^3]       |                     |                        |
+//! RUSTFLAGS/RUSTDOCFLAGS                     | ✓           |                     |                        |
+//! [`Lto`] flags                              | ✓           | ✓                   | ✓                      | ✓
+//! config settings[^5]                        | ✓           |                     |                        |
+//! `is_std`                                   |             | ✓                   | ✓                      | ✓
+//! `[lints]` table[^6]                        | ✓           |                     |                        |
+//! `[lints.rust.unexpected_cfgs.check-cfg]`   | ✓           |                     |                        |
 //!
 //! [^1]: Build script and bin dependencies are not included.
 //!
@@ -348,6 +350,10 @@
 //!
 //! [`check_filesystem`]: Fingerprint::check_filesystem
 //! [`Metadata`]: crate::core::compiler::Metadata
+//! [`Metadata::unit_id`]: crate::core::compiler::Metadata::unit_id
+//! [`Metadata::c_metadata`]: crate::core::compiler::Metadata::c_metadata
+//! [`Metadata::c_extra_filename`]: crate::core::compiler::Metadata::c_extra_filename
+//! [`UnitHash`]: crate::core::compiler::UnitHash
 //! [`Profile`]: crate::core::profiles::Profile
 //! [`CompileMode`]: crate::core::compiler::CompileMode
 //! [`Lto`]: crate::core::compiler::Lto

--- a/src/cargo/core/compiler/fingerprint/mod.rs
+++ b/src/cargo/core/compiler/fingerprint/mod.rs
@@ -68,7 +68,7 @@
 //! -------------------------------------------|-------------|---------------------|------------------------|----------
 //! rustc                                      | ✓           | ✓                   | ✓                      | ✓
 //! [`Profile`]                                | ✓           | ✓                   | ✓                      | ✓
-//! `cargo rustc` extra args                   | ✓           |                     |                        |
+//! `cargo rustc` extra args                   | ✓           | ✓                   |                        | ✓
 //! [`CompileMode`]                            | ✓           | ✓                   | ✓                      | ✓
 //! Target Name                                | ✓           | ✓                   | ✓                      | ✓
 //! `TargetKind` (bin/lib/etc.)                | ✓           | ✓                   | ✓                      | ✓
@@ -83,7 +83,7 @@
 //! Target flags (test/bench/for_host/edition) | ✓           |                     |                        |
 //! -C incremental=… flag                      | ✓           |                     |                        |
 //! mtime of sources                           | ✓[^3]       |                     |                        |
-//! RUSTFLAGS/RUSTDOCFLAGS                     | ✓           |                     |                        |
+//! RUSTFLAGS/RUSTDOCFLAGS                     | ✓           | ✓                   |                        | ✓
 //! [`Lto`] flags                              | ✓           | ✓                   | ✓                      | ✓
 //! config settings[^5]                        | ✓           |                     |                        |
 //! `is_std`                                   |             | ✓                   | ✓                      | ✓

--- a/src/cargo/core/compiler/fingerprint/mod.rs
+++ b/src/cargo/core/compiler/fingerprint/mod.rs
@@ -68,7 +68,7 @@
 //! -------------------------------------------|-------------|---------------------|------------------------|----------
 //! rustc                                      | ✓           | ✓                   | ✓                      | ✓
 //! [`Profile`]                                | ✓           | ✓                   | ✓                      | ✓
-//! `cargo rustc` extra args                   | ✓           | ✓                   |                        | ✓
+//! `cargo rustc` extra args                   | ✓           | ✓[^7]               |                        | ✓[^7]
 //! [`CompileMode`]                            | ✓           | ✓                   | ✓                      | ✓
 //! Target Name                                | ✓           | ✓                   | ✓                      | ✓
 //! `TargetKind` (bin/lib/etc.)                | ✓           | ✓                   | ✓                      | ✓
@@ -83,7 +83,7 @@
 //! Target flags (test/bench/for_host/edition) | ✓           |                     |                        |
 //! -C incremental=… flag                      | ✓           |                     |                        |
 //! mtime of sources                           | ✓[^3]       |                     |                        |
-//! RUSTFLAGS/RUSTDOCFLAGS                     | ✓           | ✓                   |                        | ✓
+//! RUSTFLAGS/RUSTDOCFLAGS                     | ✓           | ✓[^7]               |                        | ✓[^7]
 //! [`Lto`] flags                              | ✓           | ✓                   | ✓                      | ✓
 //! config settings[^5]                        | ✓           |                     |                        |
 //! `is_std`                                   |             | ✓                   | ✓                      | ✓
@@ -101,6 +101,9 @@
 //!       Currently, this is only `doc.extern-map`.
 //!
 //! [^6]: Via [`Manifest::lint_rustflags`][crate::core::Manifest::lint_rustflags]
+//!
+//! [^7]: extra-flags and RUSTFLAGS are conditionally excluded when `--remap-path-prefix` is
+//!       present to avoid breaking build reproducibility while we wait for trim-paths
 //!
 //! When deciding what should go in the Metadata vs the Fingerprint, consider
 //! that some files (like dylibs) do not have a hash in their filename. Thus,

--- a/src/cargo/util/hasher.rs
+++ b/src/cargo/util/hasher.rs
@@ -6,6 +6,7 @@
 
 use std::hash::{Hasher, SipHasher};
 
+#[derive(Clone)]
 pub struct StableHasher(SipHasher);
 
 impl StableHasher {

--- a/tests/testsuite/config_include.rs
+++ b/tests/testsuite/config_include.rs
@@ -244,7 +244,6 @@ fn works_with_cli() {
     p.cargo("check -v -Z config-include")
         .masquerade_as_nightly_cargo(&["config-include"])
         .with_stderr_data(str![[r#"
-[DIRTY] foo v0.0.1 ([ROOT]/foo): the rustflags changed
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc [..]-W unsafe-code -W unused`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -1337,7 +1337,6 @@ fn changing_rustflags_is_cached() {
     p.cargo("build -v")
         .env("RUSTFLAGS", "-C linker=cc")
         .with_stderr_data(str![[r#"
-[DIRTY] foo v0.0.1 ([ROOT]/foo): the rustflags changed
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1347,9 +1346,7 @@ fn changing_rustflags_is_cached() {
 
     p.cargo("build -v")
         .with_stderr_data(str![[r#"
-[DIRTY] foo v0.0.1 ([ROOT]/foo): the rustflags changed
-[COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc [..] src/lib.rs [..]
+[FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -1357,9 +1354,7 @@ fn changing_rustflags_is_cached() {
     p.cargo("build -v")
         .env("RUSTFLAGS", "-C linker=cc")
         .with_stderr_data(str![[r#"
-[DIRTY] foo v0.0.1 ([ROOT]/foo): the rustflags changed
-[COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc [..]
+[FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -1380,7 +1375,6 @@ fn changing_rustc_extra_flags_is_cached() {
         .run();
     p.cargo("rustc -v -- -C linker=cc")
         .with_stderr_data(str![[r#"
-[DIRTY] foo v0.0.1 ([ROOT]/foo): the profile configuration changed
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1390,18 +1384,14 @@ fn changing_rustc_extra_flags_is_cached() {
 
     p.cargo("rustc -v")
         .with_stderr_data(str![[r#"
-[DIRTY] foo v0.0.1 ([ROOT]/foo): the profile configuration changed
-[COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc [..]
+[FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
         .run();
     p.cargo("rustc -v -- -C linker=cc")
         .with_stderr_data(str![[r#"
-[DIRTY] foo v0.0.1 ([ROOT]/foo): the profile configuration changed
-[COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc [..]
+[FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])

--- a/tests/testsuite/freshness_checksum.rs
+++ b/tests/testsuite/freshness_checksum.rs
@@ -1509,7 +1509,6 @@ fn changing_rustflags_is_cached() {
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .env("RUSTFLAGS", "-C linker=cc")
         .with_stderr_data(str![[r#"
-[DIRTY] foo v0.0.1 ([ROOT]/foo): the rustflags changed
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1520,9 +1519,7 @@ fn changing_rustflags_is_cached() {
     p.cargo("build -Zchecksum-freshness -v")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
-[DIRTY] foo v0.0.1 ([ROOT]/foo): the rustflags changed
-[COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc [..] src/lib.rs [..]
+[FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -1531,9 +1528,7 @@ fn changing_rustflags_is_cached() {
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .env("RUSTFLAGS", "-C linker=cc")
         .with_stderr_data(str![[r#"
-[DIRTY] foo v0.0.1 ([ROOT]/foo): the rustflags changed
-[COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc [..]
+[FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -1556,7 +1551,6 @@ fn changing_rustc_extra_flags_is_cached() {
     p.cargo("rustc -Zchecksum-freshness -v -- -C linker=cc")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
-[DIRTY] foo v0.0.1 ([ROOT]/foo): the profile configuration changed
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1567,9 +1561,7 @@ fn changing_rustc_extra_flags_is_cached() {
     p.cargo("rustc -Zchecksum-freshness -v")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
-[DIRTY] foo v0.0.1 ([ROOT]/foo): the profile configuration changed
-[COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc [..] src/lib.rs [..]
+[FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -1577,9 +1569,7 @@ fn changing_rustc_extra_flags_is_cached() {
     p.cargo("rustc -Zchecksum-freshness -v -- -C linker=cc")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
-[DIRTY] foo v0.0.1 ([ROOT]/foo): the profile configuration changed
-[COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc [..]
+[FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])

--- a/tests/testsuite/pgo.rs
+++ b/tests/testsuite/pgo.rs
@@ -103,7 +103,6 @@ fn pgo_works() {
             ),
         )
         .with_stderr_data(str![[r#"
-[DIRTY] foo v0.0.0 ([ROOT]/foo): the rustflags changed
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
 [RUNNING] `rustc [..]-Cprofile-use=[ROOT]/foo/target/merged.profdata -Cllvm-args=-pgo-warn-missing-function`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -616,7 +616,6 @@ fn rustc_fingerprint() {
     p.cargo("rustc -v")
         .with_stderr_does_not_contain("-C debug-assertions")
         .with_stderr_data(str![[r#"
-[DIRTY] foo v0.5.0 ([ROOT]/foo): the profile configuration changed
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/rustflags.rs
+++ b/tests/testsuite/rustflags.rs
@@ -1592,7 +1592,7 @@ fn rustflags_remap_path_prefix_ignored_for_c_extra_filename() {
         .run();
     let second_c_extra_filename = dbg!(get_c_extra_filename(build_output));
 
-    assert_ne!(first_c_extra_filename, second_c_extra_filename);
+    assert_data_eq!(first_c_extra_filename, second_c_extra_filename);
 }
 
 // `--remap-path-prefix` is meant to take two different binaries and make them the same but the
@@ -1613,7 +1613,7 @@ fn rustc_remap_path_prefix_ignored_for_c_extra_filename() {
         .run();
     let second_c_extra_filename = dbg!(get_c_extra_filename(build_output));
 
-    assert_ne!(first_c_extra_filename, second_c_extra_filename);
+    assert_data_eq!(first_c_extra_filename, second_c_extra_filename);
 }
 
 fn get_c_metadata(output: RawOutput) -> String {

--- a/tests/testsuite/rustflags.rs
+++ b/tests/testsuite/rustflags.rs
@@ -1592,7 +1592,7 @@ fn rustflags_remap_path_prefix_ignored_for_c_extra_filename() {
         .run();
     let second_c_extra_filename = dbg!(get_c_extra_filename(build_output));
 
-    assert_data_eq!(first_c_extra_filename, second_c_extra_filename);
+    assert_ne!(first_c_extra_filename, second_c_extra_filename);
 }
 
 // `--remap-path-prefix` is meant to take two different binaries and make them the same but the
@@ -1613,7 +1613,7 @@ fn rustc_remap_path_prefix_ignored_for_c_extra_filename() {
         .run();
     let second_c_extra_filename = dbg!(get_c_extra_filename(build_output));
 
-    assert_data_eq!(first_c_extra_filename, second_c_extra_filename);
+    assert_ne!(first_c_extra_filename, second_c_extra_filename);
 }
 
 fn get_c_metadata(output: RawOutput) -> String {


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes #8716

This splits `-C metdata` and `-C extra-filename` and adds `RUSTFLAGS` to `-C extra-filename` in the hope that we can still make PGO and reproducible builds work while caching artifacts per RUSTFLAGS used.

### How should we test and review this PR?



### Additional information

