### PR TITLE
Implemented `build.build-dir` config option

### DIFF
--- a/src/cargo/core/compiler/build_runner/compilation_files.rs
+++ b/src/cargo/core/compiler/build_runner/compilation_files.rs
@@ -217,7 +217,7 @@ impl<'a, 'gctx: 'a> CompilationFiles<'a, 'gctx> {
         } else if unit.target.is_custom_build() {
             self.build_script_dir(unit)
         } else if unit.target.is_example() {
-            self.layout(unit.kind).examples().to_path_buf()
+            self.layout(unit.kind).build_examples().to_path_buf()
         } else if unit.artifact.is_true() {
             self.artifact_dir(unit)
         } else {

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -1124,7 +1124,7 @@ fn prepare_metabuild(
     let path = unit
         .pkg
         .manifest()
-        .metabuild_path(build_runner.bcx.ws.target_dir());
+        .metabuild_path(build_runner.bcx.ws.build_dir());
     paths::create_dir_all(path.parent().unwrap())?;
     paths::write_if_changed(path, &output)?;
     Ok(())

--- a/src/cargo/core/compiler/future_incompat.rs
+++ b/src/cargo/core/compiler/future_incompat.rs
@@ -91,7 +91,7 @@ pub struct Diagnostic {
     pub level: String,
 }
 
-/// The filename in the top-level `target` directory where we store
+/// The filename in the top-level `build-dir` directory where we store
 /// the report
 const FUTURE_INCOMPAT_FILE: &str = ".future-incompat-report.json";
 /// Max number of reports to save on disk.
@@ -166,7 +166,7 @@ impl OnDiskReports {
         }
         let on_disk = serde_json::to_vec(&self).unwrap();
         if let Err(e) = ws
-            .target_dir()
+            .build_dir()
             .open_rw_exclusive_create(
                 FUTURE_INCOMPAT_FILE,
                 ws.gctx(),
@@ -191,7 +191,7 @@ impl OnDiskReports {
 
     /// Loads the on-disk reports.
     pub fn load(ws: &Workspace<'_>) -> CargoResult<OnDiskReports> {
-        let report_file = match ws.target_dir().open_ro_shared(
+        let report_file = match ws.build_dir().open_ro_shared(
             FUTURE_INCOMPAT_FILE,
             ws.gctx(),
             "Future incompatible report",

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -297,7 +297,7 @@ fn rustc(
     let exec = exec.clone();
 
     let root_output = build_runner.files().host_dest().to_path_buf();
-    let target_dir = build_runner.bcx.ws.target_dir().into_path_unlocked();
+    let build_dir = build_runner.bcx.ws.build_dir().into_path_unlocked();
     let pkg_root = unit.pkg.root().to_path_buf();
     let cwd = rustc
         .get_cwd()
@@ -455,7 +455,7 @@ fn rustc(
                 &dep_info_loc,
                 &cwd,
                 &pkg_root,
-                &target_dir,
+                &build_dir,
                 &rustc,
                 // Do not track source files in the fingerprint for registry dependencies.
                 is_local,
@@ -555,7 +555,7 @@ fn link_targets(
         let path = unit
             .pkg
             .manifest()
-            .metabuild_path(build_runner.bcx.ws.target_dir());
+            .metabuild_path(build_runner.bcx.ws.build_dir());
         target.set_src_path(TargetSourcePath::Path(path));
     }
 

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -759,6 +759,7 @@ unstable_cli_options!(
     avoid_dev_deps: bool = ("Avoid installing dev-dependencies if possible"),
     binary_dep_depinfo: bool = ("Track changes to dependency artifacts"),
     bindeps: bool = ("Allow Cargo packages to depend on bin, cdylib, and staticlib crates, and use the artifacts built by those crates"),
+    build_dir: bool = ("Enable the `build.build-dir` option in .cargo/config.toml file"),
     #[serde(deserialize_with = "deserialize_comma_separated_list")]
     build_std: Option<Vec<String>>  = ("Enable Cargo to compile the standard library itself as part of a crate graph compilation"),
     #[serde(deserialize_with = "deserialize_comma_separated_list")]
@@ -1264,6 +1265,7 @@ impl CliUnstable {
             "avoid-dev-deps" => self.avoid_dev_deps = parse_empty(k, v)?,
             "binary-dep-depinfo" => self.binary_dep_depinfo = parse_empty(k, v)?,
             "bindeps" => self.bindeps = parse_empty(k, v)?,
+            "build-dir" => self.build_dir = parse_empty(k, v)?,
             "build-std" => self.build_std = Some(parse_list(v)),
             "build-std-features" => self.build_std_features = Some(parse_list(v)),
             "cargo-lints" => self.cargo_lints = parse_empty(k, v)?,

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -67,6 +67,10 @@ pub struct Workspace<'gctx> {
     /// `None` if the default path of `root/target` should be used.
     target_dir: Option<Filesystem>,
 
+    /// Shared build directory for intermediate build artifacts.
+    /// This directory may be shared between multiple workspaces.
+    build_dir: Option<Filesystem>,
+
     /// List of members in this workspace with a listing of all their manifest
     /// paths. The packages themselves can be looked up through the `packages`
     /// set above.
@@ -209,6 +213,7 @@ impl<'gctx> Workspace<'gctx> {
     pub fn new(manifest_path: &Path, gctx: &'gctx GlobalContext) -> CargoResult<Workspace<'gctx>> {
         let mut ws = Workspace::new_default(manifest_path.to_path_buf(), gctx);
         ws.target_dir = gctx.target_dir()?;
+        ws.build_dir = gctx.build_dir()?;
 
         if manifest_path.is_relative() {
             bail!(
@@ -238,6 +243,7 @@ impl<'gctx> Workspace<'gctx> {
             },
             root_manifest: None,
             target_dir: None,
+            build_dir: None,
             members: Vec::new(),
             member_ids: HashSet::new(),
             default_members: Vec::new(),
@@ -282,6 +288,7 @@ impl<'gctx> Workspace<'gctx> {
         } else {
             ws.gctx.target_dir()?
         };
+        ws.build_dir = ws.target_dir.clone();
         ws.members.push(ws.current_manifest.clone());
         ws.member_ids.insert(id);
         ws.default_members.push(ws.current_manifest.clone());
@@ -414,6 +421,15 @@ impl<'gctx> Workspace<'gctx> {
 
     pub fn target_dir(&self) -> Filesystem {
         self.target_dir
+            .clone()
+            .unwrap_or_else(|| self.default_target_dir())
+    }
+
+    pub fn build_dir(&self) -> Filesystem {
+        if !self.gctx().cli_unstable().build_dir {
+            return self.target_dir();
+        }
+        self.build_dir
             .clone()
             .unwrap_or_else(|| self.default_target_dir())
     }

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -429,9 +429,7 @@ impl<'gctx> Workspace<'gctx> {
         if !self.gctx().cli_unstable().build_dir {
             return self.target_dir();
         }
-        self.build_dir
-            .clone()
-            .unwrap_or_else(|| self.default_target_dir())
+        self.build_dir.clone().unwrap_or_else(|| self.target_dir())
     }
 
     fn default_target_dir(&self) -> Filesystem {

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -41,6 +41,7 @@ pub struct CleanContext<'gctx> {
 /// Cleans various caches.
 pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
     let mut target_dir = ws.target_dir();
+    let mut build_dir = ws.build_dir();
     let gctx = opts.gctx;
     let mut clean_ctx = CleanContext::new(gctx);
     clean_ctx.dry_run = opts.dry_run;
@@ -67,6 +68,7 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
             // that profile.
             let dir_name = profiles.get_dir_name();
             target_dir = target_dir.join(dir_name);
+            build_dir = build_dir.join(dir_name);
         }
 
         // If we have a spec, then we need to delete some packages, otherwise, just
@@ -75,7 +77,15 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
         // Note that we don't bother grabbing a lock here as we're just going to
         // blow it all away anyway.
         if opts.spec.is_empty() {
-            clean_ctx.remove_paths(&[target_dir.into_path_unlocked()])?;
+            let paths: &[PathBuf] = if gctx.cli_unstable().build_dir && build_dir != target_dir {
+                &[
+                    target_dir.into_path_unlocked(),
+                    build_dir.into_path_unlocked(),
+                ]
+            } else {
+                &[target_dir.into_path_unlocked()]
+            };
+            clean_ctx.remove_paths(paths)?;
         } else {
             clean_specs(
                 &mut clean_ctx,
@@ -222,7 +232,7 @@ fn clean_specs(
                         .rustc_outputs(mode, target.kind(), triple)?;
                     let (dir, uplift_dir) = match target.kind() {
                         TargetKind::ExampleBin | TargetKind::ExampleLib(..) => {
-                            (layout.examples(), Some(layout.examples()))
+                            (layout.build_examples(), Some(layout.examples()))
                         }
                         // Tests/benchmarks are never uplifted.
                         TargetKind::Test | TargetKind::Bench => (layout.deps(), None),

--- a/src/cargo/ops/cargo_package/mod.rs
+++ b/src/cargo/ops/cargo_package/mod.rs
@@ -217,7 +217,7 @@ fn do_package<'a>(
     };
 
     let mut local_reg = if ws.gctx().cli_unstable().package_workspace {
-        let reg_dir = ws.target_dir().join("package").join("tmp-registry");
+        let reg_dir = ws.build_dir().join("package").join("tmp-registry");
         sid.map(|sid| TmpRegistry::new(ws.gctx(), reg_dir, sid))
             .transpose()?
     } else {

--- a/src/cargo/util/context/mod.rs
+++ b/src/cargo/util/context/mod.rs
@@ -421,11 +421,8 @@ impl GlobalContext {
 
     /// Gets the path to the `rustc` executable.
     pub fn load_global_rustc(&self, ws: Option<&Workspace<'_>>) -> CargoResult<Rustc> {
-        let cache_location = ws.map(|ws| {
-            ws.target_dir()
-                .join(".rustc_info.json")
-                .into_path_unlocked()
-        });
+        let cache_location =
+            ws.map(|ws| ws.build_dir().join(".rustc_info.json").into_path_unlocked());
         let wrapper = self.maybe_get_tool("rustc_wrapper", &self.build_config()?.rustc_wrapper);
         let rustc_workspace_wrapper = self.maybe_get_tool(
             "rustc_workspace_wrapper",

--- a/src/cargo/util/flock.rs
+++ b/src/cargo/util/flock.rs
@@ -142,7 +142,7 @@ impl Drop for FileLock {
 ///
 /// [`flock`]: https://linux.die.net/man/2/flock
 /// [`LockFileEx`]: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-lockfileex
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Filesystem {
     root: PathBuf,
 }

--- a/src/cargo/util/workspace.rs
+++ b/src/cargo/util/workspace.rs
@@ -114,7 +114,7 @@ pub fn print_available_tests(ws: &Workspace<'_>, options: &CompileOptions) -> Ca
 pub fn path_args(ws: &Workspace<'_>, unit: &Unit) -> (PathBuf, PathBuf) {
     let src = match unit.target.src_path() {
         TargetSourcePath::Path(path) => path.to_path_buf(),
-        TargetSourcePath::Metabuild => unit.pkg.manifest().metabuild_path(ws.target_dir()),
+        TargetSourcePath::Metabuild => unit.pkg.manifest().metabuild_path(ws.build_dir()),
     };
     assert!(src.is_absolute());
     if unit.pkg.package_id().source_id().is_path() {

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -78,6 +78,7 @@ Each new feature described below should explain how to use it.
     * [feature-unification](#feature-unification) --- Enable new feature unification modes in workspaces
 * Output behavior
     * [artifact-dir](#artifact-dir) --- Adds a directory where artifacts are copied to.
+    * [build-dir](#build-dir) --- Adds a directory where intermediate build artifacts are stored.
     * [Different binary name](#different-binary-name) --- Assign a name to the built binary that is separate from the crate name.
     * [root-dir](#root-dir) --- Controls the root directory relative to which paths are printed
 * Compile behavior
@@ -237,6 +238,27 @@ This can also be specified in `.cargo/config.toml` files.
 [build]
 artifact-dir = "out"
 ```
+
+## build-dir
+* Original Issue: [#14125](https://github.com/rust-lang/cargo/issues/14125)
+* Tracking Issue: [#14125](https://github.com/rust-lang/cargo/issues/14125)
+
+The directory where intermediate build artifacts will be stored.
+Intermediate artifacts are produced by Rustc/Cargo during the build process.
+
+```toml
+[build]
+build-dir = "out"
+```
+
+### `build.build-dir`
+
+* Type: string (path)
+* Default: Defaults to the value of `build.target-dir`
+* Environment: `CARGO_BUILD_BUILD_DIR`
+
+The path to where internal files used as part of the build are placed.
+
 
 ## root-dir
 * Original Issue: [#9887](https://github.com/rust-lang/cargo/issues/9887)

--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -1,0 +1,575 @@
+//! Tests for `build.build-dir` config property.
+//!
+//! The testing strategy for build-dir functionality is primarily checking if directories / files
+//! are in the expected locations.
+//! The rational is that other tests will verify each individual feature, while the tests in this
+//! file verify the files saved to disk are in the correct locations according to the `build-dir`
+//! configuration.
+//!
+//! Tests check if directories match some "layout" by using [`assert_build_dir_layout`] and
+//! [`assert_artifact_dir_layout`].
+
+use std::path::PathBuf;
+
+use cargo_test_support::prelude::*;
+use cargo_test_support::project;
+use std::env::consts::{DLL_PREFIX, DLL_SUFFIX, EXE_SUFFIX};
+
+#[cargo_test]
+fn verify_build_dir_is_disabled_by_feature_flag() {
+    let p = project()
+        .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [build]
+            build-dir = "build-dir"
+            "#,
+        )
+        .build();
+
+    p.cargo("build")
+        .masquerade_as_nightly_cargo(&[])
+        .enable_mac_dsym()
+        .run();
+
+    assert_build_dir_layout(p.root().join("target"), "debug");
+    assert_exists(&p.root().join(format!("target/debug/foo{EXE_SUFFIX}")));
+    assert_exists(&p.root().join("target/debug/foo.d"));
+    assert_not_exists(&p.root().join("build-dir"));
+}
+
+#[cargo_test]
+fn binary_with_debug() {
+    let p = project()
+        .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [build]
+            target-dir = "target-dir"
+            "#,
+        )
+        .build();
+
+    p.cargo("build")
+        .masquerade_as_nightly_cargo(&[])
+        .enable_mac_dsym()
+        .run();
+
+    assert_build_dir_layout(p.root().join("target-dir"), "debug");
+    assert_exists_patterns_with_base_dir(
+        &p.root(),
+        &[
+            &format!("target-dir/debug/deps/foo*{EXE_SUFFIX}"),
+            "target-dir/debug/deps/foo*.d",
+        ],
+    );
+    assert_not_exists(&p.root().join("target"));
+}
+
+#[cargo_test]
+fn binary_with_release() {
+    let p = project()
+        .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [build]
+            target-dir = "target-dir"
+            "#,
+        )
+        .build();
+
+    p.cargo("build --release")
+        .masquerade_as_nightly_cargo(&[])
+        .enable_mac_dsym()
+        .run();
+
+    assert_build_dir_layout(p.root().join("target-dir"), "release");
+    assert_exists(&p.root().join(format!("target-dir/release/foo{EXE_SUFFIX}")));
+    assert_exists_patterns_with_base_dir(
+        &p.root(),
+        &[
+            &format!("target-dir/release/deps/foo*{EXE_SUFFIX}"),
+            "target-dir/release/deps/foo*.d",
+        ],
+    );
+    assert_not_exists(&p.root().join("target"));
+}
+
+#[cargo_test]
+fn libs() {
+    // https://doc.rust-lang.org/reference/linkage.html#r-link.staticlib
+    let (staticlib_prefix, staticlib_suffix) =
+        if cfg!(target_os = "windows") && cfg!(target_env = "msvc") {
+            ("", ".lib")
+        } else {
+            ("lib", ".a")
+        };
+
+    // (crate-type, list of final artifacts)
+    let lib_types = [
+        ("lib", ["libfoo.rlib", "libfoo.d"]),
+        (
+            "dylib",
+            [
+                &format!("{DLL_PREFIX}foo{DLL_SUFFIX}"),
+                &format!("{DLL_PREFIX}foo.d"),
+            ],
+        ),
+        (
+            "cdylib",
+            [
+                &format!("{DLL_PREFIX}foo{DLL_SUFFIX}"),
+                &format!("{DLL_PREFIX}foo.d"),
+            ],
+        ),
+        (
+            "staticlib",
+            [
+                &format!("{staticlib_prefix}foo{staticlib_suffix}"),
+                &format!("{staticlib_prefix}foo.d"),
+            ],
+        ),
+    ];
+
+    for (lib_type, expected_files) in lib_types {
+        let p = project()
+            .file("src/lib.rs", r#"fn foo() { println!("Hello, World!") }"#)
+            .file(
+                "Cargo.toml",
+                &format!(
+                    r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+            edition = "2015"
+
+            [lib]
+            crate-type = ["{lib_type}"]
+            "#
+                ),
+            )
+            .file(
+                ".cargo/config.toml",
+                r#"
+            [build]
+            target-dir = "target-dir"
+            "#,
+            )
+            .build();
+
+        p.cargo("build")
+            .masquerade_as_nightly_cargo(&[])
+            .enable_mac_dsym()
+            .run();
+
+        assert_build_dir_layout(p.root().join("target-dir"), "debug");
+        assert_exists_patterns_with_base_dir(&p.root().join("target-dir/debug"), &expected_files);
+        assert_not_exists(&p.root().join("target"));
+    }
+}
+
+#[cargo_test]
+fn should_default_to_target() {
+    let p = project()
+        .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
+        .build();
+
+    p.cargo("build")
+        .masquerade_as_nightly_cargo(&[])
+        .enable_mac_dsym()
+        .run();
+
+    assert_build_dir_layout(p.root().join("target"), "debug");
+    assert_exists(&p.root().join(format!("target/debug/foo{EXE_SUFFIX}")));
+}
+
+#[cargo_test]
+fn should_respect_env_var() {
+    let p = project()
+        .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
+        .build();
+
+    p.cargo("build")
+        .env("CARGO_TARGET_DIR", "target-dir")
+        .masquerade_as_nightly_cargo(&[])
+        .enable_mac_dsym()
+        .run();
+
+    assert_build_dir_layout(p.root().join("target-dir"), "debug");
+    assert_exists(&p.root().join(format!("target-dir/debug/foo{EXE_SUFFIX}")));
+    assert_not_exists(&p.root().join("target"));
+}
+
+#[cargo_test]
+fn build_script_should_output_to_target_dir() {
+    let p = project()
+        .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
+        .file(
+            "build.rs",
+            r#"
+            fn main() {
+                std::fs::write(
+                    format!("{}/foo.txt", std::env::var("OUT_DIR").unwrap()),
+                    "Hello, world!",
+                )
+                .unwrap();
+            }
+            "#,
+        )
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [build]
+            target-dir = "target-dir"
+            "#,
+        )
+        .build();
+
+    p.cargo("build")
+        .masquerade_as_nightly_cargo(&[])
+        .enable_mac_dsym()
+        .run();
+
+    assert_build_dir_layout(p.root().join("target-dir"), "debug");
+    assert_exists_patterns_with_base_dir(
+        &p.root(),
+        &[
+            &format!("target-dir/debug/build/foo-*/build-script-build{EXE_SUFFIX}"),
+            "target-dir/debug/build/foo-*/out/foo.txt", // Verify OUT_DIR
+        ],
+    );
+}
+
+#[cargo_test]
+fn cargo_tmpdir_should_output_to_target_dir() {
+    let p = project()
+        .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
+        .file(
+            "tests/foo.rs",
+            r#"
+            #[test]
+            fn test() {
+                std::fs::write(
+                    format!("{}/foo.txt", env!("CARGO_TARGET_TMPDIR")),
+                    "Hello, world!",
+                )
+                .unwrap();
+            }
+            "#,
+        )
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [build]
+            target-dir = "target-dir"
+            "#,
+        )
+        .build();
+
+    p.cargo("test")
+        .masquerade_as_nightly_cargo(&[])
+        .enable_mac_dsym()
+        .run();
+
+    assert_build_dir_layout(p.root().join("target-dir"), "debug");
+    assert_exists(&p.root().join(format!("target-dir/tmp/foo.txt")));
+}
+
+#[cargo_test]
+fn examples_should_output_to_target_dir() {
+    let p = project()
+        .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
+        .file("examples/foo.rs", r#"fn main() { }"#)
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [build]
+            target-dir = "target-dir"
+            "#,
+        )
+        .build();
+
+    p.cargo("build --examples")
+        .masquerade_as_nightly_cargo(&[])
+        .enable_mac_dsym()
+        .run();
+
+    assert_build_dir_layout(p.root().join("target-dir"), "debug");
+    assert_exists_patterns_with_base_dir(
+        &p.root(),
+        &[
+            &format!("target-dir/debug/examples/foo{EXE_SUFFIX}"),
+            "target-dir/debug/examples/foo.d",
+            &format!("target-dir/debug/examples/foo*{EXE_SUFFIX}"),
+            "target-dir/debug/examples/foo*.d",
+        ],
+    );
+}
+
+#[cargo_test]
+fn benches_should_output_to_target_dir() {
+    let p = project()
+        .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
+        .file("benches/foo.rs", r#"fn main() { }"#)
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [build]
+            target-dir = "target-dir"
+            "#,
+        )
+        .build();
+
+    p.cargo("build --bench=foo")
+        .masquerade_as_nightly_cargo(&[])
+        .enable_mac_dsym()
+        .run();
+
+    assert_build_dir_layout(p.root().join("target-dir"), "debug");
+    assert_exists_patterns_with_base_dir(
+        &p.root(),
+        &[
+            &format!("target-dir/debug/deps/foo*{EXE_SUFFIX}"),
+            "target-dir/debug/deps/foo*.d",
+        ],
+    );
+}
+
+#[cargo_test]
+fn cargo_doc_should_output_to_target_dir() {
+    let p = project()
+        .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [build]
+            target-dir = "target-dir"
+            "#,
+        )
+        .build();
+
+    p.cargo("doc")
+        .masquerade_as_nightly_cargo(&[])
+        .enable_mac_dsym()
+        .run();
+
+    let docs_dir = p.root().join("target-dir/doc");
+
+    assert_exists(&docs_dir);
+    assert_exists(&docs_dir.join("foo/index.html"));
+}
+
+#[cargo_test]
+fn cargo_package_should_output_to_target_dir() {
+    let p = project()
+        .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [build]
+            target-dir = "target-dir"
+            "#,
+        )
+        .build();
+
+    p.cargo("package")
+        .masquerade_as_nightly_cargo(&[])
+        .enable_mac_dsym()
+        .run();
+
+    assert_build_dir_layout(p.root().join("target-dir"), "debug");
+
+    let package_dir = p.root().join("target-dir/package");
+    assert_exists(&package_dir);
+    assert_exists(&package_dir.join("foo-0.0.1.crate"));
+    assert!(package_dir.join("foo-0.0.1.crate").is_file());
+    assert_exists(&package_dir.join("foo-0.0.1"));
+    assert!(package_dir.join("foo-0.0.1").is_dir());
+}
+
+#[cargo_test]
+fn cargo_clean_should_clean_the_target_dir() {
+    let p = project()
+        .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [build]
+            target-dir = "target-dir"
+            "#,
+        )
+        .build();
+
+    p.cargo("build")
+        .masquerade_as_nightly_cargo(&[])
+        .enable_mac_dsym()
+        .run();
+
+    assert_build_dir_layout(p.root().join("target-dir"), "debug");
+
+    p.cargo("clean")
+        .masquerade_as_nightly_cargo(&[])
+        .enable_mac_dsym()
+        .run();
+
+    assert!(!p.root().join("target-dir").exists());
+}
+
+#[cargo_test]
+fn timings_report_should_output_to_target_dir() {
+    let p = project()
+        .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [build]
+            target-dir = "target-dir"
+            "#,
+        )
+        .build();
+
+    p.cargo("build --timings")
+        .masquerade_as_nightly_cargo(&[])
+        .enable_mac_dsym()
+        .run();
+
+    assert_exists(&p.root().join("target-dir/cargo-timings/cargo-timing.html"));
+}
+
+#[cargo_test(
+    nightly,
+    reason = "-Zfuture-incompat-test requires nightly (permanently)"
+)]
+fn future_incompat_should_output_to_target_dir() {
+    let p = project()
+        .file("src/main.rs", r#"fn main() { let x = 1; }"#)
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [build]
+            target-dir = "target-dir"
+            "#,
+        )
+        .build();
+
+    p.cargo("check")
+        .arg("--future-incompat-report")
+        .env("RUSTFLAGS", "-Zfuture-incompat-test")
+        .run();
+
+    assert_exists(&p.root().join("target-dir/.future-incompat-report.json"));
+}
+
+#[track_caller]
+fn assert_build_dir_layout(path: PathBuf, profile: &str) {
+    assert_dir_layout(path, profile, true);
+}
+
+#[allow(dead_code)]
+#[track_caller]
+fn assert_artifact_dir_layout(path: PathBuf, profile: &str) {
+    assert_dir_layout(path, profile, false);
+}
+
+#[track_caller]
+fn assert_dir_layout(path: PathBuf, profile: &str, is_build_dir: bool) {
+    println!("checking if {path:?} is a build directory ({is_build_dir})");
+    // For things that are in both `target` and the build directory we only check if they are
+    // present if `is_build_dir` is true.
+    if is_build_dir {
+        assert_eq!(
+            is_build_dir,
+            path.join(profile).is_dir(),
+            "Expected {:?} to exist and be a directory",
+            path.join(profile)
+        );
+    }
+
+    let error_message = |dir: &str| {
+        if is_build_dir {
+            format!("`{dir}` dir was expected but not found")
+        } else {
+            format!("`{dir}` dir was not expected but was found")
+        }
+    };
+
+    if is_build_dir {
+        assert_exists(&path.join(".rustc_info.json"));
+    } else {
+        assert_not_exists(&path.join(".rustc_info.json"));
+    }
+
+    assert_eq!(
+        is_build_dir,
+        path.join(profile).join("deps").is_dir(),
+        "{}",
+        error_message("deps")
+    );
+    assert_eq!(
+        is_build_dir,
+        path.join(profile).join("build").is_dir(),
+        "{}",
+        error_message("build")
+    );
+    assert_eq!(
+        is_build_dir,
+        path.join(profile).join("incremental").is_dir(),
+        "{}",
+        error_message("incremental")
+    );
+    assert_eq!(
+        is_build_dir,
+        path.join(profile).join(".fingerprint").is_dir(),
+        "{}",
+        error_message(".fingerprint")
+    );
+}
+
+#[track_caller]
+fn assert_exists(path: &PathBuf) {
+    assert!(
+        path.exists(),
+        "Expected `{}` to exist but was not found.",
+        path.display()
+    );
+}
+
+#[track_caller]
+fn assert_not_exists(path: &PathBuf) {
+    assert!(
+        !path.exists(),
+        "Expected `{}` to NOT exist but was found.",
+        path.display()
+    );
+}
+
+#[track_caller]
+fn assert_exists_patterns_with_base_dir(base: &PathBuf, patterns: &[&str]) {
+    let root = base.to_str().unwrap();
+    let p: Vec<_> = patterns.iter().map(|p| format!("{root}/{p}")).collect();
+    let p: Vec<&str> = p.iter().map(|v| v.as_str()).collect();
+    assert_exists_patterns(&p);
+}
+
+#[track_caller]
+fn assert_exists_patterns(patterns: &[&str]) {
+    for p in patterns {
+        assert_exists_pattern(p);
+    }
+}
+
+#[track_caller]
+fn assert_exists_pattern(pattern: &str) {
+    use glob::glob;
+
+    let mut z = glob(pattern).unwrap();
+
+    assert!(
+        z.next().is_some(),
+        "Expected `{pattern}` to match existing file but was not found.",
+    )
+}

--- a/tests/testsuite/cargo/z_help/stdout.term.svg
+++ b/tests/testsuite/cargo/z_help/stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="1230px" height="794px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1230px" height="812px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -30,77 +30,79 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>    -Z bindeps                  Allow Cargo packages to depend on bin, cdylib, and staticlib crates, and use the artifacts built by those crates</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>    -Z build-std                Enable Cargo to compile the standard library itself as part of a crate graph compilation</tspan>
+    <tspan x="10px" y="154px"><tspan>    -Z build-dir                Enable the `build.build-dir` option in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>    -Z build-std-features       Configure features enabled for the standard library itself when building the standard library</tspan>
+    <tspan x="10px" y="172px"><tspan>    -Z build-std                Enable Cargo to compile the standard library itself as part of a crate graph compilation</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>    -Z cargo-lints              Enable the `[lints.cargo]` table</tspan>
+    <tspan x="10px" y="190px"><tspan>    -Z build-std-features       Configure features enabled for the standard library itself when building the standard library</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>    -Z checksum-freshness       Use a checksum to determine if output is fresh rather than filesystem mtime</tspan>
+    <tspan x="10px" y="208px"><tspan>    -Z cargo-lints              Enable the `[lints.cargo]` table</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>    -Z codegen-backend          Enable the `codegen-backend` option in profiles in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="226px"><tspan>    -Z checksum-freshness       Use a checksum to determine if output is fresh rather than filesystem mtime</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>    -Z config-include           Enable the `include` key in config files</tspan>
+    <tspan x="10px" y="244px"><tspan>    -Z codegen-backend          Enable the `codegen-backend` option in profiles in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>    -Z direct-minimal-versions  Resolve minimal dependency versions instead of maximum (direct dependencies only)</tspan>
+    <tspan x="10px" y="262px"><tspan>    -Z config-include           Enable the `include` key in config files</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>    -Z doctest-xcompile         Compile and run doctests for non-host target using runner config</tspan>
+    <tspan x="10px" y="280px"><tspan>    -Z direct-minimal-versions  Resolve minimal dependency versions instead of maximum (direct dependencies only)</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>    -Z dual-proc-macros         Build proc-macros for both the host and the target</tspan>
+    <tspan x="10px" y="298px"><tspan>    -Z doctest-xcompile         Compile and run doctests for non-host target using runner config</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>    -Z feature-unification      Enable new feature unification modes in workspaces</tspan>
+    <tspan x="10px" y="316px"><tspan>    -Z dual-proc-macros         Build proc-macros for both the host and the target</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>    -Z gc                       Track cache usage and "garbage collect" unused files</tspan>
+    <tspan x="10px" y="334px"><tspan>    -Z feature-unification      Enable new feature unification modes in workspaces</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>    -Z git                      Enable support for shallow git fetch operations</tspan>
+    <tspan x="10px" y="352px"><tspan>    -Z gc                       Track cache usage and "garbage collect" unused files</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>    -Z gitoxide                 Use gitoxide for the given git interactions, or all of them if no argument is given</tspan>
+    <tspan x="10px" y="370px"><tspan>    -Z git                      Enable support for shallow git fetch operations</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>    -Z host-config              Enable the `[host]` section in the .cargo/config.toml file</tspan>
+    <tspan x="10px" y="388px"><tspan>    -Z gitoxide                 Use gitoxide for the given git interactions, or all of them if no argument is given</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>    -Z minimal-versions         Resolve minimal dependency versions instead of maximum</tspan>
+    <tspan x="10px" y="406px"><tspan>    -Z host-config              Enable the `[host]` section in the .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>    -Z msrv-policy              Enable rust-version aware policy within cargo</tspan>
+    <tspan x="10px" y="424px"><tspan>    -Z minimal-versions         Resolve minimal dependency versions instead of maximum</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>    -Z mtime-on-use             Configure Cargo to update the mtime of used files</tspan>
+    <tspan x="10px" y="442px"><tspan>    -Z msrv-policy              Enable rust-version aware policy within cargo</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>    -Z no-index-update          Do not update the registry index even if the cache is outdated</tspan>
+    <tspan x="10px" y="460px"><tspan>    -Z mtime-on-use             Configure Cargo to update the mtime of used files</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>    -Z package-workspace        Handle intra-workspace dependencies when packaging</tspan>
+    <tspan x="10px" y="478px"><tspan>    -Z no-index-update          Do not update the registry index even if the cache is outdated</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>    -Z panic-abort-tests        Enable support to run tests with -Cpanic=abort</tspan>
+    <tspan x="10px" y="496px"><tspan>    -Z package-workspace        Handle intra-workspace dependencies when packaging</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>    -Z profile-rustflags        Enable the `rustflags` option in profiles in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="514px"><tspan>    -Z panic-abort-tests        Enable support to run tests with -Cpanic=abort</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>    -Z public-dependency        Respect a dependency's `public` field in Cargo.toml to control public/private dependencies</tspan>
+    <tspan x="10px" y="532px"><tspan>    -Z profile-rustflags        Enable the `rustflags` option in profiles in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>    -Z publish-timeout          Enable the `publish.timeout` key in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="550px"><tspan>    -Z public-dependency        Respect a dependency's `public` field in Cargo.toml to control public/private dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>    -Z root-dir                 Set the root directory relative to which paths are printed (defaults to workspace root)</tspan>
+    <tspan x="10px" y="568px"><tspan>    -Z publish-timeout          Enable the `publish.timeout` key in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>    -Z rustdoc-map              Allow passing external documentation mappings to rustdoc</tspan>
+    <tspan x="10px" y="586px"><tspan>    -Z root-dir                 Set the root directory relative to which paths are printed (defaults to workspace root)</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>    -Z rustdoc-scrape-examples  Allows Rustdoc to scrape code examples from reverse-dependencies</tspan>
+    <tspan x="10px" y="604px"><tspan>    -Z rustdoc-map              Allow passing external documentation mappings to rustdoc</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>    -Z script                   Enable support for single-file, `.rs` packages</tspan>
+    <tspan x="10px" y="622px"><tspan>    -Z rustdoc-scrape-examples  Allows Rustdoc to scrape code examples from reverse-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>    -Z target-applies-to-host   Enable the `target-applies-to-host` key in the .cargo/config.toml file</tspan>
+    <tspan x="10px" y="640px"><tspan>    -Z script                   Enable support for single-file, `.rs` packages</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>    -Z trim-paths               Enable the `trim-paths` option in profiles</tspan>
+    <tspan x="10px" y="658px"><tspan>    -Z target-applies-to-host   Enable the `target-applies-to-host` key in the .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan>    -Z unstable-options         Allow the usage of unstable options</tspan>
+    <tspan x="10px" y="676px"><tspan>    -Z trim-paths               Enable the `trim-paths` option in profiles</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan>    -Z warnings                 Allow use of the build.warnings config key</tspan>
+    <tspan x="10px" y="694px"><tspan>    -Z unstable-options         Allow the usage of unstable options</tspan>
 </tspan>
-    <tspan x="10px" y="712px">
+    <tspan x="10px" y="712px"><tspan>    -Z warnings                 Allow use of the build.warnings config key</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>Run with `cargo -Z [FLAG] [COMMAND]`</tspan>
+    <tspan x="10px" y="730px">
 </tspan>
-    <tspan x="10px" y="748px">
+    <tspan x="10px" y="748px"><tspan>Run with `cargo -Z [FLAG] [COMMAND]`</tspan>
 </tspan>
-    <tspan x="10px" y="766px"><tspan>See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html for more information about these flags.</tspan>
+    <tspan x="10px" y="766px">
 </tspan>
-    <tspan x="10px" y="784px">
+    <tspan x="10px" y="784px"><tspan>See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html for more information about these flags.</tspan>
+</tspan>
+    <tspan x="10px" y="802px">
 </tspan>
   </text>
 

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -11,6 +11,7 @@ mod bad_manifest_path;
 mod bench;
 mod binary_name;
 mod build;
+mod build_dir;
 mod build_plan;
 mod build_script;
 mod build_script_env;


### PR DESCRIPTION
## What does this PR try to resolve?

This PR adds a new `build.build-dir` configuration option that was proposed in https://github.com/rust-lang/cargo/issues/14125#issuecomment-2258708917

This new config option allows the user to specify a directory where intermediate build artifacts should be stored. 
I have shortened it to just `build-dir` from `target-build-dir`, although naming is still subject to change.

### What is a final artifact vs an intermediate build artifact

#### Final artifacts
These are the files that end users will typically want to access directly or indirectly via a third party tool.

* binary executable for bin crates
* binary executable for examples
* `.crate` files output from `cargo package`
* [depinfo files](https://doc.rust-lang.org/cargo/reference/build-cache.html#dep-info-files) (`.d` files) for third party build-system integrations (see https://github.com/rust-lang/cargo/blob/master/src/cargo/core/compiler/fingerprint/mod.rs#L194)
* `cargo doc` output (html/css/js/etc)
* Cargo's [`--timings`](https://doc.rust-lang.org/cargo/reference/timings.html) HTML report

#### Intermediate build artifact, caches, and state
These are files that are used internally by Cargo/Rustc during the build process

* other depinfo files (generated by rustc, fingerprint, etc. See https://github.com/rust-lang/cargo/blob/master/src/cargo/core/compiler/fingerprint/mod.rs#L164)
* rlibs and debug info from dependencies
* build script `OUT_DIR`
* output from proc macros (previously stored in `target/build`)
* [incremental build](https://doc.rust-lang.org/rustc/codegen-options/index.html#incremental) output from rustc
* fingerprint files used by Cargo for rebuild detection
* scratchpad used for `cargo package` verify step
* Cache of rustc invocations (`.rustc_info.json`)
* "pre and non uplifted" binary executables. (ie. bins for `examples` that contain the hash in the name, bins for `benches`, proc macros, build scripts)
* `CARGO_TARGET_TMPDIR` files (see rational for this [here](https://github.com/rust-lang/cargo/issues/14125#issuecomment-2258708917))
* [future-incompat-report](https://doc.rust-lang.org/cargo/reference/future-incompat-report.html)'s `.future-incompat-report.json` file

## Feature Gating Strategy

We are following the "Ignore the feature that is used without a gate" approach as described [here](https://doc.rust-lang.org/nightly/nightly-rustc/cargo/core/features/index.html).

The rational for this is: 
The `build.build-dir` is likely going to be set by by users "globally" (ie. `$CARGO_HOME/config.toml`) to set a shared build directory to reduce rebuilding dependencies. For users that multiple cargo versions having having an error would be disrupted.
The fallback behavior is to revert to the behavior of the current stable release (building in `$CARGO_TARGET_DIR`)

## Testing Strategy 

* We have the existing Cargo testsuite to be sure we do not introduce regressions.
  * I have also run the testsuite locally with the cli flag remove to verify all tests pass with the default build dir (which falls back to the target dir)
* For testing thus far, I have been using small hello world project with a few dependencies like `rand` to verify files are being output to the correct directory.
* When this PR is closer to merging, I plan to test with some larger projects with more dependencies, build scripts, ect.
* Other testing recommendations are welcome :bow: 

## How should we test and review this PR?

This is probably best reviewed commit by commit. I documented each commit. 
I tied to follow the atomic commits recommendation in the Cargo contributors guide, but I split out some commits for ease of review. (Otherwise I think this would have ended up being 1 or 2 large commits :sweat_smile:)


## Questions

- [x] What is the expected behavior of `cargo clean`? 
  * At the time of writing it only cleans `target` and does not impact the build-dir but this is easily changable.
  * Answer: See https://github.com/rust-lang/cargo/pull/15104#issuecomment-2616369862
- [x] When using `cargo package` are was expecting just the `.crate` file to be in `target` while all other output be stored in `build.build-dir`?  Not sure if we consider things like `Cargo.toml`, ` Cargo.toml.orig`, `.cargo_vcs_info.json` part of the user facing interface.
  * Current consensus is that only `.crate` is considered a final artifact 
- [x] Where should `cargo doc` output go? HTML/JS for many crates can be pretty large. Moving to the build-dir would help reduce duplication if we find the that acceptable. For `cargo doc --open` this is not a problem but may be problematic for other use cases?
  * Answer: https://github.com/rust-lang/cargo/pull/15104#issuecomment-2619760470
- [x] Are bins generated from `benches` considered final artifacts?
  * Since bins from `examples` are considered final artifacts, it seems natural that `benches` should also be considered final artifacts. However, unlike `examples` the `benches` bins are stored in `target/{profile}/deps` instead of a dedicated directory (like `target/{profile}/examples`). We could move them into a dedicated directory (`target/{profile}/benches`) but that mean would also be changing the structure of the `target` directory which feels out of scope for this change. If we decide that `benches` are final artifacts, it would probably be better to consider that changes as part of https://github.com/rust-lang/cargo/issues/6790
  * Answer: https://github.com/rust-lang/cargo/pull/15104#issuecomment-2636519011
- [ ] [Do we want to include a `CARGO_BUILD_DIR` shortcut env var?](https://github.com/rust-lang/cargo/pull/15104#discussion_r1943404348) 
  * The current commit (2af0c918d415b4de03e627459c3594826ae03cfb) has included the `CARGO_BUILD_DIR` shortcut. This can be removed before merging if there a good reason to.
 
## TODO

- Implementation 
  - [x] Add support in `cargo clean`
  - [ ] ~~Implement templating for `build.build-dir`~~
     * Will implement in a follow up PR [as suggested](https://github.com/rust-lang/cargo/pull/15104#issuecomment-2636514628)
  - [x] Fix issue with `target/examples` still containing "pre-uplifted" binaries
  - [x] Verify `build-dir` with non-bin crate types
- Prepare for review
  - [x] Clean up/improve docs
  - [x] Review tests and add more as needed
  - [x] Fix tests in CI (Windows is currently failing)
  - [x] Clean up commits
  - [ ] Resolve remaining questions
- [x] Request review
