### PR TITLE
test(git): Clean up shallow fetch tests

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1524,6 +1524,12 @@ impl ArgLineCommandExt for &mut ProcessBuilder {
     }
 }
 
+impl ArgLineCommandExt for &mut Execs {
+    fn arg<S: AsRef<std::ffi::OsStr>>(self, s: S) -> Self {
+        self.arg(s)
+    }
+}
+
 impl ArgLineCommandExt for snapbox::cmd::Command {
     fn arg<S: AsRef<std::ffi::OsStr>>(self, s: S) -> Self {
         self.arg(s)

--- a/tests/testsuite/git_shallow.rs
+++ b/tests/testsuite/git_shallow.rs
@@ -14,6 +14,11 @@ fn gitoxide_clones_shallow_two_revs_same_deps() {
     perform_two_revs_same_deps(true)
 }
 
+#[cargo_test]
+fn two_revs_same_deps() {
+    perform_two_revs_same_deps(false)
+}
+
 fn perform_two_revs_same_deps(shallow: bool) {
     let bar = git::new("meta-dep", |project| {
         project
@@ -104,11 +109,6 @@ fn perform_two_revs_same_deps(shallow: bool) {
         .run();
     assert!(foo.bin("foo").is_file());
     foo.process(&foo.bin("foo")).run();
-}
-
-#[cargo_test]
-fn two_revs_same_deps() {
-    perform_two_revs_same_deps(false)
 }
 
 #[cargo_test]

--- a/tests/testsuite/git_shallow.rs
+++ b/tests/testsuite/git_shallow.rs
@@ -33,16 +33,16 @@ impl RepoMode {
 }
 
 #[cargo_test]
-fn gitoxide_fetch_shallow_two_revs_same_deps() {
-    fetch_two_revs_same_deps(Backend::Gitoxide, RepoMode::Shallow)
+fn gitoxide_fetch_shallow_dep_two_revs() {
+    fetch_dep_two_revs(Backend::Gitoxide, RepoMode::Shallow)
 }
 
 #[cargo_test]
-fn git2_fetch_complete_two_revs_same_deps() {
-    fetch_two_revs_same_deps(Backend::Git2, RepoMode::Complete)
+fn git2_fetch_complete_dep_two_revs() {
+    fetch_dep_two_revs(Backend::Git2, RepoMode::Complete)
 }
 
-fn fetch_two_revs_same_deps(backend: Backend, mode: RepoMode) {
+fn fetch_dep_two_revs(backend: Backend, mode: RepoMode) {
     let bar = git::new("meta-dep", |project| {
         project
             .file("Cargo.toml", &basic_manifest("bar", "0.0.0"))
@@ -129,7 +129,7 @@ fn fetch_two_revs_same_deps(backend: Backend, mode: RepoMode) {
 }
 
 #[cargo_test]
-fn shallow_deps_work_with_revisions_and_branches_mixed_on_same_dependency() -> anyhow::Result<()> {
+fn gitoxide_fetch_shallow_dep_branch_and_rev() -> anyhow::Result<()> {
     let (bar, bar_repo) = git::new_repo("bar", |p| {
         p.file("Cargo.toml", &basic_manifest("bar", "1.0.0"))
             .file("src/lib.rs", "")
@@ -187,7 +187,7 @@ fn shallow_deps_work_with_revisions_and_branches_mixed_on_same_dependency() -> a
 }
 
 #[cargo_test]
-fn gitoxide_git_dependencies_switch_from_branch_to_rev() -> anyhow::Result<()> {
+fn gitoxide_fetch_shallow_dep_branch_to_rev() -> anyhow::Result<()> {
     // db exists from previous build, then dependency changes to refer to revision that isn't
     // available in the shallow fetch.
 
@@ -266,8 +266,7 @@ fn gitoxide_git_dependencies_switch_from_branch_to_rev() -> anyhow::Result<()> {
 }
 
 #[cargo_test]
-fn gitoxide_fetch_registry_with_shallow_protocol_and_follow_up_with_git2_fetch(
-) -> anyhow::Result<()> {
+fn gitoxide_fetch_shallow_index_then_git2_fetch_complete() -> anyhow::Result<()> {
     Package::new("bar", "1.0.0").publish();
     let p = project()
         .file(
@@ -323,8 +322,7 @@ fn gitoxide_fetch_registry_with_shallow_protocol_and_follow_up_with_git2_fetch(
 }
 
 #[cargo_test]
-fn gitoxide_fetch_git_dependency_with_shallow_protocol_and_git2_is_used_for_followup_fetches(
-) -> anyhow::Result<()> {
+fn gitoxide_fetch_shallow_dep_then_git2_fetch_complete() -> anyhow::Result<()> {
     // Example where an old lockfile with an explicit branch="master" in Cargo.toml.
     Package::new("bar", "1.0.0").publish();
     let (bar, bar_repo) = git::new_repo("bar", |p| {
@@ -461,7 +459,7 @@ fn gitoxide_fetch_git_dependency_with_shallow_protocol_and_git2_is_used_for_foll
 }
 
 #[cargo_test]
-fn gitoxide_shallow_fetch_followed_by_non_shallow_update() -> anyhow::Result<()> {
+fn gitoxide_fetch_shallow_dep_then_gitoxide_fetch_complete() -> anyhow::Result<()> {
     Package::new("bar", "1.0.0").publish();
     let (bar, bar_repo) = git::new_repo("bar", |p| {
         p.file("Cargo.toml", &basic_manifest("bar", "1.0.0"))
@@ -600,8 +598,7 @@ fn gitoxide_shallow_fetch_followed_by_non_shallow_update() -> anyhow::Result<()>
 }
 
 #[cargo_test]
-fn gitoxide_fetch_registry_with_shallow_protocol_and_follow_up_fetch_maintains_shallowness(
-) -> anyhow::Result<()> {
+fn gitoxide_fetch_shallow_index_then_preserve_shallow() -> anyhow::Result<()> {
     Package::new("bar", "1.0.0").publish();
     let p = project()
         .file(
@@ -674,8 +671,7 @@ fn gitoxide_fetch_registry_with_shallow_protocol_and_follow_up_fetch_maintains_s
 
 /// If there is shallow *and* non-shallow fetches, non-shallow will naturally be returned due to sort order.
 #[cargo_test]
-fn gitoxide_fetch_registry_without_shallow_protocol_and_follow_up_fetch_uses_shallowness(
-) -> anyhow::Result<()> {
+fn gitoxide_fetch_complete_index_then_shallow() -> anyhow::Result<()> {
     Package::new("bar", "1.0.0").publish();
     let p = project()
         .file(
@@ -765,8 +761,7 @@ fn gitoxide_fetch_registry_without_shallow_protocol_and_follow_up_fetch_uses_sha
 }
 
 #[cargo_test]
-fn gitoxide_fetch_registry_with_shallow_protocol_and_aborts_and_updates_again() -> anyhow::Result<()>
-{
+fn gitoxide_fetch_shallow_index_then_abort_and_update() -> anyhow::Result<()> {
     Package::new("bar", "1.0.0").publish();
     let p = project()
         .file(

--- a/tests/testsuite/git_shallow.rs
+++ b/tests/testsuite/git_shallow.rs
@@ -11,15 +11,15 @@ enum RepoMode {
 
 #[cargo_test]
 fn gitoxide_clones_shallow_two_revs_same_deps() {
-    perform_two_revs_same_deps(true)
+    perform_two_revs_same_deps(RepoMode::Shallow)
 }
 
 #[cargo_test]
 fn two_revs_same_deps() {
-    perform_two_revs_same_deps(false)
+    perform_two_revs_same_deps(RepoMode::Complete)
 }
 
-fn perform_two_revs_same_deps(shallow: bool) {
+fn perform_two_revs_same_deps(mode: RepoMode) {
     let bar = git::new("meta-dep", |project| {
         project
             .file("Cargo.toml", &basic_manifest("bar", "0.0.0"))
@@ -97,10 +97,9 @@ fn perform_two_revs_same_deps(shallow: bool) {
         )
         .build();
 
-    let args = if shallow {
-        "build -v -Zgitoxide=fetch -Zgit=shallow-deps"
-    } else {
-        "build -v"
+    let args = match mode {
+        RepoMode::Complete => "build -v",
+        RepoMode::Shallow => "build -v -Zgitoxide=fetch -Zgit=shallow-deps",
     };
     foo.cargo(args)
         .masquerade_as_nightly_cargo(&[

--- a/tests/testsuite/git_shallow.rs
+++ b/tests/testsuite/git_shallow.rs
@@ -98,14 +98,12 @@ fn perform_two_revs_same_deps(mode: RepoMode) {
         .build();
 
     let args = match mode {
-        RepoMode::Complete => "build -v",
-        RepoMode::Shallow => "build -v -Zgitoxide=fetch -Zgit=shallow-deps",
+        RepoMode::Complete => "check -v",
+        RepoMode::Shallow => "check -v -Zgitoxide=fetch -Zgit=shallow-deps",
     };
     foo.cargo(args)
         .masquerade_as_nightly_cargo(&["gitoxide=fetch", "git=shallow-deps"])
         .run();
-    assert!(foo.bin("foo").is_file());
-    foo.process(&foo.bin("foo")).run();
 }
 
 #[cargo_test]

--- a/tests/testsuite/git_shallow.rs
+++ b/tests/testsuite/git_shallow.rs
@@ -102,9 +102,7 @@ fn perform_two_revs_same_deps(mode: RepoMode) {
         RepoMode::Shallow => "build -v -Zgitoxide=fetch -Zgit=shallow-deps",
     };
     foo.cargo(args)
-        .masquerade_as_nightly_cargo(&[
-            "unstable features must be available for -Z gitoxide and -Z git",
-        ])
+        .masquerade_as_nightly_cargo(&["gitoxide=fetch", "git=shallow-deps"])
         .run();
     assert!(foo.bin("foo").is_file());
     foo.process(&foo.bin("foo")).run();
@@ -131,9 +129,7 @@ fn gitoxide_clones_registry_with_shallow_protocol_and_follow_up_with_git2_fetch(
     p.cargo("fetch")
         .arg("-Zgitoxide=fetch")
         .arg("-Zgit=shallow-index")
-        .masquerade_as_nightly_cargo(&[
-            "unstable features must be available for -Z gitoxide and -Z git",
-        ])
+        .masquerade_as_nightly_cargo(&["gitoxide=fetch", "git=shallow-index"])
         .run();
 
     let shallow_repo = gix::open_opts(find_index(), gix::open::Options::isolated())?;
@@ -214,9 +210,7 @@ fn gitoxide_clones_git_dependency_with_shallow_protocol_and_git2_is_used_for_fol
     p.cargo("update")
         .arg("-Zgitoxide=fetch")
         .arg("-Zgit=shallow-deps")
-        .masquerade_as_nightly_cargo(&[
-            "unstable features must be available for -Z gitoxide and -Z git",
-        ])
+        .masquerade_as_nightly_cargo(&["gitoxide=fetch", "git=shallow-deps"])
         .run();
 
     let db_clone = gix::open_opts(
@@ -352,9 +346,7 @@ fn gitoxide_shallow_clone_followed_by_non_shallow_update() -> anyhow::Result<()>
     p.cargo("update")
         .arg("-Zgitoxide=fetch")
         .arg("-Zgit=shallow-deps")
-        .masquerade_as_nightly_cargo(&[
-            "unstable features must be available for -Z gitoxide and -Z git",
-        ])
+        .masquerade_as_nightly_cargo(&["gitoxide=fetch", "git=shallow-deps"])
         .run();
 
     let shallow_db_clone = gix::open_opts(
@@ -398,7 +390,7 @@ fn gitoxide_shallow_clone_followed_by_non_shallow_update() -> anyhow::Result<()>
 
     p.cargo("update")
         .arg("-Zgitoxide=fetch") // shallow-deps is omitted intentionally
-        .masquerade_as_nightly_cargo(&["unstable features must be available for -Z gitoxide"])
+        .masquerade_as_nightly_cargo(&["gitoxide=fetch"])
         .run();
 
     let db_clone = gix::open_opts(
@@ -471,9 +463,7 @@ fn gitoxide_clones_registry_with_shallow_protocol_and_follow_up_fetch_maintains_
     p.cargo("fetch")
         .arg("-Zgitoxide=fetch")
         .arg("-Zgit=shallow-index")
-        .masquerade_as_nightly_cargo(&[
-            "unstable features must be available for -Z gitoxide and -Z git",
-        ])
+        .masquerade_as_nightly_cargo(&["gitoxide=fetch", "git=shallow-index"])
         .run();
 
     let repo = gix::open_opts(find_index(), gix::open::Options::isolated())?;
@@ -491,9 +481,7 @@ fn gitoxide_clones_registry_with_shallow_protocol_and_follow_up_fetch_maintains_
     p.cargo("update")
         .arg("-Zgitoxide=fetch")
         .arg("-Zgit=shallow-index") // NOTE: the flag needs to be consistent or else a different index is created
-        .masquerade_as_nightly_cargo(&[
-            "unstable features must be available for -Z gitoxide and -Z git",
-        ])
+        .masquerade_as_nightly_cargo(&["gitoxide=fetch", "git=shallow-index"])
         .run();
 
     assert_eq!(
@@ -511,9 +499,7 @@ fn gitoxide_clones_registry_with_shallow_protocol_and_follow_up_fetch_maintains_
     p.cargo("update")
         .arg("-Zgitoxide=fetch")
         .arg("-Zgit=shallow-index")
-        .masquerade_as_nightly_cargo(&[
-            "unstable features must be available for -Z gitoxide and -Z git",
-        ])
+        .masquerade_as_nightly_cargo(&["gitoxide=fetch", "git=shallow-index"])
         .run();
 
     assert_eq!(
@@ -550,7 +536,7 @@ fn gitoxide_clones_registry_without_shallow_protocol_and_follow_up_fetch_uses_sh
         .build();
     p.cargo("fetch")
         .arg("-Zgitoxide=fetch")
-        .masquerade_as_nightly_cargo(&["unstable features must be available for -Z gitoxide"])
+        .masquerade_as_nightly_cargo(&["gitoxide=fetch"])
         .run();
 
     let repo = gix::open_opts(find_index(), gix::open::Options::isolated())?;
@@ -568,9 +554,7 @@ fn gitoxide_clones_registry_without_shallow_protocol_and_follow_up_fetch_uses_sh
     p.cargo("update")
         .arg("-Zgitoxide=fetch")
         .arg("-Zgit=shallow-index")
-        .masquerade_as_nightly_cargo(&[
-            "unstable features must be available for -Z gitoxide and -Z git",
-        ])
+        .masquerade_as_nightly_cargo(&["gitoxide=fetch", "git=shallow-index"])
         .run();
 
     let shallow_repo = gix::open_opts(
@@ -592,9 +576,7 @@ fn gitoxide_clones_registry_without_shallow_protocol_and_follow_up_fetch_uses_sh
     p.cargo("update")
         .arg("-Zgitoxide=fetch")
         .arg("-Zgit=shallow-index")
-        .masquerade_as_nightly_cargo(&[
-            "unstable features must be available for -Z gitoxide and -Z git",
-        ])
+        .masquerade_as_nightly_cargo(&["gitoxide=fetch", "git=shallow-index"])
         .run();
 
     assert_eq!(
@@ -610,7 +592,7 @@ fn gitoxide_clones_registry_without_shallow_protocol_and_follow_up_fetch_uses_sh
 
     p.cargo("update")
         .arg("-Zgitoxide=fetch")
-        .masquerade_as_nightly_cargo(&["unstable features must be available for -Z gitoxide"])
+        .masquerade_as_nightly_cargo(&["gitoxide=fetch"])
         .run();
 
     assert_eq!(
@@ -662,9 +644,7 @@ fn gitoxide_git_dependencies_switch_from_branch_to_rev() -> anyhow::Result<()> {
     p.cargo("check")
         .arg("-Zgitoxide=fetch")
         .arg("-Zgit=shallow-deps")
-        .masquerade_as_nightly_cargo(&[
-            "unstable features must be available for -Z gitoxide and -Z git",
-        ])
+        .masquerade_as_nightly_cargo(&["gitoxide=fetch", "git=shallow-deps"])
         .run();
 
     let db_clone = gix::open_opts(
@@ -695,9 +675,7 @@ fn gitoxide_git_dependencies_switch_from_branch_to_rev() -> anyhow::Result<()> {
     p.cargo("check")
         .arg("-Zgitoxide=fetch")
         .arg("-Zgit=shallow-deps")
-        .masquerade_as_nightly_cargo(&[
-            "unstable features must be available for -Z gitoxide and -Z git",
-        ])
+        .masquerade_as_nightly_cargo(&["gitoxide=fetch", "git=shallow-deps"])
         .run();
 
     assert!(
@@ -746,9 +724,7 @@ fn shallow_deps_work_with_revisions_and_branches_mixed_on_same_dependency() -> a
     p.cargo("check")
         .arg("-Zgitoxide=fetch")
         .arg("-Zgit=shallow-deps")
-        .masquerade_as_nightly_cargo(&[
-            "unstable features must be available for -Z gitoxide and -Z git",
-        ])
+        .masquerade_as_nightly_cargo(&["gitoxide=fetch", "git=shallow-deps"])
         .run();
 
     let db_paths = glob::glob(paths::home().join(".cargo/git/db/bar-*").to_str().unwrap())?
@@ -789,9 +765,7 @@ fn gitoxide_clones_registry_with_shallow_protocol_and_aborts_and_updates_again(
     p.cargo("fetch")
         .arg("-Zgitoxide=fetch")
         .arg("-Zgit=shallow-index")
-        .masquerade_as_nightly_cargo(&[
-            "unstable features must be available for -Z gitoxide and -Z git",
-        ])
+        .masquerade_as_nightly_cargo(&["gitoxide=fetch", "git=shallow-index"])
         .run();
 
     let repo = gix::open_opts(find_index(), gix::open::Options::isolated())?;
@@ -814,9 +788,7 @@ fn gitoxide_clones_registry_with_shallow_protocol_and_aborts_and_updates_again(
     p.cargo("update")
         .arg("-Zgitoxide=fetch")
         .arg("-Zgit=shallow-index")
-        .masquerade_as_nightly_cargo(&[
-            "unstable features must be available for -Z gitoxide and -Z git",
-        ])
+        .masquerade_as_nightly_cargo(&["gitoxide=fetch", "git=shallow-index"])
         .run();
 
     assert!(!shallow_lock.is_file(), "the repository was re-initialized");

--- a/tests/testsuite/git_shallow.rs
+++ b/tests/testsuite/git_shallow.rs
@@ -97,11 +97,12 @@ fn perform_two_revs_same_deps(mode: RepoMode) {
         )
         .build();
 
-    let args = match mode {
-        RepoMode::Complete => "check -v",
-        RepoMode::Shallow => "check -v -Zgitoxide=fetch -Zgit=shallow-deps",
+    let mode_args = match mode {
+        RepoMode::Complete => "",
+        RepoMode::Shallow => "-Zgitoxide=fetch -Zgit=shallow-deps",
     };
-    foo.cargo(args)
+    foo.cargo("check -v")
+        .arg_line(mode_args)
         .masquerade_as_nightly_cargo(&["gitoxide=fetch", "git=shallow-deps"])
         .run();
 }

--- a/tests/testsuite/git_shallow.rs
+++ b/tests/testsuite/git_shallow.rs
@@ -129,7 +129,7 @@ fn fetch_two_revs_same_deps(backend: Backend, mode: RepoMode) {
 }
 
 #[cargo_test]
-fn gitoxide_clones_registry_with_shallow_protocol_and_follow_up_with_git2_fetch(
+fn gitoxide_fetch_registry_with_shallow_protocol_and_follow_up_with_git2_fetch(
 ) -> anyhow::Result<()> {
     Package::new("bar", "1.0.0").publish();
     let p = project()
@@ -160,7 +160,7 @@ fn gitoxide_clones_registry_with_shallow_protocol_and_follow_up_with_git2_fetch(
             .all()?
             .count(),
         1,
-        "shallow clones always start at depth of 1 to minimize download size"
+        "shallow fetch always start at depth of 1 to minimize download size"
     );
     assert!(shallow_repo.is_shallow());
 
@@ -179,14 +179,14 @@ fn gitoxide_clones_registry_with_shallow_protocol_and_follow_up_with_git2_fetch(
             .all()?
             .count(),
         3,
-        "an entirely new repo was cloned which is never shallow"
+        "an entirely new repo was fetched which is never shallow"
     );
     assert!(!repo.is_shallow());
     Ok(())
 }
 
 #[cargo_test]
-fn gitoxide_clones_git_dependency_with_shallow_protocol_and_git2_is_used_for_followup_fetches(
+fn gitoxide_fetch_git_dependency_with_shallow_protocol_and_git2_is_used_for_followup_fetches(
 ) -> anyhow::Result<()> {
     // Example where an old lockfile with an explicit branch="master" in Cargo.toml.
     Package::new("bar", "1.0.0").publish();
@@ -245,7 +245,7 @@ fn gitoxide_clones_git_dependency_with_shallow_protocol_and_git2_is_used_for_fol
             .all()?
             .count(),
         1,
-        "db clones are shallow and have a shortened history"
+        "db fetch are shallow and have a shortened history"
     );
 
     let dep_checkout = gix::open_opts(
@@ -256,7 +256,7 @@ fn gitoxide_clones_git_dependency_with_shallow_protocol_and_git2_is_used_for_fol
     assert_eq!(
         dep_checkout.head_id()?.ancestors().all()?.count(),
         1,
-        "db checkouts are hard-linked clones with the shallow file copied separately."
+        "db checkouts are hard-linked fetches with the shallow file copied separately."
     );
 
     bar.change_file("src/lib.rs", "// another change");
@@ -324,7 +324,7 @@ fn gitoxide_clones_git_dependency_with_shallow_protocol_and_git2_is_used_for_fol
 }
 
 #[cargo_test]
-fn gitoxide_shallow_clone_followed_by_non_shallow_update() -> anyhow::Result<()> {
+fn gitoxide_shallow_fetch_followed_by_non_shallow_update() -> anyhow::Result<()> {
     Package::new("bar", "1.0.0").publish();
     let (bar, bar_repo) = git::new_repo("bar", |p| {
         p.file("Cargo.toml", &basic_manifest("bar", "1.0.0"))
@@ -381,7 +381,7 @@ fn gitoxide_shallow_clone_followed_by_non_shallow_update() -> anyhow::Result<()>
             .all()?
             .count(),
         1,
-        "db clones are shallow and have a shortened history"
+        "db fetches are shallow and have a shortened history"
     );
 
     let dep_checkout = gix::open_opts(
@@ -392,7 +392,7 @@ fn gitoxide_shallow_clone_followed_by_non_shallow_update() -> anyhow::Result<()>
     assert_eq!(
         dep_checkout.head_id()?.ancestors().all()?.count(),
         1,
-        "db checkouts are hard-linked clones with the shallow file copied separately."
+        "db checkouts are hard-linked fetches with the shallow file copied separately."
     );
 
     bar.change_file("src/lib.rs", "// another change");
@@ -463,7 +463,7 @@ fn gitoxide_shallow_clone_followed_by_non_shallow_update() -> anyhow::Result<()>
 }
 
 #[cargo_test]
-fn gitoxide_clones_registry_with_shallow_protocol_and_follow_up_fetch_maintains_shallowness(
+fn gitoxide_fetch_registry_with_shallow_protocol_and_follow_up_fetch_maintains_shallowness(
 ) -> anyhow::Result<()> {
     Package::new("bar", "1.0.0").publish();
     let p = project()
@@ -493,7 +493,7 @@ fn gitoxide_clones_registry_with_shallow_protocol_and_follow_up_fetch_maintains_
             .all()?
             .count(),
         1,
-        "shallow clones always start at depth of 1 to minimize download size"
+        "shallow fetches always start at depth of 1 to minimize download size"
     );
     assert!(repo.is_shallow());
 
@@ -535,9 +535,9 @@ fn gitoxide_clones_registry_with_shallow_protocol_and_follow_up_fetch_maintains_
     Ok(())
 }
 
-/// If there is shallow *and* non-shallow clones, non-shallow will naturally be returned due to sort order.
+/// If there is shallow *and* non-shallow fetches, non-shallow will naturally be returned due to sort order.
 #[cargo_test]
-fn gitoxide_clones_registry_without_shallow_protocol_and_follow_up_fetch_uses_shallowness(
+fn gitoxide_fetch_registry_without_shallow_protocol_and_follow_up_fetch_uses_shallowness(
 ) -> anyhow::Result<()> {
     Package::new("bar", "1.0.0").publish();
     let p = project()
@@ -587,7 +587,7 @@ fn gitoxide_clones_registry_without_shallow_protocol_and_follow_up_fetch_uses_sh
             .all()?
             .count(),
         1,
-        "the follow up clones an entirely new index which is now shallow and which is in its own location"
+        "the follow up fetch an entirely new index which is now shallow and which is in its own location"
     );
     assert!(shallow_repo.is_shallow());
 
@@ -630,14 +630,14 @@ fn gitoxide_clones_registry_without_shallow_protocol_and_follow_up_fetch_uses_sh
 #[cargo_test]
 fn gitoxide_git_dependencies_switch_from_branch_to_rev() -> anyhow::Result<()> {
     // db exists from previous build, then dependency changes to refer to revision that isn't
-    // available in the shallow clone.
+    // available in the shallow fetch.
 
     let (bar, bar_repo) = git::new_repo("bar", |p| {
         p.file("Cargo.toml", &basic_manifest("bar", "1.0.0"))
             .file("src/lib.rs", "")
     });
 
-    // this commit would not be available in a shallow clone.
+    // this commit would not be available in a shallow fetch.
     let first_commit_pre_change = bar_repo.head().unwrap().target().unwrap();
 
     bar.change_file("src/lib.rs", "// change");
@@ -713,7 +713,7 @@ fn shallow_deps_work_with_revisions_and_branches_mixed_on_same_dependency() -> a
             .file("src/lib.rs", "")
     });
 
-    // this commit would not be available in a shallow clone.
+    // this commit would not be available in a shallow fetch.
     let first_commit_pre_change = bar_repo.head().unwrap().target().unwrap();
 
     bar.change_file("src/lib.rs", "// change");
@@ -765,8 +765,8 @@ fn shallow_deps_work_with_revisions_and_branches_mixed_on_same_dependency() -> a
 }
 
 #[cargo_test]
-fn gitoxide_clones_registry_with_shallow_protocol_and_aborts_and_updates_again(
-) -> anyhow::Result<()> {
+fn gitoxide_fetch_registry_with_shallow_protocol_and_aborts_and_updates_again() -> anyhow::Result<()>
+{
     Package::new("bar", "1.0.0").publish();
     let p = project()
         .file(
@@ -795,11 +795,11 @@ fn gitoxide_clones_registry_with_shallow_protocol_and_aborts_and_updates_again(
             .all()?
             .count(),
         1,
-        "shallow clones always start at depth of 1 to minimize download size"
+        "shallow fetches always start at depth of 1 to minimize download size"
     );
     assert!(repo.is_shallow());
     let shallow_lock = repo.shallow_file().with_extension("lock");
-    // adding a lock file and deleting the original simulates a left-over clone that was aborted, leaving a lock file
+    // adding a lock file and deleting the original simulates a left-over fetch that was aborted, leaving a lock file
     // in place without ever having moved it to the right location.
     std::fs::write(&shallow_lock, &[])?;
     std::fs::remove_file(repo.shallow_file())?;
@@ -819,7 +819,7 @@ fn gitoxide_clones_registry_with_shallow_protocol_and_aborts_and_updates_again(
             .all()?
             .count(),
         1,
-        "it's a fresh shallow clone - otherwise it would have 2 commits if the previous shallow clone would still be present"
+        "it's a fresh shallow fetch - otherwise it would have 2 commits if the previous shallow fetch would still be present"
     );
 
     Ok(())

--- a/tests/testsuite/git_shallow.rs
+++ b/tests/testsuite/git_shallow.rs
@@ -9,9 +9,27 @@ enum Backend {
     Gitoxide,
 }
 
+impl Backend {
+    fn to_arg(&self) -> &'static str {
+        match self {
+            Backend::Git2 => "",
+            Backend::Gitoxide => "-Zgitoxide=fetch",
+        }
+    }
+}
+
 enum RepoMode {
     Shallow,
     Complete,
+}
+
+impl RepoMode {
+    fn to_deps_arg(&self) -> &'static str {
+        match self {
+            RepoMode::Complete => "",
+            RepoMode::Shallow => "-Zgit=shallow-deps",
+        }
+    }
 }
 
 #[cargo_test]
@@ -102,17 +120,9 @@ fn fetch_two_revs_same_deps(backend: Backend, mode: RepoMode) {
         )
         .build();
 
-    let backend_args = match backend {
-        Backend::Git2 => "",
-        Backend::Gitoxide => "-Zgitoxide=fetch",
-    };
-    let mode_args = match mode {
-        RepoMode::Complete => "",
-        RepoMode::Shallow => "-Zgit=shallow-deps",
-    };
     foo.cargo("check -v")
-        .arg_line(backend_args)
-        .arg_line(mode_args)
+        .arg_line(backend.to_arg())
+        .arg_line(mode.to_deps_arg())
         .env("__CARGO_USE_GITOXIDE_INSTEAD_OF_GIT2", "0") // respect `backend`
         .masquerade_as_nightly_cargo(&["gitoxide=fetch", "git=shallow-deps"])
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

When looking to add shallow fetch for the git CLI, I found it hard to tell what we test.  This tries to clean up the tests and make it easier to add new ones.  My hope is to later generalize the test bodies so we can more easily test any git backend in any combination of shallow or deep fetches.

This is part of #13285.

### How should we test and review this PR?



### Additional information

