### PR TITLE
Limit release trigger to 0.* tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ name: Release
 on:
   push:
     tags:
-      - "**"
+      - "0.*"
 
 # Prevent multiple releases from starting at the same time.
 concurrency:


### PR DESCRIPTION
This changes the release trigger to only run when a tag matching the pattern `0.*` is created. The intent is to allow us to create tags for other crates that we may release out-of-band of the normal releases (and maybe consider creating tags for all crates to make them easier to find). For example, I would like to create `home-0.5.11` tags (and earlier versions that were missed due to this trigger). 

cc #14538