### PR TITLE
fix(package): check dirtiness of symlinks source files

### DIFF
--- a/crates/cargo-util/src/paths.rs
+++ b/crates/cargo-util/src/paths.rs
@@ -710,9 +710,9 @@ pub fn set_file_time_no_err<P: AsRef<Path>>(path: P, time: FileTime) {
 /// This canonicalizes both paths before stripping. This is useful if the
 /// paths are obtained in different ways, and one or the other may or may not
 /// have been normalized in some way.
-pub fn strip_prefix_canonical<P: AsRef<Path>>(
-    path: P,
-    base: P,
+pub fn strip_prefix_canonical(
+    path: impl AsRef<Path>,
+    base: impl AsRef<Path>,
 ) -> Result<PathBuf, std::path::StripPrefixError> {
     // Not all filesystems support canonicalize. Just ignore if it doesn't work.
     let safe_canonicalize = |path: &Path| match path.canonicalize() {

--- a/src/cargo/ops/cargo_package/vcs.rs
+++ b/src/cargo/ops/cargo_package/vcs.rs
@@ -242,12 +242,7 @@ fn dirty_metadata_paths(pkg: &Package, repo: &git2::Repository) -> CargoResult<V
         if let Ok(rel_path) = paths::strip_prefix_canonical(&abs_path, workdir) {
             // Outside package root but under git workdir,
             if repo.status_file(&rel_path)? != git2::Status::CURRENT {
-                dirty_files.push(if abs_path.is_symlink() {
-                    // For symlinks, shows paths to symlink sources
-                    workdir.join(rel_path)
-                } else {
-                    abs_path
-                });
+                dirty_files.push(workdir.join(rel_path))
             }
         }
     }

--- a/src/cargo/ops/cargo_package/vcs.rs
+++ b/src/cargo/ops/cargo_package/vcs.rs
@@ -235,11 +235,11 @@ fn dirty_metadata_paths(pkg: &Package, repo: &git2::Repository) -> CargoResult<V
             continue;
         };
         let abs_path = paths::normalize_path(&root.join(path));
-        if paths::strip_prefix_canonical(abs_path.as_path(), root).is_ok() {
+        if paths::strip_prefix_canonical(&abs_path, root).is_ok() {
             // Inside package root. Don't bother checking git status.
             continue;
         }
-        if let Ok(rel_path) = paths::strip_prefix_canonical(abs_path.as_path(), workdir) {
+        if let Ok(rel_path) = paths::strip_prefix_canonical(&abs_path, workdir) {
             // Outside package root but under git workdir,
             if repo.status_file(&rel_path)? != git2::Status::CURRENT {
                 dirty_files.push(if abs_path.is_symlink() {

--- a/src/cargo/ops/cargo_package/vcs.rs
+++ b/src/cargo/ops/cargo_package/vcs.rs
@@ -1,7 +1,6 @@
 //! Helpers to gather the VCS information for `cargo package`.
 
 use std::collections::HashSet;
-use std::path::Path;
 use std::path::PathBuf;
 
 use anyhow::Context as _;
@@ -187,8 +186,7 @@ fn git(
         .iter()
         .filter(|src_file| dirty_files.iter().any(|path| src_file.starts_with(path)))
         .map(|p| p.as_ref())
-        .chain(dirty_metadata_paths(pkg, repo)?.iter())
-        .chain(dirty_symlinks(pkg, repo, src_files)?.iter())
+        .chain(dirty_files_outside_pkg_root(pkg, repo, src_files)?.iter())
         .map(|path| {
             pathdiff::diff_paths(path, cwd)
                 .as_ref()
@@ -221,54 +219,39 @@ fn git(
     }
 }
 
-/// Checks whether files at paths specified in `package.readme` and
-/// `package.license-file` have been modified.
+/// Checks whether "included" source files outside package root have been modified.
+///
+/// This currently looks at
+///
+/// * `package.readme` and `package.license-file` pointing to paths outside package root
+/// * symlinks targets reside outside package root
 ///
 /// This is required because those paths may link to a file outside the
 /// current package root, but still under the git workdir, affecting the
 /// final packaged `.crate` file.
-fn dirty_metadata_paths(pkg: &Package, repo: &git2::Repository) -> CargoResult<Vec<PathBuf>> {
-    let mut dirty_files = Vec::new();
-    let workdir = repo.workdir().unwrap();
-    let root = pkg.root();
-    let meta = pkg.manifest().metadata();
-    for path in [&meta.license_file, &meta.readme] {
-        let Some(path) = path.as_deref().map(Path::new) else {
-            continue;
-        };
-        let abs_path = paths::normalize_path(&root.join(path));
-        if paths::strip_prefix_canonical(&abs_path, root).is_ok() {
-            // Inside package root. Don't bother checking git status.
-            continue;
-        }
-        if let Ok(rel_path) = paths::strip_prefix_canonical(&abs_path, workdir) {
-            // Outside package root but under git workdir,
-            if repo.status_file(&rel_path)? != git2::Status::CURRENT {
-                dirty_files.push(workdir.join(rel_path))
-            }
-        }
-    }
-    Ok(dirty_files)
-}
-
-/// Checks whether source files are symlinks and have been modified.
-///
-/// This is required because those paths may link to a file outside the
-/// current package root, but still under the git workdir, affecting the
-/// final packaged `.crate` file.
-fn dirty_symlinks(
+fn dirty_files_outside_pkg_root(
     pkg: &Package,
     repo: &git2::Repository,
     src_files: &[PathEntry],
 ) -> CargoResult<HashSet<PathBuf>> {
+    let pkg_root = pkg.root();
     let workdir = repo.workdir().unwrap();
+
+    let meta = pkg.manifest().metadata();
+    let metadata_paths: Vec<_> = [&meta.license_file, &meta.readme]
+        .into_iter()
+        .filter_map(|p| p.as_deref())
+        .map(|path| paths::normalize_path(&pkg_root.join(path)))
+        .collect();
+
     let mut dirty_symlinks = HashSet::new();
     for rel_path in src_files
         .iter()
         .filter(|p| p.is_symlink_or_under_symlink())
-        .map(|p| p.as_ref().as_path())
+        .map(|p| p.as_ref())
+        .chain(metadata_paths.iter())
         // If inside package root. Don't bother checking git status.
-        .filter(|p| paths::strip_prefix_canonical(p, pkg.root()).is_err())
+        .filter(|p| paths::strip_prefix_canonical(p, pkg_root).is_err())
         // Handle files outside package root but under git workdir,
         .filter_map(|p| paths::strip_prefix_canonical(p, workdir).ok())
     {

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1378,10 +1378,9 @@ fn dirty_file_outside_pkg_root_considered_dirty() {
     p.cargo("package --workspace --no-verify")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] 5 files in the working directory contain changes that were not yet committed into git:
+[ERROR] 4 files in the working directory contain changes that were not yet committed into git:
 
 LICENSE
-README.md
 README.md
 lib.rs
 original-dir/file

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1378,10 +1378,13 @@ fn dirty_file_outside_pkg_root_considered_dirty() {
     p.cargo("package --workspace --no-verify")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] 2 files in the working directory contain changes that were not yet committed into git:
+[ERROR] 5 files in the working directory contain changes that were not yet committed into git:
 
 LICENSE
 README.md
+README.md
+lib.rs
+original-dir/file
 
 to proceed despite this and include the uncommitted changes, pass the `--allow-dirty` flag
 


### PR DESCRIPTION
### What does this PR try to resolve?

This adds a special case for checking source files are symlinks
and have been modified when under a VCS control

This is required because those paths may link to a file outside the
current package root, but still under the git workdir, affecting the
final packaged `.crate` file.

### How should we test and review this PR?

Pretty similar to #14966, as a part of #14967.

This may have potential performance issue. If a package contains thousands of symlinks, Cargo will fire `git status` for each of them. Not sure if we want to do anything proactively now.

The introduction of the `PathEntry` struct gives us more room for storing file metadata to satisfiy use cases in the future. For instances,

* Knowing a source file is a symlink and resolving it when packaging on Windows
  * #5664
  * #14965
* Knowing more about a file's metadata (e.g. permission bits from Git)
  * #4413
  * #8006
* Provide richer information for `cargo package --list`, for example JSON output mode
  * #11666
  * #13331
  * #13953
