### PR TITLE
chore: bump gix-lock to remove thiserror@1 from `cargo`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,13 +1529,13 @@ dependencies = [
 
 [[package]]
 name = "gix-lock"
-version = "15.0.0"
+version = "15.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5102acdf4acae2644e38dbbd18cdfba9597a218f7d85f810fe5430207e03c2de"
+checksum = "1cd3ab68a452db63d9f3ebdacb10f30dba1fa0d31ac64f4203d395ed1102d940"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
- "thiserror 1.0.63",
+ "thiserror 2.0.3",
 ]
 
 [[package]]


### PR DESCRIPTION


### What does this PR try to resolve?

A follow-up of #14998

Other dev tools for cargo development are fine keeping v1. They are not shipped to end users.

Before

```
$ cargo tree --workspace -i thiserror@1.0.63
thiserror v1.0.63
├── cargo_metadata v0.19.0
│   └── capture v0.1.0 (/projects/cargo/benches/capture)
├── gix-lock v15.0.0
│   ├── gix v0.69.1
│   │   └── cargo v0.86.0 (/projects/cargo)
│   │       ├── benchsuite v0.0.0 (/projects/cargo/benches/benchsuite)
│   │       ├── resolver-tests v0.0.0 (/projects/cargo/crates/resolver-tests)
│   │       ├── xtask-bump-check v0.0.0 (/projects/cargo/crates/xtask-bump-check)
│   │       └── xtask-lint-docs v0.1.0 (/projects/cargo/crates/xtask-lint-docs)
│   │   [dev-dependencies]
│   │   └── cargo v0.86.0 (/projects/cargo) (*)
│   ├── gix-index v0.37.0
│   │   ├── gix v0.69.1 (*)
│   │   ├── gix-dir v0.11.0
│   │   │   └── gix v0.69.1 (*)
│   │   └── gix-worktree v0.38.0
│   │       ├── gix v0.69.1 (*)
│   │       └── gix-dir v0.11.0 (*)
│   ├── gix-protocol v0.47.0
│   │   └── gix v0.69.1 (*)
│   ├── gix-ref v0.49.1
│   │   ├── gix v0.69.1 (*)
│   │   ├── gix-config v0.42.0
│   │   │   ├── gix v0.69.1 (*)
│   │   │   └── gix-submodule v0.16.0
│   │   │       └── gix v0.69.1 (*)
│   │   ├── gix-discover v0.37.0
│   │   │   ├── gix v0.69.1 (*)
│   │   │   └── gix-dir v0.11.0 (*)
│   │   └── gix-protocol v0.47.0 (*)
│   └── gix-shallow v0.1.0
│       ├── gix v0.69.1 (*)
│       └── gix-protocol v0.47.0 (*)
├── handlebars v6.2.0
│   └── mdman v0.0.0 (/projects/cargo/crates/mdman)
├── pest v2.7.9
│   ├── handlebars v6.2.0 (*)
│   ├── pest_derive v2.7.9 (proc-macro)
│   │   └── handlebars v6.2.0 (*)
│   ├── pest_generator v2.7.9
│   │   └── pest_derive v2.7.9 (proc-macro) (*)
│   └── pest_meta v2.7.9
│       └── pest_generator v2.7.9 (*)
├── varisat v0.2.2
│   └── resolver-tests v0.0.0 (/projects/cargo/crates/resolver-tests)
├── varisat-checker v0.2.2
│   └── varisat v0.2.2 (*)
└── varisat-dimacs v0.2.2
    ├── varisat v0.2.2 (*)
    └── varisat-checker v0.2.2 (*)
```

After

```
$ cargo tree --workspace -i thiserror@1.0.63
thiserror v1.0.63
├── cargo_metadata v0.19.0
│   └── capture v0.1.0 (/projects/cargo/benches/capture)
├── handlebars v6.2.0
│   └── mdman v0.0.0 (/projects/cargo/crates/mdman)
├── pest v2.7.9
│   ├── handlebars v6.2.0 (*)
│   ├── pest_derive v2.7.9 (proc-macro)
│   │   └── handlebars v6.2.0 (*)
│   ├── pest_generator v2.7.9
│   │   └── pest_derive v2.7.9 (proc-macro) (*)
│   └── pest_meta v2.7.9
│       └── pest_generator v2.7.9 (*)
├── varisat v0.2.2
│   └── resolver-tests v0.0.0 (/projects/cargo/crates/resolver-tests)
├── varisat-checker v0.2.2
│   └── varisat v0.2.2 (*)
└── varisat-dimacs v0.2.2
    ├── varisat v0.2.2 (*)
    └── varisat-checker v0.2.2 (*)
```

### How should we test and review this PR?

It has nothing changed but thiserror version.

https://diff.rs/gix-lock/15.0.0/gix-lock/15.0.1/Cargo.toml/