### PR TITLE
Document that cargo automatically registers variables used in env! macro to trigger rebuilds

### DIFF
--- a/src/doc/src/reference/build-scripts.md
+++ b/src/doc/src/reference/build-scripts.md
@@ -403,6 +403,13 @@ variables like `TARGET` that [Cargo sets for build scripts][build-env]. The
 environment variables in use are those received by `cargo` invocations, not
 those received by the executable of the build script.
 
+As of 1.46, using [`env!`][env-macro] and [`option_env!`][option-env-macro] in
+source code will automatically detect changes and trigger rebuilds.
+`rerun-if-env-changed` is no longer needed for variables already referenced by
+these macros.
+
+[option-env-macro]: ../../std/macro.option_env.html
+
 ## The `links` Manifest Key
 
 The `package.links` key may be set in the `Cargo.toml` manifest to declare


### PR DESCRIPTION
Initially discussed in https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/env!.2Foption_env!.20are.20tracked.2C.20can.20documentation.20be.20improved.3F/near/491793318

### What does this PR try to resolve?

There is no documentation that I can find which indicates that cargo will rebuild for changes in the variables used in `env!` macros.

Because this was not always the case, when searching for information on this, the main result indicates otherwise https://users.rust-lang.org/t/should-env-cause-rebuild-is-env-var-changes/18013.

Users misled by this may turn to `rerun-if-changed-env` in a build script to trigger rebuilds, so this documentation is a useful place to catch users and indicate that it isn't needed for `env!` macros.

### How should we test and review this PR?

I'm not sure how to test the new relative link but I matched it to the existing `[env-macro]: ../../std/macro.env.html`.

My main concern when writing this was whether it was clear that this applies to `env!` macro usage within the main code of the crate and not just in `build.rs`.