### PR TITLE
Improve package-table-in-virtual-workspace errors

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -525,7 +525,8 @@ fn normalize_toml(
         normalized_toml.badges = original_toml.badges.clone();
     } else {
         if let Some(field) = original_toml.requires_package().next() {
-            bail!("this virtual manifest specifies a `{field}` section, which is not allowed");
+            bail!("this virtual manifest specifies a `{field}` section, which is not allowed.\n\
+                    If you were trying to provide fields for workspaces, use `workspace.{field}` instead.")
         }
     }
 

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -2321,7 +2321,8 @@ fn ws_err_unused() {
 [ERROR] failed to parse manifest at `[..]/foo/Cargo.toml`
 
 Caused by:
-  this virtual manifest specifies a `{key}` section, which is not allowed
+  this virtual manifest specifies a `{key}` section, which is not allowed.
+  If you were trying to provide fields for workspaces, use `workspace.{key}` instead.
 ",
             ))
             .run();


### PR DESCRIPTION
### What does this PR try to resolve?

Fix #13965 - and implements clearer warning for incorrect keys/fields when using virtual workspaces.

### How should we test and review this PR?

Change is fairly obvious, you can view test file for changed output. 

### Additional information

The wording/language in the new message aligns to existing errors. 
For example using `If you were trying...` and `use ... instead.` as with other toml errors.

----
I ran into this today, and spent a decent amount of time before understanding my mistake 🤦 
I came across https://users.rust-lang.org/t/configuring-lints-for-an-entire-workspace/111995 and then #13965 - so decided to put up a quick PR :)

Thanks!

