### PR TITLE
Simplify backtrack

### DIFF
--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -960,13 +960,6 @@ fn find_candidate(
     };
 
     while let Some(mut frame) = backtrack_stack.pop() {
-        let next = frame
-            .remaining_candidates
-            .next(&mut frame.conflicting_activations, &frame.context);
-        let Some((candidate, has_another)) = next else {
-            panic!("why did we save a frame that has no next?");
-        };
-
         // If all members of `conflicting_activations` are still
         // active in this back up we know that we're guaranteed to not actually
         // make any progress. As a result if we hit this condition we can
@@ -998,6 +991,11 @@ fn find_candidate(
                     .is_none());
             }
         }
+
+        let (candidate, has_another) = frame
+            .remaining_candidates
+            .next(&mut frame.conflicting_activations, &frame.context)
+            .expect("why did we save a frame that has no next?");
 
         return Some((candidate, has_another, frame));
     }

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -967,12 +967,12 @@ fn find_candidate(
         if let Some(age) = age {
             // Above we use `cx` to determine if this is going to be conflicting.
             // But lets just double check if the `pop`ed frame agrees.
-            let frame_to_new = frame.context.age >= age;
+            let frame_too_new = frame.context.age >= age;
             debug_assert!(
                 frame
                     .context
                     .is_conflicting(Some(parent.package_id()), conflicting_activations)
-                    == frame_to_new.then_some(age)
+                    == frame_too_new.then_some(age)
             );
 
             if frame_to_new {

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -965,7 +965,17 @@ fn find_candidate(
         // make any progress. As a result if we hit this condition we can
         // completely skip this backtrack frame and move on to the next.
         if let Some(age) = age {
-            if frame.context.age >= age {
+            // Above we use `cx` to determine if this is going to be conflicting.
+            // But lets just double check if the `pop`ed frame agrees.
+            let frame_to_new = frame.context.age >= age;
+            debug_assert!(
+                frame
+                    .context
+                    .is_conflicting(Some(parent.package_id()), conflicting_activations)
+                    == frame_to_new.then_some(age)
+            );
+
+            if frame_to_new {
                 trace!(
                     "{} = \"{}\" skip as not solving {}: {:?}",
                     frame.dep.package_name(),
@@ -973,22 +983,7 @@ fn find_candidate(
                     parent.package_id(),
                     conflicting_activations
                 );
-                // above we use `cx` to determine that this is still going to be conflicting.
-                // but lets just double check.
-                debug_assert!(
-                    frame
-                        .context
-                        .is_conflicting(Some(parent.package_id()), conflicting_activations)
-                        == Some(age)
-                );
                 continue;
-            } else {
-                // above we use `cx` to determine that this is not going to be conflicting.
-                // but lets just double check.
-                debug_assert!(frame
-                    .context
-                    .is_conflicting(Some(parent.package_id()), conflicting_activations)
-                    .is_none());
             }
         }
 

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -964,7 +964,7 @@ fn find_candidate(
             .remaining_candidates
             .next(&mut frame.conflicting_activations, &frame.context);
         let Some((candidate, has_another)) = next else {
-            continue;
+            panic!("why did we save a frame that has no next?");
         };
 
         // If all members of `conflicting_activations` are still


### PR DESCRIPTION
### What does this PR try to resolve?

Some very small simplifications made while poking around the resolver. I was trying to understand when we would end up hitting a `continue` in the code. The easiest way was to run the tests with a panic instead. Turns out I was right, we cannot/(can no longer) hit that code path. Which allowed us to simplify some other surrounding code.

### How should we test and review this PR?

All tests pass on each commit.

### Additional information
