### PR TITLE
Update curl from 8.9.0 to 8.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.74+curl-8.9.0"
+version = "0.4.79+curl-8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8af10b986114528fcdc4b63b6f5f021b7057618411046a4de2ba0f0149a097bf"
+checksum = "18a9bbeeb3996717ef1248018db20d1b0b5ba7165bff60e3b5135b4f4c2b37a5"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ core-foundation = { version = "0.10.0", features = ["mac_os_10_7_support"] }
 crates-io = { version = "0.40.9", path = "crates/crates-io" }
 criterion = { version = "0.5.1", features = ["html_reports"] }
 curl = "0.4.46"
-curl-sys = "0.4.73"
+curl-sys = "0.4.79"
 filetime = "0.2.23"
 flate2 = { version = "1.0.30", default-features = false, features = ["zlib"] }
 git2 = "0.20.0"


### PR DESCRIPTION
Quite a lot of changes between these releases:

Release notes: https://curl.se/ch/8.12.0.html
Release notes: https://curl.se/ch/8.11.1.html
Release notes: https://curl.se/ch/8.11.0.html
Release notes: https://curl.se/ch/8.10.1.html
Release notes: https://curl.se/ch/8.10.0.html
Blog: https://daniel.haxx.se/blog/2025/02/05/curl-8-12-0/
Blog: https://daniel.haxx.se/blog/2024/12/11/curl-8-11-1/
Blog: https://daniel.haxx.se/blog/2024/11/06/curl-8-11-0/
Blog: https://daniel.haxx.se/blog/2024/09/18/curl-8-10-1/
Blog: https://daniel.haxx.se/blog/2024/09/11/curl-8-10-0/
