### PR TITLE
Update tests to fix nightly errors

### DIFF
--- a/tests/testsuite/standard_lib.rs
+++ b/tests/testsuite/standard_lib.rs
@@ -699,7 +699,7 @@ fn no_implicit_alloc() {
         .target_host()
         .with_stderr_data(str![[r#"
 ...
-error[E0433]: failed to resolve: use of undeclared crate or module `alloc`
+error[E0433]: failed to resolve[..]`alloc`
 ...
 "#]])
         .with_status(101)


### PR DESCRIPTION
There were some changes in the latest nightly which is breaking some tests:

* https://github.com/rust-lang/rust/pull/133154 updated the wording of a message. I adjusted the test to be less sensitive to the exact wording.
* https://github.com/rust-lang/rust/pull/119286 added the `linker-messages` lint which shows the output from the linker. Some of our tests were passing dummy flags to the linker, which it was complaining about. This updates it so that it uses real directories.
* This also fixes an incidental issue, where `build_script_needed_for_host_and_target` was not testing for the correct command-line flags. These got lost in https://github.com/rust-lang/cargo/pull/14132.