### PR TITLE
fix(package): detect dirty workspace manifest

### DIFF
--- a/src/cargo/ops/cargo_package/mod.rs
+++ b/src/cargo/ops/cargo_package/mod.rs
@@ -387,7 +387,7 @@ fn prepare_archive(
     let src_files = src.list_files(pkg)?;
 
     // Check (git) repository state, getting the current commit hash.
-    let vcs_info = vcs::check_repo_state(pkg, &src_files, gctx, &opts)?;
+    let vcs_info = vcs::check_repo_state(pkg, &src_files, ws, &opts)?;
 
     build_ar_list(ws, pkg, src_files, vcs_info)
 }

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1212,15 +1212,6 @@ fn vcs_status_check_for_each_workspace_member() {
     });
     git::commit(&repo);
 
-    p.change_file(
-        "Cargo.toml",
-        r#"
-            [workspace]
-            members = ["isengard", "mordor"]
-            [workspace.package]
-            edition = "2021"
-        "#,
-    );
     // Dirty file outside won't affect packaging.
     p.change_file("hobbit", "changed!");
     p.change_file("mordor/src/lib.rs", "changed!");
@@ -1321,8 +1312,6 @@ fn dirty_file_outside_pkg_root_considered_dirty() {
                 [workspace]
                 members = ["isengard"]
                 resolver = "2"
-                [workspace.package]
-                edition = "2015"
             "#,
         )
         .file("lib.rs", r#"compile_error!("you shall not pass")"#)
@@ -1333,7 +1322,7 @@ fn dirty_file_outside_pkg_root_considered_dirty() {
             r#"
                 [package]
                 name = "isengard"
-                edition.workspace = true
+                edition = "2021"
                 homepage = "saruman"
                 description = "saruman"
                 license-file = "../LICENSE"
@@ -1357,17 +1346,6 @@ fn dirty_file_outside_pkg_root_considered_dirty() {
     p.change_file("original-dir/file", "after");
     // * Changes in files outside pkg root that `license-file`/`readme` point to
     p.change_file("LICENSE", "after");
-    // * When workspace inheritance is involved and changed
-    p.change_file(
-        "Cargo.toml",
-        r#"
-            [workspace]
-            members = ["isengard"]
-            resolver = "2"
-            [workspace.package]
-            edition = "2021"
-        "#,
-    );
     // Changes in files outside git workdir won't affect vcs status check
     p.change_file(
         &main_outside_pkg_root,
@@ -1398,14 +1376,6 @@ to proceed despite this and include the uncommitted changes, pass the `--allow-d
 "#]])
         .run();
 
-    let cargo_toml = str![[r##"
-...
-[package]
-edition = "2021"
-...
-
-"##]];
-
     let f = File::open(&p.root().join("target/package/isengard-0.0.0.crate")).unwrap();
     validate_crate_contents(
         f,
@@ -1427,7 +1397,6 @@ edition = "2021"
             ("symlink-dir/file", str!["after"]),
             ("README.md", str!["after"]),
             ("LICENSE", str!["after"]),
-            ("Cargo.toml", cargo_toml),
         ],
     );
 }

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1493,10 +1493,13 @@ version = "1"
     );
 
     p.cargo("package --workspace --no-verify --no-metadata")
+        .with_status(101)
         .with_stderr_data(str![[r#"
-[PACKAGING] isengard v0.0.0 ([ROOT]/foo/isengard)
-[UPDATING] `dummy-registry` index
-[PACKAGED] 5 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[ERROR] 1 files in the working directory contain changes that were not yet committed into git:
+
+Cargo.toml
+
+to proceed despite this and include the uncommitted changes, pass the `--allow-dirty` flag
 
 "#]])
         .run();
@@ -1571,6 +1574,18 @@ fn dirty_and_broken_workspace_manifest_with_inherited_fields() {
     );
 
     p.cargo("package --workspace --no-verify --no-metadata")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] 1 files in the working directory contain changes that were not yet committed into git:
+
+Cargo.toml
+
+to proceed despite this and include the uncommitted changes, pass the `--allow-dirty` flag
+
+"#]])
+        .run();
+
+    p.cargo("package --workspace --no-verify --no-metadata --allow-dirty")
         .with_stderr_data(str![[r#"
 [PACKAGING] isengard v0.0.0 ([ROOT]/foo/isengard)
 [PACKAGED] 5 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)


### PR DESCRIPTION
### What does this PR try to resolve?

This addresses one of the corner cases of VCS dirtiness in #14967.

> Workspace inheritance — like changing `workspace.package.edition`
> to `2021` would actually make member Cargo.toml dirty,
> but the current dirty status check doesn't capture that.

The solution here is

* Retrieve workspace manifest from Git index.
* Use the ws manifest from index to normalize package manifest.
* Compare the difference between normalized tomls from Git index and
  from Git working directory.

The implementation here is a bit ugly, as it exposes some internals
functions to `pub(crate)`.

The current implementation also has performance issues. When the
workspace contains lots of members and has a dirty workspace manifest:

* It adds one extra manifest parsing and normalization for
  checking each member.
  * Parsing part can be cached for the entire workspace.
    However normalization cannot be skipped.
* It adds two TOML serializations for checking each member.
  * If we derive `Eq` for manifest types, we might be able to skip
    serializations and instead just compare them.

### How should we test and review this PR?

Three tests are added to demonstrate that dirtiness check does not
work for Cargo.toml involved with workspace inheritance.

* One for basic check. If any change in workspace manifest could affect
  the inherited value, this should be caught as dirty.
* One for broken workspace manifest in Git index.
* The other is also for broken workspace manifest in Git index, but has
  no inherited field.

### Additional information