### PR TITLE
fix: emit_serialized_unit_graph uses the configured shell

### DIFF
--- a/src/cargo/core/compiler/unit_graph.rs
+++ b/src/cargo/core/compiler/unit_graph.rs
@@ -10,7 +10,6 @@ use crate::util::interning::InternedString;
 use crate::util::CargoResult;
 use crate::GlobalContext;
 use std::collections::HashMap;
-use std::io::Write;
 
 /// The dependency graph of Units.
 pub type UnitGraph = HashMap<Unit, Vec<UnitDep>>;
@@ -121,15 +120,10 @@ pub fn emit_serialized_unit_graph(
             }
         })
         .collect();
-    let s = SerializedUnitGraph {
+
+    gctx.shell().print_json(&SerializedUnitGraph {
         version: VERSION,
         units: ser_units,
         roots,
-    };
-
-    let stdout = std::io::stdout();
-    let mut lock = stdout.lock();
-    serde_json::to_writer(&mut lock, &s)?;
-    drop(writeln!(lock));
-    Ok(())
+    })
 }


### PR DESCRIPTION
I'm writing a compatibility layer between the cargo and meson build systems.
This change allows me to plumb that through better :)

<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
