### PR TITLE
Add the `test` cfg as a well known cfg before of compiler change

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1391,14 +1391,17 @@ fn check_cfg_args(unit: &Unit) -> Vec<OsString> {
     }
     arg_feature.push("))");
 
-    // We also include the `docsrs` cfg from the docs.rs service. We include it here
-    // (in Cargo) instead of rustc, since there is a much closer relationship between
-    // Cargo and docs.rs than rustc and docs.rs. In particular, all users of docs.rs use
-    // Cargo, but not all users of rustc (like Rust-for-Linux) use docs.rs.
+    // In addition to the package features, we also include the `test` cfg (since
+    // compiler-team#785, as to be able to someday apply yt conditionaly), as well
+    // the `docsrs` cfg from the docs.rs service.
+    //
+    // We include `docsrs` here (in Cargo) instead of rustc, since there is a much closer
+    // relationship between Cargo and docs.rs than rustc and docs.rs. In particular, all
+    // users of docs.rs use Cargo, but not all users of rustc (like Rust-for-Linux) use docs.rs.
 
     vec![
         OsString::from("--check-cfg"),
-        OsString::from("cfg(docsrs)"),
+        OsString::from("cfg(docsrs,test)"),
         OsString::from("--check-cfg"),
         arg_feature,
     ]

--- a/tests/testsuite/check_cfg.rs
+++ b/tests/testsuite/check_cfg.rs
@@ -51,7 +51,7 @@ fn features() {
 
     p.cargo("check -v")
         .with_stderr_contains(x!("rustc" => "cfg" of "feature" with "f_a" "f_b"))
-        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs"))
+        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs,test"))
         .run();
 }
 
@@ -81,7 +81,7 @@ fn features_with_deps() {
 
     p.cargo("check -v")
         .with_stderr_contains(x!("rustc" => "cfg" of "feature" with "f_a" "f_b"))
-        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs"))
+        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs,test"))
         .run();
 }
 
@@ -112,7 +112,7 @@ fn features_with_opt_deps() {
 
     p.cargo("check -v")
         .with_stderr_contains(x!("rustc" => "cfg" of "feature" with "bar" "default" "f_a" "f_b"))
-        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs"))
+        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs,test"))
         .run();
 }
 
@@ -142,7 +142,7 @@ fn features_with_namespaced_features() {
 
     p.cargo("check -v")
         .with_stderr_contains(x!("rustc" => "cfg" of "feature" with "f_a" "f_b"))
-        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs"))
+        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs,test"))
         .run();
 }
 
@@ -232,7 +232,7 @@ fn well_known_names_values() {
 
     p.cargo("check -v")
         .with_stderr_contains(x!("rustc" => "cfg" of "feature" with))
-        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs"))
+        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs,test"))
         .run();
 }
 
@@ -257,7 +257,7 @@ fn features_test() {
 
     p.cargo("test -v")
         .with_stderr_contains(x!("rustc" => "cfg" of "feature" with "f_a" "f_b"))
-        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs"))
+        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs,test"))
         .run();
 }
 
@@ -284,8 +284,8 @@ fn features_doctest() {
     p.cargo("test -v --doc")
         .with_stderr_contains(x!("rustc" => "cfg" of "feature" with "default" "f_a" "f_b"))
         .with_stderr_contains(x!("rustdoc" => "cfg" of "feature" with "default" "f_a" "f_b"))
-        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs"))
-        .with_stderr_contains(x!("rustdoc" => "cfg" of "docsrs"))
+        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs,test"))
+        .with_stderr_contains(x!("rustdoc" => "cfg" of "docsrs,test"))
         .run();
 }
 
@@ -298,7 +298,7 @@ fn well_known_names_values_test() {
 
     p.cargo("test -v")
         .with_stderr_contains(x!("rustc" => "cfg" of "feature" with))
-        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs"))
+        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs,test"))
         .run();
 }
 
@@ -312,8 +312,8 @@ fn well_known_names_values_doctest() {
     p.cargo("test -v --doc")
         .with_stderr_contains(x!("rustc" => "cfg" of "feature" with))
         .with_stderr_contains(x!("rustdoc" => "cfg" of "feature" with))
-        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs"))
-        .with_stderr_contains(x!("rustdoc" => "cfg" of "docsrs"))
+        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs,test"))
+        .with_stderr_contains(x!("rustdoc" => "cfg" of "docsrs,test"))
         .run();
 }
 
@@ -339,7 +339,7 @@ fn features_doc() {
 
     p.cargo("doc -v")
         .with_stderr_contains(x!("rustdoc" => "cfg" of "feature" with "default" "f_a" "f_b"))
-        .with_stderr_contains(x!("rustdoc" => "cfg" of "docsrs"))
+        .with_stderr_contains(x!("rustdoc" => "cfg" of "docsrs,test"))
         .run();
 }
 
@@ -366,7 +366,7 @@ fn build_script_feedback() {
 
     p.cargo("check -v")
         .with_stderr_contains(x!("rustc" => "cfg" of "foo"))
-        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs"))
+        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs,test"))
         .run();
 }
 
@@ -442,7 +442,7 @@ fn build_script_override() {
     p.cargo("check -v")
         .with_stderr_contains(x!("rustc" => "cfg" of "foo"))
         .with_stderr_contains(x!("rustc" => "cfg" of "feature" with))
-        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs"))
+        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs,test"))
         .run();
 }
 
@@ -877,7 +877,7 @@ fn config_features_and_build_script() {
         .with_stderr_contains(x!("rustc" => "cfg" of "foo")) // from build.rs
         .with_stderr_contains(x!("rustc" => "cfg" of "bar")) // from config
         .with_stderr_contains(x!("rustc" => "cfg" of "feature" with "json" "serde")) // features
-        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs")) // Cargo well known
+        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs,test")) // Cargo well known
         .run();
 }
 


### PR DESCRIPTION
### What does this PR try to resolve?

This PR adds the `test` cfg as a well known Cargo cfg as https://github.com/rust-lang/compiler-team/issues/785 is now in FCP and before the compiler change.

### How should we test and review this PR?

Look at the new argument passed and the test changes.

### Additional information

Detailed motivation at https://github.com/rust-lang/compiler-team/issues/785, but summary `test` is a weird well known cfg for `rustc` as it's mostly a convention and build system like Cargo may to set it conditionally (`lib.test = false` for Cargo, not done in this PR).

Pre-require to https://github.com/rust-lang/rust/pull/131729.

r? @epage