### PR TITLE
Conditionally mark the `test` cfg as a well known cfg

### DIFF
--- a/src/doc/src/reference/cargo-targets.md
+++ b/src/doc/src/reference/cargo-targets.md
@@ -216,7 +216,10 @@ the target name.
 ### The `test` field
 
 The `test` field indicates whether or not the target is tested by default by
-[`cargo test`]. The default is `true` for lib, bins, and tests.
+[`cargo test`], and whenever the target is expected to have tests. Warnings
+may be reported when tests are unexpected (i.e., `test = false`).
+
+The default is `true` for lib, bins, and tests.
 
 > **Note**: Examples are built by [`cargo test`] by default to ensure they
 > continue to compile, but they are not *tested* by default. Setting `test =

--- a/tests/testsuite/check_cfg.rs
+++ b/tests/testsuite/check_cfg.rs
@@ -336,17 +336,18 @@ fn test_false_lib() {
         .build();
 
     p.cargo("check -v")
-        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs,test"))
+        .with_stderr_does_not_contain(x!("rustc" => "cfg" of "docsrs,test"))
+        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs"))
         .run();
 
     p.cargo("clean").run();
     p.cargo("test -v")
-        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs,test"))
+        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs"))
         .run();
 
     p.cargo("clean").run();
     p.cargo("test --lib -v")
-        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs,test"))
+        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs"))
         .run();
 }
 
@@ -372,7 +373,8 @@ fn test_false_bins() {
         .build();
 
     p.cargo("check -v")
-        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs,test")) // for foo & deamon
+        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs,test")) // for foo
+        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs")) // for deamon
         .run();
 }
 
@@ -401,7 +403,8 @@ fn test_false_examples() {
         .build();
 
     p.cargo("check --examples -v")
-        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs,test"))
+        .with_stderr_does_not_contain(x!("rustc" => "cfg" of "docsrs,test"))
+        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs"))
         .run();
 }
 

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -4191,7 +4191,19 @@ fn test_hint_workspace_virtual() {
         .file("a/src/lib.rs", "#[test] fn t1() {}")
         .file("b/Cargo.toml", &basic_manifest("b", "0.1.0"))
         .file("b/src/lib.rs", "#[test] fn t1() {assert!(false)}")
-        .file("c/Cargo.toml", &basic_manifest("c", "0.1.0"))
+        .file(
+            "c/Cargo.toml",
+            r#"
+                [package]
+                name = "c"
+                version = "0.1.0"
+                edition = "2015"
+
+                [[example]]
+                name = "ex1"
+                test = true
+            "#,
+        )
         .file(
             "c/src/lib.rs",
             r#"
@@ -4275,14 +4287,17 @@ fn test_hint_workspace_virtual() {
 [ERROR] test failed, to rerun pass `-p c --bin c`
 [RUNNING] tests/t1.rs (target/debug/deps/t1-[HASH][EXE])
 [ERROR] test failed, to rerun pass `-p c --test t1`
+[RUNNING] unittests examples/ex1.rs (target/debug/examples/ex1-[HASH][EXE])
+[ERROR] test failed, to rerun pass `-p c --example ex1`
 [DOCTEST] a
 [DOCTEST] b
 [DOCTEST] c
 [ERROR] doctest failed, to rerun pass `-p c --doc`
-[ERROR] 4 targets failed:
+[ERROR] 5 targets failed:
     `-p b --lib`
     `-p c --bin c`
     `-p c --test t1`
+    `-p c --example ex1`
     `-p c --doc`
 
 "#]])


### PR DESCRIPTION
### What does this PR try to resolve?

This PR conditionally mark the `test` cfg as a well known cfg depending on the target unit "test" field (ie `lib.test = false`, `[[bin]] test = false` and others).

This is related to https://github.com/rust-lang/rust/issues/117778 and https://users.rust-lang.org/t/cargo-what-is-the-purpose-of-lib-test-false/102361.

When defining `lib.test = false` (and others), any use of `cfg(test)` will trigger the `unexpected_cfgs` lint. 
```toml
[lib]
test = false  # will now warn on cfg(test) 
```

### How should we test and review this PR?

Best reviewed commit by commit. Second commit removes the `test` cfg from the `--check-cfg` args.

### Additional information

T-compiler [MCP#785](https://github.com/rust-lang/compiler-team/issues/785) and https://github.com/rust-lang/cargo/pull/14963 were of preparatory work.

r? @epage