### PR TITLE
Enable triagebot merge conflict notifications

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -28,6 +28,11 @@ label = "O-windows"
 
 [transfer]
 
+[merge-conflicts]
+remove = []
+add = ["S-waiting-on-author"]
+unless = ["S-blocked", "S-waiting-on-review"]
+
 [autolabel."S-waiting-on-review"]
 new_pr = true
 


### PR DESCRIPTION
This enables merge conflict notifications on GitHub. Homu was providing this service for us, but it was shut down today. I find these notifications useful, as they give an opportunity for the author to proactively rebase and not require a round trip with the reviewer.
