### PR TITLE
fix(build-std): determine root crates by target spec `std:bool`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,6 +161,8 @@ jobs:
     - run: rustup update --no-self-update stable
     - run: rustup update --no-self-update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
     - run: rustup target add ${{ matrix.other }}
+    - run: rustup target add aarch64-unknown-none # need this for build-std mock tests
+      if: startsWith(matrix.rust, 'nightly')
     - run: rustup component add rustc-dev llvm-tools-preview rust-docs
       if: startsWith(matrix.rust, 'nightly')
     - run: sudo apt update -y && sudo apt install lldb gcc-multilib libsecret-1-0 libsecret-1-dev -y

--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -81,12 +81,10 @@ pub fn resolve_std<'gctx>(
     // `[dev-dependencies]`. No need for us to generate a `Resolve` which has
     // those included because we'll never use them anyway.
     std_ws.set_require_optional_deps(false);
-    // `sysroot` is not in the default set because it is optional, but it needs
-    // to be part of the resolve in case we do need it or `libtest`.
-    let mut spec_pkgs: Vec<String> = crates.iter().map(|s| s.to_string()).collect();
-    spec_pkgs.push("sysroot".to_string());
-    let spec = Packages::Packages(spec_pkgs);
-    let specs = spec.to_package_id_specs(&std_ws)?;
+    // `sysroot` + the default feature set below should give us a good default
+    // Resolve, which includes `libtest` as well.
+    let specs = Packages::Packages(vec!["sysroot".into()]);
+    let specs = specs.to_package_id_specs(&std_ws)?;
     let features = match &gctx.cli_unstable().build_std_features {
         Some(list) => list.clone(),
         None => vec![

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -759,7 +759,6 @@ unstable_cli_options!(
     avoid_dev_deps: bool = ("Avoid installing dev-dependencies if possible"),
     binary_dep_depinfo: bool = ("Track changes to dependency artifacts"),
     bindeps: bool = ("Allow Cargo packages to depend on bin, cdylib, and staticlib crates, and use the artifacts built by those crates"),
-    #[serde(deserialize_with = "deserialize_build_std")]
     build_std: Option<Vec<String>>  = ("Enable Cargo to compile the standard library itself as part of a crate graph compilation"),
     build_std_features: Option<Vec<String>>  = ("Configure features enabled for the standard library itself when building the standard library"),
     cargo_lints: bool = ("Enable the `[lints.cargo]` table"),
@@ -872,19 +871,6 @@ const STABILIZED_LINTS: &str = "The `[lints]` table is now always available.";
 
 const STABILIZED_CHECK_CFG: &str =
     "Compile-time checking of conditional (a.k.a. `-Zcheck-cfg`) is now always enabled.";
-
-fn deserialize_build_std<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let Some(crates) = <Option<Vec<String>>>::deserialize(deserializer)? else {
-        return Ok(None);
-    };
-    let v = crates.join(",");
-    Ok(Some(
-        crate::core::compiler::standard_lib::parse_unstable_flag(Some(&v)),
-    ))
-}
 
 #[derive(Debug, Copy, Clone, Default, Deserialize, Ord, PartialOrd, Eq, PartialEq)]
 #[serde(default)]
@@ -1257,9 +1243,7 @@ impl CliUnstable {
             "avoid-dev-deps" => self.avoid_dev_deps = parse_empty(k, v)?,
             "binary-dep-depinfo" => self.binary_dep_depinfo = parse_empty(k, v)?,
             "bindeps" => self.bindeps = parse_empty(k, v)?,
-            "build-std" => {
-                self.build_std = Some(crate::core::compiler::standard_lib::parse_unstable_flag(v))
-            }
+            "build-std" => self.build_std = Some(parse_list(v)),
             "build-std-features" => self.build_std_features = Some(parse_list(v)),
             "cargo-lints" => self.cargo_lints = parse_empty(k, v)?,
             "codegen-backend" => self.codegen_backend = parse_empty(k, v)?,

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -1148,7 +1148,8 @@ impl CliUnstable {
             }
         }
 
-        fn parse_features(value: Option<&str>) -> Vec<String> {
+        /// Parse a comma-separated list
+        fn parse_list(value: Option<&str>) -> Vec<String> {
             match value {
                 None => Vec::new(),
                 Some("") => Vec::new(),
@@ -1197,7 +1198,7 @@ impl CliUnstable {
         match k {
             // Permanently unstable features
             // Sorted alphabetically:
-            "allow-features" => self.allow_features = Some(parse_features(v).into_iter().collect()),
+            "allow-features" => self.allow_features = Some(parse_list(v).into_iter().collect()),
             "print-im-a-teapot" => self.print_im_a_teapot = parse_bool(k, v)?,
 
             // Stabilized features
@@ -1216,7 +1217,7 @@ impl CliUnstable {
                 // until we feel confident to remove entirely.
                 //
                 // See rust-lang/cargo#11168
-                let feats = parse_features(v);
+                let feats = parse_list(v);
                 let stab_is_not_empty = feats.iter().any(|feat| {
                     matches!(
                         feat.as_str(),
@@ -1259,7 +1260,7 @@ impl CliUnstable {
             "build-std" => {
                 self.build_std = Some(crate::core::compiler::standard_lib::parse_unstable_flag(v))
             }
-            "build-std-features" => self.build_std_features = Some(parse_features(v)),
+            "build-std-features" => self.build_std_features = Some(parse_list(v)),
             "cargo-lints" => self.cargo_lints = parse_empty(k, v)?,
             "codegen-backend" => self.codegen_backend = parse_empty(k, v)?,
             "config-include" => self.config_include = parse_empty(k, v)?,

--- a/src/cargo/ops/cargo_compile/mod.rs
+++ b/src/cargo/ops/cargo_compile/mod.rs
@@ -289,9 +289,9 @@ pub fn create_bcx<'a, 'gctx>(
         resolved_features,
     } = resolve;
 
-    let std_resolve_features = if let Some(crates) = &gctx.cli_unstable().build_std {
+    let std_resolve_features = if gctx.cli_unstable().build_std.is_some() {
         let (std_package_set, std_resolve, std_features) =
-            standard_lib::resolve_std(ws, &mut target_data, &build_config, crates)?;
+            standard_lib::resolve_std(ws, &mut target_data, &build_config)?;
         pkg_set.add_set(std_package_set);
         Some((std_resolve, std_features))
     } else {

--- a/src/cargo/ops/cargo_compile/mod.rs
+++ b/src/cargo/ops/cargo_compile/mod.rs
@@ -398,10 +398,11 @@ pub fn create_bcx<'a, 'gctx>(
         Vec::new()
     };
 
-    let std_roots = if let Some(crates) = standard_lib::std_crates(gctx, Some(&units)) {
+    let std_roots = if let Some(crates) = gctx.cli_unstable().build_std.as_ref() {
         let (std_resolve, std_features) = std_resolve_features.as_ref().unwrap();
         standard_lib::generate_std_roots(
             &crates,
+            &units,
             std_resolve,
             std_features,
             &explicit_host_kinds,

--- a/src/cargo/ops/cargo_fetch.rs
+++ b/src/cargo/ops/cargo_fetch.rs
@@ -64,8 +64,7 @@ pub fn fetch<'a>(
     }
 
     // If -Zbuild-std was passed, download dependencies for the standard library.
-    // We don't know ahead of time what jobs we'll be running, so tell `std_crates` that.
-    if let Some(crates) = standard_lib::std_crates(gctx, None) {
+    if let Some(crates) = gctx.cli_unstable().build_std.as_ref() {
         let (std_package_set, _, _) =
             standard_lib::resolve_std(ws, &mut data, &build_config, &crates)?;
         packages.add_set(std_package_set);

--- a/src/cargo/ops/cargo_fetch.rs
+++ b/src/cargo/ops/cargo_fetch.rs
@@ -64,9 +64,8 @@ pub fn fetch<'a>(
     }
 
     // If -Zbuild-std was passed, download dependencies for the standard library.
-    if let Some(crates) = gctx.cli_unstable().build_std.as_ref() {
-        let (std_package_set, _, _) =
-            standard_lib::resolve_std(ws, &mut data, &build_config, &crates)?;
+    if gctx.cli_unstable().build_std.is_some() {
+        let (std_package_set, _, _) = standard_lib::resolve_std(ws, &mut data, &build_config)?;
         packages.add_set(std_package_set);
     }
 

--- a/tests/testsuite/standard_lib.rs
+++ b/tests/testsuite/standard_lib.rs
@@ -429,12 +429,72 @@ fn build_std_with_no_arg_for_core_only_target() {
     p.cargo("build -v")
         .arg("--target=aarch64-unknown-none")
         .build_std(&setup)
-        .with_status(101)
-        .with_stderr_data(str![[r#"
-...
-error[E0463]: can't find crate for `std`
-...
-"#]])
+        .with_stderr_data(
+            str![[r#"
+[UPDATING] `dummy-registry` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] registry-dep-using-std v1.0.0 (registry `dummy-registry`)
+[DOWNLOADED] registry-dep-using-core v1.0.0 (registry `dummy-registry`)
+[DOWNLOADED] registry-dep-using-alloc v1.0.0 (registry `dummy-registry`)
+[COMPILING] compiler_builtins v0.1.0 ([..]/library/compiler_builtins)
+[COMPILING] core v0.1.0 ([..]/library/core)
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `[..] rustc --crate-name compiler_builtins [..]--target aarch64-unknown-none[..]`
+[RUNNING] `[..] rustc --crate-name core [..]--target aarch64-unknown-none[..]`
+[RUNNING] `[..] rustc --crate-name foo [..]--target aarch64-unknown-none[..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]]
+            .unordered(),
+        )
+        .run();
+
+    p.cargo("clean").run();
+
+    // Also work for a mix of std and core-only targets,
+    // though not sure how common it is...
+    //
+    // Note that we don't  download std dependencies for the second call
+    // because `-Zbuild-std` downloads them all also when building for core only.
+    p.cargo("build -v")
+        .arg("--target=aarch64-unknown-none")
+        .target_host()
+        .build_std(&setup)
+        .with_stderr_data(
+            str![[r#"
+[UPDATING] `dummy-registry` index
+[COMPILING] core v0.1.0 ([..]/library/core)
+[COMPILING] dep_test v0.1.0 ([..]/dep_test)
+[COMPILING] compiler_builtins v0.1.0 ([..]/library/compiler_builtins)
+[COMPILING] proc_macro v0.1.0 ([..]/library/proc_macro)
+[COMPILING] panic_unwind v0.1.0 ([..]/library/panic_unwind)
+[COMPILING] rustc-std-workspace-core v1.9.0 ([..]/library/rustc-std-workspace-core)
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[COMPILING] registry-dep-using-core v1.0.0
+[COMPILING] alloc v0.1.0 ([..]/library/alloc)
+[COMPILING] rustc-std-workspace-alloc v1.9.0 ([..]/library/rustc-std-workspace-alloc)
+[COMPILING] registry-dep-using-alloc v1.0.0
+[COMPILING] std v0.1.0 ([..]/library/std)
+[RUNNING] `[..]rustc --crate-name compiler_builtins [..]--target aarch64-unknown-none[..]`
+[RUNNING] `[..]rustc --crate-name core [..]--target aarch64-unknown-none[..]`
+[RUNNING] `[..]rustc --crate-name foo [..]--target aarch64-unknown-none[..]`
+[RUNNING] `[..]rustc --crate-name core [..]--target [HOST_TARGET][..]`
+[RUNNING] `[..]rustc --crate-name dep_test [..]--target [HOST_TARGET][..]`
+[RUNNING] `[..]rustc --crate-name proc_macro [..]--target [HOST_TARGET][..]`
+[RUNNING] `[..]rustc --crate-name panic_unwind [..]--target [HOST_TARGET][..]`
+[RUNNING] `[..]rustc --crate-name compiler_builtins [..]--target [HOST_TARGET][..]`
+[RUNNING] `[..]rustc --crate-name rustc_std_workspace_core [..]--target [HOST_TARGET][..]`
+[RUNNING] `[..]rustc --crate-name registry_dep_using_core [..]--target [HOST_TARGET][..]`
+[RUNNING] `[..]rustc --crate-name alloc [..]--target [HOST_TARGET][..]`
+[RUNNING] `[..]rustc --crate-name rustc_std_workspace_alloc [..]--target [HOST_TARGET][..]`
+[RUNNING] `[..]rustc --crate-name registry_dep_using_alloc [..]--target [HOST_TARGET][..]`
+[RUNNING] `[..]rustc --crate-name std [..]--target [HOST_TARGET][..]`
+[RUNNING] `[..]rustc --crate-name foo [..]--target [HOST_TARGET][..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]]
+            .unordered(),
+        )
         .run();
 }
 


### PR DESCRIPTION
### What does this PR try to resolve?

In rust-lang/cargo#14183 Cargo starts bailing out if the `metadata.std`
field in a target spec JSON is set to `false`.
This is problematic because std for some targets are actually buildable
even they've declared as std-unsupported.

This patch removes the hard error, and instead determines the required
root crates by the `metadata.std` field. That is to say, if a target
is explicitly declared as `std: false`, `-Zbuild-std` will build `core`
and `compiler-builtins` only, no `std` will be built.

This patch doesn't change the behavior of `-Zbuild-std` with explicit
crates set. For example `-Zbuild-std=std` will force building `std`.

See Zulip discussion:
https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/help.20debugging.20a.20docs.2Ers.20issue.20with.20a.20new.20cargo.20error

### How should we test and review this PR?

e18b64ff80c7f43758c6330beebfbb0e78da5584 and 125e873dffc4b68b263c5decd88750ec10fd441e might need a closer look.
Cargo relies on how std workspace is organized with these commits. 

Here is an e2e test, if you are willing to test manually.

* Use the current nightly toolchain `rustc 1.85.0-nightly (acabb5248 2024-12-04)`
* `rustup component add rust-src --toolchain nightly`
* `rustup target add aarch64-unknown-none --toolchain nightly`
* Create a `#![no_std]` lib package.
* Run `target/debug/cargo build -Zbuild-std --target aarch64-unknown-none` in that package. Previously it failed with a message `building std is not supported on the following targets`
