### PR TITLE
chore: update auto-label to include build-rs crate

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -55,7 +55,11 @@ trigger_files = [
 ]
 
 [autolabel."A-build-scripts"]
-trigger_files = ["src/cargo/core/compiler/custom_build.rs"]
+trigger_files = [
+  "crates/build-rs-test-lib/",
+  "crates/build-rs/",
+  "src/cargo/core/compiler/custom_build.rs",
+]
 
 [autolabel."A-cache-messages"]
 trigger_files = ["src/cargo/util/rustc.rs"]


### PR DESCRIPTION
### What does this PR try to resolve?

We have imported [build-rs](https://crates.io/crates/build-rs)
so update auto-label trigger files.

### How should we test and review this PR?

Should we create a dedicated label for build-rs?
I personally don't think so,
and I think we should have a test verifying directives in build-rs are always aligned with what cargo has.