### PR TITLE
Remove unnecessary into conversions

### DIFF
--- a/src/cargo/sources/git/known_hosts.rs
+++ b/src/cargo/sources/git/known_hosts.rs
@@ -100,7 +100,7 @@ enum KnownHostError {
 
 impl From<anyhow::Error> for KnownHostError {
     fn from(err: anyhow::Error) -> KnownHostError {
-        KnownHostError::CheckError(err.into())
+        KnownHostError::CheckError(err)
     }
 }
 

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -1187,7 +1187,7 @@ fn fetch_with_gitoxide(
                     );
                     let outcome = connection
                         .prepare_fetch(&mut progress, gix::remote::ref_map::Options::default())?
-                        .with_shallow(shallow.clone().into())
+                        .with_shallow(shallow.clone())
                         .receive(&mut progress, should_interrupt)?;
                     Ok(outcome)
                 });


### PR DESCRIPTION
"identity" `.into()` calls where the base's type isn't changed is a future compatibility foot-gun (like the issue we had with `time` a few months ago) as new `impl Into` blocks can cause previously compiling code to start failing. I don't foresee these ones in particular causing problems anytime soon, but I noticed them and might as well clean them up as a drive-by.