### PR TITLE
fix: Remove default registry reference in `info` cmd docs

### DIFF
--- a/src/bin/cargo/commands/info.rs
+++ b/src/bin/cargo/commands/info.rs
@@ -5,7 +5,7 @@ use cargo_util_schemas::core::PackageIdSpec;
 
 pub fn cli() -> Command {
     Command::new("info")
-        .about("Display information about a package in the registry")
+        .about("Display information about a package")
         .arg(
             Arg::new("package")
                 .required(true)

--- a/src/doc/man/cargo-info.md
+++ b/src/doc/man/cargo-info.md
@@ -2,7 +2,7 @@
 
 ## NAME
 
-cargo-info --- Display information about a package in the registry. Default registry is crates.io
+cargo-info --- Display information about a package.
 
 ## SYNOPSIS
 
@@ -10,7 +10,7 @@ cargo-info --- Display information about a package in the registry. Default regi
 
 ## DESCRIPTION
 
-This command displays information about a package in the registry. It fetches data from the package's Cargo.toml file
+This command displays information about a package. It fetches data from the package's Cargo.toml file
 and presents it in a human-readable format.
 
 ## OPTIONS
@@ -60,7 +60,7 @@ selected based on the Minimum Supported Rust Version (MSRV).
         cargo info serde@1.0.0
 3. Inspect the `serde` package form the local registry:
 
-        cargo info serde --registry my-registry 
+        cargo info serde --registry my-registry
 
 ## SEE ALSO
 

--- a/src/doc/man/generated_txt/cargo-info.txt
+++ b/src/doc/man/generated_txt/cargo-info.txt
@@ -1,16 +1,15 @@
 CARGO-INFO(1)
 
 NAME
-       cargo-info — Display information about a package in the registry.
-       Default registry is crates.io
+       cargo-info — Display information about a package.
 
 SYNOPSIS
        cargo info [options] spec
 
 DESCRIPTION
-       This command displays information about a package in the registry. It
-       fetches data from the package’s Cargo.toml file and presents it in a
-       human-readable format.
+       This command displays information about a package. It fetches data from
+       the package’s Cargo.toml file and presents it in a human-readable
+       format.
 
 OPTIONS
    Info Options
@@ -149,7 +148,7 @@ EXAMPLES
 
        3. Inspect the serde package form the local registry:
 
-               cargo info serde --registry my-registry 
+               cargo info serde --registry my-registry
 
 SEE ALSO
        cargo(1), cargo-search(1)

--- a/src/doc/src/commands/cargo-info.md
+++ b/src/doc/src/commands/cargo-info.md
@@ -2,7 +2,7 @@
 
 ## NAME
 
-cargo-info --- Display information about a package in the registry. Default registry is crates.io
+cargo-info --- Display information about a package.
 
 ## SYNOPSIS
 
@@ -10,7 +10,7 @@ cargo-info --- Display information about a package in the registry. Default regi
 
 ## DESCRIPTION
 
-This command displays information about a package in the registry. It fetches data from the package's Cargo.toml file
+This command displays information about a package. It fetches data from the package's Cargo.toml file
 and presents it in a human-readable format.
 
 ## OPTIONS
@@ -161,7 +161,7 @@ details on environment variables that Cargo reads.
         cargo info serde@1.0.0
 3. Inspect the `serde` package form the local registry:
 
-        cargo info serde --registry my-registry 
+        cargo info serde --registry my-registry
 
 ## SEE ALSO
 

--- a/src/etc/man/cargo-info.1
+++ b/src/etc/man/cargo-info.1
@@ -4,11 +4,11 @@
 .ad l
 .ss \n[.ss] 0
 .SH "NAME"
-cargo\-info \[em] Display information about a package in the registry. Default registry is crates.io
+cargo\-info \[em] Display information about a package.
 .SH "SYNOPSIS"
 \fBcargo info\fR [\fIoptions\fR] \fIspec\fR
 .SH "DESCRIPTION"
-This command displays information about a package in the registry. It fetches data from the package\[cq]s Cargo.toml file
+This command displays information about a package. It fetches data from the package\[cq]s Cargo.toml file
 and presents it in a human\-readable format.
 .SH "OPTIONS"
 .SS "Info Options"
@@ -193,7 +193,7 @@ details on environment variables that Cargo reads.
 .sp
 .RS 4
 .nf
- cargo info serde \-\-registry my\-registry 
+ cargo info serde \-\-registry my\-registry
 .fi
 .RE
 .RE

--- a/tests/testsuite/cargo_info/help/stdout.term.svg
+++ b/tests/testsuite/cargo_info/help/stdout.term.svg
@@ -19,7 +19,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>Display information about a package in the registry</tspan>
+    <tspan x="10px" y="28px"><tspan>Display information about a package</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>


### PR DESCRIPTION
### What does this PR try to resolve?

close https://github.com/rust-lang/cargo/issues/14810

Remove the registry description to reduce confusion, as the `spec` already explains local `Cargo.toml` inspection behavior.

### How should we test and review this PR?

The unit test has been updated.

### Additional information

r? @epage 
