### PR TITLE
Fix shared_std_dependency_rebuild running on Windows

### DIFF
--- a/tests/testsuite/standard_lib.rs
+++ b/tests/testsuite/standard_lib.rs
@@ -264,7 +264,7 @@ fn shared_std_dependency_rebuild() {
                 [build-dependencies]
                 dep_test = {{ path = \"{}/tests/testsuite/mock-std/dep_test\" }}
             ",
-                manifest_dir
+                manifest_dir.replace('\\', "/")
             )
             .as_str(),
         )


### PR DESCRIPTION
This fixes the `standard_lib::shared_std_dependency_rebuild` test while running on Windows. On my system, `CARGO_MANIFEST_DIR` is a normal windows-style path (`D:\rust\cargo`) with backslashes. That is not valid TOML syntax. I don't know why this doesn't fail on CI (maybe CI sets a unix-style current dir?).
