### PR TITLE
fix(doctest): warn only once if doctest xcompile is skipped

### DIFF
--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -178,6 +178,7 @@ fn run_doc_tests(
     let mut errors = Vec::new();
     let doctest_xcompile = gctx.cli_unstable().doctest_xcompile;
     let color = gctx.shell().color_choice();
+    let mut warned_once = false;
 
     for doctest_info in &compilation.to_doc_test {
         let Doctest {
@@ -194,10 +195,13 @@ fn run_doc_tests(
                 CompileKind::Host => {}
                 CompileKind::Target(target) => {
                     if target.short_name() != compilation.host {
+                        if !warned_once {
+                            gctx.shell().concise(|shell| {
+                                shell.warn("skipping cross-compilation doctest(s), use --verbose to see the full list in detail".to_string())
+                            })?;
+                            warned_once = true;
+                        }
 
-                        gctx.shell().concise(|shell| {
-                            shell.warn("skipping cross-compilation doctest(s), use --verbose to see the full list in detail".to_string())
-                        })?;
                         // Skip doctests, -Zdoctest-xcompile not enabled.
                         gctx.shell().verbose(|shell| {
                             shell.note(format!(

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -197,7 +197,7 @@ fn run_doc_tests(
                     if target.short_name() != compilation.host {
                         if !warned_once {
                             gctx.shell().concise(|shell| {
-                                shell.warn("skipping cross-compilation doctest(s), use --verbose to see the full list in detail".to_string())
+                                shell.warn("skipping cross-compilation doctest(s), use --verbose to see the full list in detail.".to_string())
                             })?;
                             warned_once = true;
                         }

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -194,6 +194,10 @@ fn run_doc_tests(
                 CompileKind::Host => {}
                 CompileKind::Target(target) => {
                     if target.short_name() != compilation.host {
+
+                        gctx.shell().concise(|shell| {
+                            shell.warn("skipping cross-compilation doctest(s), use --verbose to see the full list in detail".to_string())
+                        })?;
                         // Skip doctests, -Zdoctest-xcompile not enabled.
                         gctx.shell().verbose(|shell| {
                             shell.note(format!(

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -469,6 +469,7 @@ fn cross_tests() {
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] unittests src/lib.rs (target/[ALT_TARGET]/debug/deps/foo-[HASH][EXE])
 [RUNNING] unittests src/bin/bar.rs (target/[ALT_TARGET]/debug/deps/bar-[HASH][EXE])
+[WARNING] skipping cross-compilation doctest(s), use --verbose to see the full list in detail.
 
 "#]])
         .with_stdout_data(str![[r#"


### PR DESCRIPTION
as per issue/comment https://github.com/rust-lang/cargo/issues/12118#issuecomment-1541860834 added warning about skipping doctest on xcompiling even when not under verbose flag

#this pr is an attempt at solving https://github.com/rust-lang/cargo/issues/12118. i tested them myself still might need a little work as concise waring shows every time we skip a test instead of once.