### PR TITLE
Don't suggest `cargo login` when using incompatible credental providers

### DIFF
--- a/tests/testsuite/credential_process.rs
+++ b/tests/testsuite/credential_process.rs
@@ -101,7 +101,8 @@ fn credential_provider_auth_failure() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[ERROR] token rejected for `alternative`, please run `cargo login --registry alternative`
+[ERROR] token rejected for `alternative`
+You may need to log in using this registry's credential provider
 
 Caused by:
   failed to get successful HTTP response from [..]

--- a/tests/testsuite/credential_process.rs
+++ b/tests/testsuite/credential_process.rs
@@ -88,6 +88,30 @@ You may press ctrl-c [..]
 }
 
 #[cargo_test]
+fn credential_provider_auth_failure() {
+    let _reg = registry::RegistryBuilder::new()
+        .http_index()
+        .auth_required()
+        .alternative()
+        .no_configure_token()
+        .credential_provider(&["cargo:token-from-stdout", "true"])
+        .build();
+
+    cargo_process("install libc --registry=alternative")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[UPDATING] `alternative` index
+[ERROR] token rejected for `alternative`, please run `cargo login --registry alternative`
+
+Caused by:
+  failed to get successful HTTP response from [..]
+  body:
+  [..]
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn basic_unsupported() {
     // Non-action commands don't support login/logout.
     let registry = registry::RegistryBuilder::new()


### PR DESCRIPTION
Authentication errors shouldn't unconditionally recommend running `cargo login`, because alternative registries configured to use custom credential providers won't use the token obtained by `cargo login`. 
