### PR TITLE
Setup cargo environment for `cargo rustc --print`

### DIFF
--- a/src/cargo/ops/cargo_compile/mod.rs
+++ b/src/cargo/ops/cargo_compile/mod.rs
@@ -41,7 +41,7 @@ use std::sync::Arc;
 
 use crate::core::compiler::unit_dependencies::build_unit_dependencies;
 use crate::core::compiler::unit_graph::{self, UnitDep, UnitGraph};
-use crate::core::compiler::{standard_lib, CrateType, TargetInfo};
+use crate::core::compiler::{apply_env_config, standard_lib, CrateType, TargetInfo};
 use crate::core::compiler::{BuildConfig, BuildContext, BuildRunner, Compilation};
 use crate::core::compiler::{CompileKind, CompileMode, CompileTarget, RustcTargetData, Unit};
 use crate::core::compiler::{DefaultExecutor, Executor, UnitInterner};
@@ -188,6 +188,7 @@ pub fn print<'a>(
         }
         let target_info = TargetInfo::new(gctx, &build_config.requested_kinds, &rustc, *kind)?;
         let mut process = rustc.process();
+        apply_env_config(gctx, &mut process)?;
         process.args(&target_info.rustflags);
         if let Some(args) = target_rustc_args {
             process.args(args);

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -795,6 +795,38 @@ windows
 }
 
 #[cargo_test]
+fn rustc_with_print_cfg_config_toml_env() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file(
+            "targets/best-target.json",
+            r#"{
+  "llvm-target": "x86_64-unknown-none",
+  "target-pointer-width": "64",
+  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
+  "arch": "x86_64"
+}"#,
+        )
+        .file(
+            ".cargo/config.toml",
+            r#"
+[build]
+target = "best-target"
+[env]
+RUST_TARGET_PATH = { value = "./targets", relative = true }
+"#,
+        )
+        .file("src/main.rs", r#"fn main() {} "#)
+        .build();
+
+    p.cargo("rustc -Z unstable-options --print cfg")
+        .masquerade_as_nightly_cargo(&["print"])
+        .with_status(101)
+        .with_stdout_data(str!["..."].unordered())
+        .run();
+}
+
+#[cargo_test]
 fn precedence() {
     // Ensure that the precedence of cargo-rustc is only lower than RUSTFLAGS,
     // but higher than most flags set by cargo.

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -821,7 +821,6 @@ RUST_TARGET_PATH = { value = "./targets", relative = true }
 
     p.cargo("rustc -Z unstable-options --print cfg")
         .masquerade_as_nightly_cargo(&["print"])
-        .with_status(101)
         .with_stdout_data(str!["..."].unordered())
         .run();
 }


### PR DESCRIPTION
It turns out, running `cargo rustc --print cfg -Zunstable-options` (and the like, https://github.com/rust-lang/cargo/issues/9357) fail with `.cargo/config.toml` setups like
```toml
[build]
# custom target json that lives in `./targets/my-super-cool-target.json`
target = "my-super-cool-target"

[env]
RUST_TARGET_PATH = { value = "./targets", relative = true }
```
resulting in
```

❯ cargo rustc --print cfg -Zunstable-options
error: Error loading target specification: Could not find specification for target "my-super-cool-target". Run `rustc --print target-list` for a list of built-in targets

error: process didn't exit successfully: `C:\Users\lukas\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\bin\rustc.exe --target my-super-cool-target --print cfg` (exit code: 1)
```

The reason for that is that cargo recognizes the target from the `.cargo/config` and then implicitly passes that along to the spawned rustc process, but it does so without passing along the important environment that is required for the target tuple to make sense.

(can add a test if desired, just tell me where)
