### PR TITLE
Fix benchsuite issue with newer versions of git

### DIFF
--- a/benches/benchsuite/src/lib.rs
+++ b/benches/benchsuite/src/lib.rs
@@ -125,11 +125,15 @@ impl Fixtures {
             }
         } else {
             fs::create_dir_all(&index).unwrap();
-            git("init --bare");
+            // git 2.48.0 changed the behavior of setting HEAD when doing a
+            // fetch, so let's just force it to match
+            // crates.io-index-archive's default branch. This also accounts
+            // for users who may override init.defaultBranch.
+            git("init --bare --initial-branch=main");
             git("remote add origin https://github.com/rust-lang/crates.io-index-archive");
         }
         git(&format!("fetch origin {}", CRATES_IO_COMMIT));
-        git("branch -f master FETCH_HEAD");
+        git("branch -f main FETCH_HEAD");
     }
 
     /// This unpacks the compressed workspace skeletons into tmp/workspaces.


### PR DESCRIPTION
This fixes a problem introduced with git 2.48.0 where the benchsuite would fail to run. The problem is that 2.48 changed the behavior so that HEAD would get changed to follow the remote. crates.io-index's default branch is "main". The benchsuite uses git to initialize the bare repo with a HEAD of "refs/heads/master" (the default of `init.defaultBranch`). Older versions of git would leave HEAD untouched, but newer versions update it to "refs/heads/main" after fetching to match the remote. This causes cargo to try to clone a branch called "main" which is empty.

The solution here is to just force HEAD to be main, and use that as the branch for our time-travelling snapshot.

Tested with git 2.47.0 and 2.48.1. Test is roughly:

```
rm -rf target/tmp/bench ; cargo test -p benchsuite --all-targets -- cargo && cargo test -p benchsuite --all-targets -- cargo`
```

(Run it twice to verify it can do an incremental fetch.)
