### PR TITLE
test(build-std): make mock-std closer to real world

### DIFF
--- a/tests/testsuite/mock-std/library/compiler_builtins/src/lib.rs
+++ b/tests/testsuite/mock-std/library/compiler_builtins/src/lib.rs
@@ -1,1 +1,1 @@
-// intentionally blank
+#![no_std]

--- a/tests/testsuite/mock-std/library/core/src/lib.rs
+++ b/tests/testsuite/mock-std/library/core/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 #![feature(staged_api)]
 #![stable(since = "1.0.0", feature = "dummy")]
 

--- a/tests/testsuite/standard_lib.rs
+++ b/tests/testsuite/standard_lib.rs
@@ -395,12 +395,13 @@ fn test_std_on_unsupported_target() {
 
     let p = project()
         .file(
-            "src/main.rs",
+            "src/lib.rs",
             r#"
-        fn main() {
-            println!("hello");
-        }
-        "#,
+                #![no_std]
+                pub fn foo() {
+                    assert_eq!(u8::MIN, 0);
+                }
+            "#,
         )
         .build();
 


### PR DESCRIPTION
### What does this PR try to resolve?

`test_std_on_unsupported_target` never really succeed to build those targets, due to

* local rustup may not have `{aarch64,x86_64}-unknown-none` installed.
* `core` and `compiler-builtins` mock crate are not `no_std` nor `no_core`
* the dummy `main.rs` uses `println!` and is not `no_std`.

This commit make it compile, if you have those targets installed.


### How should we test and review this PR?

Change this line to `.build_std_arg(&setup, "core")`.

https://github.com/rust-lang/cargo/blob/05f54fdc34310f458033af8a63ce1d699fae8bf6/tests/testsuite/standard_lib.rs?plain=1#L410

And delete these liens: https://github.com/rust-lang/cargo/blob/05f54fdc34310f458033af8a63ce1d699fae8bf6/src/cargo/core/compiler/standard_lib.rs?plain=1#L75-L84

Then the test project should compile.