### PR TITLE
fix(resolver): Report invalid index entries 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,7 +456,7 @@ version = "0.4.0"
 
 [[package]]
 name = "cargo-test-support"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ cargo-credential-macos-keychain = { version = "0.4.7", path = "credential/cargo-
 cargo-credential-wincred = { version = "0.4.7", path = "credential/cargo-credential-wincred" }
 cargo-platform = { path = "crates/cargo-platform", version = "0.2.0" }
 cargo-test-macro = { version = "0.4.0", path = "crates/cargo-test-macro" }
-cargo-test-support = { version = "0.6.0", path = "crates/cargo-test-support" }
+cargo-test-support = { version = "0.7.0", path = "crates/cargo-test-support" }
 cargo-util = { version = "0.2.14", path = "crates/cargo-util" }
 cargo-util-schemas = { version = "0.7.0", path = "crates/cargo-util-schemas" }
 cargo_metadata = "0.19.0"

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-test-support"
-version = "0.6.1"
+version = "0.7.0"
 edition.workspace = true
 rust-version = "1.83"  # MSRV:1
 license.workspace = true

--- a/crates/cargo-test-support/src/registry.rs
+++ b/crates/cargo-test-support/src/registry.rs
@@ -570,7 +570,7 @@ pub struct Package {
     features: FeatureMap,
     local: bool,
     alternative: bool,
-    invalid_json: bool,
+    invalid_index_line: bool,
     edition: Option<String>,
     resolver: Option<String>,
     proc_macro: bool,
@@ -1251,7 +1251,7 @@ impl Package {
             features: BTreeMap::new(),
             local: false,
             alternative: false,
-            invalid_json: false,
+            invalid_index_line: false,
             edition: None,
             resolver: None,
             proc_macro: false,
@@ -1422,8 +1422,8 @@ impl Package {
 
     /// Causes the JSON line emitted in the index to be invalid, presumably
     /// causing Cargo to skip over this version.
-    pub fn invalid_json(&mut self, invalid: bool) -> &mut Package {
-        self.invalid_json = invalid;
+    pub fn invalid_index_line(&mut self, invalid: bool) -> &mut Package {
+        self.invalid_index_line = invalid;
         self
     }
 
@@ -1496,7 +1496,7 @@ impl Package {
             let c = t!(fs::read(&self.archive_dst()));
             cksum(&c)
         };
-        let name = if self.invalid_json {
+        let name = if self.invalid_index_line {
             serde_json::json!(1)
         } else {
             serde_json::json!(self.name)

--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -271,6 +271,13 @@ pub(super) fn activation_error(
                         );
                     }
                 }
+                IndexSummary::Invalid(summary) => {
+                    let _ = writeln!(
+                        &mut msg,
+                        "  version {}'s index entry is invalid",
+                        summary.version()
+                    );
+                }
             }
         }
     } else if let Some(candidates) = alt_versions(registry, dep) {

--- a/src/cargo/sources/registry/index/mod.rs
+++ b/src/cargo/sources/registry/index/mod.rs
@@ -169,12 +169,7 @@ impl IndexSummary {
 
     /// Extract the package id from any variant
     pub fn package_id(&self) -> PackageId {
-        match self {
-            IndexSummary::Candidate(sum)
-            | IndexSummary::Yanked(sum)
-            | IndexSummary::Offline(sum)
-            | IndexSummary::Unsupported(sum, _) => sum.package_id(),
-        }
+        self.as_summary().package_id()
     }
 
     /// Returns `true` if the index summary is [`Yanked`].

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -834,6 +834,9 @@ impl<'gctx> Source for RegistrySource<'gctx> {
                                 summary.version()
                             );
                         }
+                        IndexSummary::Invalid(summary) => {
+                            tracing::debug!("invalid ({} {})", summary.name(), summary.version());
+                        }
                         IndexSummary::Offline(summary) => {
                             tracing::debug!("offline ({} {})", summary.name(), summary.version());
                         }

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -2916,7 +2916,9 @@ fn ignore_invalid_json_lines_git() {
 
 fn ignore_invalid_json_lines() {
     Package::new("foo", "0.1.0").publish();
-    Package::new("foo", "0.1.1").invalid_json(true).publish();
+    Package::new("foo", "0.1.1")
+        .invalid_index_line(true)
+        .publish();
     Package::new("foo", "0.2.0").publish();
 
     let p = project()

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -3012,10 +3012,13 @@ fn invalid_json_lines_error() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [ERROR] failed to select a version for the requirement `foo = "^0.1.1"`
-candidate versions found which didn't match: 0.2.0, 0.1.0
+  version 0.1.3 requires cargo 1.2345
+  version 0.1.4 requires a Cargo version that supports index version 1000000000
+  version 0.1.5's index entry is invalid
+  version 0.1.6 requires a Cargo version that supports index version 1000000000
+  version 0.1.7's index entry is invalid
 location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `a v0.5.0 ([ROOT]/foo)`
-perhaps a crate was updated and forgotten to be re-vendored?
 
 "#]])
         .run();
@@ -3024,10 +3027,13 @@ perhaps a crate was updated and forgotten to be re-vendored?
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [ERROR] failed to select a version for the requirement `foo = "^0.1.1"`
-candidate versions found which didn't match: 0.2.0, 0.1.0
+  version 0.1.3 requires cargo 1.2345
+  version 0.1.4 requires a Cargo version that supports index version 1000000000
+  version 0.1.5's index entry is invalid
+  version 0.1.6 requires a Cargo version that supports index version 1000000000
+  version 0.1.7's index entry is invalid
 location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `a v0.5.0 ([ROOT]/foo)`
-perhaps a crate was updated and forgotten to be re-vendored?
 
 "#]])
         .run();

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -3235,6 +3235,17 @@ required by package `foo v0.1.0 ([ROOT]/foo)`
 
 "#]])
         .run();
+    p.cargo("generate-lockfile")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
+[ERROR] failed to select a version for the requirement `bar = "^1.0"`
+  version 1.0.1 requires a Cargo version that supports index version 4294967295
+location searched: `dummy-registry` index (which is replacing registry `crates-io`)
+required by package `foo v0.1.0 ([ROOT]/foo)`
+
+"#]])
+        .run();
 }
 
 #[cargo_test]


### PR DESCRIPTION
### What does this PR try to resolve?

While #14897 reported packages with an unsupported index schema version,
that only worked if the changes in the schema version did not cause
errors in deserializing `IndexPackage` or in generating a `Summary`.

This extends that change by recoverying on error with a more lax,
incomplete parse of `IndexPackage` which should always generate a valid
`Summary`.

To help with a buggy Index, we also will report as many as we can.
This does not provide a way to report to users or log on cache reads if
the index entry is not at least `{"name": "<string>", "vers": "<semver>"}`.

Fixes #10623
Fixes #14894

### How should we test and review this PR?

My biggest paranoia is some bad interaction with the index cache including more "invalid" index entries.
That should be ok as we will ignore the invalid entry in the cache when
loading it.
Ignoring of invalid entries dates back to #6880 when the index cache was
introduced.

### Additional information

