### PR TITLE
docs(embedded): Note the shebang deviation

### DIFF
--- a/src/cargo/util/toml/embedded.rs
+++ b/src/cargo/util/toml/embedded.rs
@@ -147,6 +147,9 @@ impl<'s> ScriptSource<'s> {
         if let Some(rest) = source.content.strip_prefix("#!") {
             // Ok, this is a shebang but if the next non-whitespace token is `[`,
             // then it may be valid Rust code, so consider it Rust code.
+            //
+            // NOTE: rustc considers line and block comments to be whitespace but to avoid
+            // any more awareness of Rust grammar, we are excluding it.
             if rest.trim_start().starts_with('[') {
                 return Ok(source);
             }


### PR DESCRIPTION
### What does this PR try to resolve?

rustc considers the following valid and without a shebang:
```rust

// Hello

[allow(dead_code)]

fn main() {
    println!("Hello, world!");
}
```
and
```rustc
[allow(dead_code)]

fn main() {
    println!("Hello, world!");
}
```

In both cases, we consider it to have a shebang.  This commit documents that intention.

We could add our own heuristics
(e.g. `#!` with only whitespace is not a shebang)
but we should either be a subset or intentionally different than rustc (e.g. require a non `[`-prefixes interpreter)
rather than do both.

Fixes #15170

### How should we test and review this PR?

This will be reflected in the tracking issue which will handle the final decision for the team on this matter.

### Additional information

