### PR TITLE
chore: Update clap_complete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.35"
+version = "4.5.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a13ab5b8cb13dbe35e68b83f6c12f9293b2f601797b71bc9f23befdb329feb"
+checksum = "375f9d8255adeeedd51053574fd8d4ba875ea5fa558e86617b07f09f1680c8b6"
 dependencies = [
  "clap",
  "clap_lex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ cargo-util = { version = "0.2.19", path = "crates/cargo-util" }
 cargo-util-schemas = { version = "0.7.3", path = "crates/cargo-util-schemas" }
 cargo_metadata = "0.19.0"
 clap = "4.5.20"
-clap_complete = { version = "4.5.35", features = ["unstable-dynamic"] }
+clap_complete = { version = "4.5.44", features = ["unstable-dynamic"] }
 color-print = "0.3.6"
 core-foundation = { version = "0.10.0", features = ["mac_os_10_7_support"] }
 crates-io = { version = "0.40.9", path = "crates/crates-io" }


### PR DESCRIPTION
### What does this PR try to resolve?

This includes `CARGO_COMPLETE=` and `CARGO_COMPLETE=0` to disable completions.  I'm wanting access to this for my bash script that runs Cargo out of the `target/debug` without the outer cargo doing the completions

### How should we test and review this PR?



### Additional information

