### PR TITLE
fix(publish): Allow dry-run of a non-bumped workspace 

### DIFF
--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -6056,20 +6056,21 @@ fn workspace_with_local_dep_already_published_nightly() {
     p.cargo("package -Zpackage-workspace")
         .masquerade_as_nightly_cargo(&["package-workspace"])
         .replace_crates_io(reg.index_url())
-        .with_status(101)
         .with_stderr_data(
             str![[r#"
 [PACKAGING] dep v0.1.0 ([ROOT]/foo/dep)
 [PACKAGING] main v0.0.1 ([ROOT]/foo/main)
 [UPDATING] crates.io index
-[ERROR] failed to prepare local package for uploading
-
-Caused by:
-  failed to get `dep` as a dependency of package `main v0.0.1 ([ROOT]/foo/main)`
-
-Caused by:
-  found a package in the remote registry and the local overlay: dep@0.1.0
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[VERIFYING] dep v0.1.0 ([ROOT]/foo/dep)
+[COMPILING] dep v0.1.0 ([ROOT]/foo/target/package/dep-0.1.0)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[VERIFYING] main v0.0.1 ([ROOT]/foo/main)
+[UNPACKING] dep v0.1.0 (registry `[ROOT]/foo/target/package/tmp-registry`)
+[COMPILING] dep v0.1.0
+[COMPILING] main v0.0.1 ([ROOT]/foo/target/package/main-0.0.1)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]]
             .unordered(),

--- a/tests/testsuite/registry_overlay.rs
+++ b/tests/testsuite/registry_overlay.rs
@@ -3,6 +3,7 @@
 use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::registry::{Package, RegistryBuilder, TestRegistry};
+use cargo_test_support::str;
 
 fn setup() -> (TestRegistry, String) {
     let alt = RegistryBuilder::new().alternative().build();
@@ -77,17 +78,16 @@ fn registry_version_wins() {
 
     p.cargo("check")
         .overlay_registry(&reg.index_url(), &alt_path)
-        .with_stderr_data(
-            "\
-[UPDATING] [..]
+        .with_stderr_data(str![[r#"
+[UPDATING] `sparse+http://127.0.0.1:[..]/index/` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
-[DOWNLOADED] baz v0.1.1 (registry [..])
+[DOWNLOADED] baz v0.1.1 (registry `sparse+http://127.0.0.1:[..]/index/`)
 [CHECKING] baz v0.1.1
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-",
-        )
+
+"#]])
         .run();
 }
 
@@ -120,16 +120,15 @@ fn overlay_version_wins() {
 
     p.cargo("check")
         .overlay_registry(&reg.index_url(), &alt_path)
-        .with_stderr_data(
-            "\
-[UPDATING] [..]
+        .with_stderr_data(str![[r#"
+[UPDATING] `sparse+http://127.0.0.1:[..]/index/` index
 [LOCKING] 1 package to latest compatible version
-[UNPACKING] baz v0.1.1 (registry [..])
+[UNPACKING] baz v0.1.1 (registry `[ROOT]/alternative-registry`)
 [CHECKING] baz v0.1.1
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-",
-        )
+
+"#]])
         .run();
 }
 
@@ -163,18 +162,17 @@ fn version_collision() {
     p.cargo("check")
         .overlay_registry(&reg.index_url(), &alt_path)
         .with_status(101)
-        .with_stderr_data(
-            "\
-[UPDATING] [..]
-[ERROR] failed to get `baz` [..]
+        .with_stderr_data(str![[r#"
+[UPDATING] `sparse+http://127.0.0.1:[..]/index/` index
+[ERROR] failed to get `baz` as a dependency of package `foo v0.0.1 ([ROOT]/foo)`
 
 Caused by:
   failed to query replaced source registry `crates-io`
 
 Caused by:
   found a package in the remote registry and the local overlay: baz@0.1.1
-",
-        )
+
+"#]])
         .run();
 }
 
@@ -248,22 +246,21 @@ fn registry_dep_depends_on_new_local_package() {
 
     p.cargo("check")
         .overlay_registry(&reg.index_url(), &alt_path)
-        .with_stderr_data(
-            "\
-[UPDATING] [..]
+        .with_stderr_data(str![[r#"
+[UPDATING] `sparse+http://127.0.0.1:[..]/index/` index
 [LOCKING] 3 packages to latest compatible versions
 [ADDING] workspace-package v0.0.1 (available: v0.1.1)
 [DOWNLOADING] crates ...
-[UNPACKING] [..]
-[DOWNLOADED] [..]
-[DOWNLOADED] [..]
+[UNPACKING] workspace-package v0.1.1 (registry `[ROOT]/alternative-registry`)
+[DOWNLOADED] registry-package v0.1.0 (registry `sparse+http://127.0.0.1:[..]/index/`)
+[DOWNLOADED] workspace-package v0.0.1 (registry `sparse+http://127.0.0.1:[..]/index/`)
 [CHECKING] workspace-package v0.1.1
 [CHECKING] workspace-package v0.0.1
 [CHECKING] registry-package v0.1.0
-[CHECKING] foo v0.0.1 [..]
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-",
-        )
+
+"#]])
         .run();
 }
 

--- a/tests/testsuite/registry_overlay.rs
+++ b/tests/testsuite/registry_overlay.rs
@@ -133,7 +133,7 @@ fn overlay_version_wins() {
 }
 
 #[cargo_test]
-fn version_collision() {
+fn version_precedence() {
     let (reg, alt_path) = setup();
     let p = project()
         .file(
@@ -161,16 +161,13 @@ fn version_collision() {
 
     p.cargo("check")
         .overlay_registry(&reg.index_url(), &alt_path)
-        .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `sparse+http://127.0.0.1:[..]/index/` index
-[ERROR] failed to get `baz` as a dependency of package `foo v0.0.1 ([ROOT]/foo)`
-
-Caused by:
-  failed to query replaced source registry `crates-io`
-
-Caused by:
-  found a package in the remote registry and the local overlay: baz@0.1.1
+[LOCKING] 1 package to latest compatible version
+[UNPACKING] baz v0.1.1 (registry `[ROOT]/alternative-registry`)
+[CHECKING] baz v0.1.1
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

A dry-run release process won't be bumping the versions, making it so it can't do a dry-run publish because the local/remote registries will collide.  This switches it to give the local registry precedence over the remote registry to make the dry-run release process work.

Fixes #14789

### How should we test and review this PR?


### Additional information

