### PR TITLE
fix(base): Support bases in patches in virtual manifests 

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -279,7 +279,8 @@ fn normalize_toml(
         cargo_features: original_toml.cargo_features.clone(),
         package: None,
         project: None,
-        profile: original_toml.profile.clone(),
+        badges: None,
+        features: None,
         lib: None,
         bin: None,
         example: None,
@@ -290,13 +291,12 @@ fn normalize_toml(
         dev_dependencies2: None,
         build_dependencies: None,
         build_dependencies2: None,
-        features: None,
         target: None,
-        replace: original_toml.replace.clone(),
-        patch: None,
-        workspace: original_toml.workspace.clone(),
-        badges: None,
         lints: None,
+        workspace: original_toml.workspace.clone(),
+        profile: original_toml.profile.clone(),
+        patch: None,
+        replace: original_toml.replace.clone(),
         _unused_keys: Default::default(),
     };
 
@@ -2820,9 +2820,11 @@ fn prepare_toml_for_publish(
 
     let all = |_d: &manifest::TomlDependency| true;
     let mut manifest = manifest::TomlManifest {
+        cargo_features: me.cargo_features.clone(),
         package: Some(package),
         project: None,
-        profile: me.profile.clone(),
+        badges: me.badges.clone(),
+        features: me.features.clone(),
         lib,
         bin,
         example,
@@ -2837,7 +2839,6 @@ fn prepare_toml_for_publish(
         dev_dependencies2: None,
         build_dependencies: map_deps(gctx, me.build_dependencies(), all)?,
         build_dependencies2: None,
-        features: me.features.clone(),
         target: match me.target.as_ref().map(|target_map| {
             target_map
                 .iter()
@@ -2863,12 +2864,11 @@ fn prepare_toml_for_publish(
             Some(Err(e)) => return Err(e),
             None => None,
         },
-        replace: None,
-        patch: None,
-        workspace: None,
-        badges: me.badges.clone(),
-        cargo_features: me.cargo_features.clone(),
         lints: me.lints.clone(),
+        workspace: None,
+        profile: me.profile.clone(),
+        patch: None,
+        replace: None,
         _unused_keys: Default::default(),
     };
     strip_features(&mut manifest);

--- a/tests/testsuite/features_namespaced.rs
+++ b/tests/testsuite/features_namespaced.rs
@@ -1006,6 +1006,9 @@ homepage = "https://example.com/"
 readme = false
 license = "MIT"
 
+[features]
+feat = ["opt-dep1"]
+
 [lib]
 name = "foo"
 path = "src/lib.rs"
@@ -1017,9 +1020,6 @@ optional = true
 [dependencies.opt-dep2]
 version = "1.0"
 optional = true
-
-[features]
-feat = ["opt-dep1"]
 
 "##]],
         )],
@@ -1143,6 +1143,11 @@ homepage = "https://example.com/"
 readme = false
 license = "MIT"
 
+[features]
+feat1 = []
+feat2 = ["dep:bar"]
+feat3 = ["feat2"]
+
 [lib]
 name = "foo"
 path = "src/lib.rs"
@@ -1150,11 +1155,6 @@ path = "src/lib.rs"
 [dependencies.bar]
 version = "1.0"
 optional = true
-
-[features]
-feat1 = []
-feat2 = ["dep:bar"]
-feat3 = ["feat2"]
 
 "##]],
         )],

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -3078,7 +3078,12 @@ fn patch_with_base() {
         .file("src/lib.rs", "use bar::hello as _;")
         .build();
 
-    p.cargo("build -v")
+    p.cargo("tree")
         .masquerade_as_nightly_cargo(&["path-bases"])
+        .with_stdout_data(str![[r#"
+foo v0.5.0 ([ROOT]/foo)
+└── bar v0.5.0 ([ROOT]/bar)
+
+"#]])
         .run();
 }

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -3038,7 +3038,7 @@ foo v0.0.0 ([ROOT]/foo)
 }
 
 #[cargo_test]
-fn patch_with_base() {
+fn patch_in_real_with_base() {
     let bar = project()
         .at("bar")
         .file("Cargo.toml", &basic_manifest("bar", "0.5.0"))
@@ -3083,6 +3083,73 @@ fn patch_with_base() {
         .with_stdout_data(str![[r#"
 foo v0.5.0 ([ROOT]/foo)
 └── bar v0.5.0 ([ROOT]/bar)
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn patch_in_virtual_with_base() {
+    let bar = project()
+        .at("bar")
+        .file("Cargo.toml", &basic_manifest("bar", "0.5.0"))
+        .file("src/lib.rs", "pub fn hello() {}")
+        .build();
+    Package::new("bar", "0.5.0").publish();
+
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            &format!(
+                r#"
+                    [path-bases]
+                    test = '{}'
+                "#,
+                bar.root().parent().unwrap().display()
+            ),
+        )
+        .file(
+            "Cargo.toml",
+            r#"
+                cargo-features = ["path-bases"]
+
+                [workspace]
+                members = ["foo"]
+
+                [patch.crates-io]
+                bar = { base = 'test', path = 'bar' }
+            "#,
+        )
+        .file(
+            "foo/Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
+                edition = "2018"
+
+                [dependencies]
+                bar = "0.5.0"
+            "#,
+        )
+        .file("foo/src/lib.rs", "use bar::hello as _;")
+        .build();
+
+    p.cargo("tree")
+        .masquerade_as_nightly_cargo(&["path-bases"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] failed to load source for dependency `bar`
+
+Caused by:
+  Unable to update [ROOT]/foo/bar
+
+Caused by:
+  failed to read `[ROOT]/foo/bar/Cargo.toml`
+
+Caused by:
+  [NOT_FOUND]
 
 "#]])
         .run();

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -3138,18 +3138,9 @@ fn patch_in_virtual_with_base() {
 
     p.cargo("tree")
         .masquerade_as_nightly_cargo(&["path-bases"])
-        .with_status(101)
-        .with_stderr_data(str![[r#"
-[ERROR] failed to load source for dependency `bar`
-
-Caused by:
-  Unable to update [ROOT]/foo/bar
-
-Caused by:
-  failed to read `[ROOT]/foo/bar/Cargo.toml`
-
-Caused by:
-  [NOT_FOUND]
+        .with_stdout_data(str![[r#"
+foo v0.5.0 ([ROOT]/foo/foo)
+└── bar v0.5.0 ([ROOT]/bar)
 
 "#]])
         .run();

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -1479,8 +1479,17 @@ fn patch_in_virtual() {
         .file("foo/src/lib.rs", r#""#)
         .build();
 
-    p.cargo("check").run();
-    p.cargo("check")
+    p.cargo("check -p foo")
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
+[LOCKING] 1 package to latest compatible version
+[CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
+[CHECKING] foo v0.1.0 ([ROOT]/foo/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+    p.cargo("check -p foo")
         .with_stderr_data(str![[r#"
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -2015,6 +2015,20 @@ readme = false
 license = "MIT"
 repository = "foo"
 
+[features]
+foo_feature = [
+    "normal-only/cat",
+    "build-only/cat",
+    "normal-and-dev/cat",
+    "target-normal-only/cat",
+    "target-build-only/cat",
+    "target-normal-and-dev/cat",
+    "optional-dep-feature/cat",
+    "dep:optional-namespaced",
+    "optional-renamed-dep-feature10/cat",
+    "dep:optional-renamed-namespaced10",
+]
+
 [[bin]]
 name = "foo"
 path = "src/main.rs"
@@ -2056,20 +2070,6 @@ features = ["cat"]
 [build-dependencies.build-only]
 version = "1.0"
 features = ["cat"]
-
-[features]
-foo_feature = [
-    "normal-only/cat",
-    "build-only/cat",
-    "normal-and-dev/cat",
-    "target-normal-only/cat",
-    "target-build-only/cat",
-    "target-normal-and-dev/cat",
-    "optional-dep-feature/cat",
-    "dep:optional-namespaced",
-    "optional-renamed-dep-feature10/cat",
-    "dep:optional-renamed-namespaced10",
-]
 
 [target."cfg(unix)".dependencies.target-normal-and-dev]
 version = "1.0"

--- a/tests/testsuite/weak_dep_features.rs
+++ b/tests/testsuite/weak_dep_features.rs
@@ -650,6 +650,10 @@ homepage = "https://example.com/"
 readme = false
 license = "MIT"
 
+[features]
+feat1 = []
+feat2 = ["bar?/feat"]
+
 [lib]
 name = "foo"
 path = "src/lib.rs"
@@ -657,10 +661,6 @@ path = "src/lib.rs"
 [dependencies.bar]
 version = "1.0"
 optional = true
-
-[features]
-feat1 = []
-feat2 = ["bar?/feat"]
 
 "##]],
         )],


### PR DESCRIPTION
### What does this PR try to resolve?

This bug has been there since #14360

Found this when looking to change the normalization code for cargo script.  As a result, I also changed `cargo-util-schemas` in the hope that grouping the fields would make the intent clearer.  Since I was already changing field order, I also re-ordered for my personal taste (user facing features first)

### How should we test and review this PR?



### Additional information

