### PR TITLE
test(pgo): determine test runnability at compile time

### DIFF
--- a/tests/testsuite/pgo.rs
+++ b/tests/testsuite/pgo.rs
@@ -23,13 +23,10 @@ fn llvm_profdata() -> Option<PathBuf> {
 }
 
 #[cargo_test]
+// macOS may emit different LLVM PGO warnings.
+// Windows LLVM has different requirements.
+#[cfg_attr(not(target_os = "linux"), ignore = "linux only")]
 fn pgo_works() {
-    if cfg!(not(target_os = "linux")) {
-        // macOS may emit different LLVM PGO warnings.
-        // Windows LLVM has different requirements.
-        return;
-    }
-
     let Some(llvm_profdata) = llvm_profdata() else {
         return;
     };


### PR DESCRIPTION
### What does this PR try to resolve?

Address https://github.com/rust-lang/cargo/pull/14859#discussion_r1862535261

I found that detecting llvm-profdata [requires more works](https://github.com/weihanglo/cargo/pull/73), so do this first.

