### PR TITLE
chore: remove bors mentions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,3 @@
-<!-- homu-ignore:start -->
 <!--
 Thanks for submitting a pull request 🎉! Here are some tips for you:
 
@@ -35,4 +34,3 @@ https://doc.crates.io/contrib/tests
 Other information you want to mention in this PR, such as prior arts,
 future extensions, an unresolved problem, or a TODO list.
 -->
-<!-- homu-ignore:end -->

--- a/ci/validate-version-bump.sh
+++ b/ci/validate-version-bump.sh
@@ -11,7 +11,7 @@
 
 set -euo pipefail
 
-# When `BASE_SHA` is missing, we assume it is from bors merge commit,
+# When `BASE_SHA` is missing, we assume it is from GitHub merge queue merge commit,
 # so hope `HEAD~` to find the previous commit on master branch.
 base_sha=$(git rev-parse "${BASE_SHA:-HEAD~1}")
 head_sha=$(git rev-parse "${HEAD_SHA:-HEAD}")

--- a/src/doc/contrib/src/process/index.md
+++ b/src/doc/contrib/src/process/index.md
@@ -87,12 +87,12 @@ The Cargo project uses several bots:
 * [GitHub Actions] are used to automatically run all tests for each PR.
 * [triagebot] automatically assigns reviewers for PRs, see [PR Assignment] for
   how to configure.
-* [bors] is used to merge PRs. See [The merging process].
+* [GitHub merge queue] is used to merge PRs. See [The merging process].
 * [triagebot] is used for assigning issues to non-members, see [Issue
   assignment](#issue-assignment).
 * [rfcbot] is used for making asynchronous decisions by team members.
 
-[bors]: https://buildbot2.rust-lang.org/homu/
+[GitHub merge queue]: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue
 [The merging process]: working-on-cargo.md#the-merging-process
 [GitHub Actions]: https://github.com/features/actions
 [triagebot]: https://forge.rust-lang.org/triagebot/index.html

--- a/src/doc/contrib/src/process/working-on-cargo.md
+++ b/src/doc/contrib/src/process/working-on-cargo.md
@@ -156,19 +156,18 @@ More information about these commands can be found at the [shortcuts documentati
 
 ## The merging process
 
-After a reviewer has approved your PR, they will issue a command to the [bors]
-bot (also known as "Homu", the software that powers [`@bors`]). Bors will
-create a temporary branch with your PR, and run all tests. Only if all tests
-pass will it merge the PR to master. If it fails, the bot will leave a comment
-on the PR. This system ensures that the master branch is always in a good
-state, and that merges are processed one at a time. The [Homu queue
-dashboard][homu-cargo] shows the current merge queue. Cargo's queue is rarely
-busy, but a busy project like the [rust repo][homu-rust] is constantly full.
+After a reviewer has approved your PR,
+they will add the PR to [GitHub merge queue].
+The merge queue will create a temporary branch with your PR,
+and run all required jobs.
+If it fails, it will be removed from the queue.
+The merge queue ensures that the master branch is always in a good state,
+and that merges are processed one at a time.
+The [merge queue dashboard] shows the current queued pull requests.
 
 Assuming everything works, congratulations! It may take at least a week for
 the changes to arrive on the nightly channel. See the [release chapter] for
 more information on how Cargo releases are made.
-
 
 [development-models]: https://help.github.com/articles/about-collaborative-development-models/
 [create pull requests]: https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request
@@ -179,10 +178,8 @@ more information on how Cargo releases are made.
 [how-to-clone]: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository
 [Testing chapter]: ../tests/index.md
 [GitHub's keywords]: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
-[bors]: https://buildbot2.rust-lang.org/homu/
-[`@bors`]: https://github.com/bors
-[homu-cargo]: https://buildbot2.rust-lang.org/homu/queue/cargo
-[homu-rust]: https://buildbot2.rust-lang.org/homu/queue/rust
+[GitHub merge queue]: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue
+[merge queue dashboard]: https://github.com/rust-lang/cargo/queue/master
 [release chapter]: release.md
 [internals forum]: https://internals.rust-lang.org/c/tools-and-infrastructure/cargo
 [file an issue]: https://github.com/rust-lang/cargo/issues

--- a/src/doc/contrib/src/team.md
+++ b/src/doc/contrib/src/team.md
@@ -48,7 +48,7 @@ Members are required to always:
 
 Members are given privileges, such as:
 
-- Merge permissions (bors rights)
+- Merge permissions (GitHub permissions)
 - Issue and project management (GitHub permissions)
 - Voting and decision making (RFCs, major changes)
 - Access to private communications related to team management and security discussions


### PR DESCRIPTION
### What does this PR try to resolve?

Cargo has moved to GitHub merge queue. These are the last vestiges of bors 🥲 👋🏾.