### PR TITLE
fix: wrong concat and field name

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -869,7 +869,7 @@ fn inheritable_from_path(
 macro_rules! package_field_getter {
     ( $(($key:literal, $field:ident -> $ret:ty),)* ) => (
         $(
-            #[doc = concat!("Gets the field `workspace.package", $key, "`.")]
+            #[doc = concat!("Gets the field `workspace.package.", $key, "`.")]
             fn $field(&self) -> CargoResult<$ret> {
                 let Some(val) = self.package.as_ref().and_then(|p| p.$field.as_ref()) else  {
                     bail!("`workspace.package.{}` was not defined", $key);
@@ -940,7 +940,7 @@ impl InheritableFields {
         Ok(dep)
     }
 
-    /// Gets the field `workspace.lint`.
+    /// Gets the field `workspace.lints`.
     pub fn lints(&self) -> CargoResult<manifest::TomlLints> {
         let Some(val) = &self.lints else {
             bail!("`workspace.lints` was not defined");


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes a wrong concatenation in macro, and one wrong field name.

### How should we test and review this PR?

`cargo doc --document-private-items --no-deps --open`
