### PR TITLE
Fix comment on Ord for SourceId

### DIFF
--- a/src/cargo/core/source_id.rs
+++ b/src/cargo/core/source_id.rs
@@ -581,8 +581,8 @@ impl PartialOrd for SourceId {
     }
 }
 
-// Custom comparison defined as canonical URL equality for git sources and URL
-// equality for other sources, ignoring the `precise` and `name` fields.
+// Custom comparison defined as source kind and canonical URL equality,
+// ignoring the `precise` and `name` fields.
 impl Ord for SourceId {
     fn cmp(&self, other: &SourceId) -> Ordering {
         // If our interior pointers are to the exact same `SourceIdInner` then


### PR DESCRIPTION
### What does this PR try to resolve?

In PR #14980, the Ord impl for SourceId was changed, but the comment wasn’t updated. So it is now incorrect.

This PR updates the comment to match the implementation.

### How should we test and review this PR?

Read the Ord for SourceId code and make sure the updated comment describes what it does.

### Additional information

None