### PR TITLE
Suggest similar feature names on CLI

### DIFF
--- a/tests/testsuite/features_namespaced.rs
+++ b/tests/testsuite/features_namespaced.rs
@@ -418,6 +418,8 @@ regex
     p.cargo("run --features lazy_static")
         .with_stderr_data(str![[r#"
 [ERROR] Package `foo v0.1.0 ([ROOT]/foo)` does not have feature `lazy_static`. It has an optional dependency with that name, but that dependency uses the "dep:" syntax in the features table, so it does not have an implicit feature with that name.
+Dependency `lazy_static` would be enabled by these features:
+	- `regex`
 
 "#]])
         .with_status(101)

--- a/tests/testsuite/package_features.rs
+++ b/tests/testsuite/package_features.rs
@@ -340,6 +340,8 @@ f3f4
         .with_stderr_data(str![[r#"
 [ERROR] Package `foo v0.1.0 ([ROOT]/foo)` does not have the feature `f2`
 
+[HELP] a feature with a similar name exists: `f1`
+
 "#]])
         .run();
 
@@ -406,6 +408,8 @@ fn feature_default_resolver() {
         .with_stderr_data(str![[r#"
 [ERROR] Package `a v0.1.0 ([ROOT]/foo)` does not have the feature `testt`
 
+[HELP] a feature with a similar name exists: `test`
+
 "#]])
         .run();
 
@@ -428,7 +432,7 @@ feature set
 
 #[cargo_test]
 fn command_line_optional_dep() {
-    // Enabling a dependency used as a `dep:` errors
+    // Enabling a dependency used as a `dep:` errors helpfully
     Package::new("bar", "1.0.0").publish();
     let p = project()
         .file(
@@ -455,6 +459,8 @@ fn command_line_optional_dep() {
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [ERROR] Package `a v0.1.0 ([ROOT]/foo)` does not have feature `bar`. It has an optional dependency with that name, but that dependency uses the "dep:" syntax in the features table, so it does not have an implicit feature with that name.
+Dependency `bar` would be enabled by these features:
+	- `foo`
 
 "#]])
         .run();
@@ -462,7 +468,7 @@ fn command_line_optional_dep() {
 
 #[cargo_test]
 fn command_line_optional_dep_three_options() {
-    // Trying to enable an optional dependency used as a `dep:` errors, when there are three features which would enable the dependency
+    // Trying to enable an optional dependency used as a `dep:` errors helpfully, when there are three features which would enable the dependency
     Package::new("bar", "1.0.0").publish();
     let p = project()
         .file(
@@ -491,6 +497,10 @@ fn command_line_optional_dep_three_options() {
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [ERROR] Package `a v0.1.0 ([ROOT]/foo)` does not have feature `bar`. It has an optional dependency with that name, but that dependency uses the "dep:" syntax in the features table, so it does not have an implicit feature with that name.
+Dependency `bar` would be enabled by these features:
+	- `f1`
+	- `f2`
+	- `f3`
 
 "#]])
         .run();
@@ -498,7 +508,7 @@ fn command_line_optional_dep_three_options() {
 
 #[cargo_test]
 fn command_line_optional_dep_many_options() {
-    // Trying to enable an optional dependency used as a `dep:` errors, when there are many features which would enable the dependency
+    // Trying to enable an optional dependency used as a `dep:` errors helpfully, when there are many features which would enable the dependency
     Package::new("bar", "1.0.0").publish();
     let p = project()
         .file(
@@ -528,6 +538,11 @@ fn command_line_optional_dep_many_options() {
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [ERROR] Package `a v0.1.0 ([ROOT]/foo)` does not have feature `bar`. It has an optional dependency with that name, but that dependency uses the "dep:" syntax in the features table, so it does not have an implicit feature with that name.
+Dependency `bar` would be enabled by these features:
+	- `f1`
+	- `f2`
+	- `f3`
+	  ...
 
 "#]])
         .run();
@@ -535,7 +550,7 @@ fn command_line_optional_dep_many_options() {
 
 #[cargo_test]
 fn command_line_optional_dep_many_paths() {
-    // Trying to enable an optional dependency used as a `dep:` errors, when a features would enable the dependency in multiple ways
+    // Trying to enable an optional dependency used as a `dep:` errors helpfully, when a features would enable the dependency in multiple ways
     Package::new("bar", "1.0.0")
         .feature("a", &[])
         .feature("b", &[])
@@ -569,6 +584,10 @@ fn command_line_optional_dep_many_paths() {
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [ERROR] Package `a v0.1.0 ([ROOT]/foo)` does not have feature `bar`. It has an optional dependency with that name, but that dependency uses the "dep:" syntax in the features table, so it does not have an implicit feature with that name.
+Dependency `bar` would be enabled by these features:
+	- `f1`
+	- `f2`
+	- `f3`
 
 "#]])
         .run();
@@ -802,6 +821,8 @@ m1-feature set
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] Package `member1 v0.1.0 ([ROOT]/foo/member1)` does not have the feature `m2-feature`
+
+[HELP] a feature with a similar name exists: `m1-feature`
 
 "#]])
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

When you typo a feature name on the CLI, the error message isn't very helpful. Concretely, I was testing a PR which adds a feature called `cosmic_text` to enable a `cosmic-text` dependency, and got a correct but unhelpful error message:
```rust
error: Package `scenes v0.0.0 ([ELIDED]/linebender/vello/examples/scenes)` does not have feature `cosmic-text`. It has an optional dependency with that name, but that dependency uses the "dep:" syntax in the features table, so it does not have an implicit feature with that name.
```

I had to dig into the Cargo.lock file to find out how to fix this.

### How should we test and review this PR?

Observe the new test cases