### PR TITLE
test: `requires` attribute accepts string literals for cmds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-test-macro"
-version = "0.3.4"
+version = "0.4.0"
 
 [[package]]
 name = "cargo-test-support"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ cargo-credential-libsecret = { version = "0.4.7", path = "credential/cargo-crede
 cargo-credential-macos-keychain = { version = "0.4.7", path = "credential/cargo-credential-macos-keychain" }
 cargo-credential-wincred = { version = "0.4.7", path = "credential/cargo-credential-wincred" }
 cargo-platform = { path = "crates/cargo-platform", version = "0.2.0" }
-cargo-test-macro = { version = "0.3.0", path = "crates/cargo-test-macro" }
+cargo-test-macro = { version = "0.4.0", path = "crates/cargo-test-macro" }
 cargo-test-support = { version = "0.6.0", path = "crates/cargo-test-support" }
 cargo-util = { version = "0.2.14", path = "crates/cargo-util" }
 cargo-util-schemas = { version = "0.7.0", path = "crates/cargo-util-schemas" }

--- a/crates/cargo-test-macro/Cargo.toml
+++ b/crates/cargo-test-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-test-macro"
-version = "0.3.4"
+version = "0.4.0"
 edition.workspace = true
 rust-version = "1.83"  # MSRV:1
 license.workspace = true

--- a/tests/testsuite/cargo_init/simple_hg/mod.rs
+++ b/tests/testsuite/cargo_init/simple_hg/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::prelude::*;
 use cargo_test_support::str;
 use cargo_test_support::Project;
 
-#[cargo_test(requires_hg)]
+#[cargo_test(requires = "hg")]
 fn case() {
     let project = Project::from_template(current_dir!().join("in"));
     let project_root = &project.root();

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -2917,7 +2917,7 @@ fn failed_submodule_checkout() {
     t.join().unwrap();
 }
 
-#[cargo_test(requires_git)]
+#[cargo_test(requires = "git")]
 fn use_the_cli() {
     let project = project();
     let git_project = git::new("dep1", |project| {
@@ -3028,7 +3028,7 @@ fn templatedir_doesnt_cause_problems() {
     p.cargo("check").run();
 }
 
-#[cargo_test(requires_git)]
+#[cargo_test(requires = "git")]
 fn git_with_cli_force() {
     // Supports a force-pushed repo.
     let git_project = git::new("dep1", |project| {
@@ -3095,7 +3095,7 @@ two
         .run();
 }
 
-#[cargo_test(requires_git)]
+#[cargo_test(requires = "git")]
 fn git_fetch_cli_env_clean() {
     // This tests that git-fetch-with-cli works when GIT_DIR environment
     // variable is set (for whatever reason).
@@ -4069,7 +4069,7 @@ src/lib.rs
         .run();
 }
 
-#[cargo_test(public_network_test, requires_git)]
+#[cargo_test(public_network_test, requires = "git")]
 fn github_fastpath_error_message() {
     let p = project()
         .file(

--- a/tests/testsuite/git_gc.rs
+++ b/tests/testsuite/git_gc.rs
@@ -90,7 +90,7 @@ fn run_test(path_env: Option<&OsStr>) {
     );
 }
 
-#[cargo_test(requires_git)]
+#[cargo_test(requires = "git")]
 fn use_git_gc() {
     run_test(None);
 }

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -114,7 +114,7 @@ fn simple_git() {
     cargo_process("build").cwd(&paths::root().join("foo")).run();
 }
 
-#[cargo_test(requires_hg)]
+#[cargo_test(requires = "hg")]
 fn simple_hg() {
     cargo_process("new --lib foo --edition 2015 --vcs hg").run();
 

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -445,17 +445,17 @@ mod object_works {
             .stdout
     }
 
-    #[cargo_test(requires_nm, nightly, reason = "-Zremap-path-scope is unstable")]
+    #[cargo_test(requires = "nm", nightly, reason = "-Zremap-path-scope is unstable")]
     fn with_split_debuginfo_off() {
         object_works_helper("off", inspect_debuginfo);
     }
 
-    #[cargo_test(requires_nm, nightly, reason = "-Zremap-path-scope is unstable")]
+    #[cargo_test(requires = "nm", nightly, reason = "-Zremap-path-scope is unstable")]
     fn with_split_debuginfo_packed() {
         object_works_helper("packed", inspect_debuginfo);
     }
 
-    #[cargo_test(requires_nm, nightly, reason = "-Zremap-path-scope is unstable")]
+    #[cargo_test(requires = "nm", nightly, reason = "-Zremap-path-scope is unstable")]
     fn with_split_debuginfo_unpacked() {
         object_works_helper("unpacked", inspect_debuginfo);
     }
@@ -475,17 +475,29 @@ mod object_works {
             .stdout
     }
 
-    #[cargo_test(requires_readelf, nightly, reason = "-Zremap-path-scope is unstable")]
+    #[cargo_test(
+        requires = "readelf",
+        nightly,
+        reason = "-Zremap-path-scope is unstable"
+    )]
     fn with_split_debuginfo_off() {
         object_works_helper("off", inspect_debuginfo);
     }
 
-    #[cargo_test(requires_readelf, nightly, reason = "-Zremap-path-scope is unstable")]
+    #[cargo_test(
+        requires = "readelf",
+        nightly,
+        reason = "-Zremap-path-scope is unstable"
+    )]
     fn with_split_debuginfo_packed() {
         object_works_helper("packed", inspect_debuginfo);
     }
 
-    #[cargo_test(requires_readelf, nightly, reason = "-Zremap-path-scope is unstable")]
+    #[cargo_test(
+        requires = "readelf",
+        nightly,
+        reason = "-Zremap-path-scope is unstable"
+    )]
     fn with_split_debuginfo_unpacked() {
         object_works_helper("unpacked", inspect_debuginfo);
     }
@@ -676,7 +688,7 @@ fn custom_build_env_var_trim_paths() {
 }
 
 #[cfg(unix)]
-#[cargo_test(requires_lldb, nightly, reason = "-Zremap-path-scope is unstable")]
+#[cargo_test(requires = "lldb", nightly, reason = "-Zremap-path-scope is unstable")]
 fn lldb_works_after_trimmed() {
     use cargo_test_support::compare::assert_e2e;
     use cargo_util::is_ci;


### PR DESCRIPTION
### What does this PR try to resolve?

The new syntax is key-value pair like `requires = "rustfmt"`,
comparing to the previous `requires_<cmd>`.

This enables `cargo_test` to require that the CLI contains non-alphabetic names, such as `llvm-profdata`.

### How should we test and review this PR?

CI passes

### Additional information

This is a request from <https://github.com/rust-lang/cargo/pull/14859#discussion_r1862522117>, but I found it a bit tricky so split off this change first.