### PR TITLE
feat: implement workspace feature unification

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -770,6 +770,7 @@ unstable_cli_options!(
     direct_minimal_versions: bool = ("Resolve minimal dependency versions instead of maximum (direct dependencies only)"),
     doctest_xcompile: bool = ("Compile and run doctests for non-host target using runner config"),
     dual_proc_macros: bool = ("Build proc-macros for both the host and the target"),
+    feature_unification: bool = ("Enable new feature unification modes in workspaces"),
     features: Option<Vec<String>>,
     gc: bool = ("Track cache usage and \"garbage collect\" unused files"),
     #[serde(deserialize_with = "deserialize_git_features")]
@@ -1271,6 +1272,7 @@ impl CliUnstable {
             "direct-minimal-versions" => self.direct_minimal_versions = parse_empty(k, v)?,
             "doctest-xcompile" => self.doctest_xcompile = parse_empty(k, v)?,
             "dual-proc-macros" => self.dual_proc_macros = parse_empty(k, v)?,
+            "feature-unification" => self.feature_unification = parse_empty(k, v)?,
             "gc" => self.gc = parse_empty(k, v)?,
             "git" => {
                 self.git = v.map_or_else(

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -9,6 +9,7 @@ use crate::ops::{common_for_install_and_uninstall::*, FilterRule};
 use crate::ops::{CompileFilter, Packages};
 use crate::sources::source::Source;
 use crate::sources::{GitSource, PathSource, SourceConfigMap};
+use crate::util::context::FeatureUnification;
 use crate::util::errors::CargoResult;
 use crate::util::{Filesystem, GlobalContext, Rustc};
 use crate::{drop_println, ops};
@@ -862,6 +863,7 @@ fn make_ws_rustc_target<'gctx>(
         ws.set_resolve_honors_rust_version(Some(false));
         ws
     };
+    ws.set_resolve_feature_unification(FeatureUnification::Selected);
     ws.set_ignore_lock(gctx.lock_update_allowed());
     ws.set_requested_lockfile_path(lockfile_path.map(|p| p.to_path_buf()));
     // if --lockfile-path is set, imply --locked

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -122,6 +122,7 @@ pub fn fix(
     }
     let mut ws = Workspace::new(&root_manifest, gctx)?;
     ws.set_resolve_honors_rust_version(Some(original_ws.resolve_honors_rust_version()));
+    ws.set_resolve_feature_unification(original_ws.resolve_feature_unification());
     ws.set_requested_lockfile_path(opts.requested_lockfile_path.clone());
 
     // Spin up our lock server, which our subprocesses will use to synchronize fixes.

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -75,6 +75,7 @@ use crate::core::Workspace;
 use crate::ops;
 use crate::sources::RecursivePathSource;
 use crate::util::cache_lock::CacheLockMode;
+use crate::util::context::FeatureUnification;
 use crate::util::errors::CargoResult;
 use crate::util::CanonicalUrl;
 use anyhow::Context as _;
@@ -144,6 +145,10 @@ pub fn resolve_ws_with_opts<'gctx>(
     force_all_targets: ForceAllTargets,
     dry_run: bool,
 ) -> CargoResult<WorkspaceResolve<'gctx>> {
+    let specs = match ws.resolve_feature_unification() {
+        FeatureUnification::Selected => specs,
+        FeatureUnification::Workspace => &ops::Packages::All(Vec::new()).to_package_id_specs(ws)?,
+    };
     let mut registry = ws.package_registry()?;
     let (resolve, resolved_with_overrides) = if ws.ignore_lock() {
         let add_patches = true;

--- a/src/cargo/util/context/mod.rs
+++ b/src/cargo/util/context/mod.rs
@@ -2745,6 +2745,7 @@ impl BuildTargetConfig {
 #[serde(rename_all = "kebab-case")]
 pub struct CargoResolverConfig {
     pub incompatible_rust_versions: Option<IncompatibleRustVersions>,
+    pub feature_unification: Option<FeatureUnification>,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Eq)]
@@ -2752,6 +2753,13 @@ pub struct CargoResolverConfig {
 pub enum IncompatibleRustVersions {
     Allow,
     Fallback,
+}
+
+#[derive(Copy, Clone, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum FeatureUnification {
+    Selected,
+    Workspace,
 }
 
 #[derive(Deserialize, Default)]

--- a/tests/testsuite/cargo/z_help/stdout.term.svg
+++ b/tests/testsuite/cargo/z_help/stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="1230px" height="776px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1230px" height="794px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -48,57 +48,59 @@
 </tspan>
     <tspan x="10px" y="298px"><tspan>    -Z dual-proc-macros         Build proc-macros for both the host and the target</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>    -Z gc                       Track cache usage and "garbage collect" unused files</tspan>
+    <tspan x="10px" y="316px"><tspan>    -Z feature-unification      Enable new feature unification modes in workspaces</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>    -Z git                      Enable support for shallow git fetch operations</tspan>
+    <tspan x="10px" y="334px"><tspan>    -Z gc                       Track cache usage and "garbage collect" unused files</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>    -Z gitoxide                 Use gitoxide for the given git interactions, or all of them if no argument is given</tspan>
+    <tspan x="10px" y="352px"><tspan>    -Z git                      Enable support for shallow git fetch operations</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>    -Z host-config              Enable the `[host]` section in the .cargo/config.toml file</tspan>
+    <tspan x="10px" y="370px"><tspan>    -Z gitoxide                 Use gitoxide for the given git interactions, or all of them if no argument is given</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>    -Z minimal-versions         Resolve minimal dependency versions instead of maximum</tspan>
+    <tspan x="10px" y="388px"><tspan>    -Z host-config              Enable the `[host]` section in the .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>    -Z msrv-policy              Enable rust-version aware policy within cargo</tspan>
+    <tspan x="10px" y="406px"><tspan>    -Z minimal-versions         Resolve minimal dependency versions instead of maximum</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>    -Z mtime-on-use             Configure Cargo to update the mtime of used files</tspan>
+    <tspan x="10px" y="424px"><tspan>    -Z msrv-policy              Enable rust-version aware policy within cargo</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>    -Z no-index-update          Do not update the registry index even if the cache is outdated</tspan>
+    <tspan x="10px" y="442px"><tspan>    -Z mtime-on-use             Configure Cargo to update the mtime of used files</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>    -Z package-workspace        Handle intra-workspace dependencies when packaging</tspan>
+    <tspan x="10px" y="460px"><tspan>    -Z no-index-update          Do not update the registry index even if the cache is outdated</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>    -Z panic-abort-tests        Enable support to run tests with -Cpanic=abort</tspan>
+    <tspan x="10px" y="478px"><tspan>    -Z package-workspace        Handle intra-workspace dependencies when packaging</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>    -Z profile-rustflags        Enable the `rustflags` option in profiles in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="496px"><tspan>    -Z panic-abort-tests        Enable support to run tests with -Cpanic=abort</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>    -Z public-dependency        Respect a dependency's `public` field in Cargo.toml to control public/private dependencies</tspan>
+    <tspan x="10px" y="514px"><tspan>    -Z profile-rustflags        Enable the `rustflags` option in profiles in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>    -Z publish-timeout          Enable the `publish.timeout` key in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="532px"><tspan>    -Z public-dependency        Respect a dependency's `public` field in Cargo.toml to control public/private dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>    -Z root-dir                 Set the root directory relative to which paths are printed (defaults to workspace root)</tspan>
+    <tspan x="10px" y="550px"><tspan>    -Z publish-timeout          Enable the `publish.timeout` key in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>    -Z rustdoc-map              Allow passing external documentation mappings to rustdoc</tspan>
+    <tspan x="10px" y="568px"><tspan>    -Z root-dir                 Set the root directory relative to which paths are printed (defaults to workspace root)</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>    -Z rustdoc-scrape-examples  Allows Rustdoc to scrape code examples from reverse-dependencies</tspan>
+    <tspan x="10px" y="586px"><tspan>    -Z rustdoc-map              Allow passing external documentation mappings to rustdoc</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>    -Z script                   Enable support for single-file, `.rs` packages</tspan>
+    <tspan x="10px" y="604px"><tspan>    -Z rustdoc-scrape-examples  Allows Rustdoc to scrape code examples from reverse-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>    -Z target-applies-to-host   Enable the `target-applies-to-host` key in the .cargo/config.toml file</tspan>
+    <tspan x="10px" y="622px"><tspan>    -Z script                   Enable support for single-file, `.rs` packages</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>    -Z trim-paths               Enable the `trim-paths` option in profiles</tspan>
+    <tspan x="10px" y="640px"><tspan>    -Z target-applies-to-host   Enable the `target-applies-to-host` key in the .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>    -Z unstable-options         Allow the usage of unstable options</tspan>
+    <tspan x="10px" y="658px"><tspan>    -Z trim-paths               Enable the `trim-paths` option in profiles</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan>    -Z warnings                 Allow use of the build.warnings config key</tspan>
+    <tspan x="10px" y="676px"><tspan>    -Z unstable-options         Allow the usage of unstable options</tspan>
 </tspan>
-    <tspan x="10px" y="694px">
+    <tspan x="10px" y="694px"><tspan>    -Z warnings                 Allow use of the build.warnings config key</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>Run with `cargo -Z [FLAG] [COMMAND]`</tspan>
+    <tspan x="10px" y="712px">
 </tspan>
-    <tspan x="10px" y="730px">
+    <tspan x="10px" y="730px"><tspan>Run with `cargo -Z [FLAG] [COMMAND]`</tspan>
 </tspan>
-    <tspan x="10px" y="748px"><tspan>See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html for more information about these flags.</tspan>
+    <tspan x="10px" y="748px">
 </tspan>
-    <tspan x="10px" y="766px">
+    <tspan x="10px" y="766px"><tspan>See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html for more information about these flags.</tspan>
+</tspan>
+    <tspan x="10px" y="784px">
 </tspan>
   </text>
 

--- a/tests/testsuite/feature_unification.rs
+++ b/tests/testsuite/feature_unification.rs
@@ -1,0 +1,185 @@
+//! Tests for workspace feature unification.
+
+use cargo_test_support::prelude::*;
+use cargo_test_support::{basic_manifest, cargo_process, project, str};
+
+#[cargo_test]
+fn workspace_feature_unification() {
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            r#"
+                [resolver]
+                feature-unification = "workspace"
+            "#,
+        )
+        .file(
+            "Cargo.toml",
+            r#"
+                [workspace]
+                resolver = "2"
+                members = ["common", "a", "b"]
+            "#,
+        )
+        .file(
+            "common/Cargo.toml",
+            r#"
+                [package]
+                name = "common"
+                version = "0.1.0"
+                edition = "2021"
+
+                [features]
+                a = []
+                b = []
+            "#,
+        )
+        .file(
+            "common/src/lib.rs",
+            r#"
+                #[cfg(not(all(feature = "a", feature = "b")))]
+                compile_error!("features were not unified");
+            "#,
+        )
+        .file(
+            "a/Cargo.toml",
+            r#"
+                [package]
+                name = "a"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                common = { path = "../common", features = ["a"] }
+            "#,
+        )
+        .file("a/src/lib.rs", "")
+        .file(
+            "b/Cargo.toml",
+            r#"
+                [package]
+                name = "b"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                common = { path = "../common", features = ["b"] }
+            "#,
+        )
+        .file("b/src/lib.rs", "")
+        .build();
+
+    p.cargo("check -p common")
+        .with_stderr_contains("[WARNING] unused config key `resolver.feature-unification` in `[ROOT]/foo/.cargo/config.toml`")
+        .with_stderr_contains("[ERROR] features were not unified")
+        .with_status(101)
+        .run();
+    p.cargo("check -p a")
+        .with_stderr_contains("[WARNING] unused config key `resolver.feature-unification` in `[ROOT]/foo/.cargo/config.toml`")
+        .with_stderr_contains("[ERROR] features were not unified")
+        .with_status(101)
+        .run();
+    p.cargo("check -p b")
+        .with_stderr_contains("[WARNING] unused config key `resolver.feature-unification` in `[ROOT]/foo/.cargo/config.toml`")
+        .with_stderr_contains("[ERROR] features were not unified")
+        .with_status(101)
+        .run();
+    p.cargo("check")
+        .with_stderr_contains("[WARNING] unused config key `resolver.feature-unification` in `[ROOT]/foo/.cargo/config.toml`")
+        .run();
+}
+
+#[cargo_test]
+fn cargo_install_ignores_config() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "a"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                common = { path = "common", features = ["a"] }
+
+                [workspace]
+                members = ["common", "b"]
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file(
+            "common/Cargo.toml",
+            r#"
+                [package]
+                name = "common"
+                version = "0.1.0"
+                edition = "2021"
+
+                [features]
+                a = []
+                b = []
+            "#,
+        )
+        .file(
+            "common/src/lib.rs",
+            r#"
+                #[cfg(all(feature = "a", feature = "b"))]
+                compile_error!("features should not be unified");
+            "#,
+        )
+        .file(
+            "b/Cargo.toml",
+            r#"
+                [package]
+                name = "b"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                common = { path = "../common", features = ["b"] }
+            "#,
+        )
+        .file("b/src/lib.rs", "")
+        .build();
+
+    cargo_process("install --path")
+        .arg(p.root())
+        .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "workspace")
+        .with_stderr_data(str![[r#"
+[INSTALLING] a v0.1.0 ([ROOT]/foo)
+[COMPILING] common v0.1.0 ([ROOT]/foo/common)
+[COMPILING] a v0.1.0 ([ROOT]/foo)
+[FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
+[INSTALLING] [ROOT]/home/.cargo/bin/a
+[INSTALLED] package `a v0.1.0 ([ROOT]/foo)` (executable `a`)
+[WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn unstable_config_on_stable() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [workspace]
+                resolver = "2"
+                members = ["bar"]
+            "#,
+        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file("bar/src/lib.rs", "")
+        .build();
+
+    p.cargo("check")
+        .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "workspace")
+        .with_stderr_data(str![[r#"
+[CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}

--- a/tests/testsuite/feature_unification.rs
+++ b/tests/testsuite/feature_unification.rs
@@ -70,22 +70,39 @@ fn workspace_feature_unification() {
         .build();
 
     p.cargo("check -p common")
-        .with_stderr_contains("[WARNING] unused config key `resolver.feature-unification` in `[ROOT]/foo/.cargo/config.toml`")
-        .with_stderr_contains("[ERROR] features were not unified")
-        .with_status(101)
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .with_stderr_data(str![[r#"
+[CHECKING] common v0.1.0 ([ROOT]/foo/common)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
     p.cargo("check -p a")
-        .with_stderr_contains("[WARNING] unused config key `resolver.feature-unification` in `[ROOT]/foo/.cargo/config.toml`")
-        .with_stderr_contains("[ERROR] features were not unified")
-        .with_status(101)
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .with_stderr_data(str![[r#"
+[CHECKING] a v0.1.0 ([ROOT]/foo/a)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
     p.cargo("check -p b")
-        .with_stderr_contains("[WARNING] unused config key `resolver.feature-unification` in `[ROOT]/foo/.cargo/config.toml`")
-        .with_stderr_contains("[ERROR] features were not unified")
-        .with_status(101)
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .with_stderr_data(str![[r#"
+[CHECKING] b v0.1.0 ([ROOT]/foo/b)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
     p.cargo("check")
-        .with_stderr_contains("[WARNING] unused config key `resolver.feature-unification` in `[ROOT]/foo/.cargo/config.toml`")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .with_stderr_data(str![[r#"
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -145,14 +162,16 @@ fn cargo_install_ignores_config() {
 
     cargo_process("install --path")
         .arg(p.root())
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
         .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "workspace")
         .with_stderr_data(str![[r#"
 [INSTALLING] a v0.1.0 ([ROOT]/foo)
 [COMPILING] common v0.1.0 ([ROOT]/foo/common)
 [COMPILING] a v0.1.0 ([ROOT]/foo)
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/a
-[INSTALLED] package `a v0.1.0 ([ROOT]/foo)` (executable `a`)
+[INSTALLING] [ROOT]/home/.cargo/bin/a[EXE]
+[INSTALLED] package `a v0.1.0 ([ROOT]/foo)` (executable `a[EXE]`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -177,6 +196,7 @@ fn unstable_config_on_stable() {
     p.cargo("check")
         .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "workspace")
         .with_stderr_data(str![[r#"
+[WARNING] ignoring `resolver.feature-unification` without `-Zfeature-unification`
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -85,6 +85,7 @@ mod doc;
 mod docscrape;
 mod edition;
 mod error;
+mod feature_unification;
 mod features;
 mod features2;
 mod features_namespaced;


### PR DESCRIPTION
### What does this PR try to resolve?

Adds workspace feature unification for #14774 

### How should we test and review this PR?

In a workspace that has dependencies with different activated features depending on the packages being built, add the `resolver.feature-unification = "workspace"` option to `.cargo/config.toml`. Build the entire workspace with `--workspace` and then build individual packages, ensuring no dependencies are being recompiled.

### Additional information

Originally, the RFC and tracking issue mention some more complex changes required in cargo's dependency/feature resolution phases in order to support workspace feature unification. However, it seems like it also works by just modifying the list of `PackageIdSpec`s passed to the workspace resolver to include all workspace members, and then using the original list of specs when generating the build units. I'm wondering if I missed something because this change feels a bit *too* simple...

I tested it on a fairly large workspace containing about 100 packages and didn't see any recompilations when building with different sets of packages. I also added an integration test that verifies the correct features are enabled. If there are any other test cases I should include, please let me know and I'll try to add it.