### PR TITLE
chore: add aarch64 linux runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,6 +130,14 @@ jobs:
           os: ubuntu-latest
           rust: nightly
           other: i686-unknown-linux-gnu
+        - name: Linux aarch64 stable
+          os: ubuntu-24.04-arm
+          rust: stable
+          other: TODO # cross-compile tests are disabled, this shouldn't matter.
+        - name: Linux aarch64 nightly
+          os: ubuntu-24.04-arm
+          rust: nightly
+          other: TODO # cross-compile tests are disabled, this shouldn't matter.
         - name: macOS aarch64 stable
           os: macos-14
           rust: stable
@@ -161,6 +169,7 @@ jobs:
     - run: rustup update --no-self-update stable
     - run: rustup update --no-self-update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
     - run: rustup target add ${{ matrix.other }}
+      if: matrix.os != 'ubuntu-24.04-arm' # cross-compile tests are disabled on ARM machines
     - run: rustup target add wasm32-unknown-unknown
     - run: rustup target add aarch64-unknown-none # need this for build-std mock tests
       if: startsWith(matrix.rust, 'nightly')

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ version = "0.4.2"
 
 [[package]]
 name = "cargo-test-support"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anstream",
  "anstyle",

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-test-support"
-version = "0.7.3"
+version = "0.7.4"
 edition.workspace = true
 rust-version = "1.85"  # MSRV:1
 license.workspace = true

--- a/crates/cargo-test-support/src/cross_compile.rs
+++ b/crates/cargo-test-support/src/cross_compile.rs
@@ -27,6 +27,12 @@ pub fn disabled() -> bool {
         _ => {}
     }
 
+    // It requires setting `target.linker` for cross-compilation to work on aarch64,
+    // so not going to bother now.
+    if cfg!(all(target_arch = "aarch64", target_os = "linux")) {
+        return true;
+    }
+
     // Cross tests are only tested to work on macos, linux, and MSVC windows.
     if !(cfg!(target_os = "macos") || cfg!(target_os = "linux") || cfg!(target_env = "msvc")) {
         return true;


### PR DESCRIPTION
### What does this PR try to resolve?

Linux arm64 hosted runners is in public preview.
Enable and see if is is something we can have now.

https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

### How should we test and review this PR?

aarch64-unknown-linux-gnu is a tier-1 target platform. 
It is better to have this in Cargo's CI.

Cross-compilation tests are disabled temporarily on this platform.

### Additional information

https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/Free.20Linux.20ARM64.20runners.20on.20GHA.20now.20in.20beta

