### PR TITLE
docs(fingerprint): cargo-rustc extra flags do not affect the metadata 

### DIFF
--- a/src/cargo/core/compiler/fingerprint/mod.rs
+++ b/src/cargo/core/compiler/fingerprint/mod.rs
@@ -66,7 +66,7 @@
 //! -------------------------------------------|-------------|----------
 //! rustc                                      | ✓           | ✓
 //! [`Profile`]                                | ✓           | ✓
-//! `cargo rustc` extra args                   | ✓           | ✓
+//! `cargo rustc` extra args                   | ✓           |
 //! [`CompileMode`]                            | ✓           | ✓
 //! Target Name                                | ✓           | ✓
 //! `TargetKind` (bin/lib/etc.)                | ✓           | ✓


### PR DESCRIPTION
### What does this PR try to resolve?

As the test updates in this PR show, RUSTFLAGS and extra-flags have the same
behavior: they don't affect `-Cextra-filename` or `-Cmetadata`.
I also verified this by code inspection.
I'm not sure why the table says this.

### How should we test and review this PR?



### Additional information

