### PR TITLE
Fix man page with malformed `{{#options}}` block

### DIFF
--- a/src/doc/man/cargo-publish.md
+++ b/src/doc/man/cargo-publish.md
@@ -95,13 +95,13 @@ SPEC format. This flag may be specified multiple times and supports common Unix
 glob patterns like `*`, `?` and `[]`. However, to avoid your shell accidentally 
 expanding glob patterns before Cargo handles them, you must use single quotes or
 double quotes around each pattern.
-{{/option}}
 
 Selecting more than one package with this option is unstable and available only
 on the
 [nightly channel](https://doc.rust-lang.org/book/appendix-07-nightly-rust.html)
 and requires the `-Z package-workspace` flag to enable.
 See <https://github.com/rust-lang/cargo/issues/10948> for more information.
+{{/option}}
 
 {{#option "`--workspace`" }}
 {{actionverb}} all members in the workspace.

--- a/src/doc/man/generated_txt/cargo-publish.txt
+++ b/src/doc/man/generated_txt/cargo-publish.txt
@@ -99,15 +99,12 @@ OPTIONS
            them, you must use single quotes or double quotes around each
            pattern.
 
-Selecting more than one package with this option is unstable and available only
-
-on the
-
-[nightly channel](https://doc.rust-lang.org/book/appendix-07-nightly-rust.html)
-
-and requires the `-Z package-workspace` flag to enable.
-
-See <https://github.com/rust-lang/cargo/issues/10948> for more information.
+           Selecting more than one package with this option is unstable and
+           available only on the nightly channel
+           <https://doc.rust-lang.org/book/appendix-07-nightly-rust.html> and
+           requires the -Z package-workspace flag to enable. See
+           <https://github.com/rust-lang/cargo/issues/10948> for more
+           information.
 
        --workspace
            Publish all members in the workspace.

--- a/src/doc/src/commands/cargo-publish.md
+++ b/src/doc/src/commands/cargo-publish.md
@@ -102,14 +102,13 @@ See <https://github.com/rust-lang/cargo/issues/10948> for more information.
 SPEC format. This flag may be specified multiple times and supports common Unix
 glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell accidentally
 expanding glob patterns before Cargo handles them, you must use single quotes or
-double quotes around each pattern.</dd>
-
-
-Selecting more than one package with this option is unstable and available only
+double quotes around each pattern.</p>
+<p>Selecting more than one package with this option is unstable and available only
 on the
-[nightly channel](https://doc.rust-lang.org/book/appendix-07-nightly-rust.html)
-and requires the `-Z package-workspace` flag to enable.
-See <https://github.com/rust-lang/cargo/issues/10948> for more information.
+<a href="https://doc.rust-lang.org/book/appendix-07-nightly-rust.html">nightly channel</a>
+and requires the <code>-Z package-workspace</code> flag to enable.
+See <a href="https://github.com/rust-lang/cargo/issues/10948">https://github.com/rust-lang/cargo/issues/10948</a> for more information.</dd>
+
 
 <dt class="option-term" id="option-cargo-publish---workspace"><a class="option-anchor" href="#option-cargo-publish---workspace"></a><code>--workspace</code></dt>
 <dd class="option-desc">Publish all members in the workspace.</p>

--- a/src/etc/man/cargo-publish.1
+++ b/src/etc/man/cargo-publish.1
@@ -113,12 +113,13 @@ SPEC format. This flag may be specified multiple times and supports common Unix
 glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell accidentally
 expanding glob patterns before Cargo handles them, you must use single quotes or
 double quotes around each pattern.
-.RE
+.sp
 Selecting more than one package with this option is unstable and available only
 on the
-[nightly channel](https://doc.rust-lang.org/book/appendix-07-nightly-rust.html)
-and requires the `-Z package-workspace` flag to enable.
-See <https://github.com/rust-lang/cargo/issues/10948> for more information.
+\fInightly channel\fR <https://doc.rust\-lang.org/book/appendix\-07\-nightly\-rust.html>
+and requires the \fB\-Z package\-workspace\fR flag to enable.
+See <https://github.com/rust\-lang/cargo/issues/10948> for more information.
+.RE
 .sp
 \fB\-\-workspace\fR
 .RS 4


### PR DESCRIPTION
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.
-->

### What does this PR try to resolve?

The man page template for `cargo publish` includes a malformed `{{#options}}` block containing a freestanding paragraph outside the scope of the `{{#option}}` it relates to. This results in bad formatting in the generated man pages.

### How should we test and review this PR?

Review the diffs of the generated man pages.