### PR TITLE
test: make path arguments more generic and flexible

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -299,7 +299,7 @@ impl ProjectBuilder {
     }
 
     /// Adds a symlink to a file to the project.
-    pub fn symlink<T: AsRef<Path>>(mut self, dst: T, src: T) -> Self {
+    pub fn symlink(mut self, dst: impl AsRef<Path>, src: impl AsRef<Path>) -> Self {
         self.symlinks.push(SymlinkBuilder::new(
             self.root.root().join(dst),
             self.root.root().join(src),
@@ -308,7 +308,7 @@ impl ProjectBuilder {
     }
 
     /// Create a symlink to a directory
-    pub fn symlink_dir<T: AsRef<Path>>(mut self, dst: T, src: T) -> Self {
+    pub fn symlink_dir(mut self, dst: impl AsRef<Path>, src: impl AsRef<Path>) -> Self {
         self.symlinks.push(SymlinkBuilder::new_dir(
             self.root.root().join(dst),
             self.root.root().join(src),
@@ -368,7 +368,7 @@ impl ProjectBuilder {
 
 impl Project {
     /// Copy the test project from a fixed state
-    pub fn from_template(template_path: impl AsRef<std::path::Path>) -> Self {
+    pub fn from_template(template_path: impl AsRef<Path>) -> Self {
         let root = paths::root();
         let project_root = root.join("case");
         snapbox::dir::copy_template(template_path.as_ref(), &project_root).unwrap();
@@ -459,7 +459,7 @@ impl Project {
     /// # let p = cargo_test_support::project().build();
     /// p.change_file("src/lib.rs", "fn new_fn() {}");
     /// ```
-    pub fn change_file(&self, path: &str, body: &str) {
+    pub fn change_file(&self, path: impl AsRef<Path>, body: &str) {
         FileBuilder::new(self.root().join(path), body, false).mk()
     }
 
@@ -530,7 +530,7 @@ impl Project {
     }
 
     /// Returns the contents of a path in the project root
-    pub fn read_file(&self, path: &str) -> String {
+    pub fn read_file(&self, path: impl AsRef<Path>) -> String {
         let full = self.root().join(path);
         fs::read_to_string(&full)
             .unwrap_or_else(|e| panic!("could not read file {}: {}", full.display(), e))
@@ -572,12 +572,12 @@ pub fn project() -> ProjectBuilder {
 }
 
 /// Generates a project layout in given directory, see [`ProjectBuilder`]
-pub fn project_in(dir: &str) -> ProjectBuilder {
+pub fn project_in(dir: impl AsRef<Path>) -> ProjectBuilder {
     ProjectBuilder::new(paths::root().join(dir).join("foo"))
 }
 
 /// Generates a project layout inside our fake home dir, see [`ProjectBuilder`]
-pub fn project_in_home(name: &str) -> ProjectBuilder {
+pub fn project_in_home(name: impl AsRef<Path>) -> ProjectBuilder {
     ProjectBuilder::new(paths::home().join(name))
 }
 

--- a/tests/testsuite/binary_name.rs
+++ b/tests/testsuite/binary_name.rs
@@ -91,7 +91,7 @@ fn binary_name1() {
     let deps_path = p.bin("007bar").with_extension("d");
     assert!(deps_path.is_file(), "{:?}", bar_path);
 
-    let depinfo = p.read_file(deps_path.to_str().unwrap());
+    let depinfo = p.read_file(&deps_path);
 
     // Prepare what content we expect to be present in deps file.
     let deps_exp = format!(

--- a/tests/testsuite/dep_info.rs
+++ b/tests/testsuite/dep_info.rs
@@ -25,7 +25,7 @@ fn build_dep_info() {
 
     assert!(depinfo_bin_path.is_file());
 
-    let depinfo = p.read_file(depinfo_bin_path.to_str().unwrap());
+    let depinfo = p.read_file(depinfo_bin_path);
 
     let bin_path = p.bin("foo");
     let src_path = p.root().join("src").join("foo.rs");
@@ -134,7 +134,7 @@ fn dep_path_inside_target_has_correct_path() {
 
     assert!(depinfo_path.is_file(), "{:?}", depinfo_path);
 
-    let depinfo = p.read_file(depinfo_path.to_str().unwrap());
+    let depinfo = p.read_file(depinfo_path);
 
     let bin_path = p.bin("a");
     let target_debug_blah = Path::new("target").join("debug").join("blah");


### PR DESCRIPTION
### What does this PR try to resolve?

So we don't need to `p.to_str().unwrap()`
and are able to pass different types for each argument

### How should we test and review this PR?

No response.