### PR TITLE
Make --allow-dirty imply --allow-staged

### DIFF
--- a/src/bin/cargo/commands/fix.rs
+++ b/src/bin/cargo/commands/fix.rs
@@ -21,7 +21,7 @@ pub fn cli() -> Command {
         ))
         .arg(flag(
             "allow-dirty",
-            "Fix code even if the working directory is dirty",
+            "Fix code even if the working directory is dirty or has staged changes",
         ))
         .arg(flag(
             "allow-staged",
@@ -86,6 +86,8 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
         opts.filter = ops::CompileFilter::new_all_targets();
     }
 
+    let allow_dirty = args.flag("allow-dirty");
+
     ops::fix(
         gctx,
         &ws,
@@ -94,9 +96,9 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
             edition: args.flag("edition"),
             idioms: args.flag("edition-idioms"),
             compile_opts: opts,
-            allow_dirty: args.flag("allow-dirty"),
+            allow_dirty,
+            allow_staged: allow_dirty || args.flag("allow-staged"),
             allow_no_vcs: args.flag("allow-no-vcs"),
-            allow_staged: args.flag("allow-staged"),
             broken_code: args.flag("broken-code"),
             requested_lockfile_path: lockfile_path,
         },

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -242,7 +242,7 @@ fn check_version_control(gctx: &GlobalContext, opts: &FixOptions) -> CargoResult
     bail!(
         "the working directory of this package has uncommitted changes, and \
          `cargo fix` can potentially perform destructive changes; if you'd \
-         like to suppress this error pass `--allow-dirty`, `--allow-staged`, \
+         like to suppress this error pass `--allow-dirty`, \
          or commit the changes to these files:\n\
          \n\
          {}\n\

--- a/src/doc/man/cargo-fix.md
+++ b/src/doc/man/cargo-fix.md
@@ -93,7 +93,7 @@ Fix code even if a VCS was not detected.
 {{/option}}
 
 {{#option "`--allow-dirty`" }}
-Fix code even if the working directory has changes.
+Fix code even if the working directory has changes (including staged changes).
 {{/option}}
 
 {{#option "`--allow-staged`" }}

--- a/src/doc/man/generated_txt/cargo-fix.txt
+++ b/src/doc/man/generated_txt/cargo-fix.txt
@@ -84,7 +84,8 @@ OPTIONS
            Fix code even if a VCS was not detected.
 
        --allow-dirty
-           Fix code even if the working directory has changes.
+           Fix code even if the working directory has changes (including staged
+           changes).
 
        --allow-staged
            Fix code even if the working directory has staged changes.

--- a/src/doc/src/commands/cargo-fix.md
+++ b/src/doc/src/commands/cargo-fix.md
@@ -89,7 +89,7 @@ edition.</dd>
 
 
 <dt class="option-term" id="option-cargo-fix---allow-dirty"><a class="option-anchor" href="#option-cargo-fix---allow-dirty"></a><code>--allow-dirty</code></dt>
-<dd class="option-desc">Fix code even if the working directory has changes.</dd>
+<dd class="option-desc">Fix code even if the working directory has changes (including staged changes).</dd>
 
 
 <dt class="option-term" id="option-cargo-fix---allow-staged"><a class="option-anchor" href="#option-cargo-fix---allow-staged"></a><code>--allow-staged</code></dt>

--- a/src/etc/man/cargo-fix.1
+++ b/src/etc/man/cargo-fix.1
@@ -103,7 +103,7 @@ Fix code even if a VCS was not detected.
 .sp
 \fB\-\-allow\-dirty\fR
 .RS 4
-Fix code even if the working directory has changes.
+Fix code even if the working directory has changes (including staged changes).
 .RE
 .sp
 \fB\-\-allow\-staged\fR

--- a/tests/testsuite/cargo_fix/help/stdout.term.svg
+++ b/tests/testsuite/cargo_fix/help/stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="827px" height="1136px" xmlns="http://www.w3.org/2000/svg">
+<svg width="827px" height="1154px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -37,111 +37,113 @@
 </tspan>
     <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-cyan bold">--allow-no-vcs</tspan><tspan>             Fix code even if a VCS was not detected</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-cyan bold">--allow-dirty</tspan><tspan>              Fix code even if the working directory is dirty</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-cyan bold">--allow-dirty</tspan><tspan>              Fix code even if the working directory is dirty or has staged</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-cyan bold">--allow-staged</tspan><tspan>             Fix code even if the working directory has staged changes</tspan>
+    <tspan x="10px" y="208px"><tspan>                                 changes</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-cyan bold">--message-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>     Error format</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-cyan bold">--allow-staged</tspan><tspan>             Fix code even if the working directory has staged changes</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-cyan bold">--message-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>     Error format</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring: auto, always, never</tspan>
+    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring: auto, always, never</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>                                 details</tspan>
+    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="352px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="370px">
+    <tspan x="10px" y="370px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan class="fg-green bold">Package Selection:</tspan>
+    <tspan x="10px" y="388px">
 </tspan>
-    <tspan x="10px" y="406px"><tspan>  </tspan><tspan class="fg-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package(s) to fix</tspan>
+    <tspan x="10px" y="406px"><tspan class="fg-green bold">Package Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--workspace</tspan><tspan>         Fix all packages in the workspace</tspan>
+    <tspan x="10px" y="424px"><tspan>  </tspan><tspan class="fg-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package(s) to fix</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--exclude</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>    Exclude packages from the fixes</tspan>
+    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--workspace</tspan><tspan>         Fix all packages in the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--all</tspan><tspan>               Alias for --workspace (deprecated)</tspan>
+    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--exclude</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>    Exclude packages from the fixes</tspan>
 </tspan>
-    <tspan x="10px" y="478px">
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--all</tspan><tspan>               Alias for --workspace (deprecated)</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan class="fg-green bold">Target Selection:</tspan>
+    <tspan x="10px" y="496px">
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--lib</tspan><tspan>               Fix only this package's library</tspan>
+    <tspan x="10px" y="514px"><tspan class="fg-green bold">Target Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-cyan bold">--bins</tspan><tspan>              Fix all binaries</tspan>
+    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-cyan bold">--lib</tspan><tspan>               Fix only this package's library</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-cyan bold">--bin</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>      Fix only the specified binary</tspan>
+    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-cyan bold">--bins</tspan><tspan>              Fix all binaries</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-cyan bold">--examples</tspan><tspan>          Fix all examples</tspan>
+    <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-cyan bold">--bin</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>      Fix only the specified binary</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Fix only the specified example</tspan>
+    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-cyan bold">--examples</tspan><tspan>          Fix all examples</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-cyan bold">--tests</tspan><tspan>             Fix all targets that have `test = true` set</tspan>
+    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Fix only the specified example</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-cyan bold">--test</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>     Fix only the specified test target</tspan>
+    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-cyan bold">--tests</tspan><tspan>             Fix all targets that have `test = true` set</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--benches</tspan><tspan>           Fix all targets that have `bench = true` set</tspan>
+    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--test</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>     Fix only the specified test target</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-cyan bold">--bench</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>    Fix only the specified bench target</tspan>
+    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-cyan bold">--benches</tspan><tspan>           Fix all targets that have `bench = true` set</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-targets</tspan><tspan>       Fix all targets (default)</tspan>
+    <tspan x="10px" y="676px"><tspan>      </tspan><tspan class="fg-cyan bold">--bench</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>    Fix only the specified bench target</tspan>
 </tspan>
-    <tspan x="10px" y="694px">
+    <tspan x="10px" y="694px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-targets</tspan><tspan>       Fix all targets (default)</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan class="fg-green bold">Feature Selection:</tspan>
+    <tspan x="10px" y="712px">
 </tspan>
-    <tspan x="10px" y="730px"><tspan>  </tspan><tspan class="fg-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
+    <tspan x="10px" y="730px"><tspan class="fg-green bold">Feature Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="748px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
+    <tspan x="10px" y="748px"><tspan>  </tspan><tspan class="fg-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
 </tspan>
-    <tspan x="10px" y="766px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
+    <tspan x="10px" y="766px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
 </tspan>
-    <tspan x="10px" y="784px">
+    <tspan x="10px" y="784px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan class="fg-green bold">Compilation Options:</tspan>
+    <tspan x="10px" y="802px">
 </tspan>
-    <tspan x="10px" y="820px"><tspan>  </tspan><tspan class="fg-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
+    <tspan x="10px" y="820px"><tspan class="fg-green bold">Compilation Options:</tspan>
 </tspan>
-    <tspan x="10px" y="838px"><tspan>      </tspan><tspan class="fg-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
+    <tspan x="10px" y="838px"><tspan>  </tspan><tspan class="fg-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
 </tspan>
-    <tspan x="10px" y="856px"><tspan>  </tspan><tspan class="fg-cyan bold">-r</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--release</tspan><tspan>                 Fix artifacts in release mode, with optimizations</tspan>
+    <tspan x="10px" y="856px"><tspan>      </tspan><tspan class="fg-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
 </tspan>
-    <tspan x="10px" y="874px"><tspan>      </tspan><tspan class="fg-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Build artifacts with the specified profile</tspan>
+    <tspan x="10px" y="874px"><tspan>  </tspan><tspan class="fg-cyan bold">-r</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--release</tspan><tspan>                 Fix artifacts in release mode, with optimizations</tspan>
 </tspan>
-    <tspan x="10px" y="892px"><tspan>      </tspan><tspan class="fg-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Fix for the target triple</tspan>
+    <tspan x="10px" y="892px"><tspan>      </tspan><tspan class="fg-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Build artifacts with the specified profile</tspan>
 </tspan>
-    <tspan x="10px" y="910px"><tspan>      </tspan><tspan class="fg-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
+    <tspan x="10px" y="910px"><tspan>      </tspan><tspan class="fg-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Fix for the target triple</tspan>
 </tspan>
-    <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
+    <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
 </tspan>
-    <tspan x="10px" y="946px">
+    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
 </tspan>
-    <tspan x="10px" y="964px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="964px">
 </tspan>
-    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="982px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
+    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
+    <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="1036px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="1036px"><tspan>      </tspan><tspan class="fg-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
 </tspan>
-    <tspan x="10px" y="1054px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="1054px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="1072px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="1072px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="1090px">
+    <tspan x="10px" y="1090px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
-    <tspan x="10px" y="1108px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help fix</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="1108px">
 </tspan>
-    <tspan x="10px" y="1126px">
+    <tspan x="10px" y="1126px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help fix</tspan><tspan class="bold">` for more detailed information.</tspan>
+</tspan>
+    <tspan x="10px" y="1144px">
 </tspan>
   </text>
 

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -635,7 +635,7 @@ fn warns_about_dirty_working_directory() {
     p.cargo("fix")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] the working directory of this package has uncommitted changes, and `cargo fix` can potentially perform destructive changes; if you'd like to suppress this error pass `--allow-dirty`, `--allow-staged`, or commit the changes to these files:
+[ERROR] the working directory of this package has uncommitted changes, and `cargo fix` can potentially perform destructive changes; if you'd like to suppress this error pass `--allow-dirty`, or commit the changes to these files:
 
   * src/lib.rs (dirty)
 
@@ -656,7 +656,7 @@ fn warns_about_staged_working_directory() {
     p.cargo("fix")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] the working directory of this package has uncommitted changes, and `cargo fix` can potentially perform destructive changes; if you'd like to suppress this error pass `--allow-dirty`, `--allow-staged`, or commit the changes to these files:
+[ERROR] the working directory of this package has uncommitted changes, and `cargo fix` can potentially perform destructive changes; if you'd like to suppress this error pass `--allow-dirty`, or commit the changes to these files:
 
   * src/lib.rs (staged)
 
@@ -677,7 +677,7 @@ fn errors_about_untracked_files() {
     p.cargo("fix")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] the working directory of this package has uncommitted changes, and `cargo fix` can potentially perform destructive changes; if you'd like to suppress this error pass `--allow-dirty`, `--allow-staged`, or commit the changes to these files:
+[ERROR] the working directory of this package has uncommitted changes, and `cargo fix` can potentially perform destructive changes; if you'd like to suppress this error pass `--allow-dirty`, or commit the changes to these files:
 
   * Cargo.toml (dirty)
   * src/ (dirty)


### PR DESCRIPTION
Staged changes don't really need protecting, and `--allow-dirty` is stronger than `--allow-staged`, so it can imply `--allow-staged` to make usage of `cargo fix` less verbose.

Closes #14176
