### PR TITLE
Faster conflict cache

### DIFF
--- a/src/cargo/core/resolver/conflict_cache.rs
+++ b/src/cargo/core/resolver/conflict_cache.rs
@@ -15,7 +15,10 @@ enum ConflictStoreTrie {
     /// A map from an element to a subtrie where
     /// all the sets in the subtrie contains that element.
     Node(
-        BTreeMap<ActivationsKey, HashMap<PackageId, ConflictStoreTrie, rustc_hash::FxBuildHasher>>,
+        BTreeMap<
+            ActivationsKey,
+            HashMap<&'static semver::Version, ConflictStoreTrie, rustc_hash::FxBuildHasher>,
+        >,
     ),
 }
 
@@ -56,7 +59,7 @@ impl ConflictStoreTrie {
                         continue;
                     }
                     // If the active package has a stored conflict ...
-                    let Some(store) = map.get(&pid) else {
+                    let Some(store) = map.get(pid.version()) else {
                         continue;
                     };
                     // then we need to check the corresponding subtrie.
@@ -91,7 +94,7 @@ impl ConflictStoreTrie {
             if let ConflictStoreTrie::Node(p) = self {
                 p.entry(pid.as_activations_key().clone())
                     .or_default()
-                    .entry(pid)
+                    .entry(pid.version())
                     .or_insert_with(|| ConflictStoreTrie::Node(BTreeMap::new()))
                     .insert(iter, con);
             }

--- a/src/cargo/core/resolver/context.rs
+++ b/src/cargo/core/resolver/context.rs
@@ -156,6 +156,12 @@ impl ResolverContext {
             .and_then(|(s, l)| if s.package_id() == id { Some(*l) } else { None })
     }
 
+    /// If a package is active that has the same semver compatibility range
+    /// returns the `PackageId` and `ContextAge` when it was added
+    pub fn in_activation_slot(&self, id: &ActivationsKey) -> Option<(PackageId, ContextAge)> {
+        self.activations.get(id).map(|(s, l)| (s.package_id(), *l))
+    }
+
     /// Checks whether all of `parent` and the keys of `conflicting activations`
     /// are still active.
     /// If so returns the `ContextAge` when the newest one was added.

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -857,15 +857,16 @@ fn generalize_conflicting(
                 .iter()
                 .rev() // the last one to be tried is the least likely to be in the cache, so start with that.
                 .map(|other| {
+                    let other_activations_key = other.package_id().as_activations_key();
                     past_conflicting_activations
                         .find(
                             dep,
                             &|id| {
-                                if id == other.package_id() {
+                                if id == &other_activations_key {
                                     // we are imagining that we used other instead
-                                    Some(backtrack_critical_age)
+                                    Some((other.package_id(), backtrack_critical_age))
                                 } else {
-                                    cx.is_active(id)
+                                    cx.in_activation_slot(id)
                                 }
                             },
                             Some(other.package_id()),

--- a/src/cargo/core/resolver/types.rs
+++ b/src/cargo/core/resolver/types.rs
@@ -193,9 +193,9 @@ impl std::hash::Hash for ActivationsKey {
 /// same.
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Debug, PartialOrd, Ord)]
 pub enum SemverCompatibility {
-    Major(NonZeroU64),
-    Minor(NonZeroU64),
     Patch(u64),
+    Minor(NonZeroU64),
+    Major(NonZeroU64),
 }
 
 impl From<&semver::Version> for SemverCompatibility {


### PR DESCRIPTION
Builds on #14915 

The current code loops over all package versions we have had past problems with to see which ones are currently active. This branch checks which version of the package is active to see if we have a conflict for it. If resolution is dominated by a package with many versions, then this find operation should go from `O(n)` to `O(1)`. 