### PR TITLE
feat: new `--root-only` flag for metadata

### DIFF
--- a/src/bin/cargo/commands/metadata.rs
+++ b/src/bin/cargo/commands/metadata.rs
@@ -19,6 +19,7 @@ pub fn cli() -> Command {
             "Output information only about the workspace members \
              and don't fetch dependencies",
         ))
+        .arg(flag("root-only", "Only outputs the workspace root"))
         .arg(
             opt("format-version", "Format version")
                 .value_name("VERSION")
@@ -34,6 +35,15 @@ pub fn cli() -> Command {
 }
 
 pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
+    if args.get_flag("root-only") {
+        gctx.shell()
+            .print_ansi_stdout(args.root_manifest(gctx)?.parent().map_or_else(
+                || [b'/'].as_slice(),
+                |path| path.as_os_str().as_encoded_bytes(),
+            ))?;
+        return Ok(());
+    }
+
     let ws = args.workspace(gctx)?;
 
     let version = match args.get_one::<String>("format-version") {

--- a/src/doc/man/cargo-metadata.md
+++ b/src/doc/man/cargo-metadata.md
@@ -352,6 +352,10 @@ Output information only about the workspace members and don't fetch
 dependencies.
 {{/option}}
 
+{{#option "`--root-only`" }}
+Only outputs the workspace root.
+{{/option}}
+
 {{#option "`--format-version` _version_" }}
 Specify the version of the output format to use. Currently `1` is the only
 possible value.

--- a/src/doc/man/generated_txt/cargo-metadata.txt
+++ b/src/doc/man/generated_txt/cargo-metadata.txt
@@ -345,6 +345,9 @@ OPTIONS
            Output information only about the workspace members and don’t
            fetch dependencies.
 
+       --root-only
+           Only outputs the workspace root.
+
        --format-version version
            Specify the version of the output format to use. Currently 1 is the
            only possible value.

--- a/src/doc/src/commands/cargo-metadata.md
+++ b/src/doc/src/commands/cargo-metadata.md
@@ -352,6 +352,10 @@ Notes:
 dependencies.</dd>
 
 
+<dt class="option-term" id="option-cargo-metadata---root-only"><a class="option-anchor" href="#option-cargo-metadata---root-only"></a><code>--root-only</code></dt>
+<dd class="option-desc">Only outputs the workspace root.</dd>
+
+
 <dt class="option-term" id="option-cargo-metadata---format-version"><a class="option-anchor" href="#option-cargo-metadata---format-version"></a><code>--format-version</code> <em>version</em></dt>
 <dd class="option-desc">Specify the version of the output format to use. Currently <code>1</code> is the only
 possible value.</dd>

--- a/src/etc/man/cargo-metadata.1
+++ b/src/etc/man/cargo-metadata.1
@@ -355,6 +355,11 @@ Output information only about the workspace members and don\[cq]t fetch
 dependencies.
 .RE
 .sp
+\fB\-\-root\-only\fR
+.RS 4
+Only outputs the workspace root.
+.RE
+.sp
 \fB\-\-format\-version\fR \fIversion\fR
 .RS 4
 Specify the version of the output format to use. Currently \fB1\fR is the only

--- a/tests/testsuite/cargo_metadata/help/stdout.term.svg
+++ b/tests/testsuite/cargo_metadata/help/stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="860px" height="596px" xmlns="http://www.w3.org/2000/svg">
+<svg width="860px" height="614px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -37,51 +37,53 @@
 </tspan>
     <tspan x="10px" y="172px"><tspan>                                  fetch dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-cyan bold">--format-version</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;VERSION&gt;</tspan><tspan>  Format version [possible values: 1]</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-cyan bold">--root-only</tspan><tspan>                 Only outputs the workspace root</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>                Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-cyan bold">--format-version</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;VERSION&gt;</tspan><tspan>  Format version [possible values: 1]</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                     Do not print cargo log messages</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>                Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>              Coloring: auto, always, never</tspan>
+    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                     Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>   Override a configuration value</tspan>
+    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>              Coloring: auto, always, never</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                       Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>   Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>                                  details</tspan>
+    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                       Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                      Print help</tspan>
+    <tspan x="10px" y="316px"><tspan>                                  details</tspan>
 </tspan>
-    <tspan x="10px" y="334px">
+    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                      Print help</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan class="fg-green bold">Feature Selection:</tspan>
+    <tspan x="10px" y="352px">
 </tspan>
-    <tspan x="10px" y="370px"><tspan>  </tspan><tspan class="fg-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
+    <tspan x="10px" y="370px"><tspan class="fg-green bold">Feature Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
+    <tspan x="10px" y="388px"><tspan>  </tspan><tspan class="fg-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
 </tspan>
-    <tspan x="10px" y="424px">
+    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="442px">
 </tspan>
-    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="460px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="550px">
+    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help metadata</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="568px">
 </tspan>
-    <tspan x="10px" y="586px">
+    <tspan x="10px" y="586px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help metadata</tspan><tspan class="bold">` for more detailed information.</tspan>
+</tspan>
+    <tspan x="10px" y="604px">
 </tspan>
   </text>
 

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -4954,3 +4954,15 @@ local-time = 1979-05-27
         )
         .run();
 }
+
+#[cargo_test]
+fn cargo_metadata_root_only() {
+    let p = project()
+        .file("src/foo.rs", "")
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .build();
+
+    p.cargo("metadata --root-only")
+        .with_stdout_data(str![[r#"[ROOT]/foo"#]])
+        .run();
+}


### PR DESCRIPTION
This PR introduces a new flag for `cargo metadata`: `--root-only`.

This flag will only output the cargo workspace root.

This is a useful information. But when you're in a big workspace, it can take a lot of time just to get the workspace root. Therefore, this flag allow users to get the workspace without computing all the workspace's metadata.
