### PR TITLE
fix: detect infinite file system loop and bail out

### DIFF
--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -2127,7 +2127,6 @@ fn ignore_broken_symlinks() {
 
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[WARNING] File system loop found: [ROOT]/foo/a/b/c/d/foo points to an ancestor [ROOT]/foo/a/b
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1039,9 +1039,12 @@ fn filesystem_loop() {
 
     project()
         .file("src/main.rs", r#"fn main() { println!("hello"); }"#)
+        .symlink_dir("a/b", "a/b/c/foo")
         .symlink_dir("a/b", "a/b/c/d/foo")
+        .symlink_dir("a/b", "a/b/c/d/e/foo")
         .build()
         .cargo("package -v")
+        .env("__CARGO_TEST_FS_LOOP_LIMIT_DO_NOT_USE_THIS", "2")
         .with_stderr_data(str![[r#"
 [WARNING] manifest has no description, license, license-file, documentation, homepage or repository.
 See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1045,20 +1045,14 @@ fn filesystem_loop() {
         .build()
         .cargo("package -v")
         .env("__CARGO_TEST_FS_LOOP_LIMIT_DO_NOT_USE_THIS", "2")
+        .with_status(101)
         .with_stderr_data(str![[r#"
 [WARNING] manifest has no description, license, license-file, documentation, homepage or repository.
 See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
-[WARNING] found (git) Cargo.toml ignored at `target/tmp/cit/t0/foo/Cargo.toml` in workdir `/Users/whlo/dev/cargo/`
-[PACKAGING] foo v0.0.1 ([ROOT]/foo)
-[ARCHIVING] Cargo.lock
-[ARCHIVING] Cargo.toml
-[ARCHIVING] Cargo.toml.orig
-[ARCHIVING] src/main.rs
-[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
-[VERIFYING] foo v0.0.1 ([ROOT]/foo)
-[COMPILING] foo v0.0.1 ([ROOT]/foo/target/package/foo-0.0.1)
-[RUNNING] `rustc [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[ERROR] failed to determine list of files in [ROOT]/foo
+
+Caused by:
+  file system loop detected at `[ROOT]/foo/a/b` (exceeded limit of 2)
 
 "#]])
         .run();

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1043,9 +1043,20 @@ fn filesystem_loop() {
         .build()
         .cargo("package -v")
         .with_stderr_data(str![[r#"
-...
-[WARNING] File system loop found: [ROOT]/foo/a/b/c/d/foo points to an ancestor [ROOT]/foo/a/b
-...
+[WARNING] manifest has no description, license, license-file, documentation, homepage or repository.
+See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
+[WARNING] found (git) Cargo.toml ignored at `target/tmp/cit/t0/foo/Cargo.toml` in workdir `/Users/whlo/dev/cargo/`
+[PACKAGING] foo v0.0.1 ([ROOT]/foo)
+[ARCHIVING] Cargo.lock
+[ARCHIVING] Cargo.toml
+[ARCHIVING] Cargo.toml.orig
+[ARCHIVING] src/main.rs
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[VERIFYING] foo v0.0.1 ([ROOT]/foo)
+[COMPILING] foo v0.0.1 ([ROOT]/foo/target/package/foo-0.0.1)
+[RUNNING] `rustc [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
 "#]])
         .run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?

For #9528 if the loop in inside `/sys/block` it would be an infinite loop.
In that case Cargo is better bailing out instead of emitting endless warnings.
We set a relatively large limit 1024
to ensure there is any legitimate reason to have file system loop.

This also turn the file system loop warning into a `debug!` log, per #12600 request.

### How should we test and review this PR?

I don't really know if 1024 is really a big enough number.
My naive instinct told me that there is no a valid use case for so many loops in a Cargo package.


### Additional information

Fixes #12600
