### PR TITLE
refactor(cargo-package): let-else to flatten code

### DIFF
--- a/tests/testsuite/publish_lockfile.rs
+++ b/tests/testsuite/publish_lockfile.rs
@@ -241,7 +241,7 @@ fn note_resolve_changes() {
 [ARCHIVING] Cargo.toml.orig
 [ARCHIVING] src/main.rs
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
-[WARNING] no (git) Cargo.toml found at `[..]/foo/Cargo.toml` in workdir `[..]`
+[WARNING] found (git) Cargo.toml ignored at `[..]/foo/Cargo.toml` in workdir `[..]`
 
 "#]].unordered())
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

Flatten code with let-else for easier reasoning of exit of `check_repo_state` function. 

### How should we test and review this PR?

This also adds some more debug logs.
Shouldn't affect any real production behavior.
