### PR TITLE
fix(resolver): In errors, show rejected versions over alt versions

### DIFF
--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -257,17 +257,6 @@ pub(super) fn activation_error(
             &mut msg,
             "candidate versions found which didn't match: {versions}",
         );
-        let mut location_searched_msg = registry.describe_source(dep.source_id());
-        if location_searched_msg.is_empty() {
-            location_searched_msg = format!("{}", dep.source_id());
-        }
-
-        let _ = writeln!(&mut msg, "location searched: {}", location_searched_msg);
-        let _ = write!(
-            &mut msg,
-            "required by {}",
-            describe_path_in_context(resolver_ctx, &parent.package_id()),
-        );
 
         // If we have a pre-release candidate, then that may be what our user is looking for
         if let Some(pre) = candidates.iter().find(|c| c.version().is_prerelease()) {
@@ -377,19 +366,18 @@ pub(super) fn activation_error(
                 dep.package_name()
             );
         }
-
-        let mut location_searched_msg = registry.describe_source(dep.source_id());
-        if location_searched_msg.is_empty() {
-            location_searched_msg = format!("{}", dep.source_id());
-        }
-
-        let _ = writeln!(&mut msg, "location searched: {}", location_searched_msg);
-        let _ = write!(
-            &mut msg,
-            "required by {}",
-            describe_path_in_context(resolver_ctx, &parent.package_id()),
-        );
     }
+
+    let mut location_searched_msg = registry.describe_source(dep.source_id());
+    if location_searched_msg.is_empty() {
+        location_searched_msg = format!("{}", dep.source_id());
+    }
+    let _ = writeln!(&mut msg, "location searched: {}", location_searched_msg);
+    let _ = write!(
+        &mut msg,
+        "required by {}",
+        describe_path_in_context(resolver_ctx, &parent.package_id()),
+    );
 
     if let Some(gctx) = gctx {
         if gctx.offline() {

--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -226,10 +226,18 @@ pub(super) fn activation_error(
             Ok(c) => c,
             Err(e) => return to_resolve_err(e),
         };
+
+        let locked_version = dep
+            .version_req()
+            .locked_version()
+            .map(|v| format!(" (locked to {})", v))
+            .unwrap_or_default();
         let _ = writeln!(
             &mut msg,
-            "no matching versions for `{}` found",
-            dep.package_name()
+            "failed to select a version for the requirement `{} = \"{}\"`{}",
+            dep.package_name(),
+            dep.version_req(),
+            locked_version
         );
         for candidate in version_candidates {
             match candidate {

--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -220,6 +220,7 @@ pub(super) fn activation_error(
     // We didn't actually find any candidates, so we need to
     // give an error message that nothing was found.
     let mut msg = String::new();
+    let mut hints = String::new();
     if let Some(candidates) = alt_versions(registry, dep) {
         let candidates = match candidates {
             Ok(c) => c,
@@ -269,9 +270,9 @@ pub(super) fn activation_error(
 
         // If we have a pre-release candidate, then that may be what our user is looking for
         if let Some(pre) = candidates.iter().find(|c| c.version().is_prerelease()) {
-            let _ = write!(&mut msg, "\nif you are looking for the prerelease package it needs to be specified explicitly");
+            let _ = write!(&mut hints, "\nif you are looking for the prerelease package it needs to be specified explicitly");
             let _ = write!(
-                &mut msg,
+                &mut hints,
                 "\n    {} = {{ version = \"{}\" }}",
                 pre.name(),
                 pre.version()
@@ -283,7 +284,7 @@ pub(super) fn activation_error(
         // update`. In this case try to print a helpful error!
         if dep.source_id().is_path() && dep.version_req().is_locked() {
             let _ = write!(
-                &mut msg,
+                &mut hints,
                 "\nconsider running `cargo update` to update \
                           a path dependency's locked version",
             );
@@ -291,7 +292,7 @@ pub(super) fn activation_error(
 
         if registry.is_replaced(dep.source_id()) {
             let _ = write!(
-                &mut msg,
+                &mut hints,
                 "\nperhaps a crate was updated and forgotten to be re-vendored?"
             );
         }
@@ -392,7 +393,7 @@ pub(super) fn activation_error(
     if let Some(gctx) = gctx {
         if gctx.offline() {
             let _ = write!(
-                &mut msg,
+                &mut hints,
                 "\nAs a reminder, you're using offline mode (--offline) \
                  which can sometimes cause surprising resolution failures, \
                  if this error is too confusing you may wish to retry \
@@ -401,7 +402,7 @@ pub(super) fn activation_error(
         }
     }
 
-    to_resolve_err(anyhow::format_err!("{}", msg))
+    to_resolve_err(anyhow::format_err!("{msg}{hints}"))
 }
 
 // Maybe the user mistyped the ver_req? Like `dep="2"` when `dep="0.2"`

--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -257,11 +257,12 @@ pub(super) fn activation_error(
             &mut msg,
             "candidate versions found which didn't match: {versions}",
         );
-        let _ = writeln!(
-            &mut msg,
-            "location searched: {}",
-            registry.describe_source(dep.source_id())
-        );
+        let mut location_searched_msg = registry.describe_source(dep.source_id());
+        if location_searched_msg.is_empty() {
+            location_searched_msg = format!("{}", dep.source_id());
+        }
+
+        let _ = writeln!(&mut msg, "location searched: {}", location_searched_msg);
         let _ = write!(
             &mut msg,
             "required by {}",

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -1752,10 +1752,9 @@ foo v0.1.0 ([ROOT]/foo)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [ERROR] failed to select a version for the requirement `bar = "^1.0"` (locked to 1.0.1)
-candidate versions found which didn't match: 1.0.0
+  version 1.0.1 requires a Cargo version that supports index version 3
 location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.1.0 ([ROOT]/foo)`
-perhaps a crate was updated and forgotten to be re-vendored?
 
 "#]])
         .run();

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -862,12 +862,11 @@ fn relying_on_a_yank_is_bad_http() {
     let _server = setup_http();
     relying_on_a_yank_is_bad(str![[r#"
 [UPDATING] `dummy-registry` index
-[ERROR] failed to select a version for the requirement `baz = "=0.0.2"`
-candidate versions found which didn't match: 0.0.1
+[ERROR] no matching versions for `baz` found
+  version 0.0.2 is yanked
 location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `bar v0.0.1`
     ... which satisfies dependency `bar = "*"` of package `foo v0.0.1 ([ROOT]/foo)`
-perhaps a crate was updated and forgotten to be re-vendored?
 
 "#]]);
 }
@@ -876,12 +875,11 @@ perhaps a crate was updated and forgotten to be re-vendored?
 fn relying_on_a_yank_is_bad_git() {
     relying_on_a_yank_is_bad(str![[r#"
 [UPDATING] `dummy-registry` index
-[ERROR] failed to select a version for the requirement `baz = "=0.0.2"`
-candidate versions found which didn't match: 0.0.1
+[ERROR] no matching versions for `baz` found
+  version 0.0.2 is yanked
 location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `bar v0.0.1`
     ... which satisfies dependency `bar = "*"` of package `foo v0.0.1 ([ROOT]/foo)`
-perhaps a crate was updated and forgotten to be re-vendored?
 
 "#]]);
 }

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -3202,6 +3202,7 @@ fn ignores_unknown_index_version(expected: impl IntoData) {
 
 #[cargo_test]
 fn unknown_index_version_error() {
+    Package::new("bar", "0.0.1").publish();
     // If the version field is not understood, it is ignored.
     Package::new("bar", "1.0.1")
         .schema_version(u32::MAX)
@@ -3238,6 +3239,7 @@ required by package `foo v0.1.0 ([ROOT]/foo)`
 
 #[cargo_test]
 fn unknown_index_version_with_msrv_error() {
+    Package::new("bar", "0.0.1").publish();
     // If the version field is not understood, it is ignored.
     Package::new("bar", "1.0.1")
         .schema_version(u32::MAX)

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -862,7 +862,7 @@ fn relying_on_a_yank_is_bad_http() {
     let _server = setup_http();
     relying_on_a_yank_is_bad(str![[r#"
 [UPDATING] `dummy-registry` index
-[ERROR] no matching versions for `baz` found
+[ERROR] failed to select a version for the requirement `baz = "=0.0.2"`
   version 0.0.2 is yanked
 location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `bar v0.0.1`
@@ -875,7 +875,7 @@ required by package `bar v0.0.1`
 fn relying_on_a_yank_is_bad_git() {
     relying_on_a_yank_is_bad(str![[r#"
 [UPDATING] `dummy-registry` index
-[ERROR] no matching versions for `baz` found
+[ERROR] failed to select a version for the requirement `baz = "=0.0.2"`
   version 0.0.2 is yanked
 location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `bar v0.0.1`
@@ -922,7 +922,7 @@ fn yanks_in_lockfiles_are_ok_http() {
 "#]],
         str![[r#"
 [UPDATING] `dummy-registry` index
-[ERROR] no matching versions for `bar` found
+[ERROR] failed to select a version for the requirement `bar = "*"`
   version 0.0.1 is yanked
 location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.0.1 ([ROOT]/foo)`
@@ -940,7 +940,7 @@ fn yanks_in_lockfiles_are_ok_git() {
 "#]],
         str![[r#"
 [UPDATING] `dummy-registry` index
-[ERROR] no matching versions for `bar` found
+[ERROR] failed to select a version for the requirement `bar = "*"`
   version 0.0.1 is yanked
 location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.0.1 ([ROOT]/foo)`
@@ -993,7 +993,7 @@ fn yanks_in_lockfiles_are_ok_for_other_update_http() {
 "#]],
         str![[r#"
 [UPDATING] `dummy-registry` index
-[ERROR] no matching versions for `bar` found
+[ERROR] failed to select a version for the requirement `bar = "*"`
   version 0.0.1 is yanked
 location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.0.1 ([ROOT]/foo)`
@@ -1017,7 +1017,7 @@ fn yanks_in_lockfiles_are_ok_for_other_update_git() {
 "#]],
         str![[r#"
 [UPDATING] `dummy-registry` index
-[ERROR] no matching versions for `bar` found
+[ERROR] failed to select a version for the requirement `bar = "*"`
   version 0.0.1 is yanked
 location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.0.1 ([ROOT]/foo)`
@@ -3228,7 +3228,7 @@ fn unknown_index_version_error() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[ERROR] no matching versions for `bar` found
+[ERROR] failed to select a version for the requirement `bar = "^1.0"`
   version 1.0.1 requires a Cargo version that supports index version 4294967295
 location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.1.0 ([ROOT]/foo)`
@@ -3266,7 +3266,7 @@ fn unknown_index_version_with_msrv_error() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[ERROR] no matching versions for `bar` found
+[ERROR] failed to select a version for the requirement `bar = "^1.0"`
   version 1.0.1 requires cargo 1.2345
 location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.1.0 ([ROOT]/foo)`


### PR DESCRIPTION
### What does this PR try to resolve?

The user likely intended what they said and we should tell them why it
didn't work.
Rejected versions also imply alt versions below them.

Fixes #4260

In changing the errors from alt-versions to rejected-versions, I found part of the old error message was better and changed the message introduced in #14897 from matching alt-names to alt-versions.

This includes the test for #14921.  The "fix" was done before this because as it was part of the refactors in prep for this.

### How should we test and review this PR?



### Additional information

Next steps after this are to still produce an `IndexSummary::Unsupported`  even if there are deserialization errors, so long as we know the name and version which should take care of #10623 and #14894.