### PR TITLE
test(pgo): only run on nightly

### DIFF
--- a/tests/testsuite/pgo.rs
+++ b/tests/testsuite/pgo.rs
@@ -22,10 +22,15 @@ fn llvm_profdata() -> Option<PathBuf> {
     })
 }
 
-#[cargo_test]
+// Rustc build may be without profiling support.
+// Mark it as nightly so it won't run on rust-lang/rust CI.
+#[cfg_attr(
+    target_os = "linux",
+    cargo_test(nightly, reason = "rust-lang/rust#133675")
+)]
 // macOS may emit different LLVM PGO warnings.
 // Windows LLVM has different requirements.
-#[cfg_attr(not(target_os = "linux"), ignore = "linux only")]
+#[cfg_attr(not(target_os = "linux"), cargo_test, ignore = "linux only")]
 fn pgo_works() {
     let Some(llvm_profdata) = llvm_profdata() else {
         return;


### PR DESCRIPTION
### What does this PR try to resolve?

Only run PGO test on nightly,
so it won't run on rust-lang/rust's CI
because `CARGO_TEST_DISABLE_NIGHTLY` is set on that.

### How should we test and review this PR?

This is a temporary fix to unblock Cargo submoule update (assume that rust-lang/rust#133675 won't be fixed this week).

In the future We should seek a solution that

* Disable test on rust-lang/rust's CI
* Maximize test coverage on different channels and platforms on Cargo's CI.
