### PR TITLE
chore: Bump to 0.86.0; update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,32 +1,116 @@
 # Changelog
 
 ## Cargo 1.84 (2025-01-09)
-[15fbd2f6...HEAD](https://github.com/rust-lang/cargo/compare/15fbd2f6...HEAD)
+[15fbd2f6...rust-1.84.0](https://github.com/rust-lang/cargo/compare/15fbd2f6...rust-1.84.0)
 
 ### Added
 
+- 🎉 Stabilize resolver v3, a.k.a the MSRV-aware dependency resolver.
+  The stabilization includes `package.resolver = "3"` in Cargo.toml,
+  and the `[resolver]` table in Cargo configuration.
+  ([RFC 3537](https://github.com/rust-lang/rfcs/blob/master/text/3537-msrv-resolver.md))
+  ([manifest docs](https://doc.rust-lang.org/nightly/cargo/reference/resolver.html#resolver-versions))
+  ([config docs](https://doc.rust-lang.org/nightly/cargo/reference/config.html#resolver))
+  [#14639](https://github.com/rust-lang/cargo/pull/14639)
+  [#14662](https://github.com/rust-lang/cargo/pull/14662)
+  [#14711](https://github.com/rust-lang/cargo/pull/14711)
+  [#14725](https://github.com/rust-lang/cargo/pull/14725)
+  [#14748](https://github.com/rust-lang/cargo/pull/14748)
+  [#14753](https://github.com/rust-lang/cargo/pull/14753)
+  [#14754](https://github.com/rust-lang/cargo/pull/14754)
+- Added a new build script invocation `cargo::error=MESSAGE` to report error messages.
+  ([docs](https://doc.rust-lang.org/nightly/cargo/reference/build-scripts.html#cargo-error))
+  [#14743](https://github.com/rust-lang/cargo/pull/14743)
+
 ### Changed
 
-- Pass `--no-tags` by default to git CLI when `net.git-fetch-with-cli = true`.
+- ❗️ cargo-publish: Always include Cargo.lock in published crates.
+  Originally it was only included for packages that have executables or examples
+  for use with `cargo install`.
+  [#14815](https://github.com/rust-lang/cargo/pull/14815)
+- Dependency resolver performance improvements, including shared caching,
+  reduced iteration overhead, and removing redundant fetches and clones.
+  [#14663](https://github.com/rust-lang/cargo/pull/14663)
+  [#14690](https://github.com/rust-lang/cargo/pull/14690)
+  [#14692](https://github.com/rust-lang/cargo/pull/14692)
+  [#14694](https://github.com/rust-lang/cargo/pull/14694)
+- Deprecate `cargo verify-project`.
+  [#14736](https://github.com/rust-lang/cargo/pull/14736)
+- Add source replacement info when no matching package found during dependency resolving.
+  [#14715](https://github.com/rust-lang/cargo/pull/14715)
+- Hint for using `crates-io` when `[patch.crates.io]` found.
+  [#14700](https://github.com/rust-lang/cargo/pull/14700)
+- Normalize source paths of Cargo targets for better diagnostics.
+  [#14497](https://github.com/rust-lang/cargo/pull/14497)
+  [#14750](https://github.com/rust-lang/cargo/pull/14750)
+- Allow registries to omit empty/default fields in index metadata JSON.
+  Due to backward compatibility, crates.io continues to emit them.
+  [#14838](https://github.com/rust-lang/cargo/pull/14838)
+  [#14839](https://github.com/rust-lang/cargo/pull/14839)
+- cargo-doc: display env vars in extra verbose mode.
+  [#14812](https://github.com/rust-lang/cargo/pull/14812)
+- cargo-fix: replace special-case handling of duplicate insert-only replacement.
+  [#14765](https://github.com/rust-lang/cargo/pull/14765)
+  [#14782](https://github.com/rust-lang/cargo/pull/14782)
+- cargo-remove: when a dependency is not found, try suggesting other dependencies
+  with similar names.
+  [#14818](https://github.com/rust-lang/cargo/pull/14818)
+- git: skip unnecessary submodule validations for fresh checkouts on Git dependencies.
+  [#14605](https://github.com/rust-lang/cargo/pull/14605)
+- git: Enhanced the error message for fetching Git dependencies when refspec not found.
+  [#14806](https://github.com/rust-lang/cargo/pull/14806)
+- git: Pass `--no-tags` by default to git CLI when `net.git-fetch-with-cli = true`.
   [#14688](https://github.com/rust-lang/cargo/pull/14688)
-- Several resolver performance enhancements, including
-  - Use `rustc-hash` to speed up resolver
-    [#14663](https://github.com/rust-lang/cargo/pull/14663)
-  - Share conflict cache between activation retries
-    [#14692](https://github.com/rust-lang/cargo/pull/14692)
-  - Avoid cloning when iterating using `RcVecIter`
-    [#14690](https://github.com/rust-lang/cargo/pull/14690)
 
 ### Fixed
 
+- Fixed old Cargos failing to read the newer format of dep-info in build caches.
+  [#14751](https://github.com/rust-lang/cargo/pull/14751)
+  [#14745](https://github.com/rust-lang/cargo/pull/14745)
+- Fixed rebuild detection not respecting changes in the `[env]` table.
+  [#14701](https://github.com/rust-lang/cargo/pull/14701)
+  [#14730](https://github.com/rust-lang/cargo/pull/14730)
+- cargo-fix: Added transactional semantics to `rustfix` to keep code fix in a
+  valid state when multiple suggestions contain overlapping spans.
+  [#14747](https://github.com/rust-lang/cargo/pull/14747)
+
 ### Nightly only
 
+- The unstable environment variable `CARGO_RUSTC_CURRENT_DIR` has been removed.
+  [#14799](https://github.com/rust-lang/cargo/pull/14799)
+- 🔥 Cargo now includes an experimental JSON Schema file for `Cargo.toml` in the source code.
+  It helps external tools validate or auto-complete the schema of the manifest.
+  ([manifest.schema.json](https://github.com/rust-lang/cargo/blob/master/crates/cargo-util-schemas/manifest.schema.json))
+  [#14683](https://github.com/rust-lang/cargo/pull/14683)
+- 🔥 `Zroot-dir`: A new unstable `-Zroot-dir` flag to configure the path from
+  which rustc should be invoked.
+  ([docs](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#root-dir))
+  [#14752](https://github.com/rust-lang/cargo/pull/14752)
+- 🔥 `-Zwarnings`: A new unstable feature to control how Cargo handles warnings
+  via the `build.warnings` configuration field.
+  ([docs](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#warnings))
+  [#14388](https://github.com/rust-lang/cargo/pull/14388)
+  [#14827](https://github.com/rust-lang/cargo/pull/14827)
+  [#14836](https://github.com/rust-lang/cargo/pull/14836)
+- `edition2024`: Verify 2024 edition / resolver=3 doesn't affect resolution
+  [#14724](https://github.com/rust-lang/cargo/pull/14724)
+- `native-completions`: Include descriptions in zsh
+  [#14726](https://github.com/rust-lang/cargo/pull/14726)
 - `-Zbindeps`: Fix panic when running cargo tree on a package with a cross compiled bindep
   [#14593](https://github.com/rust-lang/cargo/pull/14593)
-- `-Zpackage-workspace`: Support package selection options like `--exclude` in `cargo publish`
+- `-Zbindeps`: download targeted transitive deps of with artifact deps' target platform
+  [#14723](https://github.com/rust-lang/cargo/pull/14723)
+- `-Zbuild-std`: Remove the requirement for `--target`.
+  [#14317](https://github.com/rust-lang/cargo/pull/14317)
+- `-Zpackage-workspace`: Support package selection options, such as `--exclude`,
+  in `cargo publish`
   [#14659](https://github.com/rust-lang/cargo/pull/14659)
-- `-Zscript`: Remove the support for accepting `Cargo.toml`
+- `-Zscript`: Remove support for accepting `Cargo.toml`.
   [#14670](https://github.com/rust-lang/cargo/pull/14670)
+- `-Zscript`: Change config paths to only check `CARGO_HOME`
+  [#14749](https://github.com/rust-lang/cargo/pull/14749)
+- `-Zscript`: Update the frontmatter parser for RFC 3503.
+  [#14792](https://github.com/rust-lang/cargo/pull/14792)
 
 ### Documentation
 
@@ -38,13 +122,51 @@
   [#14684](https://github.com/rust-lang/cargo/pull/14684)
 - Document official external commands: `cargo-clippy`, `cargo-fmt`, and `cargo-miri`.
   [#14669](https://github.com/rust-lang/cargo/pull/14669)
-- Enhanced documentation on dependency resolution
-  [#14662](https://github.com/rust-lang/cargo/pull/14662)
+  [#14805](https://github.com/rust-lang/cargo/pull/14805)
+- Enhance documentation on environment variables
+  [#14676](https://github.com/rust-lang/cargo/pull/14676)
+- Simplify English used in documentations.
+  [#14825](https://github.com/rust-lang/cargo/pull/14825)
+  [#14829](https://github.com/rust-lang/cargo/pull/14829)
+- A new doc page for deprecated and removed commands.
+  [#14739](https://github.com/rust-lang/cargo/pull/14739)
+- cargo-test-support: Document `Execs` assertions based on port effort 
+  [#14793](https://github.com/rust-lang/cargo/pull/14793)
 
 ### Internal
 
-- Updated to `pulldown-cmark` 0.12.0 
+- 🎉 Migrate `build-rs` crate to the `rust-lang/cargo` repository as an
+  intentional artifact of the Cargo team.
+  [#14786](https://github.com/rust-lang/cargo/pull/14786)
+  [#14817](https://github.com/rust-lang/cargo/pull/14817)
+- Enable transfer feature in triagebot
+  [#14777](https://github.com/rust-lang/cargo/pull/14777)
+- clone-on-write when needed for InternedString
+  [#14808](https://github.com/rust-lang/cargo/pull/14808)
+- ci: Switch CI from bors to merge queue 
+  [#14718](https://github.com/rust-lang/cargo/pull/14718)
+- ci: make the `lint-docs` job required 
+  [#14797](https://github.com/rust-lang/cargo/pull/14797)
+- ci: Check for clippy `correctness`
+  [#14796](https://github.com/rust-lang/cargo/pull/14796)
+- ci: Switch matchPackageNames to matchDepNames for renovate
+  [#14704](https://github.com/rust-lang/cargo/pull/14704)
+- fingerprint: Track the intent for each use of `UnitHash`
+  [#14826](https://github.com/rust-lang/cargo/pull/14826)
+- fingerprint: Add more metadata to `rustc_fingerprint`.
+  [#14761](https://github.com/rust-lang/cargo/pull/14761)
+- test: Migrate remaining snapshotting to snapbox
+  [#14642](https://github.com/rust-lang/cargo/pull/14642)
+  [#14760](https://github.com/rust-lang/cargo/pull/14760)
+  [#14781](https://github.com/rust-lang/cargo/pull/14781)
+  [#14785](https://github.com/rust-lang/cargo/pull/14785)
+  [#14790](https://github.com/rust-lang/cargo/pull/14790)
+- Update dependencies.
   [#14668](https://github.com/rust-lang/cargo/pull/14668)
+  [#14705](https://github.com/rust-lang/cargo/pull/14705)
+  [#14762](https://github.com/rust-lang/cargo/pull/14762)
+  [#14766](https://github.com/rust-lang/cargo/pull/14766)
+  [#14772](https://github.com/rust-lang/cargo/pull/14772)
 
 ## Cargo 1.83 (2024-11-28)
 [8f40fc59...rust-1.83.0](https://github.com/rust-lang/cargo/compare/8f40fc59...rust-1.83.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,66 @@
 # Changelog
 
+## Cargo 1.85 (2025-02-20)
+[66221abd...rust-1.84.0](https://github.com/rust-lang/cargo/compare/66221abd...rust-1.84.0)
+
+### Added
+
+- 🎉 Cargo now supports the 2024 edition.
+  More information is available in the [edition guide](https://doc.rust-lang.org/nightly/edition-guide/rust-2024/index.html).
+  [#14828](https://github.com/rust-lang/cargo/pull/14828)
+
+### Changed
+
+- Added a future-incompatibility warning for keywords in `cfg`s in Cargo.toml
+  and Cargo configuration. `cfg`s with keywords like `cfg(true)` and `cfg(false)`
+  were incorrectly accepted. For backward compatibility, support for raw
+  identifiers has been introduced; for example, use `cfg(r#true)` instead.
+  [#14671](https://github.com/rust-lang/cargo/pull/14671)
+
+### Fixed
+
+- Set `GIT_DIR` to ensure compatibility with bare repositories
+  for `net.git-fetch-with-cli=true`.
+  [#14860](https://github.com/rust-lang/cargo/pull/14860)
+
+### Nightly only
+
+- `-Zbuild-std`: Check if build target supports `std`.
+  [#14183](https://github.com/rust-lang/cargo/pull/14183)
+- `-Zbuild-std`: always link to std when testing proc-macros.
+  [#14850](https://github.com/rust-lang/cargo/pull/14850)
+  [#14861](https://github.com/rust-lang/cargo/pull/14861)
+- `-Zpackage-workspace`: Allow dry-run of a non-bumped workspace.
+  [#14847](https://github.com/rust-lang/cargo/pull/14847)
+- `-Zscript`: Allow adding/removing dependencies from cargo scripts
+  [#14857](https://github.com/rust-lang/cargo/pull/14857)
+- `-Zscript`: Migrate cargo script manifests across editions
+  [#14864](https://github.com/rust-lang/cargo/pull/14864)
+
+### Documentation
+
+- Clarify how `cargo::metadata` env var is selected.
+  [#14842](https://github.com/rust-lang/cargo/pull/14842)
+- cargo-info: Remove references to the default registry in `cargo-info` docs
+  [#14880](https://github.com/rust-lang/cargo/pull/14880)
+
+### Internal
+
+- cargo-test-support: `requires` attribute accepts string literals for cmds
+  [#14875](https://github.com/rust-lang/cargo/pull/14875)
+- cargo-test-support: Switch from 'exec_with_output' to 'run'
+  [#14848](https://github.com/rust-lang/cargo/pull/14848)
+- test: Verify `-Cmetadata` directly, not through `-Cextra-filename`
+  [#14846](https://github.com/rust-lang/cargo/pull/14846)
+- test: ensure PGO works
+  [#14859](https://github.com/rust-lang/cargo/pull/14859)
+  [#14874](https://github.com/rust-lang/cargo/pull/14874)
+- Update dependencies.
+  [#14867](https://github.com/rust-lang/cargo/pull/14867)
+  [#14871](https://github.com/rust-lang/cargo/pull/14871)
+  [#14878](https://github.com/rust-lang/cargo/pull/14878)
+  [#14879](https://github.com/rust-lang/cargo/pull/14879)
+
 ## Cargo 1.84 (2025-01-09)
 [15fbd2f6...rust-1.84.0](https://github.com/rust-lang/cargo/compare/15fbd2f6...rust-1.84.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,9 @@
 - cargo-vendor: trusts the crate version only when it originates from registries.
   This causes git dependencies to be re-vendored even if they haven't changed.
   [#14530](https://github.com/rust-lang/cargo/pull/14530)
+- cargo-publish: Downgrade version-exists error to warning on dry-run
+  [#14742](https://github.com/rust-lang/cargo/pull/14742)
+  [#14744](https://github.com/rust-lang/cargo/pull/14744)
 
 ### Nightly only
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "cargo"
-version = "0.85.0"
+version = "0.86.0"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ self_named_module_files = "warn"
 
 [package]
 name = "cargo"
-version = "0.85.0"
+version = "0.86.0"
 edition.workspace = true
 license.workspace = true
 rust-version = "1.83"  # MSRV:1


### PR DESCRIPTION
[rendered](https://github.com/weihanglo/cargo/blob/version-bump/CHANGELOG.md)