### PR TITLE
fix(resolver): Report unmatched versions, rather than saying no package

### DIFF
--- a/crates/resolver-tests/src/lib.rs
+++ b/crates/resolver-tests/src/lib.rs
@@ -143,7 +143,7 @@ pub fn resolve_with_global_context_raw(
             for summary in self.list.iter() {
                 let matched = match kind {
                     QueryKind::Exact => dep.matches(summary),
-                    QueryKind::Alternatives => true,
+                    QueryKind::AlternativeNames => true,
                     QueryKind::Normalized => true,
                 };
                 if matched {

--- a/crates/resolver-tests/src/lib.rs
+++ b/crates/resolver-tests/src/lib.rs
@@ -143,6 +143,7 @@ pub fn resolve_with_global_context_raw(
             for summary in self.list.iter() {
                 let matched = match kind {
                     QueryKind::Exact => dep.matches(summary),
+                    QueryKind::AlternativeVersions => dep.matches(summary),
                     QueryKind::AlternativeNames => true,
                     QueryKind::Normalized => true,
                 };

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -674,9 +674,10 @@ impl<'gctx> Registry for PackageRegistry<'gctx> {
             let patch = patches.remove(0);
             match override_summary {
                 Some(override_summary) => {
-                    let override_summary = override_summary.into_summary();
-                    self.warn_bad_override(&override_summary, &patch)?;
-                    f(IndexSummary::Candidate(self.lock(override_summary)));
+                    self.warn_bad_override(override_summary.as_summary(), &patch)?;
+                    let override_summary =
+                        override_summary.map_summary(|summary| self.lock(summary));
+                    f(override_summary);
                 }
                 None => f(IndexSummary::Candidate(patch)),
             }
@@ -760,11 +761,11 @@ impl<'gctx> Registry for PackageRegistry<'gctx> {
                         "found an override with a non-locked list"
                     )));
                 }
-                let override_summary = override_summary.into_summary();
                 if let Some(to_warn) = to_warn {
-                    self.warn_bad_override(&override_summary, to_warn.as_summary())?;
+                    self.warn_bad_override(override_summary.as_summary(), to_warn.as_summary())?;
                 }
-                f(IndexSummary::Candidate(self.lock(override_summary)));
+                let override_summary = override_summary.map_summary(|summary| self.lock(summary));
+                f(override_summary);
             }
         }
 

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -733,8 +733,8 @@ impl<'gctx> Registry for PackageRegistry<'gctx> {
                             return;
                         }
                     }
-                    let summary = summary.into_summary();
-                    f(IndexSummary::Candidate(lock(locked, all_patches, summary)))
+                    let summary = summary.map_summary(|summary| lock(locked, all_patches, summary));
+                    f(summary)
                 };
                 return source.query(dep, kind, callback);
             }

--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -304,7 +304,7 @@ pub(super) fn activation_error(
         // Maybe the user mistyped the name? Like `dep-thing` when `Dep_Thing`
         // was meant. So we try asking the registry for a `fuzzy` search for suggestions.
         let candidates = loop {
-            match registry.query_vec(&new_dep, QueryKind::Alternatives) {
+            match registry.query_vec(&new_dep, QueryKind::AlternativeNames) {
                 Poll::Ready(Ok(candidates)) => break candidates,
                 Poll::Ready(Err(e)) => return to_resolve_err(e),
                 Poll::Pending => match registry.block_until_ready() {

--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -313,12 +313,10 @@ pub(super) fn activation_error(
                 },
             }
         };
-
         let mut name_candidates: Vec<_> = name_candidates
             .into_iter()
             .map(|s| s.into_summary())
             .collect();
-
         name_candidates.sort_unstable_by_key(|a| a.name());
         name_candidates.dedup_by(|a, b| a.name() == b.name());
         let mut name_candidates: Vec<_> = name_candidates
@@ -326,6 +324,7 @@ pub(super) fn activation_error(
             .filter_map(|n| Some((edit_distance(&*new_dep.package_name(), &*n.name(), 3)?, n)))
             .collect();
         name_candidates.sort_by_key(|o| o.0);
+
         let mut msg: String;
         if name_candidates.is_empty() {
             msg = format!("no matching package named `{}` found\n", dep.package_name());

--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -362,12 +362,23 @@ pub(super) fn activation_error(
                         let _ = writeln!(&mut msg, "  version {} is not cached", summary.version());
                     }
                     IndexSummary::Unsupported(summary, schema_version) => {
-                        let _ = writeln!(
+                        if let Some(rust_version) = summary.rust_version() {
+                            // HACK: technically its unsupported and we shouldn't make assumptions
+                            // about the entry but this is limited and for diagnostics purposes
+                            let _ = writeln!(
+                                &mut msg,
+                                "  version {} requires cargo {}",
+                                summary.version(),
+                                rust_version
+                            );
+                        } else {
+                            let _ = writeln!(
                             &mut msg,
                             "  version {} requires a Cargo version that supports index version {}",
                             summary.version(),
                             schema_version
                         );
+                        }
                     }
                 }
             }

--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -326,9 +326,7 @@ pub(super) fn activation_error(
         name_candidates.sort_by_key(|o| o.0);
 
         let mut msg: String;
-        if name_candidates.is_empty() {
-            msg = format!("no matching package named `{}` found\n", dep.package_name());
-        } else {
+        if !name_candidates.is_empty() {
             msg = format!(
                 "no matching package found\nsearched package name: `{}`\n",
                 dep.package_name()
@@ -354,6 +352,8 @@ pub(super) fn activation_error(
                 },
             ));
             msg.push('\n');
+        } else {
+            msg = format!("no matching package named `{}` found\n", dep.package_name());
         }
 
         let mut location_searched_msg = registry.describe_source(dep.source_id());

--- a/src/cargo/sources/directory.rs
+++ b/src/cargo/sources/directory.rs
@@ -108,7 +108,7 @@ impl<'gctx> Source for DirectorySource<'gctx> {
         }
         let packages = self.packages.values().map(|p| &p.0);
         let matches = packages.filter(|pkg| match kind {
-            QueryKind::Exact => dep.matches(pkg.summary()),
+            QueryKind::Exact | QueryKind::AlternativeVersions => dep.matches(pkg.summary()),
             QueryKind::AlternativeNames => true,
             QueryKind::Normalized => dep.matches(pkg.summary()),
         });

--- a/src/cargo/sources/directory.rs
+++ b/src/cargo/sources/directory.rs
@@ -109,7 +109,7 @@ impl<'gctx> Source for DirectorySource<'gctx> {
         let packages = self.packages.values().map(|p| &p.0);
         let matches = packages.filter(|pkg| match kind {
             QueryKind::Exact => dep.matches(pkg.summary()),
-            QueryKind::Alternatives => true,
+            QueryKind::AlternativeNames => true,
             QueryKind::Normalized => dep.matches(pkg.summary()),
         });
         for summary in matches.map(|pkg| pkg.summary().clone()) {

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -145,7 +145,7 @@ impl<'gctx> Source for PathSource<'gctx> {
         self.load()?;
         if let Some(s) = self.package.as_ref().map(|p| p.summary()) {
             let matched = match kind {
-                QueryKind::Exact => dep.matches(s),
+                QueryKind::Exact | QueryKind::AlternativeVersions => dep.matches(s),
                 QueryKind::AlternativeNames => true,
                 QueryKind::Normalized => dep.matches(s),
             };
@@ -332,7 +332,7 @@ impl<'gctx> Source for RecursivePathSource<'gctx> {
             .map(|p| p.summary())
         {
             let matched = match kind {
-                QueryKind::Exact => dep.matches(s),
+                QueryKind::Exact | QueryKind::AlternativeVersions => dep.matches(s),
                 QueryKind::AlternativeNames => true,
                 QueryKind::Normalized => dep.matches(s),
             };

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -146,7 +146,7 @@ impl<'gctx> Source for PathSource<'gctx> {
         if let Some(s) = self.package.as_ref().map(|p| p.summary()) {
             let matched = match kind {
                 QueryKind::Exact => dep.matches(s),
-                QueryKind::Alternatives => true,
+                QueryKind::AlternativeNames => true,
                 QueryKind::Normalized => dep.matches(s),
             };
             if matched {
@@ -333,7 +333,7 @@ impl<'gctx> Source for RecursivePathSource<'gctx> {
         {
             let matched = match kind {
                 QueryKind::Exact => dep.matches(s),
-                QueryKind::Alternatives => true,
+                QueryKind::AlternativeNames => true,
                 QueryKind::Normalized => dep.matches(s),
             };
             if matched {

--- a/src/cargo/sources/registry/index/mod.rs
+++ b/src/cargo/sources/registry/index/mod.rs
@@ -37,7 +37,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::str;
 use std::task::{ready, Poll};
-use tracing::{debug, info};
+use tracing::info;
 
 mod cache;
 use self::cache::CacheManager;
@@ -370,21 +370,7 @@ impl<'gctx> RegistryIndex<'gctx> {
             .filter_map(move |(k, v)| if req.matches(k) { Some(v) } else { None })
             .filter_map(move |maybe| {
                 match maybe.parse(raw_data, source_id, bindeps) {
-                    Ok(sum @ IndexSummary::Candidate(_) | sum @ IndexSummary::Yanked(_)) => {
-                        Some(sum)
-                    }
-                    Ok(IndexSummary::Unsupported(summary, v)) => {
-                        debug!(
-                            "unsupported schema version {} ({} {})",
-                            v,
-                            summary.name(),
-                            summary.version()
-                        );
-                        None
-                    }
-                    Ok(IndexSummary::Offline(_)) => {
-                        unreachable!("We do not check for off-line until later")
-                    }
+                    Ok(sum) => Some(sum),
                     Err(e) => {
                         info!("failed to parse `{}` registry package: {}", name, e);
                         None

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -799,7 +799,7 @@ impl<'gctx> Source for RegistrySource<'gctx> {
                 .index
                 .query_inner(dep.package_name(), &req, &mut *self.ops, &mut |s| {
                     let matched = match kind {
-                        QueryKind::Exact => {
+                        QueryKind::Exact | QueryKind::AlternativeVersions => {
                             if req.is_precise() && self.gctx.cli_unstable().unstable_options {
                                 dep.matches_prerelease(s.as_summary())
                             } else {
@@ -816,6 +816,7 @@ impl<'gctx> Source for RegistrySource<'gctx> {
                     // leak through if they're in a whitelist (aka if they were
                     // previously in `Cargo.lock`
                     match s {
+                        s @ _ if kind == QueryKind::AlternativeVersions => callback(s),
                         s @ IndexSummary::Candidate(_) => callback(s),
                         s @ IndexSummary::Yanked(_) => {
                             if self.yanked_whitelist.contains(&s.package_id()) {

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -804,7 +804,7 @@ impl<'gctx> Source for RegistrySource<'gctx> {
                                 dep.matches(s.as_summary())
                             }
                         }
-                        QueryKind::Alternatives => true,
+                        QueryKind::AlternativeNames => true,
                         QueryKind::Normalized => true,
                     };
                     if !matched {
@@ -839,7 +839,7 @@ impl<'gctx> Source for RegistrySource<'gctx> {
                 return Poll::Ready(Ok(()));
             }
             let mut any_pending = false;
-            if kind == QueryKind::Alternatives || kind == QueryKind::Normalized {
+            if kind == QueryKind::AlternativeNames || kind == QueryKind::Normalized {
                 // Attempt to handle misspellings by searching for a chain of related
                 // names to the original name. The resolver will later
                 // reject any candidates that have the wrong name, and with this it'll
@@ -859,7 +859,7 @@ impl<'gctx> Source for RegistrySource<'gctx> {
                         .query_inner(name_permutation, &req, &mut *self.ops, &mut |s| {
                             if !s.is_yanked() {
                                 f(s);
-                            } else if kind == QueryKind::Alternatives {
+                            } else if kind == QueryKind::AlternativeNames {
                                 f(s);
                             }
                         })?

--- a/src/cargo/sources/source.rs
+++ b/src/cargo/sources/source.rs
@@ -183,6 +183,13 @@ pub enum QueryKind {
     /// Each source gets to define what `close` means for it.
     ///
     /// Path/Git sources may return all dependencies that are at that URI,
+    /// whereas an `Registry` source may return dependencies that are yanked or invalid.
+    AlternativeVersions,
+    /// A query for packages close to the given dependency requirement.
+    ///
+    /// Each source gets to define what `close` means for it.
+    ///
+    /// Path/Git sources may return all dependencies that are at that URI,
     /// whereas an `Registry` source may return dependencies that have the same
     /// canonicalization.
     AlternativeNames,

--- a/src/cargo/sources/source.rs
+++ b/src/cargo/sources/source.rs
@@ -185,7 +185,7 @@ pub enum QueryKind {
     /// Path/Git sources may return all dependencies that are at that URI,
     /// whereas an `Registry` source may return dependencies that have the same
     /// canonicalization.
-    Alternatives,
+    AlternativeNames,
     /// Match a dependency in all ways and will normalize the package name.
     /// Each source defines what normalizing means.
     Normalized,

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -924,7 +924,8 @@ fn yanks_in_lockfiles_are_ok_http() {
 "#]],
         str![[r#"
 [UPDATING] `dummy-registry` index
-[ERROR] no matching package named `bar` found
+[ERROR] no matching versions for `bar` found
+  version 0.0.1 is yanked
 location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.0.1 ([ROOT]/foo)`
 
@@ -941,7 +942,8 @@ fn yanks_in_lockfiles_are_ok_git() {
 "#]],
         str![[r#"
 [UPDATING] `dummy-registry` index
-[ERROR] no matching package named `bar` found
+[ERROR] no matching versions for `bar` found
+  version 0.0.1 is yanked
 location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.0.1 ([ROOT]/foo)`
 
@@ -993,7 +995,8 @@ fn yanks_in_lockfiles_are_ok_for_other_update_http() {
 "#]],
         str![[r#"
 [UPDATING] `dummy-registry` index
-[ERROR] no matching package named `bar` found
+[ERROR] no matching versions for `bar` found
+  version 0.0.1 is yanked
 location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.0.1 ([ROOT]/foo)`
 
@@ -1016,7 +1019,8 @@ fn yanks_in_lockfiles_are_ok_for_other_update_git() {
 "#]],
         str![[r#"
 [UPDATING] `dummy-registry` index
-[ERROR] no matching package named `bar` found
+[ERROR] no matching versions for `bar` found
+  version 0.0.1 is yanked
 location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.0.1 ([ROOT]/foo)`
 
@@ -3225,7 +3229,8 @@ fn unknown_index_version_error() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[ERROR] no matching package named `bar` found
+[ERROR] no matching versions for `bar` found
+  version 1.0.1 requires a Cargo version that supports index version 4294967295
 location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.1.0 ([ROOT]/foo)`
 

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -3267,7 +3267,7 @@ fn unknown_index_version_with_msrv_error() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [ERROR] no matching versions for `bar` found
-  version 1.0.1 requires a Cargo version that supports index version 4294967295
+  version 1.0.1 requires cargo 1.2345
 location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.1.0 ([ROOT]/foo)`
 


### PR DESCRIPTION
### What does this PR try to resolve?

Instead of saying no package found when there are hidden `Summary`s, we'll instead say why the summary was hidden in the cases of
- Yanked packages
- Schema mismatch
- Offline packages?

The schema mismatch covers part of #10623.  Whats remaining is when we can't parse the `Summary` but can parse a subset (name, version, schema version, optionally rust-version).  That will be handled in a follow up.

### How should we test and review this PR?

This has a couple of risky areas
- Moving the filtering of `IndexSummary` variants from the Index to the Registry Source.  On inspection, there were other code paths but they seemed innocuous to not filter, like asking for a hash of a summary
- Switching `PackageRegistry` to preserve the `IndexSummary` variant for regular sources and overrides
  - I did not switch patches to preserve `IndexSummary` as that was more invasive and the benefits seemed more minor (normally people patch over registry dependencies and not to them)

### Additional information

