### PR TITLE
Allow registries to omit empty/default fields in JSON

### DIFF
--- a/src/cargo/sources/registry/index/mod.rs
+++ b/src/cargo/sources/registry/index/mod.rs
@@ -206,6 +206,7 @@ pub struct IndexPackage<'a> {
     #[serde(borrow)]
     pub deps: Vec<RegistryDependency<'a>>,
     /// Set of features defined for the package, i.e., `[features]` table.
+    #[serde(default)]
     pub features: BTreeMap<InternedString, Vec<InternedString>>,
     /// This field contains features with new, extended syntax. Specifically,
     /// namespaced features (`dep:`) and weak dependencies (`pkg?/feat`).
@@ -268,10 +269,13 @@ pub struct RegistryDependency<'a> {
     #[serde(borrow)]
     pub req: Cow<'a, str>,
     /// Set of features enabled for this dependency.
+    #[serde(default)]
     pub features: Vec<InternedString>,
     /// Whether or not this is an optional dependency.
+    #[serde(default)]
     pub optional: bool,
     /// Whether or not default features are enabled.
+    #[serde(default = "default_true")]
     pub default_features: bool,
     /// The target platform for this dependency.
     pub target: Option<Cow<'a, str>>,
@@ -290,6 +294,10 @@ pub struct RegistryDependency<'a> {
     pub bindep_target: Option<Cow<'a, str>>,
     #[serde(default)]
     pub lib: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 impl<'gctx> RegistryIndex<'gctx> {

--- a/src/doc/src/reference/registry-index.md
+++ b/src/doc/src/reference/registry-index.md
@@ -140,26 +140,24 @@ explaining the format of the entry.
             "req": "^0.6",
             // Array of features (as strings) enabled for this dependency.
             "features": ["i128_support"],
-            // Boolean of whether or not this is an optional dependency.
+            // Boolean of whether or not this is an optional dependency. Defaults to `false` if not specified.
             "optional": false,
-            // Boolean of whether or not default features are enabled.
+            // Boolean of whether or not default features are enabled. Defaults to `true` if not specified.
             "default_features": true,
             // The target platform for the dependency.
-            // null if not a target dependency.
+            // If not specified or `null`, it is not a target dependency.
             // Otherwise, a string such as "cfg(windows)".
             "target": null,
             // The dependency kind.
             // "dev", "build", or "normal".
-            // Note: this is a required field, but a small number of entries
-            // exist in the crates.io index with either a missing or null
-            // `kind` field due to implementation bugs.
+            // If not specified or `null`, it defaults to "normal".
             "kind": "normal",
             // The URL of the index of the registry where this dependency is
-            // from as a string. If not specified or null, it is assumed the
+            // from as a string. If not specified or `null`, it is assumed the
             // dependency is in the current registry.
             "registry": null,
             // If the dependency is renamed, this is a string of the actual
-            // package name. If not specified or null, this dependency is not
+            // package name. If not specified or `null`, this dependency is not
             // renamed.
             "package": null,
         }


### PR DESCRIPTION
Applies the patch from #14506 + documentation update.

The `kind` field has already been optional in the implementation, but documented as possibly missing due to bugs. I've changed the documentation to simply state it's optional.
