### PR TITLE
perf(cargo-package): match certain path prefix with pathspec

### DIFF
--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -824,7 +824,7 @@ fn check_repo_state(
         // Find the intersection of dirty in git, and the src_files that would
         // be packaged. This is a lazy n^2 check, but seems fine with
         // thousands of files.
-        let dirty_src_files: Vec<String> = src_files
+        let mut dirty_src_files: Vec<_> = src_files
             .iter()
             .filter(|src_file| dirty_files.iter().any(|path| src_file.starts_with(path)))
             .map(|path| {
@@ -847,6 +847,7 @@ fn check_repo_state(
                 dirty,
             }))
         } else {
+            dirty_src_files.sort_unstable();
             anyhow::bail!(
                 "{} files in the working directory contain changes that were \
                  not yet committed into git:\n\n{}\n\n\

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -805,7 +805,7 @@ fn check_repo_state(
     return Ok(Some(VcsInfo { git, path_in_vcs }));
 
     fn git(
-        pkg: &Package,
+        _pkg: &Package,
         src_files: &[PathBuf],
         repo: &git2::Repository,
         opts: &PackageOpts<'_>,
@@ -824,11 +824,12 @@ fn check_repo_state(
         // Find the intersection of dirty in git, and the src_files that would
         // be packaged. This is a lazy n^2 check, but seems fine with
         // thousands of files.
+        let workdir = repo.workdir().unwrap();
         let mut dirty_src_files: Vec<_> = src_files
             .iter()
             .filter(|src_file| dirty_files.iter().any(|path| src_file.starts_with(path)))
             .map(|path| {
-                path.strip_prefix(pkg.root())
+                path.strip_prefix(workdir)
                     .unwrap_or(path)
                     .display()
                     .to_string()

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1217,8 +1217,8 @@ fn dirty_workspace_package() {
 [PACKAGED] 5 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [ERROR] 2 files in the working directory contain changes that were not yet committed into git:
 
-src/lib.rs
-src/main.rs
+mordor/src/lib.rs
+mordor/src/main.rs
 
 to proceed despite this and include the uncommitted changes, pass the `--allow-dirty` flag
 

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1157,6 +1157,141 @@ src/lib.rs
 }
 
 #[cargo_test]
+fn dirty_workspace_package() {
+    // Cargo see them as clean if not in any local package's directory.
+    let (p, repo) = git::new_repo("foo", |p| {
+        p.file(
+            "Cargo.toml",
+            r#"
+                [workspace]
+                members = ["isengard", "mordor"]
+            "#,
+        )
+        .file("not-belong-to-any-mortal-man", "...")
+        .file(
+            "isengard/Cargo.toml",
+            r#"
+                [package]
+                name = "isengard"
+                edition = "2015"
+                homepage = "saruman"
+                description = "saruman"
+                license = "MIT"
+            "#,
+        )
+        .file("isengard/src/lib.rs", "")
+        .file(
+            "mordor/Cargo.toml",
+            r#"
+                [package]
+                name = "mordor"
+                edition = "2015"
+                homepage = "sauron"
+                description = "sauron"
+                license = "MIT"
+            "#,
+        )
+        .file("mordor/src/lib.rs", "")
+    });
+    git::commit(&repo);
+
+    p.change_file(
+        "Cargo.toml",
+        r#"
+            [workspace]
+            members = ["isengard", "mordor"]
+            [workspace.package]
+            edition = "2021"
+        "#,
+    );
+    // Dirty file outside won't affect packaging.
+    p.change_file("not-belong-to-any-mortal-man", "changed!");
+    p.change_file("mordor/src/lib.rs", "changed!");
+    p.change_file("mordor/src/main.rs", "fn main() {}");
+
+    // Ensure dirty files be reported.
+    p.cargo("package --workspace --no-verify")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[PACKAGING] isengard v0.0.0 ([ROOT]/foo/isengard)
+[PACKAGED] 5 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[ERROR] 2 files in the working directory contain changes that were not yet committed into git:
+
+src/lib.rs
+src/main.rs
+
+to proceed despite this and include the uncommitted changes, pass the `--allow-dirty` flag
+
+"#]])
+        .run();
+
+    // Ensure only dirty package mordor be dirty.
+    p.cargo("package --workspace --no-verify --allow-dirty")
+        .with_stderr_data(str![[r#"
+[PACKAGING] isengard v0.0.0 ([ROOT]/foo/isengard)
+[PACKAGED] 5 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGING] mordor v0.0.0 ([ROOT]/foo/mordor)
+[PACKAGED] 6 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+
+"#]])
+        .run();
+
+    let f = File::open(&p.root().join("target/package/isengard-0.0.0.crate")).unwrap();
+    validate_crate_contents(
+        f,
+        "isengard-0.0.0.crate",
+        &[
+            ".cargo_vcs_info.json",
+            "Cargo.toml",
+            "Cargo.toml.orig",
+            "src/lib.rs",
+            "Cargo.lock",
+        ],
+        [(
+            ".cargo_vcs_info.json",
+            // No change within `isengard/`, so not dirty at all.
+            str![[r#"
+{
+  "git": {
+    "sha1": "[..]"
+  },
+  "path_in_vcs": "isengard"
+}
+"#]]
+            .is_json(),
+        )],
+    );
+
+    let f = File::open(&p.root().join("target/package/mordor-0.0.0.crate")).unwrap();
+    validate_crate_contents(
+        f,
+        "mordor-0.0.0.crate",
+        &[
+            ".cargo_vcs_info.json",
+            "Cargo.toml",
+            "Cargo.toml.orig",
+            "src/lib.rs",
+            "src/main.rs",
+            "Cargo.lock",
+        ],
+        [(
+            ".cargo_vcs_info.json",
+            // Dirty bit is recorded.
+            str![[r#"
+{
+  "git": {
+    "dirty": true,
+    "sha1": "[..]"
+  },
+  "path_in_vcs": "mordor"
+}
+"#]]
+            .is_json(),
+        )],
+    );
+}
+
+#[cargo_test]
 fn issue_13695_allow_dirty_vcs_info() {
     let p = project()
         .file(


### PR DESCRIPTION
### What does this PR try to resolve?

Improve #14955

`check_repo_state` checks the entire git repo status.
This is usually fine if you have only a few packages in a workspace.

For huge monorepos, it may hit performance issues.

For example, on awslabs/aws-sdk-rust@2cbd34db53389aed1cafe4c56d23186ef5ff304a the workspace has roughly 434 members to publish. `git ls-files` reported us 204379 files in this Git repository. That means git may need to check status of all files 434 times.
That would be `204379 * 434 = 88,700,486` checks!

Moreover, the current algorithm is finding the intersection of `PathSource::list_files` and `git status`. It is an `O(n^2)` check. Let's assume files are evenly distributed into each package, so roughly 470 files per package. If we're unlucky to have some dirty files, say 100 files. We will have to do `470 * 100 = 47,000` times of path comparisons.

Even worse, because we `git status` everything in the repo, we'll have to it for all members,
even when those dirty files are not part of the current package in question.
So it becomes `470 * 100 * 434 = 20,398,000`!

#### Solution

Instead of comparing with the status of the entire repository,
this patch use the magic pathspec[1] to tell git only reports
paths that match a certain path prefix.

This wouldn't help the `O(n^2)` algorithm,
but at least it won't check dirty files outside the current package.

[1]: https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec


### How should we test and review this PR?

Run this command against awslabs/aws-sdk-rust@2cbd34db53389aed1cafe4c56d23186ef5ff304a,
and see if it is getting better.

```
CARGO_LOG_PROFILE=1 cargor package --no-verify --offline --allow-dirty -p aws-sdk-accessanalyzer -p aws-sdk-apigateway
```

### Additional information

There are some other alternatives, like making `PathSource::list_files` additionally reports dirty files. I don't want to touch that part right now because it is already overly complicated.

Some other approaches like

* switching to gitoxide
* a flag `--no-vcs` to skip vcs at all
* improve the `O(n^2)` algorithm.

This approach should be the most straighforward one.

