### PR TITLE
test(build-std): download deps first

### DIFF
--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -379,6 +379,9 @@ fn test_proc_macro() {
         .file("src/lib.rs", "")
         .build();
 
+    // Download dependencies first,
+    // so we can compare  `cargo test` output without any wildcard
+    p.cargo("fetch").build_std().run();
     p.cargo("test --lib")
         .env_remove(cargo_util::paths::dylib_path_envvar())
         .build_std()


### PR DESCRIPTION

### What does this PR try to resolve?

Download dependencies first,
So that we can assert the full output of `cargo test` without wildcard.

This regressed since #14850

### How should we test and review this PR?

CI passes.
