### PR TITLE
enhance(build): finish to log compilied pkg.

### DIFF
--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -1125,13 +1125,21 @@ impl<'gctx> DrainState<'gctx> {
                 debug!("Finished unit: {:?}", unit);
                 if unit.mode.is_doc() {
                     self.documented.insert(unit.pkg.package_id());
-                    build_runner.bcx.gctx.shell().status("Documented", &unit.pkg)?;
+                    build_runner
+                        .bcx
+                        .gctx
+                        .shell()
+                        .status("Documented", &unit.pkg)?;
                 } else if unit.mode.is_doc_scrape() {
                     self.scraped.insert(unit.pkg.package_id());
                     build_runner.bcx.gctx.shell().status("Scraped", &unit.pkg)?;
                 } else {
                     self.compiled.insert(unit.pkg.package_id());
-                    build_runner.bcx.gctx.shell().status("Compiled", &unit.pkg)?;
+                    build_runner
+                        .bcx
+                        .gctx
+                        .shell()
+                        .status("Compiled", &unit.pkg)?;
                 }
             }
             Artifact::Metadata => self.timings.unit_rmeta_finished(id, unlocked),


### PR DESCRIPTION
This pull request includes a little change to the `DrainState` implementation in the `src/cargo/core/compiler/job_queue/mod.rs` file. The change enhances the logging and tracking of the job queue's progress by adding detailed logging for different types of artifacts.

Enhancements to logging and tracking:

* [`src/cargo/core/compiler/job_queue/mod.rs`](diffhunk://#diff-760fbef71d557f3e4344d337e6b6e81c6f860bb32498b751d015d26f9a5951cfL1121-R1136): Added detailed logging for the completion of a unit of work, including specific statuses for documentation, scraping, and compilation. This helps in tracking the progress of the job queue more effectively.
 