### PR TITLE
test: remove the use of `CARGO_RUSTC_CURRENT_DIR`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ version = "0.3.4"
 
 [[package]]
 name = "cargo-test-support"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ cargo-credential-macos-keychain = { version = "0.4.7", path = "credential/cargo-
 cargo-credential-wincred = { version = "0.4.7", path = "credential/cargo-credential-wincred" }
 cargo-platform = { path = "crates/cargo-platform", version = "0.2.0" }
 cargo-test-macro = { version = "0.3.0", path = "crates/cargo-test-macro" }
-cargo-test-support = { version = "0.6.0", path = "crates/cargo-test-support" }
+cargo-test-support = { version = "0.7.0", path = "crates/cargo-test-support" }
 cargo-util = { version = "0.2.14", path = "crates/cargo-util" }
 cargo-util-schemas = { version = "0.7.0", path = "crates/cargo-util-schemas" }
 cargo_metadata = "0.18.1"

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-test-support"
-version = "0.6.1"
+version = "0.7.0"
 edition.workspace = true
 rust-version = "1.83"  # MSRV:1
 license.workspace = true

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -80,9 +80,32 @@ macro_rules! t {
 }
 
 pub use cargo_util::ProcessBuilder;
-pub use snapbox::file;
 pub use snapbox::str;
-pub use snapbox::utils::current_dir;
+
+/// Find the directory for your source file
+#[macro_export]
+macro_rules! current_dir {
+    () => {{
+        let root = ::std::path::Path::new(::std::env!("CARGO_MANIFEST_DIR"));
+        let file = ::std::file!();
+        let rel_path = ::std::path::Path::new(file).parent().unwrap();
+        root.join(rel_path)
+    }};
+}
+
+/// Declare an expected value for an assert from a file
+///
+/// This is relative to the source file the macro is run from
+///
+/// Output type: [`snapbox::Data`]
+#[macro_export]
+macro_rules! file {
+    [$path:literal] => {{
+        let mut path = $crate::current_dir!();
+        path.push($path);
+        ::snapbox::Data::read_from(&path, None)
+    }};
+}
 
 /// `panic!`, reporting the specified error , see also [`t!`]
 #[track_caller]

--- a/src/cargo/util/lints.rs
+++ b/src/cargo/util/lints.rs
@@ -610,6 +610,7 @@ mod tests {
     use itertools::Itertools;
     use snapbox::ToDebug;
     use std::collections::HashSet;
+    use std::path::Path;
 
     #[test]
     fn ensure_sorted_lints() {
@@ -647,7 +648,7 @@ mod tests {
 
     #[test]
     fn ensure_updated_lints() {
-        let path = snapbox::utils::current_rs!();
+        let path = Path::new(std::env!("CARGO_MANIFEST_DIR")).join(file!());
         let expected = std::fs::read_to_string(&path).unwrap();
         let expected = expected
             .lines()
@@ -686,7 +687,7 @@ mod tests {
 
     #[test]
     fn ensure_updated_lint_groups() {
-        let path = snapbox::utils::current_rs!();
+        let path = Path::new(std::env!("CARGO_MANIFEST_DIR")).join(file!());
         let expected = std::fs::read_to_string(&path).unwrap();
         let expected = expected
             .lines()


### PR DESCRIPTION
### What does this PR try to resolve?

The environment variable has been removed in #14799.
Switch to plain old `CARGO_MANIFEST_DIR`
because snapbox's `current_rs` favors furthest Cargo.toml,
blocking tests running in rust-lang/rust as a submodule.

See also build failures in rust-lang/rust#133533

### How should we test and review this PR?

Pull this change into rust-lang/rust and run

```
./x.py test src/tools/cargo
```
