### PR TITLE
git-fetch-with-cli: Set `GIT_DIR` for bare repository compatibility

### DIFF
--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -1101,9 +1101,8 @@ fn fetch_with_cli(
         .args(refspecs)
         // If cargo is run by git (for example, the `exec` command in `git
         // rebase`), the GIT_DIR is set by git and will point to the wrong
-        // location (this takes precedence over the cwd). Make sure this is
-        // unset so git will look at cwd for the repo.
-        .env_remove("GIT_DIR")
+        // location. This makes sure GIT_DIR is always the repository path.
+        .env("GIT_DIR", repo.path())
         // The reset of these may not be necessary, but I'm including them
         // just to be extra paranoid and avoid any issues.
         .env_remove("GIT_WORK_TREE")


### PR DESCRIPTION
When using `net.git-fetch-with-cli = true` , Cargo fails to clone the git repository into the cache because `safe.bareRepository` defaults to `explicit`. This results in an error stating that a bare repository cannot be used.

This patch sets the `GIT_DIR` environment variable to the correct repository path instead of removing it. This ensures that Git uses the correct repository directory and avoids the "cannot use bare repository" error.

Fixes #14758 