### PR TITLE
Fix https::self_signed_should_fail for macos

### DIFF
--- a/tests/testsuite/https.rs
+++ b/tests/testsuite/https.rs
@@ -33,7 +33,7 @@ fn self_signed_should_fail() {
         .build();
     // I think the text here depends on the curl backend.
     let err_msg = if cfg!(target_os = "macos") {
-        "untrusted connection error; class=Ssl (16); code=Certificate (-17)"
+        "untrusted connection error; class=Ssl (16)[..]"
     } else if cfg!(unix) {
         "the SSL certificate is invalid; class=Ssl (16)[..]"
     } else if cfg!(windows) {


### PR DESCRIPTION
This no longer generates the same error message for the same reason that it changed for linux in https://github.com/rust-lang/cargo/pull/13970.

Note that Windows does things slightly differently, and doesn't need adjustment.
