### PR TITLE
[DO NOT MERGE] Migrate to edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,9 +136,9 @@ self_named_module_files = "warn"
 [package]
 name = "cargo"
 version = "0.87.0"
-edition.workspace = true
+edition = "2024"
 license.workspace = true
-rust-version = "1.84"  # MSRV:1
+rust-version = "1.85"  # MSRV:1
 homepage = "https://doc.rust-lang.org/cargo/index.html"
 repository.workspace = true
 documentation = "https://docs.rs/cargo"

--- a/crates/cargo-test-macro/Cargo.toml
+++ b/crates/cargo-test-macro/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "cargo-test-macro"
 version = "0.4.1"
-edition.workspace = true
-rust-version = "1.84"  # MSRV:1
+edition = "2024"
+rust-version = "1.85"  # MSRV:1
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/crates/cargo-util-schemas/Cargo.toml
+++ b/crates/cargo-util-schemas/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "cargo-util-schemas"
 version = "0.7.3"
-rust-version = "1.84"  # MSRV:1
-edition.workspace = true
+rust-version = "1.85"  # MSRV:1
+edition = "2024"
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/crates/cargo-util/Cargo.toml
+++ b/crates/cargo-util/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "cargo-util"
 version = "0.2.19"
-rust-version = "1.84"  # MSRV:1
-edition.workspace = true
+rust-version = "1.85"  # MSRV:1
+edition = "2024"
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/crates/crates-io/Cargo.toml
+++ b/crates/crates-io/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "crates-io"
 version = "0.40.9"
-rust-version = "1.84"  # MSRV:1
-edition.workspace = true
+rust-version = "1.85"  # MSRV:1
+edition = "2024"
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/credential/cargo-credential-libsecret/Cargo.toml
+++ b/credential/cargo-credential-libsecret/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "cargo-credential-libsecret"
 version = "0.4.12"
-rust-version = "1.84"  # MSRV:1
-edition.workspace = true
+rust-version = "1.85"  # MSRV:1
+edition = "2024"
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/credential/cargo-credential-macos-keychain/Cargo.toml
+++ b/credential/cargo-credential-macos-keychain/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "cargo-credential-macos-keychain"
 version = "0.4.12"
-rust-version = "1.84"  # MSRV:1
-edition.workspace = true
+rust-version = "1.85"  # MSRV:1
+edition = "2024"
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/credential/cargo-credential-wincred/Cargo.toml
+++ b/credential/cargo-credential-wincred/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "cargo-credential-wincred"
 version = "0.4.12"
-rust-version = "1.84"  # MSRV:1
-edition.workspace = true
+rust-version = "1.85"  # MSRV:1
+edition = "2024"
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -65,12 +65,12 @@ pub fn main(gctx: &mut GlobalContext) -> CliResult {
         let _ = configure_gctx(gctx, &expanded_args, None, global_args, None);
         let version = get_version_string(is_verbose);
         drop_print!(gctx, "{}", version);
-    } else if let Some(code) = expanded_args.get_one::<String>("explain") {
+    } else { match expanded_args.get_one::<String>("explain") { Some(code) => {
         // Don't let config errors get in the way of parsing arguments
         let _ = configure_gctx(gctx, &expanded_args, None, global_args, None);
         let mut procss = gctx.load_global_rustc(None)?.process();
         procss.arg("--explain").arg(code).exec()?;
-    } else if expanded_args.flag("list") {
+    } _ => if expanded_args.flag("list") {
         // Don't let config errors get in the way of parsing arguments
         let _ = configure_gctx(gctx, &expanded_args, None, global_args, None);
         print_list(gctx, is_verbose);
@@ -94,7 +94,7 @@ pub fn main(gctx: &mut GlobalContext) -> CliResult {
         super::init_git(gctx);
 
         exec.exec(gctx, subcommand_args)?;
-    }
+    }}}
     Ok(())
 }
 

--- a/src/bin/cargo/commands/build.rs
+++ b/src/bin/cargo/commands/build.rs
@@ -59,18 +59,18 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
         gctx.shell()
             .warn("the --out-dir flag has been changed to --artifact-dir")?;
         compile_opts.build_config.export_dir = Some(artifact_dir);
-    } else if let Some(artifact_dir) = gctx.build_config()?.artifact_dir.as_ref() {
+    } else { match gctx.build_config()?.artifact_dir.as_ref() { Some(artifact_dir) => {
         // If a CLI option is not specified for choosing the artifact dir, use the `artifact-dir` from the build config, if
         // present
         let artifact_dir = artifact_dir.resolve_path(gctx);
         compile_opts.build_config.export_dir = Some(artifact_dir);
-    } else if let Some(artifact_dir) = gctx.build_config()?.out_dir.as_ref() {
+    } _ => { match gctx.build_config()?.out_dir.as_ref() { Some(artifact_dir) => {
         // As a last priority, check `out-dir` in the build config
         gctx.shell()
             .warn("the out-dir config option has been changed to artifact-dir")?;
         let artifact_dir = artifact_dir.resolve_path(gctx);
         compile_opts.build_config.export_dir = Some(artifact_dir);
-    }
+    } _ => {}}}}}
 
     if compile_opts.build_config.export_dir.is_some() {
         gctx.cli_unstable()

--- a/src/bin/cargo/commands/build.rs
+++ b/src/bin/cargo/commands/build.rs
@@ -59,18 +59,28 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
         gctx.shell()
             .warn("the --out-dir flag has been changed to --artifact-dir")?;
         compile_opts.build_config.export_dir = Some(artifact_dir);
-    } else { match gctx.build_config()?.artifact_dir.as_ref() { Some(artifact_dir) => {
-        // If a CLI option is not specified for choosing the artifact dir, use the `artifact-dir` from the build config, if
-        // present
-        let artifact_dir = artifact_dir.resolve_path(gctx);
-        compile_opts.build_config.export_dir = Some(artifact_dir);
-    } _ => { match gctx.build_config()?.out_dir.as_ref() { Some(artifact_dir) => {
-        // As a last priority, check `out-dir` in the build config
-        gctx.shell()
-            .warn("the out-dir config option has been changed to artifact-dir")?;
-        let artifact_dir = artifact_dir.resolve_path(gctx);
-        compile_opts.build_config.export_dir = Some(artifact_dir);
-    } _ => {}}}}}
+    } else {
+        match gctx.build_config()?.artifact_dir.as_ref() {
+            Some(artifact_dir) => {
+                // If a CLI option is not specified for choosing the artifact dir, use the `artifact-dir` from the build config, if
+                // present
+                let artifact_dir = artifact_dir.resolve_path(gctx);
+                compile_opts.build_config.export_dir = Some(artifact_dir);
+            }
+            _ => {
+                match gctx.build_config()?.out_dir.as_ref() {
+                    Some(artifact_dir) => {
+                        // As a last priority, check `out-dir` in the build config
+                        gctx.shell()
+                            .warn("the out-dir config option has been changed to artifact-dir")?;
+                        let artifact_dir = artifact_dir.resolve_path(gctx);
+                        compile_opts.build_config.export_dir = Some(artifact_dir);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
 
     if compile_opts.build_config.export_dir.is_some() {
         gctx.cli_unstable()

--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -167,14 +167,14 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
     } else if krates.is_empty() {
         from_cwd = true;
         SourceId::for_path(gctx.cwd())?
-    } else if let Some(reg_or_index) = args.registry_or_index(gctx)? {
+    } else { match args.registry_or_index(gctx)? { Some(reg_or_index) => {
         match reg_or_index {
             ops::RegistryOrIndex::Registry(r) => SourceId::alt_registry(gctx, &r)?,
             ops::RegistryOrIndex::Index(url) => SourceId::for_registry(&url)?,
         }
-    } else {
+    } _ => {
         SourceId::crates_io(gctx)?
-    };
+    }}};
 
     let root = args.get_one::<String>("root").map(String::as_str);
 

--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -167,14 +167,15 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
     } else if krates.is_empty() {
         from_cwd = true;
         SourceId::for_path(gctx.cwd())?
-    } else { match args.registry_or_index(gctx)? { Some(reg_or_index) => {
-        match reg_or_index {
-            ops::RegistryOrIndex::Registry(r) => SourceId::alt_registry(gctx, &r)?,
-            ops::RegistryOrIndex::Index(url) => SourceId::for_registry(&url)?,
+    } else {
+        match args.registry_or_index(gctx)? {
+            Some(reg_or_index) => match reg_or_index {
+                ops::RegistryOrIndex::Registry(r) => SourceId::alt_registry(gctx, &r)?,
+                ops::RegistryOrIndex::Index(url) => SourceId::for_registry(&url)?,
+            },
+            _ => SourceId::crates_io(gctx)?,
         }
-    } _ => {
-        SourceId::crates_io(gctx)?
-    }}};
+    };
 
     let root = args.get_one::<String>("root").map(String::as_str);
 

--- a/src/bin/cargo/commands/remove.rs
+++ b/src/bin/cargo/commands/remove.rs
@@ -363,12 +363,14 @@ fn gc_unused_patches(workspace: &Workspace<'_>, resolve: &Resolve) -> CargoResul
                     )?;
 
                     // Generate a PackageIdSpec url for querying
-                    let url = match dep.source_id(workspace.gctx())?
-                    { MaybeWorkspace::Other(source_id) => {
-                        format!("{}#{}", source_id.url(), dep.name)
-                    } _ => {
-                        continue;
-                    }};
+                    let url = match dep.source_id(workspace.gctx())? {
+                        MaybeWorkspace::Other(source_id) => {
+                            format!("{}#{}", source_id.url(), dep.name)
+                        }
+                        _ => {
+                            continue;
+                        }
+                    };
 
                     if PackageIdSpec::query_str(&url, resolve.unused_patches().iter().cloned())
                         .is_ok()

--- a/src/bin/cargo/commands/remove.rs
+++ b/src/bin/cargo/commands/remove.rs
@@ -363,13 +363,12 @@ fn gc_unused_patches(workspace: &Workspace<'_>, resolve: &Resolve) -> CargoResul
                     )?;
 
                     // Generate a PackageIdSpec url for querying
-                    let url = if let MaybeWorkspace::Other(source_id) =
-                        dep.source_id(workspace.gctx())?
-                    {
+                    let url = match dep.source_id(workspace.gctx())?
+                    { MaybeWorkspace::Other(source_id) => {
                         format!("{}#{}", source_id.url(), dep.name)
-                    } else {
+                    } _ => {
                         continue;
-                    };
+                    }};
 
                     if PackageIdSpec::query_str(&url, resolve.unused_patches().iter().cloned())
                         .is_ok()

--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -787,15 +787,14 @@ fn extra_args(
 
     if let Some(rustflags) = rustflags_from_env(gctx, flags) {
         Ok(rustflags)
-    } else if let Some(rustflags) =
-        rustflags_from_target(gctx, host_triple, target_cfg, kind, flags)?
-    {
+    } else { match rustflags_from_target(gctx, host_triple, target_cfg, kind, flags)?
+    { Some(rustflags) => {
         Ok(rustflags)
-    } else if let Some(rustflags) = rustflags_from_build(gctx, flags)? {
+    } _ => { match rustflags_from_build(gctx, flags)? { Some(rustflags) => {
         Ok(rustflags)
-    } else {
+    } _ => {
         Ok(Vec::new())
-    }
+    }}}}}
 }
 
 /// Gets compiler flags from environment variables.

--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -787,14 +787,15 @@ fn extra_args(
 
     if let Some(rustflags) = rustflags_from_env(gctx, flags) {
         Ok(rustflags)
-    } else { match rustflags_from_target(gctx, host_triple, target_cfg, kind, flags)?
-    { Some(rustflags) => {
-        Ok(rustflags)
-    } _ => { match rustflags_from_build(gctx, flags)? { Some(rustflags) => {
-        Ok(rustflags)
-    } _ => {
-        Ok(Vec::new())
-    }}}}}
+    } else {
+        match rustflags_from_target(gctx, host_triple, target_cfg, kind, flags)? {
+            Some(rustflags) => Ok(rustflags),
+            _ => match rustflags_from_build(gctx, flags)? {
+                Some(rustflags) => Ok(rustflags),
+                _ => Ok(Vec::new()),
+            },
+        }
+    }
 }
 
 /// Gets compiler flags from environment variables.

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -548,7 +548,7 @@ fn build_work(build_runner: &mut BuildRunner<'_, '_>, unit: &Unit) -> CargoResul
             });
 
         // If the build failed
-        if let Err(error) = output {
+        match output { Err(error) => {
             insert_log_messages_in_build_outputs(
                 build_script_outputs,
                 id,
@@ -556,9 +556,7 @@ fn build_work(build_runner: &mut BuildRunner<'_, '_>, unit: &Unit) -> CargoResul
                 log_messages_in_case_of_panic,
             );
             return Err(error);
-        }
-        // ... or it logged any errors
-        else if log_messages_in_case_of_panic
+        } _ => if log_messages_in_case_of_panic
             .iter()
             .any(|(severity, _)| *severity == Severity::Error)
         {
@@ -569,7 +567,7 @@ fn build_work(build_runner: &mut BuildRunner<'_, '_>, unit: &Unit) -> CargoResul
                 log_messages_in_case_of_panic,
             );
             anyhow::bail!("build script logged errors");
-        }
+        }}
 
         let output = output.unwrap();
 
@@ -863,7 +861,7 @@ impl BuildOutput {
 
             let syntax_prefix = if old_syntax { "cargo:" } else { "cargo::" };
             macro_rules! check_and_add_target {
-                ($target_kind: expr, $is_target_kind: expr, $link_type: expr) => {
+                ($target_kind: expr_2021, $is_target_kind: expr_2021, $link_type: expr_2021) => {
                     if !targets.iter().any(|target| $is_target_kind(target)) {
                         bail!(
                             "invalid instruction `{}{}` from {}\n\

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -548,26 +548,31 @@ fn build_work(build_runner: &mut BuildRunner<'_, '_>, unit: &Unit) -> CargoResul
             });
 
         // If the build failed
-        match output { Err(error) => {
-            insert_log_messages_in_build_outputs(
-                build_script_outputs,
-                id,
-                metadata_hash,
-                log_messages_in_case_of_panic,
-            );
-            return Err(error);
-        } _ => if log_messages_in_case_of_panic
-            .iter()
-            .any(|(severity, _)| *severity == Severity::Error)
-        {
-            insert_log_messages_in_build_outputs(
-                build_script_outputs,
-                id,
-                metadata_hash,
-                log_messages_in_case_of_panic,
-            );
-            anyhow::bail!("build script logged errors");
-        }}
+        match output {
+            Err(error) => {
+                insert_log_messages_in_build_outputs(
+                    build_script_outputs,
+                    id,
+                    metadata_hash,
+                    log_messages_in_case_of_panic,
+                );
+                return Err(error);
+            }
+            _ => {
+                if log_messages_in_case_of_panic
+                    .iter()
+                    .any(|(severity, _)| *severity == Severity::Error)
+                {
+                    insert_log_messages_in_build_outputs(
+                        build_script_outputs,
+                        id,
+                        metadata_hash,
+                        log_messages_in_case_of_panic,
+                    );
+                    anyhow::bail!("build script logged errors");
+                }
+            }
+        }
 
         let output = output.unwrap();
 

--- a/src/cargo/core/compiler/fingerprint/mod.rs
+++ b/src/cargo/core/compiler/fingerprint/mod.rs
@@ -871,11 +871,10 @@ impl LocalFingerprint {
                             )
                         })?)
                     } else {
-                        match gctx.env_config()?.get(key) { Some(value) => {
-                            value.to_str()
-                        } _ => {
-                            gctx.get_env(key).ok()
-                        }}
+                        match gctx.env_config()?.get(key) {
+                            Some(value) => value.to_str(),
+                            _ => gctx.get_env(key).ok(),
+                        }
                     };
                     if current == previous.as_deref() {
                         continue;

--- a/src/cargo/core/compiler/fingerprint/mod.rs
+++ b/src/cargo/core/compiler/fingerprint/mod.rs
@@ -871,11 +871,11 @@ impl LocalFingerprint {
                             )
                         })?)
                     } else {
-                        if let Some(value) = gctx.env_config()?.get(key) {
+                        match gctx.env_config()?.get(key) { Some(value) => {
                             value.to_str()
-                        } else {
+                        } _ => {
                             gctx.get_env(key).ok()
-                        }
+                        }}
                     };
                     if current == previous.as_deref() {
                         continue;

--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -826,11 +826,11 @@ impl<'gctx> DrainState<'gctx> {
             }
         }
 
-        if let Some(error) = errors.to_error() {
+        match errors.to_error() { Some(error) => {
             // Any errors up to this point have already been printed via the
             // `display_error` inside `handle_error`.
             Some(anyhow::Error::new(AlreadyPrintedError::new(error)))
-        } else if self.queue.is_empty() && self.pending_queue.is_empty() {
+        } _ => if self.queue.is_empty() && self.pending_queue.is_empty() {
             let profile_link = build_runner.bcx.gctx.shell().err_hyperlink(
                 "https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles",
             );
@@ -850,7 +850,7 @@ impl<'gctx> DrainState<'gctx> {
         } else {
             debug!("queue: {:#?}", self.queue);
             Some(internal("finished with jobs still left in the queue"))
-        }
+        }}
     }
 
     fn handle_error(

--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -826,31 +826,36 @@ impl<'gctx> DrainState<'gctx> {
             }
         }
 
-        match errors.to_error() { Some(error) => {
-            // Any errors up to this point have already been printed via the
-            // `display_error` inside `handle_error`.
-            Some(anyhow::Error::new(AlreadyPrintedError::new(error)))
-        } _ => if self.queue.is_empty() && self.pending_queue.is_empty() {
-            let profile_link = build_runner.bcx.gctx.shell().err_hyperlink(
-                "https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles",
-            );
-            let message = format!(
+        match errors.to_error() {
+            Some(error) => {
+                // Any errors up to this point have already been printed via the
+                // `display_error` inside `handle_error`.
+                Some(anyhow::Error::new(AlreadyPrintedError::new(error)))
+            }
+            _ => {
+                if self.queue.is_empty() && self.pending_queue.is_empty() {
+                    let profile_link = build_runner.bcx.gctx.shell().err_hyperlink(
+                        "https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles",
+                    );
+                    let message = format!(
                 "{profile_link}`{profile_name}` profile [{opt_type}]{profile_link:#} target(s) in {time_elapsed}",
             );
-            if !build_runner.bcx.build_config.build_plan {
-                // It doesn't really matter if this fails.
-                let _ = build_runner.bcx.gctx.shell().status("Finished", message);
-                future_incompat::save_and_display_report(
-                    build_runner.bcx,
-                    &self.per_package_future_incompat_reports,
-                );
-            }
+                    if !build_runner.bcx.build_config.build_plan {
+                        // It doesn't really matter if this fails.
+                        let _ = build_runner.bcx.gctx.shell().status("Finished", message);
+                        future_incompat::save_and_display_report(
+                            build_runner.bcx,
+                            &self.per_package_future_incompat_reports,
+                        );
+                    }
 
-            None
-        } else {
-            debug!("queue: {:#?}", self.queue);
-            Some(internal("finished with jobs still left in the queue"))
-        }}
+                    None
+                } else {
+                    debug!("queue: {:#?}", self.queue);
+                    Some(internal("finished with jobs still left in the queue"))
+                }
+            }
+        }
     }
 
     fn handle_error(

--- a/src/cargo/core/compiler/output_depinfo.rs
+++ b/src/cargo/core/compiler/output_depinfo.rs
@@ -56,22 +56,22 @@ fn add_deps_for_unit(
     if !unit.mode.is_run_custom_build() {
         // Add dependencies from rustc dep-info output (stored in fingerprint directory)
         let dep_info_loc = fingerprint::dep_info_loc(build_runner, unit);
-        if let Some(paths) = fingerprint::parse_dep_info(
+        match fingerprint::parse_dep_info(
             unit.pkg.root(),
             build_runner.files().host_root(),
             &dep_info_loc,
-        )? {
+        )? { Some(paths) => {
             for path in paths.files.into_keys() {
                 deps.insert(path);
             }
-        } else {
+        } _ => {
             debug!(
                 "can't find dep_info for {:?} {}",
                 unit.pkg.package_id(),
                 unit.target
             );
             return Err(internal("dep_info missing"));
-        }
+        }}
     }
 
     // Add rerun-if-changed dependencies

--- a/src/cargo/core/compiler/output_depinfo.rs
+++ b/src/cargo/core/compiler/output_depinfo.rs
@@ -60,18 +60,21 @@ fn add_deps_for_unit(
             unit.pkg.root(),
             build_runner.files().host_root(),
             &dep_info_loc,
-        )? { Some(paths) => {
-            for path in paths.files.into_keys() {
-                deps.insert(path);
+        )? {
+            Some(paths) => {
+                for path in paths.files.into_keys() {
+                    deps.insert(path);
+                }
             }
-        } _ => {
-            debug!(
-                "can't find dep_info for {:?} {}",
-                unit.pkg.package_id(),
-                unit.target
-            );
-            return Err(internal("dep_info missing"));
-        }}
+            _ => {
+                debug!(
+                    "can't find dep_info for {:?} {}",
+                    unit.pkg.package_id(),
+                    unit.target
+                );
+                return Err(internal("dep_info missing"));
+            }
+        }
     }
 
     // Add rerun-if-changed dependencies

--- a/src/cargo/core/compiler/rustdoc.rs
+++ b/src/cargo/core/compiler/rustdoc.rs
@@ -187,15 +187,15 @@ pub fn add_root_urls(
         .registries
         .keys()
         .filter_map(|name| {
-            if let Ok(index_url) = gctx.get_registry_index(name) {
+            match gctx.get_registry_index(name) { Ok(index_url) => {
                 Some((name, index_url))
-            } else {
+            } _ => {
                 tracing::warn!(
                     "`doc.extern-map.{}` specifies a registry that is not defined",
                     name
                 );
                 None
-            }
+            }}
         })
         .collect();
     build_all_urls(

--- a/src/cargo/core/compiler/rustdoc.rs
+++ b/src/cargo/core/compiler/rustdoc.rs
@@ -186,16 +186,15 @@ pub fn add_root_urls(
     let name2url: HashMap<&String, Url> = map
         .registries
         .keys()
-        .filter_map(|name| {
-            match gctx.get_registry_index(name) { Ok(index_url) => {
-                Some((name, index_url))
-            } _ => {
+        .filter_map(|name| match gctx.get_registry_index(name) {
+            Ok(index_url) => Some((name, index_url)),
+            _ => {
                 tracing::warn!(
                     "`doc.extern-map.{}` specifies a registry that is not defined",
                     name
                 );
                 None
-            }}
+            }
         })
         .collect();
     build_all_urls(

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -368,7 +368,7 @@ macro_rules! features {
     (
         $(
             $(#[$attr:meta])*
-            ($stab:ident, $feature:ident, $version:expr, $docs:expr),
+            ($stab:ident, $feature:ident, $version:expr_2021, $docs:expr_2021),
         )*
     ) => (
         /// Unstable feature context for querying if a new Cargo.toml syntax

--- a/src/cargo/core/global_cache_tracker.rs
+++ b/src/cargo/core/global_cache_tracker.rs
@@ -1364,7 +1364,7 @@ impl GlobalCacheTracker {
 ///
 /// Unfortunately it is a bit tricky to share this code without a macro.
 macro_rules! insert_or_update_parent {
-    ($self:expr, $conn:expr, $table_name:expr, $timestamps_field:ident, $keys_field:ident, $encoded_name:ident) => {
+    ($self:expr_2021, $conn:expr_2021, $table_name:expr_2021, $timestamps_field:ident, $keys_field:ident, $encoded_name:ident) => {
         let mut select_stmt = $conn.prepare_cached(concat!(
             "SELECT id, timestamp FROM ",
             $table_name,

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -169,7 +169,7 @@ macro_rules! get_metadata_env {
     ($meta:ident, $field:ident) => {
         $meta.$field.as_deref().unwrap_or_default().into()
     };
-    ($meta:ident, $field:ident, $to_var:expr) => {
+    ($meta:ident, $field:ident, $to_var:expr_2021) => {
         $to_var($meta).into()
     };
 }
@@ -179,7 +179,7 @@ struct MetadataEnvs;
 macro_rules! metadata_envs {
     (
         $(
-            ($field:ident, $key:literal$(, $to_var:expr)?),
+            ($field:ident, $key:literal$(, $to_var:expr_2021)?),
         )*
     ) => {
         impl MetadataEnvs {
@@ -992,7 +992,7 @@ impl Target {
 
     pub fn doctestable(&self) -> bool {
         match self.kind() {
-            TargetKind::Lib(ref kinds) => kinds.iter().any(|k| {
+            &TargetKind::Lib(ref kinds) => kinds.iter().any(|k| {
                 *k == CrateType::Rlib || *k == CrateType::Lib || *k == CrateType::ProcMacro
             }),
             _ => false,

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -417,11 +417,11 @@ impl<'gctx> PackageSet<'gctx> {
         })
     }
 
-    pub fn package_ids(&self) -> impl Iterator<Item = PackageId> + '_ {
+    pub fn package_ids(&self) -> impl Iterator<Item = PackageId> + '_ + use<'_> {
         self.packages.keys().cloned()
     }
 
-    pub fn packages(&self) -> impl Iterator<Item = &Package> {
+    pub fn packages(&self) -> impl Iterator<Item = &Package> + use<'_> {
         self.packages.values().filter_map(|p| p.borrow())
     }
 
@@ -635,7 +635,7 @@ impl<'gctx> PackageSet<'gctx> {
         requested_kinds: &'a [CompileKind],
         target_data: &'a RustcTargetData<'_>,
         force_all_targets: ForceAllTargets,
-    ) -> impl Iterator<Item = (PackageId, &'a HashSet<Dependency>)> + 'a {
+    ) -> impl Iterator<Item = (PackageId, &'a HashSet<Dependency>)> + 'a + use<'a> {
         resolve
             .deps(pkg_id)
             .filter(move |&(_id, deps)| {

--- a/src/cargo/core/package_id_spec.rs
+++ b/src/cargo/core/package_id_spec.rs
@@ -84,11 +84,11 @@ impl PackageIdSpecQuery for PackageIdSpec {
             };
             if self.url().is_some() {
                 let spec = PackageIdSpec::new(self.name().to_owned());
-                let spec = if let Some(version) = self.partial_version().cloned() {
+                let spec = match self.partial_version().cloned() { Some(version) => {
                     spec.with_version(version)
-                } else {
+                } _ => {
                     spec
-                };
+                }};
                 try_spec(spec, &mut suggestion);
             }
             if suggestion.is_empty() && self.version().is_some() {

--- a/src/cargo/core/package_id_spec.rs
+++ b/src/cargo/core/package_id_spec.rs
@@ -84,11 +84,10 @@ impl PackageIdSpecQuery for PackageIdSpec {
             };
             if self.url().is_some() {
                 let spec = PackageIdSpec::new(self.name().to_owned());
-                let spec = match self.partial_version().cloned() { Some(version) => {
-                    spec.with_version(version)
-                } _ => {
-                    spec
-                }};
+                let spec = match self.partial_version().cloned() {
+                    Some(version) => spec.with_version(version),
+                    _ => spec,
+                };
                 try_spec(spec, &mut suggestion);
             }
             if suggestion.is_empty() && self.version().is_some() {

--- a/src/cargo/core/resolver/conflict_cache.rs
+++ b/src/cargo/core/resolver/conflict_cache.rs
@@ -76,14 +76,14 @@ impl ConflictStoreTrie {
     }
 
     fn insert(&mut self, mut iter: impl Iterator<Item = PackageId>, con: ConflictMap) {
-        if let Some(pid) = iter.next() {
+        match iter.next() { Some(pid) => {
             if let ConflictStoreTrie::Node(p) = self {
                 p.entry(pid)
                     .or_insert_with(|| ConflictStoreTrie::Node(BTreeMap::new()))
                     .insert(iter, con);
             }
         // Else, we already have a subset of this in the `ConflictStore`.
-        } else {
+        } _ => {
             // We are at the end of the set we are adding, there are three cases for what to do
             // next:
             // 1. `self` is an empty dummy Node inserted by `or_insert_with`
@@ -104,7 +104,7 @@ impl ConflictStoreTrie {
                 }
             }
             *self = ConflictStoreTrie::Leaf(con)
-        }
+        }}
     }
 }
 

--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -221,7 +221,7 @@ pub(super) fn activation_error(
     // give an error message that nothing was found.
     let mut msg = String::new();
     let mut hints = String::new();
-    if let Some(version_candidates) = rejected_versions(registry, dep) {
+    match rejected_versions(registry, dep) { Some(version_candidates) => {
         let version_candidates = match version_candidates {
             Ok(c) => c,
             Err(e) => return to_resolve_err(e),
@@ -253,7 +253,7 @@ pub(super) fn activation_error(
                     let _ = writeln!(&mut msg, "  version {} is not cached", summary.version());
                 }
                 IndexSummary::Unsupported(summary, schema_version) => {
-                    if let Some(rust_version) = summary.rust_version() {
+                    match summary.rust_version() { Some(rust_version) => {
                         // HACK: technically its unsupported and we shouldn't make assumptions
                         // about the entry but this is limited and for diagnostics purposes
                         let _ = writeln!(
@@ -262,14 +262,14 @@ pub(super) fn activation_error(
                             summary.version(),
                             rust_version
                         );
-                    } else {
+                    } _ => {
                         let _ = writeln!(
                             &mut msg,
                             "  version {} requires a Cargo version that supports index version {}",
                             summary.version(),
                             schema_version
                         );
-                    }
+                    }}
                 }
                 IndexSummary::Invalid(summary) => {
                     let _ = writeln!(
@@ -280,7 +280,7 @@ pub(super) fn activation_error(
                 }
             }
         }
-    } else if let Some(candidates) = alt_versions(registry, dep) {
+    } _ => { match alt_versions(registry, dep) { Some(candidates) => {
         let candidates = match candidates {
             Ok(c) => c,
             Err(e) => return to_resolve_err(e),
@@ -345,7 +345,7 @@ pub(super) fn activation_error(
                 "\nperhaps a crate was updated and forgotten to be re-vendored?"
             );
         }
-    } else if let Some(name_candidates) = alt_names(registry, dep) {
+    } _ => { match alt_names(registry, dep) { Some(name_candidates) => {
         let name_candidates = match name_candidates {
             Ok(c) => c,
             Err(e) => return to_resolve_err(e),
@@ -373,13 +373,13 @@ pub(super) fn activation_error(
                     _ => acc + ", " + el,
                 });
         let _ = writeln!(&mut msg, "perhaps you meant:      {suggestions}");
-    } else {
+    } _ => {
         let _ = writeln!(
             &mut msg,
             "no matching package named `{}` found",
             dep.package_name()
         );
-    }
+    }}}}}}
 
     let mut location_searched_msg = registry.describe_source(dep.source_id());
     if location_searched_msg.is_empty() {

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -447,7 +447,7 @@ fn activate_deps_loop(
                             frame
                                 .remaining_siblings
                                 .remaining()
-                                .find_map(|(ref new_dep, _, _)| {
+                                .find_map(|&(ref new_dep, _, _)| {
                                     past_conflicting_activations.conflicting(&resolver_ctx, new_dep)
                                 })
                         {

--- a/src/cargo/macros.rs
+++ b/src/cargo/macros.rs
@@ -4,7 +4,7 @@ macro_rules! compact_debug {
     (
         impl fmt::Debug for $ty:ident {
             fn fmt(&$this:ident, f: &mut fmt::Formatter) -> fmt::Result {
-                let (default, default_name) = $e:expr;
+                let (default, default_name) = $e:expr_2021;
                 [debug_the_fields($($field:ident)*)]
             }
         }

--- a/src/cargo/ops/cargo_update.rs
+++ b/src/cargo/ops/cargo_update.rs
@@ -525,18 +525,19 @@ fn print_lockfile_generation(
         };
         match change.kind {
             PackageChangeKind::Added => {
-                let possibilities = match change.alternatives_query() { Some(query) => {
-                    loop {
+                let possibilities = match change.alternatives_query() {
+                    Some(query) => loop {
                         match registry.query_vec(&query, QueryKind::Exact) {
                             std::task::Poll::Ready(res) => {
                                 break res?;
                             }
                             std::task::Poll::Pending => registry.block_until_ready()?,
                         }
+                    },
+                    _ => {
+                        vec![]
                     }
-                } _ => {
-                    vec![]
-                }};
+                };
 
                 let required_rust_version = report_required_rust_version(resolve, change);
                 let latest = report_latest(&possibilities, change);
@@ -588,18 +589,19 @@ fn print_lockfile_sync(
             PackageChangeKind::Added
             | PackageChangeKind::Upgraded
             | PackageChangeKind::Downgraded => {
-                let possibilities = match change.alternatives_query() { Some(query) => {
-                    loop {
+                let possibilities = match change.alternatives_query() {
+                    Some(query) => loop {
                         match registry.query_vec(&query, QueryKind::Exact) {
                             std::task::Poll::Ready(res) => {
                                 break res?;
                             }
                             std::task::Poll::Pending => registry.block_until_ready()?,
                         }
+                    },
+                    _ => {
+                        vec![]
                     }
-                } _ => {
-                    vec![]
-                }};
+                };
 
                 let required_rust_version = report_required_rust_version(resolve, change);
                 let latest = report_latest(&possibilities, change);
@@ -637,18 +639,19 @@ fn print_lockfile_updates(
     }
     let mut unchanged_behind = 0;
     for change in changes.values() {
-        let possibilities = match change.alternatives_query() { Some(query) => {
-            loop {
+        let possibilities = match change.alternatives_query() {
+            Some(query) => loop {
                 match registry.query_vec(&query, QueryKind::Exact) {
                     std::task::Poll::Ready(res) => {
                         break res?;
                     }
                     std::task::Poll::Pending => registry.block_until_ready()?,
                 }
+            },
+            _ => {
+                vec![]
             }
-        } _ => {
-            vec![]
-        }};
+        };
 
         match change.kind {
             PackageChangeKind::Added
@@ -1094,7 +1097,10 @@ impl PackageDiff {
         changes.into_iter().map(|(_, v)| v)
     }
 
-    pub fn diff(previous_resolve: &Resolve, resolve: &Resolve) -> impl Iterator<Item = Self> + use<> {
+    pub fn diff(
+        previous_resolve: &Resolve,
+        resolve: &Resolve,
+    ) -> impl Iterator<Item = Self> + use<> {
         fn vec_subset(a: &[PackageId], b: &[PackageId]) -> Vec<PackageId> {
             a.iter().filter(|a| !contains_id(b, a)).cloned().collect()
         }

--- a/src/cargo/ops/cargo_update.rs
+++ b/src/cargo/ops/cargo_update.rs
@@ -525,7 +525,7 @@ fn print_lockfile_generation(
         };
         match change.kind {
             PackageChangeKind::Added => {
-                let possibilities = if let Some(query) = change.alternatives_query() {
+                let possibilities = match change.alternatives_query() { Some(query) => {
                     loop {
                         match registry.query_vec(&query, QueryKind::Exact) {
                             std::task::Poll::Ready(res) => {
@@ -534,9 +534,9 @@ fn print_lockfile_generation(
                             std::task::Poll::Pending => registry.block_until_ready()?,
                         }
                     }
-                } else {
+                } _ => {
                     vec![]
-                };
+                }};
 
                 let required_rust_version = report_required_rust_version(resolve, change);
                 let latest = report_latest(&possibilities, change);
@@ -588,7 +588,7 @@ fn print_lockfile_sync(
             PackageChangeKind::Added
             | PackageChangeKind::Upgraded
             | PackageChangeKind::Downgraded => {
-                let possibilities = if let Some(query) = change.alternatives_query() {
+                let possibilities = match change.alternatives_query() { Some(query) => {
                     loop {
                         match registry.query_vec(&query, QueryKind::Exact) {
                             std::task::Poll::Ready(res) => {
@@ -597,9 +597,9 @@ fn print_lockfile_sync(
                             std::task::Poll::Pending => registry.block_until_ready()?,
                         }
                     }
-                } else {
+                } _ => {
                     vec![]
-                };
+                }};
 
                 let required_rust_version = report_required_rust_version(resolve, change);
                 let latest = report_latest(&possibilities, change);
@@ -637,7 +637,7 @@ fn print_lockfile_updates(
     }
     let mut unchanged_behind = 0;
     for change in changes.values() {
-        let possibilities = if let Some(query) = change.alternatives_query() {
+        let possibilities = match change.alternatives_query() { Some(query) => {
             loop {
                 match registry.query_vec(&query, QueryKind::Exact) {
                     std::task::Poll::Ready(res) => {
@@ -646,9 +646,9 @@ fn print_lockfile_updates(
                     std::task::Poll::Pending => registry.block_until_ready()?,
                 }
             }
-        } else {
+        } _ => {
             vec![]
-        };
+        }};
 
         match change.kind {
             PackageChangeKind::Added
@@ -1080,7 +1080,7 @@ pub struct PackageDiff {
 }
 
 impl PackageDiff {
-    pub fn new(resolve: &Resolve) -> impl Iterator<Item = Self> {
+    pub fn new(resolve: &Resolve) -> impl Iterator<Item = Self> + use<> {
         let mut changes = BTreeMap::new();
         let empty = Self::default();
         for dep in resolve.iter() {
@@ -1094,7 +1094,7 @@ impl PackageDiff {
         changes.into_iter().map(|(_, v)| v)
     }
 
-    pub fn diff(previous_resolve: &Resolve, resolve: &Resolve) -> impl Iterator<Item = Self> {
+    pub fn diff(previous_resolve: &Resolve, resolve: &Resolve) -> impl Iterator<Item = Self> + use<> {
         fn vec_subset(a: &[PackageId], b: &[PackageId]) -> Vec<PackageId> {
             a.iter().filter(|a| !contains_id(b, a)).cloned().collect()
         }

--- a/src/cargo/ops/registry/publish.rs
+++ b/src/cargo/ops/registry/publish.rs
@@ -102,7 +102,7 @@ pub fn publish(ws: &Workspace<'_>, opts: &PublishOpts<'_>) -> CargoResult<()> {
         None => {
             let reg = super::infer_registry(&just_pkgs)?;
             validate_registry(&just_pkgs, reg.as_ref())?;
-            if let Some(RegistryOrIndex::Registry(ref registry)) = &reg {
+            if let &Some(RegistryOrIndex::Registry(ref registry)) = &reg {
                 if registry != CRATES_IO_REGISTRY {
                     // Don't warn for crates.io.
                     opts.gctx.shell().note(&format!(

--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -471,16 +471,15 @@ fn prepare_toml_for_vendor(
         package.build = Some(build);
     }
 
-    let lib = match &me.lib { Some(target) => {
-        crate::util::toml::prepare_target_for_publish(
+    let lib = match &me.lib {
+        Some(target) => crate::util::toml::prepare_target_for_publish(
             target,
             Some(packaged_files),
             "library",
             gctx,
-        )?
-    } _ => {
-        None
-    }};
+        )?,
+        _ => None,
+    };
     let bin = crate::util::toml::prepare_targets_for_publish(
         me.bin.as_ref(),
         Some(packaged_files),

--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -471,16 +471,16 @@ fn prepare_toml_for_vendor(
         package.build = Some(build);
     }
 
-    let lib = if let Some(target) = &me.lib {
+    let lib = match &me.lib { Some(target) => {
         crate::util::toml::prepare_target_for_publish(
             target,
             Some(packaged_files),
             "library",
             gctx,
         )?
-    } else {
+    } _ => {
         None
-    };
+    }};
     let bin = crate::util::toml::prepare_targets_for_publish(
         me.bin.as_ref(),
         Some(packaged_files),

--- a/src/cargo/sources/git/known_hosts.rs
+++ b/src/cargo/sources/git/known_hosts.rs
@@ -480,13 +480,16 @@ fn check_ssh_known_hosts_loaded(
         match latent_errors
             .iter()
             .position(|e| matches!(e, KnownHostError::HostKeyHasChanged { .. }))
-        { Some(index) => {
-            return Err(latent_errors.remove(index));
-        } _ => {
-            // Otherwise, we take the first error (which we expect to be
-            // a CertAuthority error).
-            Err(latent_errors.pop().unwrap())
-        }}
+        {
+            Some(index) => {
+                return Err(latent_errors.remove(index));
+            }
+            _ => {
+                // Otherwise, we take the first error (which we expect to be
+                // a CertAuthority error).
+                Err(latent_errors.pop().unwrap())
+            }
+        }
     }
 }
 

--- a/src/cargo/sources/git/known_hosts.rs
+++ b/src/cargo/sources/git/known_hosts.rs
@@ -477,16 +477,16 @@ fn check_ssh_known_hosts_loaded(
         // We're going to take the first HostKeyHasChanged error if
         // we find one, otherwise we'll take the first error (which
         // we expect to be a CertAuthority error).
-        if let Some(index) = latent_errors
+        match latent_errors
             .iter()
             .position(|e| matches!(e, KnownHostError::HostKeyHasChanged { .. }))
-        {
+        { Some(index) => {
             return Err(latent_errors.remove(index));
-        } else {
+        } _ => {
             // Otherwise, we take the first error (which we expect to be
             // a CertAuthority error).
             Err(latent_errors.pop().unwrap())
-        }
+        }}
     }
 }
 

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -243,11 +243,10 @@ impl<'gctx> Source for GitSource<'gctx> {
         kind: QueryKind,
         f: &mut dyn FnMut(IndexSummary),
     ) -> Poll<CargoResult<()>> {
-        match self.path_source.as_mut() { Some(src) => {
-            src.query(dep, kind, f)
-        } _ => {
-            Poll::Pending
-        }}
+        match self.path_source.as_mut() {
+            Some(src) => src.query(dep, kind, f),
+            _ => Poll::Pending,
+        }
     }
 
     fn supports_checksums(&self) -> bool {

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -243,11 +243,11 @@ impl<'gctx> Source for GitSource<'gctx> {
         kind: QueryKind,
         f: &mut dyn FnMut(IndexSummary),
     ) -> Poll<CargoResult<()>> {
-        if let Some(src) = self.path_source.as_mut() {
+        match self.path_source.as_mut() { Some(src) => {
             src.query(dep, kind, f)
-        } else {
+        } _ => {
             Poll::Pending
-        }
+        }}
     }
 
     fn supports_checksums(&self) -> bool {

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -791,7 +791,7 @@ where
         // Otherwise if we didn't even get to the authentication phase them we may
         // have failed to set up a connection, in these cases hint on the
         // `net.git-fetch-with-cli` configuration option.
-    } else if let Some(e) = err.downcast_ref::<git2::Error>() {
+    } else { match err.downcast_ref::<git2::Error>() { Some(e) => {
         match e.class() {
             ErrorClass::Net
             | ErrorClass::Ssl
@@ -817,7 +817,7 @@ where
             }
             _ => {}
         }
-    }
+    } _ => {}}}
 
     Err(err)
 }
@@ -1034,13 +1034,13 @@ pub fn fetch(
         }
     }
 
-    let result = if let Some(true) = gctx.net_config()?.git_fetch_with_cli {
+    let result = match gctx.net_config()?.git_fetch_with_cli { Some(true) => {
         fetch_with_cli(repo, remote_url, &refspecs, tags, gctx)
-    } else if gctx.cli_unstable().gitoxide.map_or(false, |git| git.fetch) {
+    } _ => if gctx.cli_unstable().gitoxide.map_or(false, |git| git.fetch) {
         fetch_with_gitoxide(repo, remote_url, refspecs, tags, shallow, gctx)
     } else {
         fetch_with_libgit2(repo, remote_url, refspecs, tags, shallow, gctx)
-    };
+    }};
 
     if fast_path_rev {
         if let Some(oid) = oid_to_fetch {

--- a/src/cargo/sources/registry/index/cache.rs
+++ b/src/cargo/sources/registry/index/cache.rs
@@ -182,11 +182,11 @@ impl<'a> SummariesCache<'a> {
         let rest = &rest[4..];
 
         let mut iter = split(rest, 0);
-        let last_index_update = if let Some(update) = iter.next() {
+        let last_index_update = match iter.next() { Some(update) => {
             str::from_utf8(update)?
-        } else {
+        } _ => {
             bail!("malformed file");
-        };
+        }};
         let mut ret = SummariesCache::default();
         ret.index_version = last_index_update;
         while let Some(version) = iter.next() {

--- a/src/cargo/sources/registry/index/cache.rs
+++ b/src/cargo/sources/registry/index/cache.rs
@@ -182,11 +182,12 @@ impl<'a> SummariesCache<'a> {
         let rest = &rest[4..];
 
         let mut iter = split(rest, 0);
-        let last_index_update = match iter.next() { Some(update) => {
-            str::from_utf8(update)?
-        } _ => {
-            bail!("malformed file");
-        }};
+        let last_index_update = match iter.next() {
+            Some(update) => str::from_utf8(update)?,
+            _ => {
+                bail!("malformed file");
+            }
+        };
         let mut ret = SummariesCache::default();
         ret.index_version = last_index_update;
         while let Some(version) = iter.next() {

--- a/src/cargo/sources/registry/index/mod.rs
+++ b/src/cargo/sources/registry/index/mod.rs
@@ -390,7 +390,7 @@ impl<'gctx> RegistryIndex<'gctx> {
         name: InternedString,
         req: &'b OptVersionReq,
         load: &mut dyn RegistryData,
-    ) -> Poll<CargoResult<impl Iterator<Item = &'a IndexSummary> + 'b>>
+    ) -> Poll<CargoResult<impl Iterator<Item = &'a IndexSummary> + 'b + use<'a, 'b>>>
     where
         'a: 'b,
     {

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -1071,16 +1071,15 @@ pub fn lockfile_path(
 pub fn get_registry_candidates() -> CargoResult<Vec<clap_complete::CompletionCandidate>> {
     let gctx = new_gctx_for_completions()?;
 
-    if let Ok(Some(registries)) =
-        gctx.get::<Option<HashMap<String, HashMap<String, String>>>>("registries")
-    {
+    match gctx.get::<Option<HashMap<String, HashMap<String, String>>>>("registries")
+    { Ok(Some(registries)) => {
         Ok(registries
             .keys()
             .map(|name| clap_complete::CompletionCandidate::new(name.to_owned()))
             .collect())
-    } else {
+    } _ => {
         Ok(vec![])
-    }
+    }}
 }
 
 fn get_example_candidates() -> Vec<clap_complete::CompletionCandidate> {

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -1071,15 +1071,13 @@ pub fn lockfile_path(
 pub fn get_registry_candidates() -> CargoResult<Vec<clap_complete::CompletionCandidate>> {
     let gctx = new_gctx_for_completions()?;
 
-    match gctx.get::<Option<HashMap<String, HashMap<String, String>>>>("registries")
-    { Ok(Some(registries)) => {
-        Ok(registries
+    match gctx.get::<Option<HashMap<String, HashMap<String, String>>>>("registries") {
+        Ok(Some(registries)) => Ok(registries
             .keys()
             .map(|name| clap_complete::CompletionCandidate::new(name.to_owned()))
-            .collect())
-    } _ => {
-        Ok(vec![])
-    }}
+            .collect()),
+        _ => Ok(vec![]),
+    }
 }
 
 fn get_example_candidates() -> Vec<clap_complete::CompletionCandidate> {

--- a/src/cargo/util/context/mod.rs
+++ b/src/cargo/util/context/mod.rs
@@ -115,7 +115,7 @@ use super::auth::RegistryConfig;
 
 /// Helper macro for creating typed access methods.
 macro_rules! get_value_typed {
-    ($name:ident, $ty:ty, $variant:ident, $expected:expr) => {
+    ($name:ident, $ty:ty, $variant:ident, $expected:expr_2021) => {
         /// Low-level private method for getting a config value as an [`OptValue`].
         fn $name(&self, key: &ConfigKey) -> Result<OptValue<$ty>, ConfigError> {
             let cv = self.get_cv(key)?;
@@ -617,7 +617,7 @@ impl GlobalContext {
             }
 
             Ok(Some(Filesystem::new(self.cwd.join(dir))))
-        } else if let Some(val) = &self.build_config()?.target_dir {
+        } else { match &self.build_config()?.target_dir { Some(val) => {
             let path = val.resolve_path(self);
 
             // Check if the target directory is set to an empty string in the config.toml file.
@@ -629,9 +629,9 @@ impl GlobalContext {
             }
 
             Ok(Some(Filesystem::new(path)))
-        } else {
+        } _ => {
             Ok(None)
-        }
+        }}}
     }
 
     /// Get a configuration value by key.
@@ -1537,11 +1537,10 @@ impl GlobalContext {
         let possible = dir.join(filename_without_extension);
         let possible_with_extension = dir.join(format!("{}.toml", filename_without_extension));
 
-        if let Ok(possible_handle) = same_file::Handle::from_path(&possible) {
+        match same_file::Handle::from_path(&possible) { Ok(possible_handle) => {
             if warn {
-                if let Ok(possible_with_extension_handle) =
-                    same_file::Handle::from_path(&possible_with_extension)
-                {
+                match same_file::Handle::from_path(&possible_with_extension)
+                { Ok(possible_with_extension_handle) => {
                     // We don't want to print a warning if the version
                     // without the extension is just a symlink to the version
                     // WITH an extension, which people may want to do to
@@ -1555,7 +1554,7 @@ impl GlobalContext {
                             possible.display()
                         ))?;
                     }
-                } else {
+                } _ => {
                     self.shell().warn(format!(
                         "`{}` is deprecated in favor of `{filename_without_extension}.toml`",
                         possible.display(),
@@ -1563,15 +1562,15 @@ impl GlobalContext {
                     self.shell().note(
                         format!("if you need to support cargo 1.38 or earlier, you can symlink `{filename_without_extension}` to `{filename_without_extension}.toml`"),
                     )?;
-                }
+                }}
             }
 
             Ok(Some(possible))
-        } else if possible_with_extension.exists() {
+        } _ => if possible_with_extension.exists() {
             Ok(Some(possible_with_extension))
         } else {
             Ok(None)
-        }
+        }}
     }
 
     fn walk_tree<F>(&self, pwd: &Path, home: &Path, mut walk: F) -> CargoResult<()>
@@ -1603,19 +1602,19 @@ impl GlobalContext {
     /// Gets the index for a registry.
     pub fn get_registry_index(&self, registry: &str) -> CargoResult<Url> {
         RegistryName::new(registry)?;
-        if let Some(index) = self.get_string(&format!("registries.{}.index", registry))? {
+        match self.get_string(&format!("registries.{}.index", registry))? { Some(index) => {
             self.resolve_registry_index(&index).with_context(|| {
                 format!(
                     "invalid index URL for registry `{}` defined in {}",
                     registry, index.definition
                 )
             })
-        } else {
+        } _ => {
             bail!(
                 "registry index was not found in any configuration: `{}`",
                 registry
             );
-        }
+        }}
     }
 
     /// Returns an error if `registry.index` is set.
@@ -2941,7 +2940,7 @@ impl StringList {
 
 #[macro_export]
 macro_rules! __shell_print {
-    ($config:expr, $which:ident, $newline:literal, $($arg:tt)*) => ({
+    ($config:expr_2021, $which:ident, $newline:literal, $($arg:tt)*) => ({
         let mut shell = $config.shell();
         let out = shell.$which();
         drop(out.write_fmt(format_args!($($arg)*)));
@@ -2953,30 +2952,30 @@ macro_rules! __shell_print {
 
 #[macro_export]
 macro_rules! drop_println {
-    ($config:expr) => ( $crate::drop_print!($config, "\n") );
-    ($config:expr, $($arg:tt)*) => (
+    ($config:expr_2021) => ( $crate::drop_print!($config, "\n") );
+    ($config:expr_2021, $($arg:tt)*) => (
         $crate::__shell_print!($config, out, true, $($arg)*)
     );
 }
 
 #[macro_export]
 macro_rules! drop_eprintln {
-    ($config:expr) => ( $crate::drop_eprint!($config, "\n") );
-    ($config:expr, $($arg:tt)*) => (
+    ($config:expr_2021) => ( $crate::drop_eprint!($config, "\n") );
+    ($config:expr_2021, $($arg:tt)*) => (
         $crate::__shell_print!($config, err, true, $($arg)*)
     );
 }
 
 #[macro_export]
 macro_rules! drop_print {
-    ($config:expr, $($arg:tt)*) => (
+    ($config:expr_2021, $($arg:tt)*) => (
         $crate::__shell_print!($config, out, false, $($arg)*)
     );
 }
 
 #[macro_export]
 macro_rules! drop_eprint {
-    ($config:expr, $($arg:tt)*) => (
+    ($config:expr_2021, $($arg:tt)*) => (
         $crate::__shell_print!($config, err, false, $($arg)*)
     );
 }

--- a/src/cargo/util/context/target.rs
+++ b/src/cargo/util/context/target.rs
@@ -80,11 +80,10 @@ pub(super) fn load_target_cfgs(
 /// Returns true if the `[target]` table should be applied to host targets.
 pub(super) fn get_target_applies_to_host(gctx: &GlobalContext) -> CargoResult<bool> {
     if gctx.cli_unstable().target_applies_to_host {
-        match gctx.get::<bool>("target-applies-to-host") { Ok(target_applies_to_host) => {
-            Ok(target_applies_to_host)
-        } _ => {
-            Ok(!gctx.cli_unstable().host_config)
-        }}
+        match gctx.get::<bool>("target-applies-to-host") {
+            Ok(target_applies_to_host) => Ok(target_applies_to_host),
+            _ => Ok(!gctx.cli_unstable().host_config),
+        }
     } else if gctx.cli_unstable().host_config {
         anyhow::bail!(
             "the -Zhost-config flag requires the -Ztarget-applies-to-host flag to be set"

--- a/src/cargo/util/context/target.rs
+++ b/src/cargo/util/context/target.rs
@@ -80,11 +80,11 @@ pub(super) fn load_target_cfgs(
 /// Returns true if the `[target]` table should be applied to host targets.
 pub(super) fn get_target_applies_to_host(gctx: &GlobalContext) -> CargoResult<bool> {
     if gctx.cli_unstable().target_applies_to_host {
-        if let Ok(target_applies_to_host) = gctx.get::<bool>("target-applies-to-host") {
+        match gctx.get::<bool>("target-applies-to-host") { Ok(target_applies_to_host) => {
             Ok(target_applies_to_host)
-        } else {
+        } _ => {
             Ok(!gctx.cli_unstable().host_config)
-        }
+        }}
     } else if gctx.cli_unstable().host_config {
         anyhow::bail!(
             "the -Zhost-config flag requires the -Ztarget-applies-to-host flag to be set"
@@ -238,7 +238,7 @@ fn extra_link_args<'a>(
     link_type: LinkArgTarget,
     key: &str,
     value: &'a CV,
-) -> CargoResult<impl Iterator<Item = (LinkArgTarget, String)> + 'a> {
+) -> CargoResult<impl Iterator<Item = (LinkArgTarget, String)> + 'a + use<'a>> {
     let args = value.list(key)?;
     Ok(args.iter().map(move |v| (link_type.clone(), v.0.clone())))
 }

--- a/src/cargo/util/cpu.rs
+++ b/src/cargo/util/cpu.rs
@@ -108,7 +108,7 @@ mod imp {
     const CPU_STATE_NICE: usize = 3;
     const CPU_STATE_MAX: usize = 4;
 
-    extern "C" {
+    unsafe extern "C" {
         static mut mach_task_self_: mach_port_t;
 
         fn mach_host_self() -> mach_port_t;

--- a/src/cargo/util/diagnostic_server.rs
+++ b/src/cargo/util/diagnostic_server.rs
@@ -303,14 +303,15 @@ impl RustfixDiagnosticServer {
             }
             let mut client = BufReader::new(client);
             let mut s = String::new();
-            match client.read_to_string(&mut s) { Err(e) => {
-                warn!("diagnostic server failed to read: {}", e);
-            } _ => {
-                match serde_json::from_str(&s) {
+            match client.read_to_string(&mut s) {
+                Err(e) => {
+                    warn!("diagnostic server failed to read: {}", e);
+                }
+                _ => match serde_json::from_str(&s) {
                     Ok(message) => on_message(message),
                     Err(e) => warn!("invalid diagnostics message: {}", e),
-                }
-            }}
+                },
+            }
             // The client should be kept alive until after `on_message` is
             // called to ensure that the client doesn't exit too soon (and
             // Message::Finish getting posted before Message::FixDiagnostic).

--- a/src/cargo/util/diagnostic_server.rs
+++ b/src/cargo/util/diagnostic_server.rs
@@ -303,14 +303,14 @@ impl RustfixDiagnosticServer {
             }
             let mut client = BufReader::new(client);
             let mut s = String::new();
-            if let Err(e) = client.read_to_string(&mut s) {
+            match client.read_to_string(&mut s) { Err(e) => {
                 warn!("diagnostic server failed to read: {}", e);
-            } else {
+            } _ => {
                 match serde_json::from_str(&s) {
                     Ok(message) => on_message(message),
                     Err(e) => warn!("invalid diagnostics message: {}", e),
                 }
-            }
+            }}
             // The client should be kept alive until after `on_message` is
             // called to ensure that the client doesn't exit too soon (and
             // Message::Finish getting posted before Message::FixDiagnostic).

--- a/src/cargo/util/graph.rs
+++ b/src/cargo/util/graph.rs
@@ -51,7 +51,7 @@ impl<N: Eq + Ord + Clone, E: Default + Clone> Graph<N, E> {
         self.nodes.get(from)?.get(to)
     }
 
-    pub fn edges(&self, from: &N) -> impl Iterator<Item = (&N, &E)> {
+    pub fn edges(&self, from: &N) -> impl Iterator<Item = (&N, &E)> + use<'_, N, E> {
         self.nodes.get(from).into_iter().flat_map(|x| x.iter())
     }
 

--- a/src/cargo/util/job.rs
+++ b/src/cargo/util/job.rs
@@ -27,19 +27,21 @@ mod imp {
 
     pub type Setup = ();
 
-    pub unsafe fn setup() -> Option<()> { unsafe {
-        // There's a test case for the behavior of
-        // when-cargo-is-killed-subprocesses-are-also-killed, but that requires
-        // one cargo spawned to become its own session leader, so we do that
-        // here.
-        //
-        // ALLOWED: For testing cargo itself only.
-        #[allow(clippy::disallowed_methods)]
-        if env::var("__CARGO_TEST_SETSID_PLEASE_DONT_USE_ELSEWHERE").is_ok() {
-            libc::setsid();
+    pub unsafe fn setup() -> Option<()> {
+        unsafe {
+            // There's a test case for the behavior of
+            // when-cargo-is-killed-subprocesses-are-also-killed, but that requires
+            // one cargo spawned to become its own session leader, so we do that
+            // here.
+            //
+            // ALLOWED: For testing cargo itself only.
+            #[allow(clippy::disallowed_methods)]
+            if env::var("__CARGO_TEST_SETSID_PLEASE_DONT_USE_ELSEWHERE").is_ok() {
+                libc::setsid();
+            }
+            Some(())
         }
-        Some(())
-    }}
+    }
 }
 
 #[cfg(windows)]

--- a/src/cargo/util/job.rs
+++ b/src/cargo/util/job.rs
@@ -27,7 +27,7 @@ mod imp {
 
     pub type Setup = ();
 
-    pub unsafe fn setup() -> Option<()> {
+    pub unsafe fn setup() -> Option<()> { unsafe {
         // There's a test case for the behavior of
         // when-cargo-is-killed-subprocesses-are-also-killed, but that requires
         // one cargo spawned to become its own session leader, so we do that
@@ -39,7 +39,7 @@ mod imp {
             libc::setsid();
         }
         Some(())
-    }
+    }}
 }
 
 #[cfg(windows)]

--- a/src/cargo/util/network/mod.rs
+++ b/src/cargo/util/network/mod.rs
@@ -36,7 +36,7 @@ impl<T> PollExt<T> for Poll<T> {
 /// when using old versions that don't support certain features.
 #[macro_export]
 macro_rules! try_old_curl {
-    ($e:expr, $msg:expr) => {
+    ($e:expr_2021, $msg:expr_2021) => {
         let result = $e;
         if cfg!(target_os = "macos") {
             if let Err(e) = result {
@@ -71,7 +71,7 @@ macro_rules! try_old_curl {
 /// of connections down to a more manageable state.
 #[macro_export]
 macro_rules! try_old_curl_http2_pipewait {
-    ($multiplexing:expr, $handle:expr) => {
+    ($multiplexing:expr_2021, $handle:expr_2021) => {
         if $multiplexing {
             $crate::try_old_curl!($handle.http_version(curl::easy::HttpVersion::V2), "HTTP/2");
         } else {

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -816,7 +816,7 @@ fn load_inheritable_fields(
 ) -> CargoResult<InheritableFields> {
     match workspace_config {
         WorkspaceConfig::Root(root) => Ok(root.inheritable().clone()),
-        WorkspaceConfig::Member {
+        &WorkspaceConfig::Member {
             root: Some(ref path_to_root),
         } => {
             let path = normalized_path
@@ -1175,7 +1175,7 @@ pub fn to_real_manifest(
         }
         edition
     } else {
-        let msrv_edition = if let Some(pkg_msrv) = &rust_version {
+        let msrv_edition = match &rust_version { Some(pkg_msrv) => {
             Edition::ALL
                 .iter()
                 .filter(|e| {
@@ -1188,9 +1188,9 @@ pub fn to_real_manifest(
                 })
                 .max()
                 .copied()
-        } else {
+        } _ => {
             None
-        }
+        }}
         .unwrap_or_default();
         let default_edition = Edition::default();
         let latest_edition = Edition::LATEST_STABLE;
@@ -1468,7 +1468,7 @@ pub fn to_real_manifest(
         .normalized_publish()
         .expect("previously normalized")
     {
-        Some(manifest::VecStringOrBool::VecString(ref vecstring)) => Some(vecstring.clone()),
+        Some(&manifest::VecStringOrBool::VecString(ref vecstring)) => Some(vecstring.clone()),
         Some(manifest::VecStringOrBool::Bool(false)) => Some(vec![]),
         Some(manifest::VecStringOrBool::Bool(true)) => None,
         None => version.is_none().then_some(vec![]),
@@ -2199,9 +2199,9 @@ pub(crate) fn lookup_path_base<'a>(
     let base_key = format!("path-bases.{base}");
 
     // Look up the relevant base in the Config and use that as the root.
-    if let Some(path_bases) = gctx.get::<Option<ConfigRelativePath>>(&base_key)? {
+    match gctx.get::<Option<ConfigRelativePath>>(&base_key)? { Some(path_bases) => {
         Ok(path_bases.resolve_path(gctx))
-    } else {
+    } _ => {
         // Otherwise, check the built-in bases.
         match base.as_str() {
             "workspace" => Ok(workspace_root()?.to_path_buf()),
@@ -2210,7 +2210,7 @@ pub(crate) fn lookup_path_base<'a>(
             You must add an entry for `{base}` in the Cargo configuration [path-bases] table."
             ),
         }
-    }
+    }}
 }
 
 pub trait ResolveToPath {

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1175,8 +1175,8 @@ pub fn to_real_manifest(
         }
         edition
     } else {
-        let msrv_edition = match &rust_version { Some(pkg_msrv) => {
-            Edition::ALL
+        let msrv_edition = match &rust_version {
+            Some(pkg_msrv) => Edition::ALL
                 .iter()
                 .filter(|e| {
                     e.first_version()
@@ -1187,10 +1187,9 @@ pub fn to_real_manifest(
                         .unwrap_or_default()
                 })
                 .max()
-                .copied()
-        } _ => {
-            None
-        }}
+                .copied(),
+            _ => None,
+        }
         .unwrap_or_default();
         let default_edition = Edition::default();
         let latest_edition = Edition::LATEST_STABLE;
@@ -2199,18 +2198,19 @@ pub(crate) fn lookup_path_base<'a>(
     let base_key = format!("path-bases.{base}");
 
     // Look up the relevant base in the Config and use that as the root.
-    match gctx.get::<Option<ConfigRelativePath>>(&base_key)? { Some(path_bases) => {
-        Ok(path_bases.resolve_path(gctx))
-    } _ => {
-        // Otherwise, check the built-in bases.
-        match base.as_str() {
-            "workspace" => Ok(workspace_root()?.to_path_buf()),
-            _ => bail!(
-                "path base `{base}` is undefined. \
+    match gctx.get::<Option<ConfigRelativePath>>(&base_key)? {
+        Some(path_bases) => Ok(path_bases.resolve_path(gctx)),
+        _ => {
+            // Otherwise, check the built-in bases.
+            match base.as_str() {
+                "workspace" => Ok(workspace_root()?.to_path_buf()),
+                _ => bail!(
+                    "path base `{base}` is undefined. \
             You must add an entry for `{base}` in the Cargo configuration [path-bases] table."
-            ),
+                ),
+            }
         }
-    }}
+    }
 }
 
 pub trait ResolveToPath {

--- a/src/cargo/util/toml_mut/dependency.rs
+++ b/src/cargo/util/toml_mut/dependency.rs
@@ -627,29 +627,32 @@ impl Dependency {
                     table.remove("default-features");
                 }
             }
-            match self.features.as_ref() { Some(new_features) => {
-                let mut features = table
-                    .get("features")
-                    .and_then(|i| i.as_value())
-                    .and_then(|v| v.as_array())
-                    .and_then(|a| {
-                        a.iter()
-                            .map(|v| v.as_str())
-                            .collect::<Option<IndexSet<_>>>()
-                    })
-                    .unwrap_or_default();
-                let is_already_sorted = features.iter().is_sorted();
-                features.extend(new_features.iter().map(|s| s.as_str()));
-                let features = if is_already_sorted {
-                    features.into_iter().sorted().collect::<toml_edit::Value>()
-                } else {
-                    features.into_iter().collect::<toml_edit::Value>()
-                };
-                table.set_dotted(false);
-                overwrite_value(table, "features", features);
-            } _ => {
-                table.remove("features");
-            }}
+            match self.features.as_ref() {
+                Some(new_features) => {
+                    let mut features = table
+                        .get("features")
+                        .and_then(|i| i.as_value())
+                        .and_then(|v| v.as_array())
+                        .and_then(|a| {
+                            a.iter()
+                                .map(|v| v.as_str())
+                                .collect::<Option<IndexSet<_>>>()
+                        })
+                        .unwrap_or_default();
+                    let is_already_sorted = features.iter().is_sorted();
+                    features.extend(new_features.iter().map(|s| s.as_str()));
+                    let features = if is_already_sorted {
+                        features.into_iter().sorted().collect::<toml_edit::Value>()
+                    } else {
+                        features.into_iter().collect::<toml_edit::Value>()
+                    };
+                    table.set_dotted(false);
+                    overwrite_value(table, "features", features);
+                }
+                _ => {
+                    table.remove("features");
+                }
+            }
             match self.optional {
                 Some(v) => {
                     table.set_dotted(false);

--- a/src/cargo/util/toml_mut/dependency.rs
+++ b/src/cargo/util/toml_mut/dependency.rs
@@ -627,7 +627,7 @@ impl Dependency {
                     table.remove("default-features");
                 }
             }
-            if let Some(new_features) = self.features.as_ref() {
+            match self.features.as_ref() { Some(new_features) => {
                 let mut features = table
                     .get("features")
                     .and_then(|i| i.as_value())
@@ -647,9 +647,9 @@ impl Dependency {
                 };
                 table.set_dotted(false);
                 overwrite_value(table, "features", features);
-            } else {
+            } _ => {
                 table.remove("features");
-            }
+            }}
             match self.optional {
                 Some(v) => {
                     table.set_dotted(false);

--- a/src/cargo/util/toml_mut/manifest.rs
+++ b/src/cargo/util/toml_mut/manifest.rs
@@ -705,11 +705,16 @@ fn non_existent_dependency_err(
     alt_name: Option<&str>,
 ) -> anyhow::Error {
     let mut msg = format!("the dependency `{name}` could not be found in `{search_table}`");
-    match found_table { Some(found_table) => {
-        msg.push_str(&format!("; it is present in `{found_table}`",));
-    } _ => if let Some(alt_name) = alt_name {
-        msg.push_str(&format!("; dependency `{alt_name}` exists",));
-    }}
+    match found_table {
+        Some(found_table) => {
+            msg.push_str(&format!("; it is present in `{found_table}`",));
+        }
+        _ => {
+            if let Some(alt_name) = alt_name {
+                msg.push_str(&format!("; dependency `{alt_name}` exists",));
+            }
+        }
+    }
     anyhow::format_err!(msg)
 }
 

--- a/src/cargo/util/toml_mut/manifest.rs
+++ b/src/cargo/util/toml_mut/manifest.rs
@@ -705,11 +705,11 @@ fn non_existent_dependency_err(
     alt_name: Option<&str>,
 ) -> anyhow::Error {
     let mut msg = format!("the dependency `{name}` could not be found in `{search_table}`");
-    if let Some(found_table) = found_table {
+    match found_table { Some(found_table) => {
         msg.push_str(&format!("; it is present in `{found_table}`",));
-    } else if let Some(alt_name) = alt_name {
+    } _ => if let Some(alt_name) = alt_name {
         msg.push_str(&format!("; dependency `{alt_name}` exists",));
-    }
+    }}
     anyhow::format_err!(msg)
 }
 

--- a/src/cargo/util/vcs.rs
+++ b/src/cargo/util/vcs.rs
@@ -10,16 +10,17 @@ use std::path::Path;
 // 2. We are in an HG repo.
 pub fn existing_vcs_repo(path: &Path, cwd: &Path) -> bool {
     fn in_git_repo(path: &Path, cwd: &Path) -> bool {
-        match GitRepo::discover(path, cwd) { Ok(repo) => {
-            // Don't check if the working directory itself is ignored.
-            if repo.workdir().map_or(false, |workdir| workdir == path) {
-                true
-            } else {
-                !repo.is_path_ignored(path).unwrap_or(false)
+        match GitRepo::discover(path, cwd) {
+            Ok(repo) => {
+                // Don't check if the working directory itself is ignored.
+                if repo.workdir().map_or(false, |workdir| workdir == path) {
+                    true
+                } else {
+                    !repo.is_path_ignored(path).unwrap_or(false)
+                }
             }
-        } _ => {
-            false
-        }}
+            _ => false,
+        }
     }
 
     in_git_repo(path, cwd) || HgRepo::discover(path, cwd).is_ok()

--- a/src/cargo/util/vcs.rs
+++ b/src/cargo/util/vcs.rs
@@ -10,16 +10,16 @@ use std::path::Path;
 // 2. We are in an HG repo.
 pub fn existing_vcs_repo(path: &Path, cwd: &Path) -> bool {
     fn in_git_repo(path: &Path, cwd: &Path) -> bool {
-        if let Ok(repo) = GitRepo::discover(path, cwd) {
+        match GitRepo::discover(path, cwd) { Ok(repo) => {
             // Don't check if the working directory itself is ignored.
             if repo.workdir().map_or(false, |workdir| workdir == path) {
                 true
             } else {
                 !repo.is_path_ignored(path).unwrap_or(false)
             }
-        } else {
+        } _ => {
             false
-        }
+        }}
     }
 
     in_git_repo(path, cwd) || HgRepo::discover(path, cwd).is_ok()

--- a/src/cargo/version.rs
+++ b/src/cargo/version.rs
@@ -37,7 +37,7 @@ impl fmt::Display for VersionInfo {
 /// Returns information about cargo's version.
 pub fn version() -> VersionInfo {
     macro_rules! option_env_str {
-        ($name:expr) => {
+        ($name:expr_2021) => {
             option_env!($name).map(|s| s.to_string())
         };
     }

--- a/tests/testsuite/login.rs
+++ b/tests/testsuite/login.rs
@@ -53,7 +53,7 @@ pub fn check_token(expected_token: Option<&str>, registry: Option<&str>) {
             .get("registry")
             .and_then(|registry_table| registry_table.get("token"))
             .and_then(|v| match v {
-                toml::Value::String(ref token) => Some(token.as_str().to_string()),
+                &toml::Value::String(ref token) => Some(token.as_str().to_string()),
                 _ => None,
             }),
     };

--- a/tests/testsuite/messages.rs
+++ b/tests/testsuite/messages.rs
@@ -47,7 +47,7 @@ pub fn raw_rustc_output(project: &Project, path: &str, extra: &[&str]) -> String
     result
 }
 
-fn redact_rustc_message(msg: &str) -> impl IntoData {
+fn redact_rustc_message(msg: &str) -> impl IntoData + use<> {
     use snapbox::filter::{Filter, FilterPaths};
     let assert = assert_e2e();
     let redactions = assert.redactions();

--- a/tests/testsuite/old_cargos.rs
+++ b/tests/testsuite/old_cargos.rs
@@ -385,13 +385,13 @@ fn new_features() {
         };
 
         macro_rules! check_lock {
-            ($tc_result:ident, $pkg:expr, $which:expr, $actual:expr, None) => {
+            ($tc_result:ident, $pkg:expr_2021, $which:expr_2021, $actual:expr_2021, None) => {
                 check_lock!(= $tc_result, $pkg, $which, $actual, None);
             };
-            ($tc_result:ident, $pkg:expr, $which:expr, $actual:expr, $expected:expr) => {
+            ($tc_result:ident, $pkg:expr_2021, $which:expr_2021, $actual:expr_2021, $expected:expr_2021) => {
                 check_lock!(= $tc_result, $pkg, $which, $actual, Some(Version::parse($expected).unwrap()));
             };
-            (= $tc_result:ident, $pkg:expr, $which:expr, $actual:expr, $expected:expr) => {
+            (= $tc_result:ident, $pkg:expr_2021, $which:expr_2021, $actual:expr_2021, $expected:expr_2021) => {
                 let exp: Option<Version> = $expected;
                 if $actual != $expected {
                     $tc_result.push(format!(
@@ -403,11 +403,11 @@ fn new_features() {
         }
 
         let check_err_contains = |tc_result: &mut Vec<_>, err: anyhow::Error, contents| {
-            if let Some(ProcessError {
+            match err.downcast_ref::<ProcessError>()
+            { Some(ProcessError {
                 stderr: Some(stderr),
                 ..
-            }) = err.downcast_ref::<ProcessError>()
-            {
+            }) => {
                 let stderr = std::str::from_utf8(stderr).unwrap();
                 if !stderr.contains(contents) {
                     tc_result.push(format!(
@@ -415,9 +415,9 @@ fn new_features() {
                         toolchain, contents, stderr
                     ));
                 }
-            } else {
+            } _ => {
                 panic!("{} unexpected error {}", toolchain, err);
-            }
+            }}
         };
 
         // Unlocked behavior.

--- a/tests/testsuite/old_cargos.rs
+++ b/tests/testsuite/old_cargos.rs
@@ -402,23 +402,26 @@ fn new_features() {
             };
         }
 
-        let check_err_contains = |tc_result: &mut Vec<_>, err: anyhow::Error, contents| {
-            match err.downcast_ref::<ProcessError>()
-            { Some(ProcessError {
-                stderr: Some(stderr),
-                ..
-            }) => {
-                let stderr = std::str::from_utf8(stderr).unwrap();
-                if !stderr.contains(contents) {
-                    tc_result.push(format!(
-                        "{} expected to see error contents:\n{}\nbut saw:\n{}",
-                        toolchain, contents, stderr
-                    ));
+        let check_err_contains =
+            |tc_result: &mut Vec<_>, err: anyhow::Error, contents| match err
+                .downcast_ref::<ProcessError>()
+            {
+                Some(ProcessError {
+                    stderr: Some(stderr),
+                    ..
+                }) => {
+                    let stderr = std::str::from_utf8(stderr).unwrap();
+                    if !stderr.contains(contents) {
+                        tc_result.push(format!(
+                            "{} expected to see error contents:\n{}\nbut saw:\n{}",
+                            toolchain, contents, stderr
+                        ));
+                    }
                 }
-            } _ => {
-                panic!("{} unexpected error {}", toolchain, err);
-            }}
-        };
+                _ => {
+                    panic!("{} unexpected error {}", toolchain, err);
+                }
+            };
 
         // Unlocked behavior.
         let which = "unlocked";


### PR DESCRIPTION
Just want to see how smooth the edition 2024 migration is in cargo repo.
It seems like

* Most of the changes are if-let rescope. Among those, almost none of them are necessary.
* Some are new lifetime `use<_>` capture changes.
* Some are macro `expr_2021` but seems unnecessary for our use cases.

I wouldn't say the migration experience was good, as I needed to really looking into each case to determine whether to keep (haven't done it yet in this PR). Yet, I didn't encounter any compilation error and the main testsuite has passed. The experience could be better if it can auto-detect whether an if-let rescope  is needed.