### PR TITLE
fix(cargo_new): format members list of workspace in Cargo.toml

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -999,6 +999,7 @@ fn update_manifest_with_new_member(
         if was_sorted {
             members.sort_by(|lhs, rhs| lhs.as_str().cmp(&rhs.as_str()));
         }
+        members.fmt();
     } else {
         let mut array = Array::new();
         array.push(display_path);


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes #15084 
formats members list in workspace of Cargo.toml.

### How should we test and review this PR?

Steps

1. mkdir work_space
2. cd work_space
3. echo "[workspace]" > Cargo.toml
4. cargo new crates/lib_core
5. cargo new crates/lib_auth

Current Output:

    [workspace]
    members = [ "crates/lib_auth","crates/lib_core"]

Fixed Output:

    [workspace]
    members = ["crates/lib_auth", "crates/lib_core"]


can write tests if required.

Thank You