### PR TITLE
fix: add error message for github PR url in dep

### DIFF
--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -2152,6 +2152,37 @@ Caused by:
 }
 
 #[cargo_test]
+fn github_pull_request_url() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                edition = "2015"
+                authors = []
+
+                [dependencies.bar]
+                git = "https://github.com/foo/bar/pull/123"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check -v")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
+
+Caused by:
+  dependency (bar) specifies a GitHub pull request link. If you were trying to specify a specific github PR, replace the URL with the git URL (e.g. `git = "https://github.com/foo/bar.git"`) and add `rev = "refs/pull/123/head"` in the dependency declaration.
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn fragment_in_git_url() {
     let p = project()
         .file(


### PR DESCRIPTION
Prior to this, using a github PR URL would cause cargo to attempt to
fetch from an incorrect URL several times before failing.
Providing a github pull request url now fails with an error message
that shows how to fix the problem.

E.g.:
```toml
bar = { git = "https://github.com/foo/bar/pull/123" }
```
Now gives the following error message:
```
dependency (bar) specifies a GitHub pull request link. If you were trying to specify a specific github PR, replace the URL with the git URL (e.g. `git = "https://github.com/foo/bar.git"`) and add `rev = "refs/pull/123/head"` in the dependency declaration.
```

Fixes: #15001

<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Passing a github PR issue url as the URL for a dependency causes cargo to attempt to incorrectly fetch from the wrong URL. Instead this PR makes that an error with meaningful next steps.

### How should we test and review this PR?

Unit test for this is added to the test suite which checks that the error message aligns with the expected value.

### Additional information

This could be expanded to other forges (Gitlab, Codeberg, etc.) fairly simply if someone was so inclined, but for now this solves the 99% problem.