### PR TITLE
Avoid naming variables `str`

### DIFF
--- a/src/cargo/util/context/de.rs
+++ b/src/cargo/util/context/de.rs
@@ -531,11 +531,11 @@ impl<'de, 'gctx> de::MapAccess<'de> for ValueDeserializer<'gctx> {
                 seed.deserialize(Tuple2Deserializer(1i32, env.as_str()))
             }
             Definition::Cli(path) => {
-                let str = path
+                let s = path
                     .as_ref()
                     .map(|p| p.to_string_lossy())
                     .unwrap_or_default();
-                seed.deserialize(Tuple2Deserializer(2i32, str))
+                seed.deserialize(Tuple2Deserializer(2i32, s))
             }
         }
     }

--- a/src/cargo/util/interning.rs
+++ b/src/cargo/util/interning.rs
@@ -72,14 +72,14 @@ impl<'a> PartialEq<&'a str> for InternedString {
 impl Eq for InternedString {}
 
 impl InternedString {
-    pub fn new(str: &str) -> InternedString {
-        InternedString::from_cow(str.into())
+    pub fn new(s: &str) -> InternedString {
+        InternedString::from_cow(s.into())
     }
 
-    fn from_cow<'a>(str: Cow<'a, str>) -> InternedString {
+    fn from_cow<'a>(cs: Cow<'a, str>) -> InternedString {
         let mut cache = interned_storage();
-        let s = cache.get(str.as_ref()).copied().unwrap_or_else(|| {
-            let s = str.into_owned().leak();
+        let s = cache.get(cs.as_ref()).copied().unwrap_or_else(|| {
+            let s = cs.into_owned().leak();
             cache.insert(s);
             s
         });


### PR DESCRIPTION
This renames variables named `str` to other names, to make sure `str`
always refers to a type.
