### PR TITLE
Make target dir self-ignoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util"
-version = "0.2.30"
+version = "0.2.31"
 dependencies = [
  "anyhow",
  "core-foundation",

--- a/crates/cargo-util/Cargo.toml
+++ b/crates/cargo-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-util"
-version = "0.2.30"
+version = "0.2.31"
 rust-version = "1.95"  # MSRV:1
 edition.workspace = true
 license.workspace = true

--- a/crates/cargo-util/src/paths.rs
+++ b/crates/cargo-util/src/paths.rs
@@ -766,6 +766,7 @@ pub fn create_dir_all_excluded_from_backups_atomic(p: impl AsRef<Path>) -> Resul
     let tempdir = TempFileBuilder::new().prefix(base).tempdir_in(parent)?;
     exclude_from_backups(tempdir.path());
     exclude_from_content_indexing(tempdir.path());
+    exclude_from_version_control(tempdir.path());
     // Previously std::fs::create_dir_all() (through paths::create_dir_all()) was used
     // here to create the directory directly and fs::create_dir_all() explicitly treats
     // the directory being created concurrently by another thread or process as success,
@@ -839,6 +840,28 @@ fn exclude_from_content_indexing(path: &Path) {
     #[cfg(not(windows))]
     {
         let _ = path;
+    }
+}
+
+/// Marks the directory as ignored by Git and compatible VCS.
+///
+/// This is recommended to prevent derived/temporary files from bloating VCS
+/// repositories. It is achieved by writing the content "*" to a ".gitignore"
+/// file in the directory.
+///
+/// Another way to do this is to write the path to the top-level .gitignore
+/// file. Cargo already does this, but it has a downside: When a previous
+/// revision of a project is checked out where the path was not yet added
+/// to the top-level .gitignore file, the directory may accidentally become
+/// tracked later. Adding a .gitignore file with the content "*" to the ignored
+/// directory itself avoids this problem, since it will still be present if an
+/// old revision is checked out.
+fn exclude_from_version_control(path: &Path) {
+    let file = path.join(".gitignore");
+    if !file.exists() {
+        // Similarly to exclude_from_time_machine_and_cloud_sync() we ignore
+        // errors here as it's an optional feature.
+        let _ = std::fs::write(file, "*\n");
     }
 }
 

--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -39,6 +39,7 @@ fn binary_with_debug() {
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/.gitignore
 [ROOT]/foo/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
@@ -54,6 +55,7 @@ fn binary_with_debug() {
         .join("target-dir")
         .assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target-dir/CACHEDIR.TAG
+[ROOT]/foo/target-dir/.gitignore
 [ROOT]/foo/target-dir/debug/.cargo-lock
 [ROOT]/foo/target-dir/debug/.cargo-artifact-lock
 [ROOT]/foo/target-dir/debug/foo[EXE]
@@ -95,6 +97,7 @@ fn binary_with_release() {
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/.gitignore
 [ROOT]/foo/build-dir/release/.cargo-build-lock
 [ROOT]/foo/build-dir/release/build/foo/[HASH]/fingerprint/bin-foo
 [ROOT]/foo/build-dir/release/build/foo/[HASH]/fingerprint/bin-foo.json
@@ -110,6 +113,7 @@ fn binary_with_release() {
         .join("target-dir")
         .assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target-dir/CACHEDIR.TAG
+[ROOT]/foo/target-dir/.gitignore
 [ROOT]/foo/target-dir/release/.cargo-lock
 [ROOT]/foo/target-dir/release/.cargo-artifact-lock
 [ROOT]/foo/target-dir/release/foo[EXE]
@@ -206,6 +210,7 @@ fn should_default_to_target() {
     p.root().join("target").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target/.rustc_info.json
 [ROOT]/foo/target/CACHEDIR.TAG
+[ROOT]/foo/target/.gitignore
 [ROOT]/foo/target/debug/.cargo-lock
 [ROOT]/foo/target/debug/.cargo-artifact-lock
 [ROOT]/foo/target/debug/.cargo-build-lock
@@ -237,6 +242,7 @@ fn should_respect_env_var() {
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/.gitignore
 [ROOT]/foo/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
@@ -282,6 +288,7 @@ fn build_script_should_output_to_build_dir() {
 
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/.gitignore
 [ROOT]/foo/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo.txt
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/build_script_build.d
@@ -344,6 +351,7 @@ fn cargo_tmpdir_should_output_to_build_dir() {
 
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/.gitignore
 [ROOT]/foo/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo-[HASH].d
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo.d
@@ -375,6 +383,7 @@ fn cargo_tmpdir_should_output_to_build_dir() {
         .join("target-dir")
         .assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target-dir/CACHEDIR.TAG
+[ROOT]/foo/target-dir/.gitignore
 [ROOT]/foo/target-dir/debug/.cargo-lock
 [ROOT]/foo/target-dir/debug/.cargo-artifact-lock
 [ROOT]/foo/target-dir/debug/foo[EXE]
@@ -405,6 +414,7 @@ fn examples_should_output_to_build_dir_and_uplift_to_target_dir() {
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/.gitignore
 [ROOT]/foo/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-example-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/example-foo
@@ -422,6 +432,7 @@ fn examples_should_output_to_build_dir_and_uplift_to_target_dir() {
         .join("target-dir")
         .assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target-dir/CACHEDIR.TAG
+[ROOT]/foo/target-dir/.gitignore
 [ROOT]/foo/target-dir/debug/.cargo-lock
 [ROOT]/foo/target-dir/debug/.cargo-artifact-lock
 [ROOT]/foo/target-dir/debug/examples/foo[EXE]
@@ -452,6 +463,7 @@ fn benches_should_output_to_build_dir() {
 
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/.gitignore
 [ROOT]/foo/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo-[HASH].d
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
@@ -475,6 +487,7 @@ fn benches_should_output_to_build_dir() {
         .join("target-dir")
         .assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target-dir/CACHEDIR.TAG
+[ROOT]/foo/target-dir/.gitignore
 [ROOT]/foo/target-dir/debug/.cargo-lock
 [ROOT]/foo/target-dir/debug/.cargo-artifact-lock
 [ROOT]/foo/target-dir/debug/foo[EXE]
@@ -536,6 +549,7 @@ fn cargo_rustdoc_json_should_output_to_target_dir() {
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/.rustdoc_fingerprint.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/.gitignore
 [ROOT]/foo/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/doc-lib-foo
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/doc-lib-foo.json
@@ -589,6 +603,7 @@ fn cargo_package_should_build_in_build_dir_and_output_to_target_dir() {
 [ROOT]/foo/build-dir/package/foo-0.0.1/Cargo.toml.orig
 [ROOT]/foo/build-dir/package/foo-0.0.1/src/main.rs
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/.gitignore
 [ROOT]/foo/build-dir/package/tmp-crate/foo-0.0.1.crate
 
 "#]]);
@@ -598,6 +613,7 @@ fn cargo_package_should_build_in_build_dir_and_output_to_target_dir() {
         .assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target-dir/package/foo-0.0.1.crate
 [ROOT]/foo/target-dir/CACHEDIR.TAG
+[ROOT]/foo/target-dir/.gitignore
 
 "#]]);
 }
@@ -655,6 +671,7 @@ fn cargo_clean_should_clean_the_target_dir_and_build_dir() {
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/.gitignore
 [ROOT]/foo/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
@@ -670,6 +687,7 @@ fn cargo_clean_should_clean_the_target_dir_and_build_dir() {
         .join("target-dir")
         .assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target-dir/CACHEDIR.TAG
+[ROOT]/foo/target-dir/.gitignore
 [ROOT]/foo/target-dir/debug/.cargo-lock
 [ROOT]/foo/target-dir/debug/.cargo-artifact-lock
 [ROOT]/foo/target-dir/debug/foo[EXE]
@@ -726,6 +744,7 @@ fn cargo_clean_should_remove_correct_files() {
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/.gitignore
 [ROOT]/foo/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/build-dir/debug/build/bar/[HASH]/out/bar-[HASH].d
 [ROOT]/foo/build-dir/debug/build/bar/[HASH]/out/libbar-[HASH].rlib
@@ -753,6 +772,7 @@ fn cargo_clean_should_remove_correct_files() {
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/.gitignore
 [ROOT]/foo/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
@@ -889,6 +909,7 @@ fn template_workspace_root() {
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/.gitignore
 [ROOT]/foo/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
@@ -904,6 +925,7 @@ fn template_workspace_root() {
         .join("target-dir")
         .assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target-dir/CACHEDIR.TAG
+[ROOT]/foo/target-dir/.gitignore
 [ROOT]/foo/target-dir/debug/.cargo-lock
 [ROOT]/foo/target-dir/debug/.cargo-artifact-lock
 [ROOT]/foo/target-dir/debug/foo[EXE]
@@ -938,6 +960,7 @@ fn template_cargo_cache_home() {
         .assert_build_dir_layout(str![[r#"
 [ROOT]/home/.cargo/build-dir/.rustc_info.json
 [ROOT]/home/.cargo/build-dir/CACHEDIR.TAG
+[ROOT]/home/.cargo/build-dir/.gitignore
 [ROOT]/home/.cargo/build-dir/debug/.cargo-build-lock
 [ROOT]/home/.cargo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo
 [ROOT]/home/.cargo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
@@ -953,6 +976,7 @@ fn template_cargo_cache_home() {
         .join("target-dir")
         .assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target-dir/CACHEDIR.TAG
+[ROOT]/foo/target-dir/.gitignore
 [ROOT]/foo/target-dir/debug/.cargo-lock
 [ROOT]/foo/target-dir/debug/.cargo-artifact-lock
 [ROOT]/foo/target-dir/debug/foo[EXE]
@@ -1001,6 +1025,7 @@ fn template_workspace_path_hash() {
     build_dir.assert_build_dir_layout(str![[r#"
 [ROOT]/foo/foo/[HASH]/build-dir/.rustc_info.json
 [ROOT]/foo/foo/[HASH]/build-dir/CACHEDIR.TAG
+[ROOT]/foo/foo/[HASH]/build-dir/.gitignore
 [ROOT]/foo/foo/[HASH]/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
@@ -1016,6 +1041,7 @@ fn template_workspace_path_hash() {
         .join("target-dir")
         .assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target-dir/CACHEDIR.TAG
+[ROOT]/foo/target-dir/.gitignore
 [ROOT]/foo/target-dir/debug/.cargo-lock
 [ROOT]/foo/target-dir/debug/.cargo-artifact-lock
 [ROOT]/foo/target-dir/debug/foo[EXE]
@@ -1070,6 +1096,7 @@ fn template_workspace_path_hash_should_handle_symlink() {
     original_hash_dir.assert_build_dir_layout(str![[r#"
 [ROOT]/foo/foo/[HASH]/build-dir/.rustc_info.json
 [ROOT]/foo/foo/[HASH]/build-dir/CACHEDIR.TAG
+[ROOT]/foo/foo/[HASH]/build-dir/.gitignore
 [ROOT]/foo/foo/[HASH]/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/dep-lib-foo
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
@@ -1083,6 +1110,7 @@ fn template_workspace_path_hash_should_handle_symlink() {
 
     p.root().join("target").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target/CACHEDIR.TAG
+[ROOT]/foo/target/.gitignore
 [ROOT]/foo/target/debug/.cargo-lock
 
 "#]]);
@@ -1110,6 +1138,7 @@ fn template_workspace_path_hash_should_handle_symlink() {
     symlink_hash_dir.assert_build_dir_layout(str![[r#"
 [ROOT]/foo/foo/[HASH]/build-dir/.rustc_info.json
 [ROOT]/foo/foo/[HASH]/build-dir/CACHEDIR.TAG
+[ROOT]/foo/foo/[HASH]/build-dir/.gitignore
 [ROOT]/foo/foo/[HASH]/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/dep-lib-foo
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
@@ -1123,6 +1152,7 @@ fn template_workspace_path_hash_should_handle_symlink() {
 
     p.root().join("target").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target/CACHEDIR.TAG
+[ROOT]/foo/target/.gitignore
 [ROOT]/foo/target/debug/.cargo-lock
 
 "#]]);
@@ -1244,6 +1274,7 @@ CARGO_BIN_FILE_BAR_bar=[ROOT]/foo/build-dir/debug/build/bar/[HASH]/artifact/bin/
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/.gitignore
 [ROOT]/foo/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/build-dir/debug/build/bar/[HASH]/fingerprint/bin-bar
 [ROOT]/foo/build-dir/debug/build/bar/[HASH]/fingerprint/bin-bar.json
@@ -1264,6 +1295,7 @@ CARGO_BIN_FILE_BAR_bar=[ROOT]/foo/build-dir/debug/build/bar/[HASH]/artifact/bin/
         .join("target-dir")
         .assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target-dir/CACHEDIR.TAG
+[ROOT]/foo/target-dir/.gitignore
 [ROOT]/foo/target-dir/debug/.cargo-lock
 [ROOT]/foo/target-dir/debug/.cargo-artifact-lock
 [ROOT]/foo/target-dir/debug/foo[EXE]
@@ -1304,6 +1336,7 @@ fn should_work_with_cargo_default_lib_metadata() {
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/.gitignore
 [ROOT]/foo/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json

--- a/tests/testsuite/build_dir_legacy.rs
+++ b/tests/testsuite/build_dir_legacy.rs
@@ -36,6 +36,7 @@ fn binary_with_debug() {
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/.gitignore
 [ROOT]/foo/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo.json
@@ -50,6 +51,7 @@ fn binary_with_debug() {
         .join("target-dir")
         .assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target-dir/CACHEDIR.TAG
+[ROOT]/foo/target-dir/.gitignore
 [ROOT]/foo/target-dir/debug/.cargo-lock
 [ROOT]/foo/target-dir/debug/.cargo-artifact-lock
 [ROOT]/foo/target-dir/debug/foo[EXE]
@@ -88,6 +90,7 @@ fn binary_with_release() {
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/.gitignore
 [ROOT]/foo/build-dir/release/.cargo-build-lock
 [ROOT]/foo/build-dir/release/.fingerprint/foo-[HASH]/bin-foo
 [ROOT]/foo/build-dir/release/.fingerprint/foo-[HASH]/bin-foo.json
@@ -102,6 +105,7 @@ fn binary_with_release() {
         .join("target-dir")
         .assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target-dir/CACHEDIR.TAG
+[ROOT]/foo/target-dir/.gitignore
 [ROOT]/foo/target-dir/release/.cargo-lock
 [ROOT]/foo/target-dir/release/.cargo-artifact-lock
 [ROOT]/foo/target-dir/release/foo[EXE]
@@ -192,6 +196,7 @@ fn should_default_to_target() {
     p.root().join("target").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target/.rustc_info.json
 [ROOT]/foo/target/CACHEDIR.TAG
+[ROOT]/foo/target/.gitignore
 [ROOT]/foo/target/debug/.cargo-lock
 [ROOT]/foo/target/debug/.cargo-artifact-lock
 [ROOT]/foo/target/debug/.cargo-build-lock
@@ -221,6 +226,7 @@ fn should_respect_env_var() {
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/.gitignore
 [ROOT]/foo/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo.json
@@ -262,6 +268,7 @@ fn build_script_should_output_to_build_dir() {
 
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/.gitignore
 [ROOT]/foo/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/build-dir/debug/deps/foo[..].d
 [ROOT]/foo/build-dir/debug/deps/foo[..][EXE]
@@ -319,6 +326,7 @@ fn cargo_tmpdir_should_output_to_build_dir() {
 
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/.gitignore
 [ROOT]/foo/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/build-dir/debug/deps/foo-[HASH].d
 [ROOT]/foo/build-dir/debug/deps/foo-[HASH].d
@@ -347,6 +355,7 @@ fn cargo_tmpdir_should_output_to_build_dir() {
         .join("target-dir")
         .assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target-dir/CACHEDIR.TAG
+[ROOT]/foo/target-dir/.gitignore
 [ROOT]/foo/target-dir/debug/.cargo-lock
 [ROOT]/foo/target-dir/debug/.cargo-artifact-lock
 [ROOT]/foo/target-dir/debug/foo[EXE]
@@ -374,6 +383,7 @@ fn examples_should_output_to_build_dir_and_uplift_to_target_dir() {
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/.gitignore
 [ROOT]/foo/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/dep-example-foo
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/example-foo
@@ -388,6 +398,7 @@ fn examples_should_output_to_build_dir_and_uplift_to_target_dir() {
         .join("target-dir")
         .assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target-dir/CACHEDIR.TAG
+[ROOT]/foo/target-dir/.gitignore
 [ROOT]/foo/target-dir/debug/.cargo-lock
 [ROOT]/foo/target-dir/debug/.cargo-artifact-lock
 [ROOT]/foo/target-dir/debug/examples/foo[EXE]
@@ -415,6 +426,7 @@ fn benches_should_output_to_build_dir() {
 
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/.gitignore
 [ROOT]/foo/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/build-dir/debug/deps/foo-[HASH].d
 [ROOT]/foo/build-dir/debug/deps/foo[..].d
@@ -436,6 +448,7 @@ fn benches_should_output_to_build_dir() {
         .join("target-dir")
         .assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target-dir/CACHEDIR.TAG
+[ROOT]/foo/target-dir/.gitignore
 [ROOT]/foo/target-dir/debug/.cargo-lock
 [ROOT]/foo/target-dir/debug/.cargo-artifact-lock
 [ROOT]/foo/target-dir/debug/foo[EXE]
@@ -494,6 +507,7 @@ fn cargo_rustdoc_json_should_output_to_target_dir() {
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/.rustdoc_fingerprint.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/.gitignore
 [ROOT]/foo/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/doc-lib-foo
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/doc-lib-foo.json
@@ -543,6 +557,7 @@ fn cargo_package_should_build_in_build_dir_and_output_to_target_dir() {
 [ROOT]/foo/build-dir/package/foo-0.0.1/Cargo.toml.orig
 [ROOT]/foo/build-dir/package/foo-0.0.1/src/main.rs
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/.gitignore
 [ROOT]/foo/build-dir/package/tmp-crate/foo-0.0.1.crate
 
 "#]]);
@@ -552,6 +567,7 @@ fn cargo_package_should_build_in_build_dir_and_output_to_target_dir() {
         .assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target-dir/package/foo-0.0.1.crate
 [ROOT]/foo/target-dir/CACHEDIR.TAG
+[ROOT]/foo/target-dir/.gitignore
 
 "#]]);
 }
@@ -605,6 +621,7 @@ fn cargo_clean_should_clean_the_target_dir_and_build_dir() {
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/.gitignore
 [ROOT]/foo/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo.json
@@ -619,6 +636,7 @@ fn cargo_clean_should_clean_the_target_dir_and_build_dir() {
         .join("target-dir")
         .assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target-dir/CACHEDIR.TAG
+[ROOT]/foo/target-dir/.gitignore
 [ROOT]/foo/target-dir/debug/.cargo-lock
 [ROOT]/foo/target-dir/debug/.cargo-artifact-lock
 [ROOT]/foo/target-dir/debug/foo[EXE]
@@ -669,6 +687,7 @@ fn cargo_clean_should_remove_correct_files() {
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/.gitignore
 [ROOT]/foo/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo.json
@@ -691,6 +710,7 @@ fn cargo_clean_should_remove_correct_files() {
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/.gitignore
 [ROOT]/foo/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo.json
@@ -817,6 +837,7 @@ fn template_workspace_root() {
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/.gitignore
 [ROOT]/foo/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo.json
@@ -831,6 +852,7 @@ fn template_workspace_root() {
         .join("target-dir")
         .assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target-dir/CACHEDIR.TAG
+[ROOT]/foo/target-dir/.gitignore
 [ROOT]/foo/target-dir/debug/.cargo-lock
 [ROOT]/foo/target-dir/debug/.cargo-artifact-lock
 [ROOT]/foo/target-dir/debug/foo[EXE]
@@ -862,6 +884,7 @@ fn template_cargo_cache_home() {
         .assert_build_dir_layout(str![[r#"
 [ROOT]/home/.cargo/build-dir/.rustc_info.json
 [ROOT]/home/.cargo/build-dir/CACHEDIR.TAG
+[ROOT]/home/.cargo/build-dir/.gitignore
 [ROOT]/home/.cargo/build-dir/debug/.cargo-build-lock
 [ROOT]/home/.cargo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo
 [ROOT]/home/.cargo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo.json
@@ -876,6 +899,7 @@ fn template_cargo_cache_home() {
         .join("target-dir")
         .assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target-dir/CACHEDIR.TAG
+[ROOT]/foo/target-dir/.gitignore
 [ROOT]/foo/target-dir/debug/.cargo-lock
 [ROOT]/foo/target-dir/debug/.cargo-artifact-lock
 [ROOT]/foo/target-dir/debug/foo[EXE]
@@ -921,6 +945,7 @@ fn template_workspace_path_hash() {
     build_dir.assert_build_dir_layout(str![[r#"
 [ROOT]/foo/foo/[HASH]/build-dir/.rustc_info.json
 [ROOT]/foo/foo/[HASH]/build-dir/CACHEDIR.TAG
+[ROOT]/foo/foo/[HASH]/build-dir/.gitignore
 [ROOT]/foo/foo/[HASH]/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/foo/[HASH]/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo
 [ROOT]/foo/foo/[HASH]/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo.json
@@ -935,6 +960,7 @@ fn template_workspace_path_hash() {
         .join("target-dir")
         .assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target-dir/CACHEDIR.TAG
+[ROOT]/foo/target-dir/.gitignore
 [ROOT]/foo/target-dir/debug/.cargo-lock
 [ROOT]/foo/target-dir/debug/.cargo-artifact-lock
 [ROOT]/foo/target-dir/debug/foo[EXE]
@@ -986,6 +1012,7 @@ fn template_workspace_path_hash_should_handle_symlink() {
     original_hash_dir.assert_build_dir_layout(str![[r#"
 [ROOT]/foo/foo/[HASH]/build-dir/.rustc_info.json
 [ROOT]/foo/foo/[HASH]/build-dir/CACHEDIR.TAG
+[ROOT]/foo/foo/[HASH]/build-dir/.gitignore
 [ROOT]/foo/foo/[HASH]/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/foo/[HASH]/build-dir/debug/.fingerprint/foo-[HASH]/dep-lib-foo
 [ROOT]/foo/foo/[HASH]/build-dir/debug/.fingerprint/foo-[HASH]/invoked.timestamp
@@ -998,6 +1025,7 @@ fn template_workspace_path_hash_should_handle_symlink() {
 
     p.root().join("target").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target/CACHEDIR.TAG
+[ROOT]/foo/target/.gitignore
 [ROOT]/foo/target/debug/.cargo-lock
 
 "#]]);
@@ -1021,6 +1049,7 @@ fn template_workspace_path_hash_should_handle_symlink() {
     symlink_hash_dir.assert_build_dir_layout(str![[r#"
 [ROOT]/foo/foo/[HASH]/build-dir/.rustc_info.json
 [ROOT]/foo/foo/[HASH]/build-dir/CACHEDIR.TAG
+[ROOT]/foo/foo/[HASH]/build-dir/.gitignore
 [ROOT]/foo/foo/[HASH]/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/foo/[HASH]/build-dir/debug/.fingerprint/foo-[HASH]/dep-lib-foo
 [ROOT]/foo/foo/[HASH]/build-dir/debug/.fingerprint/foo-[HASH]/invoked.timestamp
@@ -1033,6 +1062,7 @@ fn template_workspace_path_hash_should_handle_symlink() {
 
     p.root().join("target").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target/CACHEDIR.TAG
+[ROOT]/foo/target/.gitignore
 [ROOT]/foo/target/debug/.cargo-lock
 
 "#]]);
@@ -1153,6 +1183,7 @@ CARGO_BIN_FILE_BAR_bar=[ROOT]/foo/build-dir/debug/deps/artifact/bar-[HASH]/bin/b
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/.gitignore
 [ROOT]/foo/build-dir/debug/.cargo-build-lock
 [ROOT]/foo/build-dir/debug/.fingerprint/bar-[HASH]/bin-bar
 [ROOT]/foo/build-dir/debug/.fingerprint/bar-[HASH]/bin-bar.json
@@ -1173,6 +1204,7 @@ CARGO_BIN_FILE_BAR_bar=[ROOT]/foo/build-dir/debug/deps/artifact/bar-[HASH]/bin/b
         .join("target-dir")
         .assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target-dir/CACHEDIR.TAG
+[ROOT]/foo/target-dir/.gitignore
 [ROOT]/foo/target-dir/debug/.cargo-lock
 [ROOT]/foo/target-dir/debug/.cargo-artifact-lock
 [ROOT]/foo/target-dir/debug/foo[EXE]

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -1715,6 +1715,7 @@ fn check_build_should_not_output_files_to_artifact_dir() {
         .join("target-dir")
         .assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target-dir/CACHEDIR.TAG
+[ROOT]/foo/target-dir/.gitignore
 [ROOT]/foo/target-dir/debug/.cargo-lock
 
 "#]]);
@@ -1843,6 +1844,7 @@ fn check_build_should_not_uplift_proc_macro_dylib_deps() {
         .join("target-dir")
         .assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target-dir/CACHEDIR.TAG
+[ROOT]/foo/target-dir/.gitignore
 [ROOT]/foo/target-dir/debug/.cargo-lock
 
 "#]]);

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -740,7 +740,8 @@ fn assert_all_clean(build_dir: &Path) {
         | ".cargo-lock"
         | ".cargo-build-lock"
         | ".cargo-artifact-lock"
-        | "CACHEDIR.TAG" = path.file_name().unwrap().to_str().unwrap()
+        | "CACHEDIR.TAG"
+        | ".gitignore" = path.file_name().unwrap().to_str().unwrap()
         {
             continue;
         }

--- a/tests/testsuite/clean_new_layout.rs
+++ b/tests/testsuite/clean_new_layout.rs
@@ -706,7 +706,8 @@ fn assert_all_clean(build_dir: &Path) {
         | ".cargo-lock"
         | ".cargo-build-lock"
         | ".cargo-artifact-lock"
-        | "CACHEDIR.TAG" = path.file_name().unwrap().to_str().unwrap()
+        | "CACHEDIR.TAG"
+        | ".gitignore" = path.file_name().unwrap().to_str().unwrap()
         {
             continue;
         }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->

Fixes #15061 

How to test:
- run `cargo new`, observer that no `.gitignore` is generated
- run `cargo build`, observe that git still ignores the target directory
- run `cargo build` with different ways to override the default target directory location:
  - CLI arg (`--target-dir`)
  - environment variable (`CARGO_TARGET_DIR`)
  - `.cargo/config.toml`: `build.target-dir`