### PR TITLE
test: Switch from 'exec_with_output' to 'run'

### DIFF
--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -5452,9 +5452,7 @@ fn same_metadata_different_directory() {
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
-    let output = t!(String::from_utf8(
-        t!(p.cargo("build -v").exec_with_output()).stderr,
-    ));
+    let output = t!(String::from_utf8(p.cargo("build -v").run().stderr,));
     let metadata = output
         .split_whitespace()
         .find(|arg| arg.starts_with("metadata="))

--- a/tests/testsuite/cache_messages.rs
+++ b/tests/testsuite/cache_messages.rs
@@ -29,17 +29,11 @@ fn simple() {
     let rustc_output = raw_rustc_output(&p, "src/lib.rs", &[]);
 
     // -q so the output is the same as rustc (no "Compiling" or "Finished").
-    let cargo_output1 = p
-        .cargo("check -q --color=never")
-        .exec_with_output()
-        .expect("cargo to run");
+    let cargo_output1 = p.cargo("check -q --color=never").run();
     assert_eq!(rustc_output, as_str(&cargo_output1.stderr));
     assert!(cargo_output1.stdout.is_empty());
     // Check that the cached version is exactly the same.
-    let cargo_output2 = p
-        .cargo("check -q")
-        .exec_with_output()
-        .expect("cargo to run");
+    let cargo_output2 = p.cargo("check -q").run();
     assert_eq!(rustc_output, as_str(&cargo_output2.stderr));
     assert!(cargo_output2.stdout.is_empty());
 }
@@ -61,14 +55,10 @@ fn simple_short() {
 
     let cargo_output1 = p
         .cargo("check -q --color=never --message-format=short")
-        .exec_with_output()
-        .expect("cargo to run");
+        .run();
     assert_eq!(rustc_output, as_str(&cargo_output1.stderr));
     // assert!(cargo_output1.stdout.is_empty());
-    let cargo_output2 = p
-        .cargo("check -q --message-format=short")
-        .exec_with_output()
-        .expect("cargo to run");
+    let cargo_output2 = p.cargo("check -q --message-format=short").run();
     println!("{}", String::from_utf8_lossy(&cargo_output2.stdout));
     assert_eq!(rustc_output, as_str(&cargo_output2.stderr));
     assert!(cargo_output2.stdout.is_empty());
@@ -102,24 +92,15 @@ fn color() {
     assert!(!rustc_nocolor.contains("\x1b["));
 
     // First pass, non-cached, with color, should be the same.
-    let cargo_output1 = p
-        .cargo("check -q --color=always")
-        .exec_with_output()
-        .expect("cargo to run");
+    let cargo_output1 = p.cargo("check -q --color=always").run();
     compare(&rustc_color, as_str(&cargo_output1.stderr));
 
     // Replay cached, with color.
-    let cargo_output2 = p
-        .cargo("check -q --color=always")
-        .exec_with_output()
-        .expect("cargo to run");
+    let cargo_output2 = p.cargo("check -q --color=always").run();
     compare(&rustc_color, as_str(&cargo_output2.stderr));
 
     // Replay cached, no color.
-    let cargo_output_nocolor = p
-        .cargo("check -q --color=never")
-        .exec_with_output()
-        .expect("cargo to run");
+    let cargo_output_nocolor = p.cargo("check -q --color=never").run();
     compare(&rustc_nocolor, as_str(&cargo_output_nocolor.stderr));
 }
 
@@ -130,27 +111,17 @@ fn cached_as_json() {
 
     // Grab the non-cached output, feature disabled.
     // NOTE: When stabilizing, this will need to be redone.
-    let cargo_output = p
-        .cargo("check --message-format=json")
-        .exec_with_output()
-        .expect("cargo to run");
-    assert!(cargo_output.status.success());
+    let cargo_output = p.cargo("check --message-format=json").run();
     let orig_cargo_out = as_str(&cargo_output.stdout);
     assert!(orig_cargo_out.contains("compiler-message"));
     p.cargo("clean").run();
 
     // Check JSON output, not fresh.
-    let cargo_output1 = p
-        .cargo("check --message-format=json")
-        .exec_with_output()
-        .expect("cargo to run");
+    let cargo_output1 = p.cargo("check --message-format=json").run();
     assert_eq!(as_str(&cargo_output1.stdout), orig_cargo_out);
 
     // Check JSON output, fresh.
-    let cargo_output2 = p
-        .cargo("check --message-format=json")
-        .exec_with_output()
-        .expect("cargo to run");
+    let cargo_output2 = p.cargo("check --message-format=json").run();
     // The only difference should be this field.
     let fix_fresh = as_str(&cargo_output2.stdout).replace("\"fresh\":true", "\"fresh\":false");
     assert_eq!(fix_fresh, orig_cargo_out);
@@ -220,11 +191,7 @@ fn rustdoc() {
         )
         .build();
 
-    let rustdoc_output = p
-        .cargo("doc -q --color=always")
-        .exec_with_output()
-        .expect("rustdoc to run");
-    assert!(rustdoc_output.status.success());
+    let rustdoc_output = p.cargo("doc -q --color=always").run();
     let rustdoc_stderr = as_str(&rustdoc_output.stderr);
     assert!(rustdoc_stderr.contains("missing"));
     assert!(rustdoc_stderr.contains("\x1b["));
@@ -234,10 +201,7 @@ fn rustdoc() {
     );
 
     // Check the cached output.
-    let rustdoc_output = p
-        .cargo("doc -q --color=always")
-        .exec_with_output()
-        .expect("rustdoc to run");
+    let rustdoc_output = p.cargo("doc -q --color=always").run();
     assert_eq!(as_str(&rustdoc_output.stderr), rustdoc_stderr);
 }
 

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -99,10 +99,7 @@ fn list_command_looks_at_path() {
     let mut path = path();
     path.push(proj.root().join("path-test"));
     let path = env::join_paths(path.iter()).unwrap();
-    let output = cargo_process("-v --list")
-        .env("PATH", &path)
-        .exec_with_output()
-        .unwrap();
+    let output = cargo_process("-v --list").env("PATH", &path).run();
     let output = str::from_utf8(&output.stdout).unwrap();
     assert!(
         output.contains("\n    1                   "),
@@ -127,8 +124,7 @@ fn list_command_looks_at_path_case_mismatch() {
     let output = cargo_process("-v --list")
         .env("Path", &path)
         .env_remove("PATH")
-        .exec_with_output()
-        .unwrap();
+        .run();
     let output = str::from_utf8(&output.stdout).unwrap();
     assert!(
         output.contains("\n    1                   "),
@@ -174,10 +170,7 @@ fn list_command_resolves_symlinks() {
     let mut path = path();
     path.push(proj.root().join("path-test"));
     let path = env::join_paths(path.iter()).unwrap();
-    let output = cargo_process("-v --list")
-        .env("PATH", &path)
-        .exec_with_output()
-        .unwrap();
+    let output = cargo_process("-v --list").env("PATH", &path).run();
     let output = str::from_utf8(&output.stdout).unwrap();
     assert!(
         output.contains("\n    2                   "),

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -1648,7 +1648,7 @@ fn pkgid_querystring_works() {
 
     p.cargo("generate-lockfile").run();
 
-    let output = p.cargo("pkgid").arg("gitdep").exec_with_output().unwrap();
+    let output = p.cargo("pkgid").arg("gitdep").run();
     let gitdep_pkgid = String::from_utf8(output.stdout).unwrap();
     let gitdep_pkgid = gitdep_pkgid.trim();
     assert_e2e().eq(

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -2527,8 +2527,7 @@ LLVM version: 9.0
         let output = p
             .cargo("check --message-format=json")
             .env("RUSTC", compiler.bin(version))
-            .exec_with_output()
-            .unwrap();
+            .run();
         // Collect the filenames generated.
         let mut artifacts: Vec<_> = std::str::from_utf8(&output.stdout)
             .unwrap()

--- a/tests/testsuite/freshness_checksum.rs
+++ b/tests/testsuite/freshness_checksum.rs
@@ -2435,8 +2435,7 @@ LLVM version: 9.0
             .cargo("check -Zchecksum-freshness --message-format=json")
             .masquerade_as_nightly_cargo(&["checksum-freshness"])
             .env("RUSTC", compiler.bin(version))
-            .exec_with_output()
-            .unwrap();
+            .run();
         // Collect the filenames generated.
         let mut artifacts: Vec<_> = std::str::from_utf8(&output.stdout)
             .unwrap()

--- a/tests/testsuite/future_incompat_report.rs
+++ b/tests/testsuite/future_incompat_report.rs
@@ -252,8 +252,7 @@ The package `second-dep v0.0.2` currently triggers the following future incompat
     let output = p
         .cargo("check")
         .env("RUSTFLAGS", "-Zfuture-incompat-test")
-        .exec_with_output()
-        .unwrap();
+        .run();
 
     // Extract the 'id' from the stdout. We are looking
     // for the id in a line of the form "run `cargo report future-incompatibilities --id yZ7S`"
@@ -282,10 +281,7 @@ The package `second-dep v0.0.2` currently triggers the following future incompat
         .run();
 
     // Test without --id, and also the full output of the report.
-    let output = p
-        .cargo("report future-incompat")
-        .exec_with_output()
-        .unwrap();
+    let output = p.cargo("report future-incompat").run();
     let output = std::str::from_utf8(&output.stdout).unwrap();
     assert!(output.starts_with("The following warnings were discovered"));
     let mut lines = output

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -3396,7 +3396,7 @@ fn historical_lockfile_works_with_vendor() {
         .file("src/lib.rs", "")
         .build();
 
-    let output = project.cargo("vendor").exec_with_output().unwrap();
+    let output = project.cargo("vendor").run();
     project.change_file(
         ".cargo/config.toml",
         str::from_utf8(&output.stdout).unwrap(),

--- a/tests/testsuite/help.rs
+++ b/tests/testsuite/help.rs
@@ -7,7 +7,7 @@ use std::str::from_utf8;
 use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
 use cargo_test_support::str;
-use cargo_test_support::{basic_manifest, cargo_exe, cargo_process, paths, process, project};
+use cargo_test_support::{basic_manifest, cargo_process, paths, project};
 
 #[cargo_test]
 fn help() {
@@ -83,13 +83,9 @@ fn help_with_man_and_path(
         .unwrap()
     };
 
-    let output = process(&cargo_exe())
-        .arg("help")
-        .arg(subcommand)
+    let output = cargo_process(&format!("help {subcommand}"))
         .env("PATH", path)
-        .exec_with_output()
-        .unwrap();
-    assert!(output.status.success());
+        .run();
     let stderr = from_utf8(&output.stderr).unwrap();
     if display_command.is_empty() {
         assert_eq!(stderr, "");
@@ -101,13 +97,9 @@ fn help_with_man_and_path(
 }
 
 fn help_with_stdout_and_path(subcommand: &str, path: &Path) -> String {
-    let output = process(&cargo_exe())
-        .arg("help")
-        .arg(subcommand)
+    let output = cargo_process(&format!("help {subcommand}"))
         .env("PATH", path)
-        .exec_with_output()
-        .unwrap();
-    assert!(output.status.success());
+        .run();
     let stderr = from_utf8(&output.stderr).unwrap();
     assert_eq!(stderr, "");
     let stdout = from_utf8(&output.stdout).unwrap();

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -3143,7 +3143,7 @@ path = "src/lib.rs"
 }
 
 fn verify_packaged_status_line(
-    output: std::process::Output,
+    output: cargo_test_support::RawOutput,
     num_files: usize,
     uncompressed_size: u64,
     compressed_size: u64,
@@ -3228,7 +3228,7 @@ version = "0.0.1"
         + main_rs_contents.len()
         + cargo_toml_contents.len()
         + cargo_lock_contents.len()) as u64;
-    let output = p.cargo("package").exec_with_output().unwrap();
+    let output = p.cargo("package").run();
 
     assert!(p.root().join("target/package/foo-0.0.1.crate").is_file());
     p.cargo("package -l")
@@ -3333,7 +3333,7 @@ version = "0.0.1"
         + cargo_lock_contents.len()
         + bar_txt_contents.len()) as u64;
 
-    let output = p.cargo("package").exec_with_output().unwrap();
+    let output = p.cargo("package").run();
     assert!(p.root().join("target/package/foo-0.0.1.crate").is_file());
     p.cargo("package -l")
         .with_stdout_data(str![[r#"
@@ -3452,7 +3452,7 @@ version = "0.0.1"
         + cargo_lock_contents.len()
         + bar_txt_contents.len() * 2) as u64;
 
-    let output = p.cargo("package").exec_with_output().unwrap();
+    let output = p.cargo("package").run();
     assert!(p.root().join("target/package/foo-0.0.1.crate").is_file());
     p.cargo("package -l")
         .with_stdout_data(str![[r#"

--- a/tests/testsuite/pkgid.rs
+++ b/tests/testsuite/pkgid.rs
@@ -301,7 +301,7 @@ fn pkgid_json_message_metadata_consistency() {
 
     p.cargo("generate-lockfile").run();
 
-    let output = p.cargo("pkgid").arg("foo").exec_with_output().unwrap();
+    let output = p.cargo("pkgid").arg("foo").run();
     let pkgid = String::from_utf8(output.stdout).unwrap();
     let pkgid = pkgid.trim();
     assert_e2e().eq(pkgid, str!["path+[ROOTURL]/foo#0.5.0"]);

--- a/tests/testsuite/registry_auth.rs
+++ b/tests/testsuite/registry_auth.rs
@@ -542,8 +542,7 @@ fn token_not_logged() {
         .replace_crates_io(crates_io.index_url())
         .env("CARGO_HTTP_DEBUG", "true")
         .env("CARGO_LOG", "trace")
-        .exec_with_output()
-        .unwrap();
+        .run();
     let log = String::from_utf8(output.stderr).unwrap();
     assert_e2e().eq(
         &log,

--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -130,11 +130,7 @@ fn vendor_path_specified() {
         "deps/.vendor"
     };
 
-    let output = p
-        .cargo("vendor --respect-source-config")
-        .arg(path)
-        .exec_with_output()
-        .unwrap();
+    let output = p.cargo("vendor --respect-source-config").arg(path).run();
     // Assert against original output to ensure that
     // path is normalized by `ops::vendor` on Windows.
     assert_eq!(
@@ -1425,10 +1421,7 @@ fn git_complex() {
         .file("src/lib.rs", "")
         .build();
 
-    let output = p
-        .cargo("vendor --respect-source-config")
-        .exec_with_output()
-        .unwrap();
+    let output = p.cargo("vendor --respect-source-config").run();
     let output = String::from_utf8(output.stdout).unwrap();
     p.change_file(".cargo/config.toml", &output);
 
@@ -1505,10 +1498,7 @@ fn git_deterministic() {
         .file("src/lib.rs", "")
         .build();
 
-    let output = p
-        .cargo("vendor --respect-source-config")
-        .exec_with_output()
-        .unwrap();
+    let output = p.cargo("vendor --respect-source-config").run();
     let output = String::from_utf8(output.stdout).unwrap();
     p.change_file(".cargo/config.toml", &output);
 
@@ -1744,10 +1734,7 @@ fn config_instructions_works() {
         )
         .file("src/lib.rs", "")
         .build();
-    let output = p
-        .cargo("vendor --respect-source-config")
-        .exec_with_output()
-        .unwrap();
+    let output = p.cargo("vendor --respect-source-config").run();
     let output = String::from_utf8(output.stdout).unwrap();
     p.change_file(".cargo/config.toml", &output);
 


### PR DESCRIPTION
### What does this PR try to resolve?

This is a follow up to #14846 which changed `run` to return the `RawOutput`.

Reasons I didn't "update" some code to the new `run` return value
- We were actually using `ProcessBuilder::exec_with_output` and I didn't want to disentangle what it would take to switch to `Execs`
- We did processing on the `Result` and I didn't want to check how that could be updated

### How should we test and review this PR?


### Additional information

