### PR TITLE
fix(build-rs)!: Remove meaningless 'cargo_cfg_debug_assertions'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "build-rs"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ anstyle = "1.0.8"
 anyhow = "1.0.86"
 base64 = "0.22.1"
 blake3 = "1.5.2"
-build-rs = { version = "0.2.0", path = "crates/build-rs" }
+build-rs = { version = "0.3.0", path = "crates/build-rs" }
 bytesize = "1.3"
 cargo = { path = "" }
 cargo-credential = { version = "0.4.2", path = "credential/cargo-credential" }

--- a/crates/build-rs-test-lib/build.rs
+++ b/crates/build-rs-test-lib/build.rs
@@ -10,7 +10,6 @@ fn smoke_test_inputs() {
     use build_rs::input::*;
     dbg!(cargo());
     dbg!(cargo_cfg("careful"));
-    dbg!(cargo_cfg_debug_assertions());
     #[cfg(feature = "unstable")]
     dbg!(cargo_cfg_fmt_debug());
     #[cfg(feature = "unstable")]

--- a/crates/build-rs/Cargo.toml
+++ b/crates/build-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "build-rs"
-version = "0.2.0"
+version = "0.3.0"
 rust-version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/build-rs/src/input.rs
+++ b/crates/build-rs/src/input.rs
@@ -109,6 +109,11 @@ mod cfg {
     }
 
     /// If we are compiling with debug assertions enabled.
+    ///
+    /// Build scripts are not passed this cfg because
+    /// this cfg is always true and misleading.
+    /// That is because Cargo queries rustc without any profile settings.
+    #[cfg(any())]
     #[track_caller]
     pub fn cargo_cfg_debug_assertions() -> bool {
         is_present("CARGO_CFG_DEBUG_ASSERTIONS")


### PR DESCRIPTION
### What does this PR try to resolve?

The documentation that was added was pulled straight from a comment in `custom_build.rs`:

> This cfg is always true and misleading, so avoid setting it.
> That is because Cargo queries rustc without any profile settings.

It is therefore misleading to expose this in the API

### How should we test and review this PR?



### Additional information

