### PR TITLE
test: relax `bad_crate_type` to only match error message prefix

### DIFF
--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -427,7 +427,7 @@ fn bad_crate_type() {
 Caused by:
   process didn't exit successfully: `rustc - --crate-name ___ --print=file-names --crate-type bad_type` ([EXIT_STATUS]: 1)
   --- stderr
-  [ERROR] unknown crate type: `bad_type`
+  [ERROR] unknown crate type: `bad_type`[..]
 
 
 "#]])


### PR DESCRIPTION
### What does this PR try to resolve?

This PR relaxes the `bad_crate_type` test to have it only match the prefix of the unknown crate type error message emitted by rustc.

This is so that the cargo test isn't sensitive to (future) suggestions for known crate types that rustc may emit to help the user.

### How should we test and review this PR?

This test should already be run as part of cargo CI. (This is definitely run as part of rust-lang/rust CI, lol.)

### Additional information

rust-lang/rust side PR that's trying to add a suffix to the bad crate type error message to list all valid `--crate-type` values: https://github.com/rust-lang/rust/pull/134720.

Without relaxing this test, the rust-lang/rust side PR [fails with](https://github.com/rust-lang/rust/pull/134720#issuecomment-2561993224):

<details>
<summary>rust-lang/rust CI fail message</summary>

(Ignore the missing colon after `unknown crate type`)

```
---- bad_config::bad_crate_type stdout ----
running `/checkout/obj/build/x86_64-unknown-linux-gnu/stage2-tools/x86_64-unknown-linux-gnu/release/cargo build -v`
thread 'bad_config::bad_crate_type' panicked at src/tools/cargo/tests/testsuite/bad_config.rs:434:10:

---- expected: tests/testsuite/bad_config.rs:424:27
++++ actual:   stderr
   1    1 | [ERROR] failed to run `rustc` to learn about crate-type bad_type information
   2    2 | 
   3    3 | Caused by:
   4    4 |   process didn't exit successfully: `rustc - --crate-name ___ --print=file-names --crate-type bad_type` ([EXIT_STATUS]: 1)
   5    5 |   --- stderr
   6      -   [ERROR] unknown crate type: `bad_type`
Error:      6 +   [ERROR] unknown crate type `bad_type`, expected one of: `bin`, `cdylib`, `dylib`, `lib`, `proc-macro`, `rlib`
   7    7 | 
```
</details>

Discussed at https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/Reblessing.20a.20cargo.20test.
