### PR TITLE
Fix race condition in panic_abort_tests

### DIFF
--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -5009,7 +5009,11 @@ fn panic_abort_tests() {
         .file("a/src/lib.rs", "pub fn foo() {}")
         .build();
 
-    p.cargo("test -Z panic-abort-tests -v")
+    // This uses -j1 because of a race condition. Otherwise it will build the
+    // two copies of `foo` in parallel, and which one is first is random. If
+    // `--test` is first, then the first line with `[..]` will match, and the
+    // second line with `--test` will fail.
+    p.cargo("test -Z panic-abort-tests -v -j1")
         .with_stderr_data(
             str![[r#"
 [RUNNING] `[..]--crate-name a [..]-C panic=abort[..]`


### PR DESCRIPTION
This fixes a race condition in the `panic_abort_tests` test which can randomly fail. Prior to https://github.com/rust-lang/cargo/pull/14226 the test would check the lines individually (which was also kinda broken for the same reason, but wouldn't actually fail).
