### PR TITLE
created a function for user defined aliases

### DIFF
--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -205,16 +205,8 @@ fn list_commands(gctx: &GlobalContext) -> BTreeMap<String, CommandInfo> {
     }
 
     // Add the user-defined aliases
-    if let Ok(aliases) = gctx.get::<BTreeMap<String, StringOrVec>>("alias") {
-        for (name, target) in aliases.iter() {
-            commands.insert(
-                name.to_string(),
-                CommandInfo::Alias {
-                    target: target.clone(),
-                },
-            );
-        }
-    }
+    let alias_commands = user_defined_aliases(gctx);
+    commands.extend(alias_commands);
 
     // `help` is special, so it needs to be inserted separately.
     commands.insert(
@@ -253,6 +245,21 @@ fn third_party_subcommands(gctx: &GlobalContext) -> BTreeMap<String, CommandInfo
                     CommandInfo::External { path: path.clone() },
                 );
             }
+        }
+    }
+    commands
+}
+
+fn user_defined_aliases(gctx: &GlobalContext) -> BTreeMap<String, CommandInfo> {
+    let mut commands = BTreeMap::new();
+    if let Ok(aliases) = gctx.get::<BTreeMap<String, StringOrVec>>("alias") {
+        for (name, target) in aliases.iter() {
+            commands.insert(
+                name.to_string(),
+                CommandInfo::Alias {
+                    target: target.clone(),
+                },
+            );
         }
     }
     commands


### PR DESCRIPTION
Hey there,

As mentioned in this [issue](https://github.com/rust-lang/cargo/issues/14520), I worked on the functionality of autocompleting the user-defined aliases and I moved the code of user-defined aliases into a separate function by defining two parameters. The first one is global context or gctx and the second one is the commands that can be called in the list_commands function.

Thank you!

<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
