### PR TITLE
Improve error handling when PathSource is relative

### DIFF
--- a/src/cargo/util/toml_mut/dependency.rs
+++ b/src/cargo/util/toml_mut/dependency.rs
@@ -748,7 +748,8 @@ fn path_field<'a>(
     } else {
         Cow::Borrowed(crate_root)
     };
-    let relpath = pathdiff::diff_paths(&source.path, relative_to).expect("both paths are absolute");
+    let relpath = pathdiff::diff_paths(&source.path, relative_to)
+        .expect("PathSource::path and workspace path must be absolute");
     let relpath = relpath.to_str().unwrap().replace('\\', "/");
     Ok(relpath)
 }


### PR DESCRIPTION
When editing dependencies with cargo, if a relative PathSource is supplied cargo panics with "both paths are absolute". This is the opposite of what's actually wrong leading to confusion.

Instead, use the same error formatting we use in other diff_paths calls and return that error instead of panicking.
