### PR TITLE
fix(build-std): parse as comma-separated list

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -759,7 +759,9 @@ unstable_cli_options!(
     avoid_dev_deps: bool = ("Avoid installing dev-dependencies if possible"),
     binary_dep_depinfo: bool = ("Track changes to dependency artifacts"),
     bindeps: bool = ("Allow Cargo packages to depend on bin, cdylib, and staticlib crates, and use the artifacts built by those crates"),
+    #[serde(deserialize_with = "deserialize_comma_separated_list")]
     build_std: Option<Vec<String>>  = ("Enable Cargo to compile the standard library itself as part of a crate graph compilation"),
+    #[serde(deserialize_with = "deserialize_comma_separated_list")]
     build_std_features: Option<Vec<String>>  = ("Configure features enabled for the standard library itself when building the standard library"),
     cargo_lints: bool = ("Enable the `[lints.cargo]` table"),
     checksum_freshness: bool = ("Use a checksum to determine if output is fresh rather than filesystem mtime"),
@@ -871,6 +873,24 @@ const STABILIZED_LINTS: &str = "The `[lints]` table is now always available.";
 
 const STABILIZED_CHECK_CFG: &str =
     "Compile-time checking of conditional (a.k.a. `-Zcheck-cfg`) is now always enabled.";
+
+fn deserialize_comma_separated_list<'de, D>(
+    deserializer: D,
+) -> Result<Option<Vec<String>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let Some(list) = <Option<Vec<String>>>::deserialize(deserializer)? else {
+        return Ok(None);
+    };
+    let v = list
+        .iter()
+        .flat_map(|s| s.split(','))
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect();
+    Ok(Some(v))
+}
 
 #[derive(Debug, Copy, Clone, Default, Deserialize, Ord, PartialOrd, Eq, PartialEq)]
 #[serde(default)]

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -2175,7 +2175,14 @@ fn build_std() {
         .unwrap()
         .build_std
         .unwrap();
-    assert_eq!(value, vec!["core,std,panic_abort".to_string()]);
+    assert_eq!(
+        value,
+        vec![
+            "core".to_string(),
+            "std".to_string(),
+            "panic_abort".to_string(),
+        ],
+    );
 
     let gctx = GlobalContextBuilder::new()
         .config_arg("unstable.build-std=['core', 'std,panic_abort']")
@@ -2188,7 +2195,11 @@ fn build_std() {
         .unwrap();
     assert_eq!(
         value,
-        vec!["core".to_string(), "std,panic_abort".to_string()]
+        vec![
+            "core".to_string(),
+            "std".to_string(),
+            "panic_abort".to_string(),
+        ]
     );
 
     let gctx = GlobalContextBuilder::new()
@@ -2205,7 +2216,11 @@ fn build_std() {
         .unwrap();
     assert_eq!(
         value,
-        vec!["backtrace,panic-unwind,windows_raw_dylib".to_string()]
+        vec![
+            "backtrace".to_string(),
+            "panic-unwind".to_string(),
+            "windows_raw_dylib".to_string(),
+        ]
     );
 
     let gctx = GlobalContextBuilder::new()
@@ -2221,7 +2236,8 @@ fn build_std() {
         value,
         vec![
             "backtrace".to_string(),
-            "panic-unwind,windows_raw_dylib".to_string()
+            "panic-unwind".to_string(),
+            "windows_raw_dylib".to_string(),
         ]
     );
 }

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -2163,3 +2163,65 @@ gitoxide = \"fetch\"
         unstable_flags.gitoxide == expect
     }
 }
+
+#[cargo_test]
+fn build_std() {
+    let gctx = GlobalContextBuilder::new()
+        .env("CARGO_UNSTABLE_BUILD_STD", "core,std,panic_abort")
+        .build();
+    let value = gctx
+        .get::<Option<cargo::core::CliUnstable>>("unstable")
+        .unwrap()
+        .unwrap()
+        .build_std
+        .unwrap();
+    assert_eq!(value, vec!["core,std,panic_abort".to_string()]);
+
+    let gctx = GlobalContextBuilder::new()
+        .config_arg("unstable.build-std=['core', 'std,panic_abort']")
+        .build();
+    let value = gctx
+        .get::<Option<cargo::core::CliUnstable>>("unstable")
+        .unwrap()
+        .unwrap()
+        .build_std
+        .unwrap();
+    assert_eq!(
+        value,
+        vec!["core".to_string(), "std,panic_abort".to_string()]
+    );
+
+    let gctx = GlobalContextBuilder::new()
+        .env(
+            "CARGO_UNSTABLE_BUILD_STD_FEATURES",
+            "backtrace,panic-unwind,windows_raw_dylib",
+        )
+        .build();
+    let value = gctx
+        .get::<Option<cargo::core::CliUnstable>>("unstable")
+        .unwrap()
+        .unwrap()
+        .build_std_features
+        .unwrap();
+    assert_eq!(
+        value,
+        vec!["backtrace,panic-unwind,windows_raw_dylib".to_string()]
+    );
+
+    let gctx = GlobalContextBuilder::new()
+        .config_arg("unstable.build-std-features=['backtrace', 'panic-unwind,windows_raw_dylib']")
+        .build();
+    let value = gctx
+        .get::<Option<cargo::core::CliUnstable>>("unstable")
+        .unwrap()
+        .unwrap()
+        .build_std_features
+        .unwrap();
+    assert_eq!(
+        value,
+        vec![
+            "backtrace".to_string(),
+            "panic-unwind,windows_raw_dylib".to_string()
+        ]
+    );
+}


### PR DESCRIPTION
### What does this PR try to resolve?

Restore to the behavior prior to 30d11ce1d9f06907d1e707c4fe379ebf57305a5e
Also extend `build-std-features` to support comma-separated list.

Fixes #15064

### How should we test and review this PR?

A test has been added.

