### PR TITLE
fix(build-std): always link to std when testing proc-macros

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -315,7 +315,10 @@ impl<'gctx> Compilation<'gctx> {
             // libs from the sysroot that ships with rustc. This may not be
             // required (at least I cannot craft a situation where it
             // matters), but is here to be safe.
-            if self.gctx.cli_unstable().build_std.is_none() {
+            if self.gctx.cli_unstable().build_std.is_none() ||
+                // Proc macros dynamically link to std, so set it anyway.
+                pkg.proc_macro()
+            {
                 search_path.push(self.sysroot_target_libdir[&kind].clone());
             }
         }

--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -386,15 +386,7 @@ fn test_proc_macro() {
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH])
-dyld[[..]]: Library not loaded: @rpath/libstd-[HASH].dylib
-  Referenced from: <[..]> [ROOT]/foo/target/debug/deps/foo-[HASH]
-  Reason: tried: '[ROOT]/foo/target/debug/deps/libstd-[HASH].dylib' (no such file), '[ROOT]/foo/target/debug/libstd-[HASH].dylib' (no such file), '/usr/local/lib/libstd-[HASH].dylib' (no such file), '/usr/lib/libstd-[HASH].dylib' (no such file, not in dyld cache)
-[ERROR] test failed, to rerun pass `--lib`
-
-Caused by:
-  process didn't exit successfully: `[ROOT]/foo/target/debug/deps/foo-[HASH]` ([..])
 
 "#]])
-        .with_status(101)
         .run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes #14735

https://github.com/rust-lang/rust/pull/131188 removes libstd.so from sysroot so `cargo test -Zbuild-std` no longer links to it. That results in a "Library not loaded: @rpath/libstd-[HASH].dylib" when testing a proc macro.

This is a pretty niche use case, though it can be easily reproduced by running `cargo test -Zbuild-std` in any proc-macro package. Like in [serde-rs/serde](https://github.com/serde-rs/serde/tree/b9dbfcb4ac3b7a663d9efc6eb1387c62302a6fb4) running it would fail.

This patch adds a special case that if it is `cargo run/test` against a proc-macro, fill in std dynamic library search path for it.



### How should we test and review this PR?

```
CARGO_RUN_BUILD_STD_TESTS=1 cargo +nightly t --test build-std test_proc_macro
```

or

```
git clone https://github.com/serde-rs/serde
cd serde
git switch -d b9dbfcb4ac3b7a663d9efc6eb1387c62302a6fb4
cargo +nightly t --test build-std
```

### Additional information
