### PR TITLE
test: relax panic output assertion

### DIFF
--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -376,6 +376,7 @@ fn remap_path_scope() {
             str![[r#"
 [FINISHED] `release` profile [optimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `target/[HOST_TARGET]/release/foo`
+...
 [..]thread '[..]' panicked at [..]src/main.rs:3:[..]:
 [..]remap to /rustc/<hash>[..]
 [..]at /rustc/[..]/library/std/src/[..]

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -4000,7 +4000,7 @@ fn warnings_emitted_when_build_script_panics() {
                 fn main() {
                     println!("cargo::warning=foo");
                     println!("cargo::warning=bar");
-                    panic!();
+                    panic!("our crate panicked");
                 }
             "#,
         )
@@ -4022,10 +4022,9 @@ Caused by:
   cargo::warning=bar
 
   --- stderr
-  thread 'main' panicked at build.rs:5:21:
-  explicit panic
-  [NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-
+...
+[..]our crate panicked[..]
+...
 "#]])
         .run();
 }
@@ -4039,7 +4038,7 @@ fn warnings_emitted_when_dependency_panics() {
                 fn main() {
                     println!("cargo::warning=foo");
                     println!("cargo::warning=bar");
-                    panic!();
+                    panic!("dependency panicked");
                 }
             "#,
         )
@@ -4093,10 +4092,9 @@ Caused by:
   cargo::warning=bar
 
   --- stderr
-  thread 'main' panicked at [ROOT]/home/.cargo/registry/src/-[HASH]/published-0.1.0/build.rs:5:21:
-  explicit panic
-  [NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-
+...
+[..]dependency panicked[..]
+...
 "#]])
         .run();
 }


### PR DESCRIPTION


### What does this PR try to resolve?

rust-lang/rust#122565 adds a new line to thread panic output.
To make the current test suites works on stable, beta, and nightly,
similar to rust-lang/cargo#14602,
this relaxes the assertion around that by globbing everything.
