### PR TITLE
fix: emit warnings as warnings when learning rust target info

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,6 +161,7 @@ jobs:
     - run: rustup update --no-self-update stable
     - run: rustup update --no-self-update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
     - run: rustup target add ${{ matrix.other }}
+    - run: rustup target add wasm32-unknown-unknown
     - run: rustup target add aarch64-unknown-none # need this for build-std mock tests
       if: startsWith(matrix.rust, 'nightly')
     - run: rustup component add rustc-dev llvm-tools-preview rust-docs
@@ -225,6 +226,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: rustup update --no-self-update stable && rustup default stable
       - run: rustup target add i686-unknown-linux-gnu
+      - run: rustup target add wasm32-unknown-unknown
       - run: sudo apt update -y && sudo apt install gcc-multilib libsecret-1-0 libsecret-1-dev -y
       - run: rustup component add rustfmt || echo "rustfmt not available"
       - run: cargo test -p cargo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,7 +456,7 @@ version = "0.4.0"
 
 [[package]]
 name = "cargo-test-support"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ cargo-credential-macos-keychain = { version = "0.4.7", path = "credential/cargo-
 cargo-credential-wincred = { version = "0.4.7", path = "credential/cargo-credential-wincred" }
 cargo-platform = { path = "crates/cargo-platform", version = "0.2.0" }
 cargo-test-macro = { version = "0.4.0", path = "crates/cargo-test-macro" }
-cargo-test-support = { version = "0.7.0", path = "crates/cargo-test-support" }
+cargo-test-support = { version = "0.7.1", path = "crates/cargo-test-support" }
 cargo-util = { version = "0.2.14", path = "crates/cargo-util" }
 cargo-util-schemas = { version = "0.7.0", path = "crates/cargo-util-schemas" }
 cargo_metadata = "0.19.0"

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-test-support"
-version = "0.7.0"
+version = "0.7.1"
 edition.workspace = true
 rust-version = "1.83"  # MSRV:1
 license.workspace = true

--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -206,6 +206,10 @@ impl TargetInfo {
             process.arg("--print=crate-name"); // `___` as a delimiter.
             process.arg("--print=cfg");
 
+            // parse_crate_type() relies on "unsupported/unknown crate type" error message,
+            // so make warnings always emitted as warnings.
+            process.arg("-Wwarnings");
+
             let (output, error) = rustc
                 .cached_output(&process, extra_fingerprint)
                 .with_context(|| {

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -1287,11 +1287,11 @@ fn always_emit_warnings_as_warnings_when_learning_target_info() {
     p.cargo("build -v --target")
         .env("RUSTFLAGS", "-Awarnings")
         .arg(target)
-        .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] output of --print=file-names missing when learning about target-specific information from rustc
-command was: `rustc - --crate-name ___ --print=file-names -Awarnings --target wasm32-unknown-unknown --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib --crate-type proc-macro --print=sysroot --print=split-debuginfo --print=crate-name --print=cfg`
-...
+[COMPILING] foo v0.0.0 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]-Awarnings[..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
 "#]])
         .run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?

This is a horrible hack,
which lets the rustc invocation for learning target info always emit warnings as warnings.
But at least it unblocks people who pass `-Awarnings` via RUSTFLAGS.

A long-term solution is a better interface
between build systems and the compiler.
See the discussion on Zulip:
https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/Improving.20communication.20interface.20between.20cargo.2Frustc

Fixes rust-lang/cargo#8010

### How should we test and review this PR?

Ensure `CFG_DISABLE_CROSS_TESTS` is not set,
and run `cargo t --test testsuite always_emit_warnings_as_warnings_when_learning_target_info`

This also additionally adds `wasm32-unknown-unknown` target to Cargo's CI.

### Additional information