### PR TITLE
fix: assure possibly blocking non-files (like FIFOs) won't be picked up for publishing.

### DIFF
--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -4221,3 +4221,34 @@ src/lib.rs
 "#]])
         .run();
 }
+
+#[cargo_test]
+#[cfg(unix)]
+fn simple_with_fifo() {
+    let git_project = git::new("foo", |project| {
+        project
+            .file(
+                "Cargo.toml",
+                r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2015"
+            "#,
+            )
+            .file("src/main.rs", "fn main() {}")
+    });
+
+    std::process::Command::new("mkfifo")
+        .current_dir(git_project.root())
+        .arg(git_project.root().join("blocks-when-read"))
+        .status()
+        .expect("a FIFO can be created");
+
+    // Avoid actual blocking even in case of failure, assuming that what it lists here
+    // would also be read eventually.
+    git_project
+        .cargo("package -l")
+        .with_stdout_does_not_contain("blocks-when-read")
+        .run();
+}

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -4249,6 +4249,13 @@ fn simple_with_fifo() {
     // would also be read eventually.
     git_project
         .cargo("package -l")
-        .with_stdout_does_not_contain("blocks-when-read")
+        .with_stdout_data(str![[r#"
+.cargo_vcs_info.json
+Cargo.lock
+Cargo.toml
+Cargo.toml.orig
+src/main.rs
+
+"#]])
         .run();
 }

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -6873,3 +6873,32 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 "#]])
         .run();
 }
+
+#[cargo_test]
+#[cfg(unix)]
+fn simple_with_fifo() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2015"
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    std::process::Command::new("mkfifo")
+        .current_dir(p.root())
+        .arg(p.root().join("blocks-when-read"))
+        .status()
+        .expect("a FIFO can be created");
+
+    // Avoid actual blocking even in case of failure, assuming that what it lists here
+    // would also be read eventually.
+    p.cargo("package -l")
+        .with_stdout_does_not_contain("blocks-when-read")
+        .run();
+}

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -6899,6 +6899,12 @@ fn simple_with_fifo() {
     // Avoid actual blocking even in case of failure, assuming that what it lists here
     // would also be read eventually.
     p.cargo("package -l")
-        .with_stdout_does_not_contain("blocks-when-read")
+        .with_stdout_data(str![[r#"
+Cargo.lock
+Cargo.toml
+Cargo.toml.orig
+src/main.rs
+
+"#]])
         .run();
 }


### PR DESCRIPTION
Follow-up of #14975, related to https://github.com/GitoxideLabs/gitoxide/pull/1629.

This would otherwise cause the publish to hang if it tries to read from a fifo.
