### PR TITLE
fix(package): use relpath to cwd for vcs dirtiness report

### DIFF
--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1101,6 +1101,20 @@ to proceed despite this and include the uncommitted changes, pass the `--allow-d
 
 "#]])
         .run();
+
+    // cd to `src` and cargo report relative paths.
+    p.cargo("package")
+        .cwd(p.root().join("src"))
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] 1 files in the working directory contain changes that were not yet committed into git:
+
+Cargo.toml
+
+to proceed despite this and include the uncommitted changes, pass the `--allow-dirty` flag
+
+"#]])
+        .run();
 }
 
 #[cargo_test]

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1109,7 +1109,7 @@ to proceed despite this and include the uncommitted changes, pass the `--allow-d
         .with_stderr_data(str![[r#"
 [ERROR] 1 files in the working directory contain changes that were not yet committed into git:
 
-Cargo.toml
+../Cargo.toml
 
 to proceed despite this and include the uncommitted changes, pass the `--allow-dirty` flag
 


### PR DESCRIPTION
### What does this PR try to resolve?

Address https://github.com/rust-lang/cargo/pull/14968#issuecomment-2555901072

> I think the ideal solution is to be relative to the current directory but that takes more work and this incremental improvement is great!

Sorry I should have noticed your comment earlier.
