### PR TITLE
fix(fix): Migrate cargo script manifests across editions

### DIFF
--- a/tests/testsuite/edition.rs
+++ b/tests/testsuite/edition.rs
@@ -135,7 +135,7 @@ fn unset_edition_with_unset_rust_version() {
 
     p.cargo("check -v")
         .with_stderr_data(str![[r#"
-[WARNING] no edition set: defaulting to the 2015 edition while the latest is 2024
+[WARNING] no edition set: defaulting to the 2015 edition while the latest is [..]
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [RUNNING] `rustc [..] --edition=2015 [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -2479,57 +2479,27 @@ fn main() {
         .with_stderr_data(str![[r#"
 [MIGRATING] foo.rs from 2021 edition to 2024
 [FIXED] foo.rs (1 fix)
-[WARNING] `package.edition` is unspecified, defaulting to `2024`
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
-[WARNING] `foo.rs` is already on the latest edition (2024), unable to migrate further
-
-If you are trying to migrate from the previous edition (2021), the
-process requires following these steps:
-
-1. Start with `edition = "2021"` in `Cargo.toml`
-2. Run `cargo fix --edition`
-3. Modify `Cargo.toml` to set `edition = "2024"`
-4. Run `cargo build` or `cargo test` to verify the fixes worked
-
-More details may be found at
-https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html
-
-[ERROR] expected item, found `[`
- --> foo.rs:1:1
-  |
-1 | [[bin]]
-  | ^ expected item
-  |
-  = [NOTE] for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
-
-[ERROR] could not compile `foo` (bin "foo" test) due to 1 previous error
-[WARNING] build failed, waiting for other jobs to finish...
-[ERROR] could not compile `foo` (bin "foo") due to 1 previous error
+[MIGRATING] [ROOT]/home/.cargo/target/[HASH]/foo.rs from 2021 edition to 2024
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
-        .with_status(101)
         .run();
     assert_e2e().eq(
         p.read_file("foo.rs"),
         str![[r#"
-[[bin]]
-name = "foo"
-path = "[ROOT]/home/.cargo/target/[HASH]/foo.rs"
 
-[package]
-autobenches = false
-autobins = false
-autoexamples = false
-autolib = false
-autotests = false
-build = false
+---
+# Before package
+[ package ] # After package header
+# After package header line
+name = "foo"
 edition = "2021"
-name = "foo"
+# After project table
+---
 
-[profile.release]
-strip = true
-
-[workspace]
+fn main() {
+}
 
 "#]],
     );

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -142,6 +142,7 @@ fn duplicate_version() {
                 [package]
                 name = "foo"
                 version = "0.0.1"
+                edition = "2015"
                 authors = []
                 license = "MIT"
                 description = "foo"
@@ -160,7 +161,6 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [PACKAGING] foo v0.0.1 ([ROOT]/foo)
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [VERIFYING] foo v0.0.1 ([ROOT]/foo)
-[WARNING] no edition set: defaulting to the 2015 edition while the latest is 2024
 [COMPILING] foo v0.0.1 ([ROOT]/foo/target/package/foo-0.0.1)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)


### PR DESCRIPTION
### What does this PR try to resolve?

At this point it is unlikely for a script to be written for pre-2024
edition and migrated to 2024+ but this code is independent of Editions
so this means we have one less bug and are better prepared for the next
edition.

When we add `cargo fix` support for regular manifest warnings, we'll
need to take into account cargo scripts.

This is a part of #12207.

### How should we test and review this PR?


### Additional information

While looking for where the tests go, I found a couple places with a hard coded latest-edition in test output and fixed it.