### PR TITLE
fix: Don't use "did you mean" in errors

### DIFF
--- a/src/bin/cargo/commands/run.rs
+++ b/src/bin/cargo/commands/run.rs
@@ -103,7 +103,7 @@ pub fn exec_manifest_command(gctx: &mut GlobalContext, cmd: &str, args: &[OsStri
         (false, true) => {
             let possible_commands = crate::list_commands(gctx);
             let is_dir = if manifest_path.is_dir() {
-                format!("\n\t`{cmd}` is a directory")
+                format!(": `{cmd}` is a directory")
             } else {
                 "".to_owned()
             };
@@ -121,12 +121,12 @@ pub fn exec_manifest_command(gctx: &mut GlobalContext, cmd: &str, args: &[OsStri
                         args.into_iter().map(|os| os.to_string_lossy()).join(" ")
                     )
                 };
-                format!("\n\thelp: there is a command with a similar name: `{suggested_command} {actual_args}{args}`")
+                format!("\nhelp: there is a command with a similar name: `{suggested_command} {actual_args}{args}`")
             } else {
                 "".to_owned()
             };
             let suggested_script = if let Some(suggested_script) = suggested_script(cmd) {
-                format!("\n\thelp: there is a script with a similar name: `{suggested_script}`")
+                format!("\nhelp: there is a script with a similar name: `{suggested_script}`")
             } else {
                 "".to_owned()
             };
@@ -153,12 +153,12 @@ pub fn exec_manifest_command(gctx: &mut GlobalContext, cmd: &str, args: &[OsStri
                         args.into_iter().map(|os| os.to_string_lossy()).join(" ")
                     )
                 };
-                format!("\n\thelp: there is a command with a similar name: `{suggested_command} {actual_args}{args}`")
+                format!("\nhelp: there is a command with a similar name: `{suggested_command} {actual_args}{args}`")
             } else {
                 "".to_owned()
             };
             let suggested_script = if let Some(suggested_script) = suggested_script(cmd) {
-                format!("\n\thelp: there is a script with a similar name: `{suggested_script}` (requires `-Zscript`)")
+                format!("\nhelp: there is a script with a similar name: `{suggested_script}` (requires `-Zscript`)")
             } else {
                 "".to_owned()
             };

--- a/src/bin/cargo/commands/run.rs
+++ b/src/bin/cargo/commands/run.rs
@@ -121,12 +121,12 @@ pub fn exec_manifest_command(gctx: &mut GlobalContext, cmd: &str, args: &[OsStri
                         args.into_iter().map(|os| os.to_string_lossy()).join(" ")
                     )
                 };
-                format!("\n\tDid you mean the command `{suggested_command} {actual_args}{args}`")
+                format!("\n\thelp: there is a command with a similar name: `{suggested_command} {actual_args}{args}`")
             } else {
                 "".to_owned()
             };
             let suggested_script = if let Some(suggested_script) = suggested_script(cmd) {
-                format!("\n\tDid you mean the file `{suggested_script}`")
+                format!("\n\thelp: there is a script with a similar name: `{suggested_script}`")
             } else {
                 "".to_owned()
             };
@@ -153,12 +153,12 @@ pub fn exec_manifest_command(gctx: &mut GlobalContext, cmd: &str, args: &[OsStri
                         args.into_iter().map(|os| os.to_string_lossy()).join(" ")
                     )
                 };
-                format!("\n\tDid you mean the command `{suggested_command} {actual_args}{args}`")
+                format!("\n\thelp: there is a command with a similar name: `{suggested_command} {actual_args}{args}`")
             } else {
                 "".to_owned()
             };
             let suggested_script = if let Some(suggested_script) = suggested_script(cmd) {
-                format!("\n\tDid you mean the file `{suggested_script}` with `-Zscript`")
+                format!("\n\thelp: there is a script with a similar name: `{suggested_script}` (requires `-Zscript`)")
             } else {
                 "".to_owned()
             };

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -278,17 +278,18 @@ fn execute_external_subcommand(gctx: &GlobalContext, cmd: &str, args: &[&OsStr])
     let command = match path {
         Some(command) => command,
         None => {
-            let script_suggestion = if gctx.cli_unstable().script
-                && std::path::Path::new(cmd).is_file()
-            {
-                let sep = std::path::MAIN_SEPARATOR;
-                format!("\n\tTo run the file `{cmd}`, provide a relative path like `.{sep}{cmd}`")
-            } else {
-                "".to_owned()
-            };
+            let script_suggestion =
+                if gctx.cli_unstable().script && std::path::Path::new(cmd).is_file() {
+                    let sep = std::path::MAIN_SEPARATOR;
+                    format!(
+                    "\nhelp: To run the file `{cmd}`, provide a relative path like `.{sep}{cmd}`"
+                )
+                } else {
+                    "".to_owned()
+                };
             let err = if cmd.starts_with('+') {
                 anyhow::format_err!(
-                    "no such command: `{cmd}`\n\n\t\
+                    "no such command: `{cmd}`\n\n\
                     help: invoke `cargo` through `rustup` to handle `+toolchain` directives{script_suggestion}",
                 )
             } else {
@@ -296,9 +297,9 @@ fn execute_external_subcommand(gctx: &GlobalContext, cmd: &str, args: &[&OsStr])
                 let did_you_mean = closest_msg(cmd, suggestions.keys(), |c| c, "command");
 
                 anyhow::format_err!(
-                    "no such command: `{cmd}`{did_you_mean}\n\n\t\
-                    View all installed commands with `cargo --list`\n\t\
-                    Find a package to install `{cmd}` with `cargo search cargo-{cmd}`{script_suggestion}",
+                    "no such command: `{cmd}`{did_you_mean}\n\n\
+                    help: view all installed commands with `cargo --list`\n\
+                    help: find a package to install `{cmd}` with `cargo search cargo-{cmd}`{script_suggestion}",
                 )
             };
 

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -293,7 +293,7 @@ fn execute_external_subcommand(gctx: &GlobalContext, cmd: &str, args: &[&OsStr])
                 )
             } else {
                 let suggestions = list_commands(gctx);
-                let did_you_mean = closest_msg(cmd, suggestions.keys(), |c| c);
+                let did_you_mean = closest_msg(cmd, suggestions.keys(), |c| c, "command");
 
                 anyhow::format_err!(
                     "no such command: `{cmd}`{did_you_mean}\n\n\t\

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -289,8 +289,7 @@ fn execute_external_subcommand(gctx: &GlobalContext, cmd: &str, args: &[&OsStr])
             let err = if cmd.starts_with('+') {
                 anyhow::format_err!(
                     "no such command: `{cmd}`\n\n\t\
-                    Cargo does not handle `+toolchain` directives.\n\t\
-                    Did you mean to invoke `cargo` through `rustup` instead?{script_suggestion}",
+                    help: invoke `cargo` through `rustup` to handle `+toolchain` directives{script_suggestion}",
                 )
             } else {
                 let suggestions = list_commands(gctx);

--- a/src/cargo/core/package_id_spec.rs
+++ b/src/cargo/core/package_id_spec.rs
@@ -30,7 +30,8 @@ impl PackageIdSpecQuery for PackageIdSpec {
     {
         let i: Vec<_> = i.into_iter().collect();
         let spec = PackageIdSpec::parse(spec).with_context(|| {
-            let suggestion = edit_distance::closest_msg(spec, i.iter(), |id| id.name().as_str());
+            let suggestion =
+                edit_distance::closest_msg(spec, i.iter(), |id| id.name().as_str(), "package");
             format!("invalid package ID specification: `{}`{}", spec, suggestion)
         })?;
         spec.query(i)
@@ -98,6 +99,7 @@ impl PackageIdSpecQuery for PackageIdSpec {
                     self.name(),
                     all_ids.iter(),
                     |id| id.name().as_str(),
+                    "package",
                 ));
             }
 

--- a/src/cargo/core/package_id_spec.rs
+++ b/src/cargo/core/package_id_spec.rs
@@ -77,7 +77,7 @@ impl PackageIdSpecQuery for PackageIdSpec {
                     .filter(|&id| spec.matches(id))
                     .collect();
                 if !try_matches.is_empty() {
-                    suggestion.push_str("\nDid you mean one of these?\n");
+                    suggestion.push_str("\nhelp: there are similar package ID specifications:\n");
                     minimize(suggestion, &try_matches, self);
                 }
             };

--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -1414,7 +1414,12 @@ fn validate_packages_unmatched(
             })
             .collect();
         if name_matches.is_empty() {
-            let suggestion = closest_msg(&spec.name(), resolve.iter(), |p| p.name().as_str());
+            let suggestion = closest_msg(
+                &spec.name(),
+                resolve.iter(),
+                |p| p.name().as_str(),
+                "package",
+            );
             shell.warn(format!(
                 "profile package spec `{}` in profile `{}` did not match any packages{}",
                 spec, name, suggestion

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -166,6 +166,7 @@ fn clean_specs(
                 &spec.name(),
                 resolve.iter(),
                 |id| id.name().as_str(),
+                "package",
             ));
             anyhow::bail!(
                 "package ID specification `{}` did not match any packages{}",

--- a/src/cargo/ops/cargo_compile/unit_generator.rs
+++ b/src/cargo/ops/cargo_compile/unit_generator.rs
@@ -266,7 +266,7 @@ impl<'a> UnitGenerator<'a, '_> {
                         .filter(|target| is_expected_kind(target))
                 })
                 .collect::<Vec<_>>();
-            let suggestion = closest_msg(target_name, targets.iter(), |t| t.name());
+            let suggestion = closest_msg(target_name, targets.iter(), |t| t.name(), "target");
             if !suggestion.is_empty() {
                 anyhow::bail!(
                     "no {} target {} `{}`{}",

--- a/src/cargo/util/edit_distance.rs
+++ b/src/cargo/util/edit_distance.rs
@@ -113,9 +113,13 @@ pub fn closest_msg<'a, T>(
     choice: &str,
     iter: impl Iterator<Item = T>,
     key: impl Fn(&T) -> &'a str,
+    kind: &str,
 ) -> String {
     match closest(choice, iter, &key) {
-        Some(e) => format!("\n\n\tDid you mean `{}`?", key(&e)),
+        Some(e) => format!(
+            "\n\n\thelp: a {kind} with a similar name exists: `{}`",
+            key(&e)
+        ),
         None => String::new(),
     }
 }

--- a/src/cargo/util/edit_distance.rs
+++ b/src/cargo/util/edit_distance.rs
@@ -117,7 +117,7 @@ pub fn closest_msg<'a, T>(
 ) -> String {
     match closest(choice, iter, &key) {
         Some(e) => format!(
-            "\n\n\thelp: a {kind} with a similar name exists: `{}`",
+            "\n\nhelp: a {kind} with a similar name exists: `{}`",
             key(&e)
         ),
         None => String::new(),

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1535,8 +1535,12 @@ pub fn to_real_manifest(
             .filter(|t| t.is_bin())
             .any(|t| t.name() == run)
         {
-            let suggestion =
-                util::closest_msg(run, targets.iter().filter(|t| t.is_bin()), |t| t.name());
+            let suggestion = util::closest_msg(
+                run,
+                targets.iter().filter(|t| t.is_bin()),
+                |t| t.name(),
+                "target",
+            );
             bail!("default-run target `{}` not found{}", run, suggestion);
         }
     }

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -1350,7 +1350,7 @@ Available bin targets:
         .with_stderr_data(str![[r#"
 [ERROR] no bin target named `a.rs`
 
-	Did you mean `a`?
+	[HELP] a target with a similar name exists: `a`
 
 "#]])
         .run();
@@ -1371,7 +1371,7 @@ Available example targets:
         .with_stderr_data(str![[r#"
 [ERROR] no example target named `a.rs`
 
-	Did you mean `a`?
+	[HELP] a target with a similar name exists: `a`
 
 "#]])
         .run();
@@ -5908,7 +5908,7 @@ fn target_filters_workspace() {
         .with_stderr_data(str![[r#"
 [ERROR] no example target named `ex`
 
-	Did you mean `ex1`?
+	[HELP] a target with a similar name exists: `ex1`
 
 "#]])
         .run();
@@ -5918,7 +5918,7 @@ fn target_filters_workspace() {
         .with_stderr_data(str![[r#"
 [ERROR] no example target matches pattern `ex??`
 
-	Did you mean `ex1`?
+	[HELP] a target with a similar name exists: `ex1`
 
 "#]])
         .run();

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -1350,7 +1350,7 @@ Available bin targets:
         .with_stderr_data(str![[r#"
 [ERROR] no bin target named `a.rs`
 
-	[HELP] a target with a similar name exists: `a`
+[HELP] a target with a similar name exists: `a`
 
 "#]])
         .run();
@@ -1371,7 +1371,7 @@ Available example targets:
         .with_stderr_data(str![[r#"
 [ERROR] no example target named `a.rs`
 
-	[HELP] a target with a similar name exists: `a`
+[HELP] a target with a similar name exists: `a`
 
 "#]])
         .run();
@@ -5908,7 +5908,7 @@ fn target_filters_workspace() {
         .with_stderr_data(str![[r#"
 [ERROR] no example target named `ex`
 
-	[HELP] a target with a similar name exists: `ex1`
+[HELP] a target with a similar name exists: `ex1`
 
 "#]])
         .run();
@@ -5918,7 +5918,7 @@ fn target_filters_workspace() {
         .with_stderr_data(str![[r#"
 [ERROR] no example target matches pattern `ex??`
 
-	[HELP] a target with a similar name exists: `ex1`
+[HELP] a target with a similar name exists: `ex1`
 
 "#]])
         .run();

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -549,8 +549,7 @@ fn subcommand_leading_plus_output_contains() {
         .with_stderr_data(str![[r#"
 [ERROR] no such command: `+nightly`
 
-	Cargo does not handle `+toolchain` directives.
-	Did you mean to invoke `cargo` through `rustup` instead?
+	[HELP] invoke `cargo` through `rustup` to handle `+toolchain` directives
 
 "#]])
         .run();

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -186,10 +186,10 @@ fn find_closest_capital_c_to_c() {
         .with_stderr_data(str![[r#"
 [ERROR] no such command: `C`
 
-	[HELP] a command with a similar name exists: `c`
+[HELP] a command with a similar name exists: `c`
 
-	View all installed commands with `cargo --list`
-	Find a package to install `C` with `cargo search cargo-C`
+[HELP] view all installed commands with `cargo --list`
+[HELP] find a package to install `C` with `cargo search cargo-C`
 
 "#]])
         .run();
@@ -202,10 +202,10 @@ fn find_closest_capital_b_to_b() {
         .with_stderr_data(str![[r#"
 [ERROR] no such command: `B`
 
-	[HELP] a command with a similar name exists: `b`
+[HELP] a command with a similar name exists: `b`
 
-	View all installed commands with `cargo --list`
-	Find a package to install `B` with `cargo search cargo-B`
+[HELP] view all installed commands with `cargo --list`
+[HELP] find a package to install `B` with `cargo search cargo-B`
 
 "#]])
         .run();
@@ -218,10 +218,10 @@ fn find_closest_biuld_to_build() {
         .with_stderr_data(str![[r#"
 [ERROR] no such command: `biuld`
 
-	[HELP] a command with a similar name exists: `build`
+[HELP] a command with a similar name exists: `build`
 
-	View all installed commands with `cargo --list`
-	Find a package to install `biuld` with `cargo search cargo-biuld`
+[HELP] view all installed commands with `cargo --list`
+[HELP] find a package to install `biuld` with `cargo search cargo-biuld`
 
 "#]])
         .run();
@@ -276,10 +276,10 @@ fn find_closest_alias() {
         .with_stderr_data(str![[r#"
 [ERROR] no such command: `myalais`
 
-	[HELP] a command with a similar name exists: `myalias`
+[HELP] a command with a similar name exists: `myalias`
 
-	View all installed commands with `cargo --list`
-	Find a package to install `myalais` with `cargo search cargo-myalais`
+[HELP] view all installed commands with `cargo --list`
+[HELP] find a package to install `myalais` with `cargo search cargo-myalais`
 
 "#]])
         .run();
@@ -290,8 +290,8 @@ fn find_closest_alias() {
         .with_stderr_data(str![[r#"
 [ERROR] no such command: `myalais`
 
-	View all installed commands with `cargo --list`
-	Find a package to install `myalais` with `cargo search cargo-myalais`
+[HELP] view all installed commands with `cargo --list`
+[HELP] find a package to install `myalais` with `cargo search cargo-myalais`
 
 "#]])
         .run();
@@ -306,8 +306,8 @@ fn find_closest_dont_correct_nonsense() {
 		.with_stderr_data(str![[r#"
 [ERROR] no such command: `there-is-no-way-that-there-is-a-command-close-to-this`
 
-	View all installed commands with `cargo --list`
-	Find a package to install `there-is-no-way-that-there-is-a-command-close-to-this` with `cargo search cargo-there-is-no-way-that-there-is-a-command-close-to-this`
+[HELP] view all installed commands with `cargo --list`
+[HELP] find a package to install `there-is-no-way-that-there-is-a-command-close-to-this` with `cargo search cargo-there-is-no-way-that-there-is-a-command-close-to-this`
 
 "#]])
         .run();
@@ -320,8 +320,8 @@ fn displays_subcommand_on_error() {
         .with_stderr_data(str![[r#"
 [ERROR] no such command: `invalid-command`
 
-	View all installed commands with `cargo --list`
-	Find a package to install `invalid-command` with `cargo search cargo-invalid-command`
+[HELP] view all installed commands with `cargo --list`
+[HELP] find a package to install `invalid-command` with `cargo search cargo-invalid-command`
 
 "#]])
         .run();
@@ -549,7 +549,7 @@ fn subcommand_leading_plus_output_contains() {
         .with_stderr_data(str![[r#"
 [ERROR] no such command: `+nightly`
 
-	[HELP] invoke `cargo` through `rustup` to handle `+toolchain` directives
+[HELP] invoke `cargo` through `rustup` to handle `+toolchain` directives
 
 "#]])
         .run();
@@ -562,10 +562,10 @@ fn full_did_you_mean() {
         .with_stderr_data(str![[r#"
 [ERROR] no such command: `bluid`
 
-	[HELP] a command with a similar name exists: `build`
+[HELP] a command with a similar name exists: `build`
 
-	View all installed commands with `cargo --list`
-	Find a package to install `bluid` with `cargo search cargo-bluid`
+[HELP] view all installed commands with `cargo --list`
+[HELP] find a package to install `bluid` with `cargo search cargo-bluid`
 
 "#]])
         .run();

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -186,7 +186,7 @@ fn find_closest_capital_c_to_c() {
         .with_stderr_data(str![[r#"
 [ERROR] no such command: `C`
 
-	Did you mean `c`?
+	[HELP] a command with a similar name exists: `c`
 
 	View all installed commands with `cargo --list`
 	Find a package to install `C` with `cargo search cargo-C`
@@ -202,7 +202,7 @@ fn find_closest_capital_b_to_b() {
         .with_stderr_data(str![[r#"
 [ERROR] no such command: `B`
 
-	Did you mean `b`?
+	[HELP] a command with a similar name exists: `b`
 
 	View all installed commands with `cargo --list`
 	Find a package to install `B` with `cargo search cargo-B`
@@ -218,7 +218,7 @@ fn find_closest_biuld_to_build() {
         .with_stderr_data(str![[r#"
 [ERROR] no such command: `biuld`
 
-	Did you mean `build`?
+	[HELP] a command with a similar name exists: `build`
 
 	View all installed commands with `cargo --list`
 	Find a package to install `biuld` with `cargo search cargo-biuld`
@@ -276,7 +276,7 @@ fn find_closest_alias() {
         .with_stderr_data(str![[r#"
 [ERROR] no such command: `myalais`
 
-	Did you mean `myalias`?
+	[HELP] a command with a similar name exists: `myalias`
 
 	View all installed commands with `cargo --list`
 	Find a package to install `myalais` with `cargo search cargo-myalais`
@@ -562,7 +562,7 @@ fn full_did_you_mean() {
         .with_stderr_data(str![[r#"
 [ERROR] no such command: `bluid`
 
-	Did you mean `build`?
+	[HELP] a command with a similar name exists: `build`
 
 	View all installed commands with `cargo --list`
 	Find a package to install `bluid` with `cargo search cargo-bluid`

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -639,7 +639,7 @@ fn clean_spec_version() {
         .with_stderr_data(str![[r#"
 [ERROR] package ID specification `baz` did not match any packages
 
-	[HELP] a package with a similar name exists: `bar`
+[HELP] a package with a similar name exists: `bar`
 
 "#]])
         .run();
@@ -694,7 +694,7 @@ fn clean_spec_partial_version() {
         .with_stderr_data(str![[r#"
 [ERROR] package ID specification `baz` did not match any packages
 
-	[HELP] a package with a similar name exists: `bar`
+[HELP] a package with a similar name exists: `bar`
 
 "#]])
         .run();
@@ -749,7 +749,7 @@ fn clean_spec_partial_version_ambiguous() {
         .with_stderr_data(str![[r#"
 [ERROR] package ID specification `baz` did not match any packages
 
-	[HELP] a package with a similar name exists: `bar`
+[HELP] a package with a similar name exists: `bar`
 
 "#]])
         .run();

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -639,7 +639,7 @@ fn clean_spec_version() {
         .with_stderr_data(str![[r#"
 [ERROR] package ID specification `baz` did not match any packages
 
-	Did you mean `bar`?
+	[HELP] a package with a similar name exists: `bar`
 
 "#]])
         .run();
@@ -694,7 +694,7 @@ fn clean_spec_partial_version() {
         .with_stderr_data(str![[r#"
 [ERROR] package ID specification `baz` did not match any packages
 
-	Did you mean `bar`?
+	[HELP] a package with a similar name exists: `bar`
 
 "#]])
         .run();
@@ -749,7 +749,7 @@ fn clean_spec_partial_version_ambiguous() {
         .with_stderr_data(str![[r#"
 [ERROR] package ID specification `baz` did not match any packages
 
-	Did you mean `bar`?
+	[HELP] a package with a similar name exists: `bar`
 
 "#]])
         .run();

--- a/tests/testsuite/help.rs
+++ b/tests/testsuite/help.rs
@@ -142,10 +142,10 @@ fn help_alias() {
         .with_stderr_data(str![[r#"
 [ERROR] no such command: `empty-alias`
 
-	[HELP] a command with a similar name exists: `empty-alias`
+[HELP] a command with a similar name exists: `empty-alias`
 
-	View all installed commands with `cargo --list`
-	Find a package to install `empty-alias` with `cargo search cargo-empty-alias`
+[HELP] view all installed commands with `cargo --list`
+[HELP] find a package to install `empty-alias` with `cargo search cargo-empty-alias`
 
 "#]])
         .run();

--- a/tests/testsuite/help.rs
+++ b/tests/testsuite/help.rs
@@ -142,7 +142,7 @@ fn help_alias() {
         .with_stderr_data(str![[r#"
 [ERROR] no such command: `empty-alias`
 
-	Did you mean `empty-alias`?
+	[HELP] a command with a similar name exists: `empty-alias`
 
 	View all installed commands with `cargo --list`
 	Find a package to install `empty-alias` with `cargo search cargo-empty-alias`

--- a/tests/testsuite/package_features.rs
+++ b/tests/testsuite/package_features.rs
@@ -737,7 +737,7 @@ fn non_member_feature() {
         .with_stderr_data(str![[r#"
 [ERROR] package ID specification `bar` did not match any packages
 
-	Did you mean `foo`?
+	[HELP] a package with a similar name exists: `foo`
 
 "#]])
         .run();
@@ -796,7 +796,7 @@ fn non_member_feature() {
         .with_stderr_data(str![[r#"
 [ERROR] package ID specification `bar` did not match any packages
 
-	Did you mean `foo`?
+	[HELP] a package with a similar name exists: `foo`
 
 "#]])
         .run();

--- a/tests/testsuite/package_features.rs
+++ b/tests/testsuite/package_features.rs
@@ -737,7 +737,7 @@ fn non_member_feature() {
         .with_stderr_data(str![[r#"
 [ERROR] package ID specification `bar` did not match any packages
 
-	[HELP] a package with a similar name exists: `foo`
+[HELP] a package with a similar name exists: `foo`
 
 "#]])
         .run();
@@ -796,7 +796,7 @@ fn non_member_feature() {
         .with_stderr_data(str![[r#"
 [ERROR] package ID specification `bar` did not match any packages
 
-	[HELP] a package with a similar name exists: `foo`
+[HELP] a package with a similar name exists: `foo`
 
 "#]])
         .run();

--- a/tests/testsuite/pkgid.rs
+++ b/tests/testsuite/pkgid.rs
@@ -63,7 +63,7 @@ Caused by:
         .with_stderr_data(str![[r#"
 [ERROR] invalid package ID specification: `./bar`
 
-	[HELP] a package with a similar name exists: `bar`
+[HELP] a package with a similar name exists: `bar`
 
 Caused by:
   package ID specification `./bar` looks like a file path, maybe try [ROOTURL]/foo/bar
@@ -119,7 +119,7 @@ registry+https://github.com/rust-lang/crates.io-index#crates-io@0.1.0
         .with_stderr_data(str![[r#"
 [ERROR] package ID specification `crates_io` did not match any packages
 
-	[HELP] a package with a similar name exists: `crates-io`
+[HELP] a package with a similar name exists: `crates-io`
 
 "#]])
         .run();

--- a/tests/testsuite/pkgid.rs
+++ b/tests/testsuite/pkgid.rs
@@ -63,7 +63,7 @@ Caused by:
         .with_stderr_data(str![[r#"
 [ERROR] invalid package ID specification: `./bar`
 
-	Did you mean `bar`?
+	[HELP] a package with a similar name exists: `bar`
 
 Caused by:
   package ID specification `./bar` looks like a file path, maybe try [ROOTURL]/foo/bar
@@ -119,7 +119,7 @@ registry+https://github.com/rust-lang/crates.io-index#crates-io@0.1.0
         .with_stderr_data(str![[r#"
 [ERROR] package ID specification `crates_io` did not match any packages
 
-	Did you mean `crates-io`?
+	[HELP] a package with a similar name exists: `crates-io`
 
 "#]])
         .run();

--- a/tests/testsuite/pkgid.rs
+++ b/tests/testsuite/pkgid.rs
@@ -106,7 +106,7 @@ registry+https://github.com/rust-lang/crates.io-index#crates-io@0.1.0
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] package ID specification `https://example.com/crates-io` did not match any packages
-Did you mean one of these?
+[HELP] there are similar package ID specifications:
 
   crates-io@0.1.0
 
@@ -193,7 +193,7 @@ Please re-run this command with one of the following specifications:
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] package ID specification `two-ver@0.3.0` did not match any packages
-Did you mean one of these?
+[HELP] there are similar package ID specifications:
 
   two-ver@0.1.0
   two-ver@0.2.0

--- a/tests/testsuite/profile_overrides.rs
+++ b/tests/testsuite/profile_overrides.rs
@@ -78,7 +78,7 @@ fn profile_override_warnings() {
 [WARNING] profile package spec `bar@1.2.3` in profile `dev` has a version or URL that does not match any of the packages: bar v0.5.0 ([ROOT]/foo/bar)
 [WARNING] profile package spec `bart` in profile `dev` did not match any packages
 
-	[HELP] a package with a similar name exists: `bar`
+[HELP] a package with a similar name exists: `bar`
 [WARNING] profile package spec `no-suggestion` in profile `dev` did not match any packages
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)

--- a/tests/testsuite/profile_overrides.rs
+++ b/tests/testsuite/profile_overrides.rs
@@ -78,7 +78,7 @@ fn profile_override_warnings() {
 [WARNING] profile package spec `bar@1.2.3` in profile `dev` has a version or URL that does not match any of the packages: bar v0.5.0 ([ROOT]/foo/bar)
 [WARNING] profile package spec `bart` in profile `dev` did not match any packages
 
-	Did you mean `bar`?
+	[HELP] a package with a similar name exists: `bar`
 [WARNING] profile package spec `no-suggestion` in profile `dev` did not match any packages
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -2763,7 +2763,7 @@ fn in_package_workspace_not_found() {
         .with_stderr_data(str![[r#"
 [ERROR] package ID specification `li` did not match any packages
 
-	Did you mean `foo`?
+	[HELP] a package with a similar name exists: `foo`
 
 "#]])
         .run();
@@ -2865,7 +2865,7 @@ fn publish_path_dependency_without_workspace() {
         .with_stderr_data(str![[r#"
 [ERROR] package ID specification `bar` did not match any packages
 
-	Did you mean `foo`?
+	[HELP] a package with a similar name exists: `foo`
 
 "#]])
         .run();

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -2763,7 +2763,7 @@ fn in_package_workspace_not_found() {
         .with_stderr_data(str![[r#"
 [ERROR] package ID specification `li` did not match any packages
 
-	[HELP] a package with a similar name exists: `foo`
+[HELP] a package with a similar name exists: `foo`
 
 "#]])
         .run();
@@ -2865,7 +2865,7 @@ fn publish_path_dependency_without_workspace() {
         .with_stderr_data(str![[r#"
 [ERROR] package ID specification `bar` did not match any packages
 
-	[HELP] a package with a similar name exists: `foo`
+[HELP] a package with a similar name exists: `foo`
 
 "#]])
         .run();

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -474,7 +474,7 @@ fn bogus_default_run() {
 Caused by:
   default-run target `b` not found
 
-  	[HELP] a target with a similar name exists: `a`
+  [HELP] a target with a similar name exists: `a`
 
 "#]])
         .run();
@@ -756,7 +756,7 @@ Available bin targets:
         .with_stderr_data(str![[r#"
 [ERROR] no bin target named `a.rs`
 
-	[HELP] a target with a similar name exists: `a`
+[HELP] a target with a similar name exists: `a`
 
 "#]])
         .run();
@@ -777,7 +777,7 @@ Available example targets:
         .with_stderr_data(str![[r#"
 [ERROR] no example target named `a.rs`
 
-	[HELP] a target with a similar name exists: `a`
+[HELP] a target with a similar name exists: `a`
 
 "#]])
         .run();

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -474,7 +474,7 @@ fn bogus_default_run() {
 Caused by:
   default-run target `b` not found
 
-  	Did you mean `a`?
+  	[HELP] a target with a similar name exists: `a`
 
 "#]])
         .run();
@@ -756,7 +756,7 @@ Available bin targets:
         .with_stderr_data(str![[r#"
 [ERROR] no bin target named `a.rs`
 
-	Did you mean `a`?
+	[HELP] a target with a similar name exists: `a`
 
 "#]])
         .run();
@@ -777,7 +777,7 @@ Available example targets:
         .with_stderr_data(str![[r#"
 [ERROR] no example target named `a.rs`
 
-	Did you mean `a`?
+	[HELP] a target with a similar name exists: `a`
 
 "#]])
         .run();

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -84,7 +84,7 @@ fn path_required() {
         .with_stderr_data(str![[r#"
 [ERROR] no such command: `echo`
 
-	Did you mean `bench`?
+	[HELP] a command with a similar name exists: `bench`
 
 	View all installed commands with `cargo --list`
 	Find a package to install `echo` with `cargo search cargo-echo`

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -630,7 +630,7 @@ fn did_you_mean_file() {
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [ERROR] no such file or subcommand `foo.rs`
-	Did you mean the file `./food.rs`
+	[HELP] there is a script with a similar name: `./food.rs`
 
 "#]])
         .run();
@@ -648,7 +648,7 @@ fn did_you_mean_file_stable() {
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [ERROR] no such subcommand `foo.rs`
-	Did you mean the file `./food.rs` with `-Zscript`
+	[HELP] there is a script with a similar name: `./food.rs` (requires `-Zscript`)
 
 "#]])
         .run();
@@ -664,7 +664,7 @@ fn did_you_mean_command() {
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [ERROR] no such file or subcommand `build--manifest-path=./Cargo.toml`
-	Did you mean the command `build --manifest-path=./Cargo.toml`
+	[HELP] there is a command with a similar name: `build --manifest-path=./Cargo.toml`
 
 "#]])
         .run();
@@ -680,7 +680,7 @@ fn did_you_mean_command_stable() {
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [ERROR] no such subcommand `build--manifest-path=./Cargo.toml`
-	Did you mean the command `build --manifest-path=./Cargo.toml`
+	[HELP] there is a command with a similar name: `build --manifest-path=./Cargo.toml`
 
 "#]])
         .run();

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -84,11 +84,11 @@ fn path_required() {
         .with_stderr_data(str![[r#"
 [ERROR] no such command: `echo`
 
-	[HELP] a command with a similar name exists: `bench`
+[HELP] a command with a similar name exists: `bench`
 
-	View all installed commands with `cargo --list`
-	Find a package to install `echo` with `cargo search cargo-echo`
-	To run the file `echo`, provide a relative path like `./echo`
+[HELP] view all installed commands with `cargo --list`
+[HELP] find a package to install `echo` with `cargo search cargo-echo`
+[HELP] To run the file `echo`, provide a relative path like `./echo`
 
 "#]])
         .run();
@@ -582,8 +582,7 @@ fn script_like_dir() {
         .masquerade_as_nightly_cargo(&["script"])
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] no such file or subcommand `foo.rs`
-	`foo.rs` is a directory
+[ERROR] no such file or subcommand `foo.rs`: `foo.rs` is a directory
 
 "#]])
         .run();
@@ -630,7 +629,7 @@ fn did_you_mean_file() {
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [ERROR] no such file or subcommand `foo.rs`
-	[HELP] there is a script with a similar name: `./food.rs`
+[HELP] there is a script with a similar name: `./food.rs`
 
 "#]])
         .run();
@@ -648,7 +647,7 @@ fn did_you_mean_file_stable() {
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [ERROR] no such subcommand `foo.rs`
-	[HELP] there is a script with a similar name: `./food.rs` (requires `-Zscript`)
+[HELP] there is a script with a similar name: `./food.rs` (requires `-Zscript`)
 
 "#]])
         .run();
@@ -664,7 +663,7 @@ fn did_you_mean_command() {
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [ERROR] no such file or subcommand `build--manifest-path=./Cargo.toml`
-	[HELP] there is a command with a similar name: `build --manifest-path=./Cargo.toml`
+[HELP] there is a command with a similar name: `build --manifest-path=./Cargo.toml`
 
 "#]])
         .run();
@@ -680,7 +679,7 @@ fn did_you_mean_command_stable() {
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [ERROR] no such subcommand `build--manifest-path=./Cargo.toml`
-	[HELP] there is a command with a similar name: `build --manifest-path=./Cargo.toml`
+[HELP] there is a command with a similar name: `build --manifest-path=./Cargo.toml`
 
 "#]])
         .run();

--- a/tests/testsuite/tree.rs
+++ b/tests/testsuite/tree.rs
@@ -1967,7 +1967,7 @@ foo v0.1.0 ([ROOT]/foo)
         .with_stderr_data(str![[r#"
 [ERROR] package ID specification `no-dep` did not match any packages
 
-	Did you mean `bdep`?
+	[HELP] a package with a similar name exists: `bdep`
 
 "#]])
         .with_status(101)

--- a/tests/testsuite/tree.rs
+++ b/tests/testsuite/tree.rs
@@ -1967,7 +1967,7 @@ foo v0.1.0 ([ROOT]/foo)
         .with_stderr_data(str![[r#"
 [ERROR] package ID specification `no-dep` did not match any packages
 
-	[HELP] a package with a similar name exists: `bdep`
+[HELP] a package with a similar name exists: `bdep`
 
 "#]])
         .with_status(101)


### PR DESCRIPTION
### What does this PR try to resolve?

This is an attempt at moving Cargo closer to [rustc's diagnostic guide](https://rustc-dev-guide.rust-lang.org/diagnostics.html#suggestion-style-guide) (clap already did this)

> Suggestions should not be a question. In particular, language like "did you mean" should be avoided. Sometimes, it's unclear why a particular suggestion is being made. In these cases, it's better to be upfront about what the suggestion is.
>
> Compare "did you mean: Foo" vs. "there is a struct with a similar name: Foo".

### How should we test and review this PR?



### Additional information

I did leave behind three "did you mean"s as I was a little less sure in how to handle them