### PR TITLE
test(build-std): dont require rustup

### DIFF
--- a/tests/testsuite/standard_lib.rs
+++ b/tests/testsuite/standard_lib.rs
@@ -389,7 +389,7 @@ fn check_core() {
         .run();
 }
 
-#[cargo_test(build_std_mock, requires = "rustup")]
+#[cargo_test(build_std_mock)]
 fn build_std_with_no_arg_for_core_only_target() {
     let has_rustup_aarch64_unknown_none = std::process::Command::new("rustup")
         .args(["target", "list", "--installed"])


### PR DESCRIPTION

### What does this PR try to resolve?

It checks rustup existence even when test is skipped for other reasons.


### How should we test and review this PR?

See <https://github.com/rust-lang/rust/pull/134278#issuecomment-2542665291>.


### Additional information
