### PR TITLE
Fix warnings on Windows

### DIFF
--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -3143,6 +3143,7 @@ fn unaccessible_registry_cache_still_works() {
     // make sure we add the permissions to the files afterwards so "cargo clean" can remove them (#6934)
     set_permissions(&f_cache_path, 0o777);
 
+    #[cfg_attr(windows, allow(unused_variables))]
     fn set_permissions(path: &Path, permissions: u32) {
         #[cfg(not(windows))]
         {


### PR DESCRIPTION
This fixes some warnings that show up on Windows:

```
warning: unused variable: `path`
    --> tests\testsuite\registry.rs:3146:24
     |
3146 |     fn set_permissions(path: &Path, permissions: u32) {
     |                        ^^^^ help: if this is intentional, prefix it with an underscore: `_path`
     |
     = note: `#[warn(unused_variables)]` on by default

warning: unused variable: `permissions`
    --> tests\testsuite\registry.rs:3146:37
     |
3146 |     fn set_permissions(path: &Path, permissions: u32) {
     |                                     ^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_permissions`
```
