### PR TITLE
fix: Adjust "to see how you depend on a package" message to use a command format that supports flags like --all-features

### DIFF
--- a/src/cargo/ops/cargo_update.rs
+++ b/src/cargo/ops/cargo_update.rs
@@ -694,7 +694,7 @@ fn print_lockfile_updates(
 
     if ws.gctx().shell().verbosity() == Verbosity::Verbose {
         ws.gctx().shell().note(
-            "to see how you depend on a package, run `cargo tree --invert --package <dep>@<ver>`",
+            "to see how you depend on a package, run `cargo tree --all-features --invert <dep>@<ver>`",
         )?;
     } else {
         if 0 < unchanged_behind {

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -1535,7 +1535,7 @@ fn report_behind() {
 [UPDATING] breaking v0.1.0 -> v0.1.1 (available: v0.2.0)
 [UNCHANGED] pre v1.0.0-alpha.0 (available: v1.0.0-alpha.1)
 [UNCHANGED] two-ver v0.1.0 (available: v0.2.0)
-[NOTE] to see how you depend on a package, run `cargo tree --invert --package <dep>@<ver>`
+[NOTE] to see how you depend on a package, run `cargo tree --all-features --invert <dep>@<ver>`
 [WARNING] not updating lockfile due to dry run
 
 "#]])
@@ -1560,7 +1560,7 @@ fn report_behind() {
 [UNCHANGED] breaking v0.1.1 (available: v0.2.0)
 [UNCHANGED] pre v1.0.0-alpha.0 (available: v1.0.0-alpha.1)
 [UNCHANGED] two-ver v0.1.0 (available: v0.2.0)
-[NOTE] to see how you depend on a package, run `cargo tree --invert --package <dep>@<ver>`
+[NOTE] to see how you depend on a package, run `cargo tree --all-features --invert <dep>@<ver>`
 [WARNING] not updating lockfile due to dry run
 
 "#]])


### PR DESCRIPTION
When running cargo update in a workspace, it applies to all packages, including transitive dependencies which are only used when specific non default features are enabled.

This means that when a given package is not updated by cargo update, it might only be included in `cargo tree` if the specific feature, or --all-features is specified.

cargo update suggests the command `cargo tree --invert --package <dep>@<ver>` to see now the noted packages are depended on, but this fails to find packages if they are only included with a specific feature.

Additionally, adding `--all-features` to this command as is fails with the message:

> error: cannot specify features for packages outside of workspace

This PR changes the the suggested command so that it should work for all packages which cargo update might suggest using it with.

I am aware that creating this PR is not exactly following the process outlined in https://doc.crates.io/contrib/process/index.html : since this is a minor change that is easier to just show in a diff I figured a PR would be simpler to evaluate than an issue.  If it would be better to file an issue for this and only create the PR if/when it gets marked as "[S-accepted](https://github.com/rust-lang/cargo/labels/S-accepted)", let me know, and I'll close the PR for now and file an issue.