### PR TITLE
fix(package): warn if symlinks checked out as plain text files

### DIFF
--- a/src/cargo/ops/cargo_package/mod.rs
+++ b/src/cargo/ops/cargo_package/mod.rs
@@ -16,6 +16,7 @@ use crate::core::Workspace;
 use crate::core::{Package, PackageId, PackageSet, Resolve, SourceId};
 use crate::ops::lockfile::LOCKFILE_NAME;
 use crate::ops::registry::{infer_registry, RegistryOrIndex};
+use crate::sources::path::PathEntry;
 use crate::sources::registry::index::{IndexPackage, RegistryDependency};
 use crate::sources::{PathSource, CRATES_IO_REGISTRY};
 use crate::util::cache_lock::CacheLockMode;
@@ -396,7 +397,7 @@ fn prepare_archive(
 fn build_ar_list(
     ws: &Workspace<'_>,
     pkg: &Package,
-    src_files: Vec<PathBuf>,
+    src_files: Vec<PathEntry>,
     vcs_info: Option<vcs::VcsInfo>,
 ) -> CargoResult<Vec<ArchiveFile>> {
     let mut result = HashMap::new();
@@ -420,7 +421,7 @@ fn build_ar_list(
                     .push(ArchiveFile {
                         rel_path: rel_path.to_owned(),
                         rel_str: rel_str.to_owned(),
-                        contents: FileContents::OnDisk(src_file.clone()),
+                        contents: FileContents::OnDisk(src_file.to_path_buf()),
                     });
             }
         }

--- a/src/cargo/ops/cargo_package/vcs.rs
+++ b/src/cargo/ops/cargo_package/vcs.rs
@@ -9,6 +9,7 @@ use serde::Serialize;
 use tracing::debug;
 
 use crate::core::Package;
+use crate::sources::PathEntry;
 use crate::CargoResult;
 use crate::GlobalContext;
 
@@ -41,7 +42,7 @@ pub struct GitVcsInfo {
 #[tracing::instrument(skip_all)]
 pub fn check_repo_state(
     p: &Package,
-    src_files: &[PathBuf],
+    src_files: &[PathEntry],
     gctx: &GlobalContext,
     opts: &PackageOpts<'_>,
 ) -> CargoResult<Option<VcsInfo>> {
@@ -114,7 +115,7 @@ pub fn check_repo_state(
 fn git(
     pkg: &Package,
     gctx: &GlobalContext,
-    src_files: &[PathBuf],
+    src_files: &[PathEntry],
     repo: &git2::Repository,
     opts: &PackageOpts<'_>,
 ) -> CargoResult<Option<GitVcsInfo>> {
@@ -136,6 +137,7 @@ fn git(
     let mut dirty_src_files: Vec<_> = src_files
         .iter()
         .filter(|src_file| dirty_files.iter().any(|path| src_file.starts_with(path)))
+        .map(|p| p.as_ref())
         .chain(dirty_metadata_paths(pkg, repo)?.iter())
         .map(|path| {
             pathdiff::diff_paths(path, cwd)

--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -2,6 +2,7 @@ use crate::core::shell::Verbosity;
 use crate::core::{GitReference, Package, Workspace};
 use crate::ops;
 use crate::sources::path::PathSource;
+use crate::sources::PathEntry;
 use crate::sources::CRATES_IO_REGISTRY;
 use crate::util::cache_lock::CacheLockMode;
 use crate::util::{try_canonicalize, CargoResult, GlobalContext};
@@ -315,13 +316,14 @@ fn sync(
 fn cp_sources(
     pkg: &Package,
     src: &Path,
-    paths: &[PathBuf],
+    paths: &[PathEntry],
     dst: &Path,
     cksums: &mut BTreeMap<String, String>,
     tmp_buf: &mut [u8],
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     for p in paths {
+        let p = p.as_ref();
         let relative = p.strip_prefix(&src).unwrap();
 
         match relative.to_str() {

--- a/src/cargo/sources/mod.rs
+++ b/src/cargo/sources/mod.rs
@@ -29,6 +29,7 @@
 pub use self::config::SourceConfigMap;
 pub use self::directory::DirectorySource;
 pub use self::git::GitSource;
+pub use self::path::PathEntry;
 pub use self::path::PathSource;
 pub use self::path::RecursivePathSource;
 pub use self::registry::{

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -7077,6 +7077,10 @@ fn git_core_symlinks_false() {
 
     p.cargo("package --allow-dirty")
         .with_stderr_data(str![[r#"
+[WARNING] found symbolic links that may be checked out as regular files for git repo at `[ROOT]/foo/`
+This might cause the `.crate` file to include incorrect or incomplete files
+[NOTE] to avoid this, set the Git config `core.symlinks` to `true`
+...
 [PACKAGING] bar v0.0.0 ([ROOT]/foo)
 [PACKAGED] 7 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [VERIFYING] bar v0.0.0 ([ROOT]/foo)

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -7025,3 +7025,85 @@ src/main.rs
 "#]])
         .run();
 }
+
+#[cargo_test]
+fn git_core_symlinks_false() {
+    if !symlink_supported() {
+        return;
+    }
+
+    let git_project = git::new("bar", |p| {
+        p.file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "bar"
+                description = "bar"
+                license = "MIT"
+                edition = "2021"
+                documentation = "foo"
+            "#,
+        )
+        .file("src/lib.rs", "//! This is a module")
+        .symlink("src/lib.rs", "symlink-lib.rs")
+        .symlink_dir("src", "symlink-dir")
+    });
+
+    let url = git_project.root().to_url().to_string();
+
+    let p = project().build();
+    let root = p.root();
+    // Remove the default project layout,
+    // so we can git-fetch from git_project under the same directory
+    fs::remove_dir_all(&root).unwrap();
+    fs::create_dir_all(&root).unwrap();
+    let repo = git::init(&root);
+
+    let mut cfg = repo.config().unwrap();
+    cfg.set_bool("core.symlinks", false).unwrap();
+
+    // let's fetch from git_project so it respects our core.symlinks=false config.
+    repo.remote_anonymous(&url)
+        .unwrap()
+        .fetch(&["HEAD"], None, None)
+        .unwrap();
+    let rev = repo
+        .find_reference("FETCH_HEAD")
+        .unwrap()
+        .peel_to_commit()
+        .unwrap();
+    repo.reset(rev.as_object(), git2::ResetType::Hard, None)
+        .unwrap();
+
+    p.cargo("package --allow-dirty")
+        .with_stderr_data(str![[r#"
+[PACKAGING] bar v0.0.0 ([ROOT]/foo)
+[PACKAGED] 7 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[VERIFYING] bar v0.0.0 ([ROOT]/foo)
+[COMPILING] bar v0.0.0 ([ROOT]/foo/target/package/bar-0.0.0)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+
+    let f = File::open(&p.root().join("target/package/bar-0.0.0.crate")).unwrap();
+    validate_crate_contents(
+        f,
+        "bar-0.0.0.crate",
+        &[
+            "Cargo.lock",
+            "Cargo.toml",
+            "Cargo.toml.orig",
+            "src/lib.rs",
+            // We're missing symlink-dir/lib.rs in the `.crate` file.
+            "symlink-dir",
+            "symlink-lib.rs",
+            ".cargo_vcs_info.json",
+        ],
+        [
+            // And their contents are incorrect.
+            ("symlink-dir", str!["[ROOT]/bar/src"]),
+            ("symlink-lib.rs", str!["[ROOT]/bar/src/lib.rs"]),
+        ],
+    );
+}


### PR DESCRIPTION
### What does this PR try to resolve?

`cargo package` will warn users when git `core.symlinks` is `false`
and some symlinks were checked out as plain files during packaging.


Git config [`core.symlinks`] defaults to true when unset.
In git-for-windows (and git as well),
the config should be set to false explicitly when the repo was created,
if symlink support wasn't detected [^1].

We assume the config was always set at creation time and never changed.
So, if it is true, we don't bother users with any warning.

[^1]: https://github.com/git-for-windows/git/blob/f1241afcc7956918d5da33ef74abd9cbba369247/setup.c#L2394-L2403

[`core.symlinks`]: https://git-scm.com/docs/git-config#Documentation/git-config.txt-coresymlinks

### How should we test and review this PR?

CI passes.

This shares two commits 42dc4eff43ce480350979e07c8605e0f12983b79 and c8c8223c265ba8e7ea4cd29f829583ce786834f6 with #14981.

I didn't commit to fix all symlink issues all at once.
This PR demonstrates how we could leverage metadata in `PathEntry`.
Maybe later we can really follow plain-text symlinks and resolve the issue.

### Additional information

cc #5664