### PR TITLE
docs(cargo-clippy): correct typo

### DIFF
--- a/src/doc/src/commands/cargo-clippy.md
+++ b/src/doc/src/commands/cargo-clippy.md
@@ -2,7 +2,7 @@
 
 ## NAME
 
-cargo-miri --- Checks a package to catch common mistakes and improve your Rust code
+cargo-clippy --- Checks a package to catch common mistakes and improve your Rust code
 
 ## DESCRIPTION
 


### PR DESCRIPTION
Fix typo in command docs for `cargo-clippy`. The command is `cargo-clippy` not `cargo-miri`!
