### PR TITLE
Update release information for home 0.5.11

### DIFF
--- a/crates/home/CHANGELOG.md
+++ b/crates/home/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.11 - 2024-12-16
+
+Note: 0.5.10 was not published.
+
+- Updated package metadata.
+  [#13184](https://github.com/rust-lang/cargo/pull/13184)
+- Updated minimum Rust version to 1.81.
+  [#13266](https://github.com/rust-lang/cargo/pull/13266)
+  [#13324](https://github.com/rust-lang/cargo/pull/13324)
+  [#14871](https://github.com/rust-lang/cargo/pull/14871)
+- Updated windows-sys to 0.59.
+  [#14335](https://github.com/rust-lang/cargo/pull/14335)
+- Clarified support level of this crate (not intended for external use).
+  [#14600](https://github.com/rust-lang/cargo/pull/14600)
+- Docs cleanup.
+  [#14823]()
+- Add notice that this crate should not be used, and to use the standard library's `home_dir` instead.
+  [#14939](https://github.com/rust-lang/cargo/pull/14939)
+
 ## 0.5.9 - 2023-12-15
 
 - Replace SHGetFolderPathW with SHGetKnownFolderPath

--- a/crates/home/README.md
+++ b/crates/home/README.md
@@ -7,12 +7,18 @@ This provides the definition of `home_dir` used by Cargo and rustup,
 as well functions to find the correct value of `CARGO_HOME` and
 `RUSTUP_HOME`.
 
-The definition of `home_dir` provided by the standard library is
+The definition of [`home_dir`] provided by the standard library is
 incorrect because it considers the `HOME` environment variable on
 Windows. This causes surprising situations where a Rust program will
 behave differently depending on whether it is run under a Unix
 emulation environment like Cygwin or MinGW. Neither Cargo nor rustup
 use the standard library's definition - they use the definition here.
+
+**Note:** This has been fixed in Rust 1.85 to no longer use the `HOME`
+environment variable on Windows. If you are still using this crate for the
+purpose of getting a home directory, you are strongly encouraged to switch to
+using the standard library's [`home_dir`] instead. It is planned to have the
+deprecation notice removed in 1.86.
 
 This crate further provides two functions, `cargo_home` and
 `rustup_home`, which are the canonical way to determine the location
@@ -25,6 +31,7 @@ See [rust-lang/rust#43321].
 > crate may make major changes to its APIs or be deprecated without warning.
 
 [rust-lang/rust#43321]: https://github.com/rust-lang/rust/issues/43321
+[`home_dir`]: https://doc.rust-lang.org/nightly/std/env/fn.home_dir.html
 
 ## License
 


### PR DESCRIPTION
This is in preparation to publish a new release of the home crate (from the current master branch).