### PR TITLE
fix(build-std): make Resolve  align to what to build

### DIFF
--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -619,6 +619,16 @@ impl TargetInfo {
             .iter()
             .any(|sup| sup.as_str() == split.as_str())
     }
+
+    /// Checks if a target maybe support std.
+    ///
+    /// If no explictly stated in target spec json, we treat it as "maybe support".
+    ///
+    /// This is only useful for `-Zbuild-std` to determine the default set of
+    /// crates it is going to build.
+    pub fn maybe_support_std(&self) -> bool {
+        matches!(self.supports_std, Some(true) | None)
+    }
 }
 
 /// Takes rustc output (using specialized command line args), and calculates the file prefix and

--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -115,10 +115,10 @@ pub fn generate_std_roots(
 ) -> CargoResult<HashMap<CompileKind, Vec<Unit>>> {
     // Generate a map of Units for each kind requested.
     let mut ret = HashMap::new();
-    let (core_only, maybe_std): (Vec<&CompileKind>, Vec<_>) = kinds.iter().partition(|kind|
-        // Only include targets that explicitly don't support std
-        target_data.info(**kind).supports_std == Some(false));
-    for (default_crate, kinds) in [("core", core_only), ("std", maybe_std)] {
+    let (maybe_std, maybe_core): (Vec<&CompileKind>, Vec<_>) = kinds
+        .iter()
+        .partition(|kind| target_data.info(**kind).maybe_support_std());
+    for (default_crate, kinds) in [("core", maybe_core), ("std", maybe_std)] {
         if kinds.is_empty() {
             continue;
         }

--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -44,10 +44,14 @@ fn std_crates<'a>(crates: &'a [String], default: &'static str, units: &[Unit]) -
 }
 
 /// Resolve the standard library dependencies.
+///
+/// * `crates` is the arg value from `-Zbuild-std`.
 pub fn resolve_std<'gctx>(
     ws: &Workspace<'gctx>,
     target_data: &mut RustcTargetData<'gctx>,
     build_config: &BuildConfig,
+    crates: &[String],
+    kinds: &[CompileKind],
 ) -> CargoResult<(PackageSet<'gctx>, Resolve, ResolvedFeatures)> {
     if build_config.build_plan {
         ws.gctx()
@@ -65,10 +69,21 @@ pub fn resolve_std<'gctx>(
     // `[dev-dependencies]`. No need for us to generate a `Resolve` which has
     // those included because we'll never use them anyway.
     std_ws.set_require_optional_deps(false);
-    // `sysroot` + the default feature set below should give us a good default
-    // Resolve, which includes `libtest` as well.
-    let specs = Packages::Packages(vec!["sysroot".into()]);
-    let specs = specs.to_package_id_specs(&std_ws)?;
+    let specs = {
+        // If there is anything looks like needing std, resolve with it.
+        // If not, we assume only `core` maye be needed, as `core the most fundamental crate.
+        //
+        // This may need a UI overhaul if `build-std` wants to fully support multi-targets.
+        let maybe_std = kinds
+            .iter()
+            .any(|kind| target_data.info(*kind).maybe_support_std());
+        let mut crates = std_crates(crates, if maybe_std { "std" } else { "core" }, &[]);
+        // `sysroot` is not in the default set because it is optional, but it needs
+        // to be part of the resolve in case we do need it or `libtest`.
+        crates.insert("sysroot");
+        let specs = Packages::Packages(crates.into_iter().map(Into::into).collect());
+        specs.to_package_id_specs(&std_ws)?
+    };
     let features = match &gctx.cli_unstable().build_std_features {
         Some(list) => list.clone(),
         None => vec![

--- a/src/cargo/ops/cargo_compile/mod.rs
+++ b/src/cargo/ops/cargo_compile/mod.rs
@@ -289,9 +289,14 @@ pub fn create_bcx<'a, 'gctx>(
         resolved_features,
     } = resolve;
 
-    let std_resolve_features = if gctx.cli_unstable().build_std.is_some() {
-        let (std_package_set, std_resolve, std_features) =
-            standard_lib::resolve_std(ws, &mut target_data, &build_config)?;
+    let std_resolve_features = if let Some(crates) = &gctx.cli_unstable().build_std {
+        let (std_package_set, std_resolve, std_features) = standard_lib::resolve_std(
+            ws,
+            &mut target_data,
+            &build_config,
+            crates,
+            &build_config.requested_kinds,
+        )?;
         pkg_set.add_set(std_package_set);
         Some((std_resolve, std_features))
     } else {

--- a/src/cargo/ops/cargo_fetch.rs
+++ b/src/cargo/ops/cargo_fetch.rs
@@ -64,8 +64,14 @@ pub fn fetch<'a>(
     }
 
     // If -Zbuild-std was passed, download dependencies for the standard library.
-    if gctx.cli_unstable().build_std.is_some() {
-        let (std_package_set, _, _) = standard_lib::resolve_std(ws, &mut data, &build_config)?;
+    if let Some(crates) = &gctx.cli_unstable().build_std {
+        let (std_package_set, _, _) = standard_lib::resolve_std(
+            ws,
+            &mut data,
+            &build_config,
+            crates,
+            &build_config.requested_kinds,
+        )?;
         packages.add_set(std_package_set);
     }
 

--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -418,3 +418,30 @@ fn test_proc_macro() {
 "#]])
         .run();
 }
+
+#[cargo_test(build_std_real)]
+fn test_panic_abort() {
+    // See rust-lang/cargo#14935
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                edition = "2021"
+            "#,
+        )
+        .file("src/lib.rs", "#![no_std]")
+        .build();
+
+    p.cargo("check")
+        .build_std_arg("std,panic_abort")
+        .env("RUSTFLAGS", "-C panic=abort")
+        .arg("-Zbuild-std-features=panic_immediate_abort")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] package ID specification `panic_unwind` did not match any packages
+
+"#]])
+        .run();
+}

--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -438,10 +438,5 @@ fn test_panic_abort() {
         .build_std_arg("std,panic_abort")
         .env("RUSTFLAGS", "-C panic=abort")
         .arg("-Zbuild-std-features=panic_immediate_abort")
-        .with_status(101)
-        .with_stderr_data(str![[r#"
-[ERROR] package ID specification `panic_unwind` did not match any packages
-
-"#]])
         .run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?

Blocked on <https://github.com/rust-lang/cargo/pull/14943> (or can just merge this one).

Fixes #14935

#14935 failed because since 125e873dffc4b68b263c5decd88750ec10fd441e
[`std_resolve`][1] only includes `sysroot` as primary package.
When any custom Cargo feature is provided via `-Zbuild-std-feature`,
the default feature set `panic-unwind` would be gone, so no
`panic_unwind` crate presents in `std_resolve`.

When then calling [`std_resolve.query`][2] with the default set of
crates from [`std_crates`][3], which automatically includes
`panic_unwind` when `std` presents, it'll result in spec not found
because `panic_unwind` was not in `std_resolve` anyway.

[1]: https://github.com/rust-lang/cargo/blob/addcc8ca715bc7fe20df66afd6efbf3c77ef43f8/src/cargo/core/compiler/standard_lib.rs#L96
[2]: https://github.com/rust-lang/cargo/blob/addcc8ca715bc7fe20df66afd6efbf3c77ef43f8/src/cargo/core/compiler/standard_lib.rs#L158
[3]: https://github.com/rust-lang/cargo/blob/addcc8ca715bc7fe20df66afd6efbf3c77ef43f8/src/cargo/core/compiler/standard_lib.rs#L156

### How should we test and review this PR?

This patch is kinda a revert of 125e873dffc4b68b263c5decd88750ec10fd441e
in terms of the behavior.

With this, now `std_resolve` is always resolved to the same set of
packages that Cargo will use to generate the unit graph, (technically
the same set of crates + `sysroot`), by sharing the same set of primary
packages via `std_crates` functions.

Note that when multiple `--target`s provided, if std is specified or there
is one might support std, Cargo will always resolve std dep graph.

To test it manually, run

```
RUSTFLAGS="-C panic=abort" cargo +nightly-2024-12-15 b -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
```

change to this PR's cargo with the same nightly rustc, it would succeed.

I am a bit reluctant to add an new end-2end build-std test, but I still did it.
A bit scared when mock-std gets out-of-sync of features in std in rust-lang/rust.