### PR TITLE
added the third_party_subcommands function in the cli.rs file

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -15,6 +15,9 @@ use crate::command_prelude::*;
 use crate::util::is_rustup;
 use cargo::core::shell::ColorChoice;
 use cargo::util::style;
+use crate::third_party_subcommands;
+use clap_complete::engine::SubcommandCandidates;
+use clap_complete::CompletionCandidate;
 
 #[tracing::instrument(skip_all)]
 pub fn main(gctx: &mut GlobalContext) -> CliResult {
@@ -578,6 +581,10 @@ pub fn cli(gctx: &GlobalContext) -> Command {
         // We also want these to come before auto-generated `--help`
         .next_display_order(800)
         .allow_external_subcommands(true)
+        .add(SubcommandCandidates::new(|| {
+            let third_party = third_party_subcommands(gctx);
+            vec![CompletionCandidate::new(third_party)]
+        }))
         .color(color)
         .styles(styles)
         // Provide a custom help subcommand for calling into man pages

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -219,7 +219,7 @@ fn list_commands(gctx: &GlobalContext) -> BTreeMap<String, CommandInfo> {
     commands
 }
 
-fn third_party_subcommands(gctx: &GlobalContext) -> BTreeMap<String, CommandInfo> {
+pub fn third_party_subcommands(gctx: &GlobalContext) -> BTreeMap<String, CommandInfo> {
     let prefix = "cargo-";
     let suffix = env::consts::EXE_SUFFIX;
     let mut commands = BTreeMap::new();


### PR DESCRIPTION
Hey there,

After grinding for hours, I think I found a place to call the `third_party_subcommands` function in the [cli.rs](https://github.com/rust-lang/cargo/blob/cecde95c119a456c30e57d3e4b31fff5a7d83df4/src/bin/cargo/cli.rs#L574) file and after putting `third_party` return value inside the `CodeCompletion::new()`, it gave me the following error: 

```
the trait bound `OsString: From<BTreeMap<std::string::String, cargo::util::command_prelude::CommandInfo>>` is not satisfied
the following other types implement trait `From<T>`:
  `OsString` implements `From<&T>`
  `OsString` implements `From<Box<std::ffi::OsStr>>`
  `OsString` implements `From<Cow<'_, std::ffi::OsStr>>`
  `OsString` implements `From<PathBuf>`
  `OsString` implements `From<clap::builder::OsStr>`
  `OsString` implements `From<clap::builder::Str>`
  `OsString` implements `From<std::string::String>`
required for `BTreeMap<std::string::String, cargo::util::command_prelude::CommandInfo>` to implement `Into<OsString>`rustc[Click for full compiler diagnostic](rust-analyzer-diagnostics-view:/diagnostic%20message%20[0]?0#file:///home/ibilalkayy/Documents/cargo/src/bin/cargo/cli.rs)
cli.rs(586, 18): required by a bound introduced by this call
candidate.rs(19, 28): required by a bound in `CompletionCandidate::new`
```

After going to the `candidate.rs` file (that is not present in the cargo repo as I looked through it), I noticed that another fields needs to be added to be implemented in a method that will take arguments and then pass on.

Let me know if I am on the right track and if further improvements need to be added.

Thank you!

<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
