### PR TITLE
tests: refactor testsuite `cargo build --target`

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1123,6 +1123,21 @@ impl Execs {
         }
         Ok(())
     }
+
+    pub fn target(&mut self, target: &str) -> &mut Self {
+        self.arg("--target").arg(target);
+        self
+    }
+
+    pub fn target_host(&mut self) -> &mut Self {
+        self.target(rustc_host());
+        self
+    }
+
+    pub fn target_dir(&mut self, dir: &str) -> &mut Self {
+        self.arg("--target-dir").arg(dir);
+        self
+    }
 }
 
 impl Drop for Execs {

--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -42,7 +42,6 @@ fn enable_build_std(e: &mut Execs, arg: Option<&str>) {
 trait BuildStd: Sized {
     fn build_std(&mut self) -> &mut Self;
     fn build_std_arg(&mut self, arg: &str) -> &mut Self;
-    fn target_host(&mut self) -> &mut Self;
 }
 
 impl BuildStd for Execs {
@@ -53,11 +52,6 @@ impl BuildStd for Execs {
 
     fn build_std_arg(&mut self, arg: &str) -> &mut Self {
         enable_build_std(self, Some(arg));
-        self
-    }
-
-    fn target_host(&mut self) -> &mut Self {
-        self.arg("--target").arg(rustc_host());
         self
     }
 }
@@ -192,7 +186,9 @@ fn cross_custom() {
         )
         .build();
 
-    p.cargo("build --target custom-target.json -v")
+    p.cargo("build")
+        .target("custom-target.json")
+        .arg("-v")
         .build_std_arg("core")
         .run();
 }

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -3991,7 +3991,7 @@ fn custom_target_dir_line_parameter() {
 
     let exe_name = format!("foo{}", env::consts::EXE_SUFFIX);
 
-    p.cargo("build --target-dir foo/target").run();
+    p.cargo("build").target_dir("foo/target").run();
     assert!(p.root().join("foo/target/debug").join(&exe_name).is_file());
     assert!(!p.root().join("target/debug").join(&exe_name).is_file());
 
@@ -4006,12 +4006,13 @@ fn custom_target_dir_line_parameter() {
             target-dir = "foo/target"
         "#,
     );
-    p.cargo("build --target-dir bar/target").run();
+    p.cargo("build").target_dir("bar/target").run();
     assert!(p.root().join("bar/target/debug").join(&exe_name).is_file());
     assert!(p.root().join("foo/target/debug").join(&exe_name).is_file());
     assert!(p.root().join("target/debug").join(&exe_name).is_file());
 
-    p.cargo("build --target-dir foobar/target")
+    p.cargo("build")
+        .target_dir("foobar/target")
         .env("CARGO_TARGET_DIR", "bar/target")
         .run();
     assert!(p
@@ -4456,8 +4457,8 @@ fn cargo_build_empty_target() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build --target")
-        .arg("")
+    p.cargo("build")
+        .target("")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] target was empty

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -457,7 +457,7 @@ fn custom_build_env_var_rustc_linker() {
 
     // no crate type set => linker never called => build succeeds if and
     // only if build.rs succeeds, despite linker binary not existing.
-    p.cargo("build --target").arg(&target).run();
+    p.cargo("build").target(&target).run();
 }
 
 // Only run this test on linux, since it's difficult to construct
@@ -494,7 +494,7 @@ fn custom_build_env_var_rustc_linker_with_target_cfg() {
 
     // no crate type set => linker never called => build succeeds if and
     // only if build.rs succeeds, despite linker binary not existing.
-    p.cargo("build --target").arg(&target).run();
+    p.cargo("build").target(&target).run();
 }
 
 #[cargo_test]

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -150,7 +150,7 @@ fn simple_deps() {
         .build();
 
     let target = cross_compile::alternate();
-    p.cargo("build --target").arg(&target).run();
+    p.cargo("build").target(&target).run();
     assert!(p.target_bin(target, "foo").is_file());
 
     if cross_compile::can_run_on_host() {

--- a/tests/testsuite/custom_target.rs
+++ b/tests/testsuite/custom_target.rs
@@ -53,8 +53,13 @@ fn custom_target_minimal() {
         .file("custom-target.json", SIMPLE_SPEC)
         .build();
 
-    p.cargo("build --lib --target custom-target.json -v").run();
-    p.cargo("build --lib --target src/../custom-target.json -v")
+    p.cargo("build --lib")
+        .target("custom-target.json")
+        .arg("-v")
+        .run();
+    p.cargo("build --lib")
+        .target("src/../custom-target.json")
+        .arg("-v")
         .run();
 
     // Ensure that the correct style of flag is passed to --target with doc tests.
@@ -140,7 +145,10 @@ fn custom_bin_target() {
         .file("custom-bin-target.json", SIMPLE_SPEC)
         .build();
 
-    p.cargo("build --target custom-bin-target.json -v").run();
+    p.cargo("build")
+        .target("custom-bin-target.json")
+        .arg("-v")
+        .run();
 }
 
 #[cargo_test(nightly, reason = "requires features no_core, lang_items")]

--- a/tests/testsuite/standard_lib.rs
+++ b/tests/testsuite/standard_lib.rs
@@ -163,7 +163,6 @@ fn enable_build_std(e: &mut Execs, setup: &Setup) {
 trait BuildStd: Sized {
     fn build_std(&mut self, setup: &Setup) -> &mut Self;
     fn build_std_arg(&mut self, setup: &Setup, arg: &str) -> &mut Self;
-    fn target_host(&mut self) -> &mut Self;
 }
 
 impl BuildStd for Execs {
@@ -176,11 +175,6 @@ impl BuildStd for Execs {
     fn build_std_arg(&mut self, setup: &Setup, arg: &str) -> &mut Self {
         enable_build_std(self, setup);
         self.arg(format!("-Zbuild-std={}", arg));
-        self
-    }
-
-    fn target_host(&mut self) -> &mut Self {
-        self.arg("--target").arg(rustc_host());
         self
     }
 }


### PR DESCRIPTION
### What does this PR try to resolve?

Mentioned [here](https://github.com/rust-lang/cargo/pull/14183#discussion_r1838979612), this PR is a small refactor to add three additional functions to `Execs` in order to pass a target triple, host target or target directory more cleanly when running a test case.
