### PR TITLE
Get all members as `available targets` even though default-members was specified.

### DIFF
--- a/src/cargo/ops/cargo_compile/mod.rs
+++ b/src/cargo/ops/cargo_compile/mod.rs
@@ -374,6 +374,7 @@ pub fn create_bcx<'a, 'gctx>(
     let generator = UnitGenerator {
         ws,
         packages: &to_builds,
+        spec,
         target_data: &target_data,
         filter,
         requested_kinds: &build_config.requested_kinds,

--- a/src/cargo/ops/cargo_compile/unit_generator.rs
+++ b/src/cargo/ops/cargo_compile/unit_generator.rs
@@ -247,15 +247,15 @@ impl<'a> UnitGenerator<'a, '_> {
         mode: CompileMode,
     ) -> CargoResult<Vec<Proposal<'a>>> {
         let is_glob = is_glob_pattern(target_name);
-        let proposals = if is_glob {
-            let pattern = build_glob(target_name)?;
-            let filter = |t: &Target| is_expected_kind(t) && pattern.matches(t.name());
-            self.filter_targets(filter, true, mode)
-        } else {
-            let filter = |t: &Target| t.name() == target_name && is_expected_kind(t);
-            self.filter_targets(filter, true, mode)
+        let pattern = build_glob(target_name)?;
+        let filter = |t: &Target| {
+            if is_glob {
+                is_expected_kind(t) && pattern.matches(t.name())
+            } else {
+                is_expected_kind(t) && t.name() == target_name
+            }
         };
-
+        let proposals = self.filter_targets(filter, true, mode);
         if proposals.is_empty() {
             let targets = self
                 .packages

--- a/src/cargo/ops/cargo_compile/unit_generator.rs
+++ b/src/cargo/ops/cargo_compile/unit_generator.rs
@@ -17,6 +17,7 @@ use crate::util::{closest_msg, CargoResult};
 
 use super::compile_filter::{CompileFilter, FilterRule, LibRule};
 use super::packages::build_glob;
+use super::Packages;
 
 /// A proposed target.
 ///
@@ -267,14 +268,37 @@ impl<'a> UnitGenerator<'a, '_> {
                 })
                 .collect::<Vec<_>>();
             let suggestion = closest_msg(target_name, targets.iter(), |t| t.name(), "target");
+            let targets_elsewhere = self.get_targets_from_other_packages(filter)?;
+            let need_append_targets_elsewhere = !targets_elsewhere.is_empty();
+            let append_targets_elsewhere = |msg: &mut String, prefix: &str| {
+                let mut available_msg = Vec::new();
+                for (package, targets) in targets_elsewhere {
+                    if !targets.is_empty() {
+                        available_msg.push(format!(
+                            "help: Available {target_desc} in `{package}` package:"
+                        ));
+                        for target in targets {
+                            available_msg.push(format!("    {target}"));
+                        }
+                    }
+                }
+                if !available_msg.is_empty() {
+                    write!(msg, "{prefix}{}", available_msg.join("\n"))?;
+                }
+                CargoResult::Ok(())
+            };
             if !suggestion.is_empty() {
-                anyhow::bail!(
+                let mut msg = String::new();
+                write!(
+                    msg,
                     "no {} target {} `{}`{}",
                     target_desc,
                     if is_glob { "matches pattern" } else { "named" },
                     target_name,
-                    suggestion
-                );
+                    suggestion,
+                )?;
+                append_targets_elsewhere(&mut msg, "\n")?;
+                anyhow::bail!(msg);
             } else {
                 let mut msg = String::new();
                 writeln!(
@@ -284,7 +308,9 @@ impl<'a> UnitGenerator<'a, '_> {
                     if is_glob { "matches pattern" } else { "named" },
                     target_name,
                 )?;
-                if !targets.is_empty() {
+
+                append_targets_elsewhere(&mut msg, "")?;
+                if !targets.is_empty() && !need_append_targets_elsewhere {
                     writeln!(msg, "Available {} targets:", target_desc)?;
                     for target in targets {
                         writeln!(msg, "    {}", target.name())?;
@@ -294,6 +320,32 @@ impl<'a> UnitGenerator<'a, '_> {
             }
         }
         Ok(proposals)
+    }
+
+    fn get_targets_from_other_packages(
+        &self,
+        filter_fn: impl Fn(&Target) -> bool,
+    ) -> CargoResult<Vec<(&str, Vec<&str>)>> {
+        let packages = Packages::All(Vec::new()).get_packages(self.ws)?;
+        let targets = packages
+            .into_iter()
+            .filter_map(|pkg| {
+                let mut targets: Vec<_> = pkg
+                    .manifest()
+                    .targets()
+                    .iter()
+                    .filter_map(|target| filter_fn(target).then(|| target.name()))
+                    .collect();
+                if targets.is_empty() {
+                    None
+                } else {
+                    targets.sort();
+                    Some((pkg.name().as_str(), targets))
+                }
+            })
+            .collect();
+
+        Ok(targets)
     }
 
     /// Returns a list of proposed targets based on command-line target selection flags.

--- a/src/cargo/ops/cargo_compile/unit_generator.rs
+++ b/src/cargo/ops/cargo_compile/unit_generator.rs
@@ -287,8 +287,9 @@ impl<'a> UnitGenerator<'a, '_> {
                 }
                 CargoResult::Ok(())
             };
+
+            let mut msg = String::new();
             if !suggestion.is_empty() {
-                let mut msg = String::new();
                 write!(
                     msg,
                     "no {} target {} `{}`{}",
@@ -298,9 +299,7 @@ impl<'a> UnitGenerator<'a, '_> {
                     suggestion,
                 )?;
                 append_targets_elsewhere(&mut msg, "\n")?;
-                anyhow::bail!(msg);
             } else {
-                let mut msg = String::new();
                 writeln!(
                     msg,
                     "no {} target {} `{}`.",
@@ -316,8 +315,8 @@ impl<'a> UnitGenerator<'a, '_> {
                         writeln!(msg, "    {}", target.name())?;
                     }
                 }
-                anyhow::bail!(msg);
             }
+            anyhow::bail!(msg);
         }
         Ok(proposals)
     }

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -1337,7 +1337,7 @@ fn cargo_compile_with_filename() {
     p.cargo("build --bin bin.rs")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] no bin target named `bin.rs`.
+[ERROR] no bin target named `bin.rs` in default-run packages.
 Available bin targets:
     a
 
@@ -1348,7 +1348,7 @@ Available bin targets:
     p.cargo("build --bin a.rs")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] no bin target named `a.rs`
+[ERROR] no bin target named `a.rs` in default-run packages
 
 [HELP] a target with a similar name exists: `a`
 
@@ -1358,7 +1358,7 @@ Available bin targets:
     p.cargo("build --example example.rs")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] no example target named `example.rs`.
+[ERROR] no example target named `example.rs` in default-run packages.
 Available example targets:
     a
 
@@ -1369,7 +1369,7 @@ Available example targets:
     p.cargo("build --example a.rs")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] no example target named `a.rs`
+[ERROR] no example target named `a.rs` in default-run packages
 
 [HELP] a target with a similar name exists: `a`
 
@@ -5906,7 +5906,7 @@ fn target_filters_workspace() {
     ws.cargo("build -v --example ex")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] no example target named `ex`
+[ERROR] no example target named `ex` in default-run packages
 
 [HELP] a target with a similar name exists: `ex1`
 
@@ -5916,7 +5916,7 @@ fn target_filters_workspace() {
     ws.cargo("build -v --example 'ex??'")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] no example target matches pattern `ex??`
+[ERROR] no example target matches pattern `ex??` in default-run packages
 
 [HELP] a target with a similar name exists: `ex1`
 

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -623,7 +623,7 @@ automatically infer them to be a target, such as in subfolders.
 
 For more information on this warning you can consult
 https://github.com/rust-lang/cargo/issues/5330
-[ERROR] no example target named `a`.
+[ERROR] no example target named `a` in default-run packages.
 Available example targets:
     do_magic
 
@@ -655,7 +655,7 @@ fn run_example_autodiscover_2015_with_autoexamples_disabled() {
     p.cargo("run --example a")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] no example target named `a`.
+[ERROR] no example target named `a` in default-run packages.
 Available example targets:
     do_magic
 
@@ -743,7 +743,7 @@ fn run_with_filename() {
     p.cargo("run --bin bin.rs")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] no bin target named `bin.rs`.
+[ERROR] no bin target named `bin.rs` in default-run packages.
 Available bin targets:
     a
 
@@ -754,7 +754,7 @@ Available bin targets:
     p.cargo("run --bin a.rs")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] no bin target named `a.rs`
+[ERROR] no bin target named `a.rs` in default-run packages
 
 [HELP] a target with a similar name exists: `a`
 
@@ -764,7 +764,7 @@ Available bin targets:
     p.cargo("run --example example.rs")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] no example target named `example.rs`.
+[ERROR] no example target named `example.rs` in default-run packages.
 Available example targets:
     a
 
@@ -775,7 +775,7 @@ Available example targets:
     p.cargo("run --example a.rs")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] no example target named `a.rs`
+[ERROR] no example target named `a.rs` in default-run packages
 
 [HELP] a target with a similar name exists: `a`
 

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -2447,7 +2447,7 @@ fn bad_example() {
     p.cargo("run --example foo")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] no example target named `foo`.
+[ERROR] no example target named `foo` in default-run packages.
 
 
 "#]])
@@ -2455,7 +2455,7 @@ fn bad_example() {
     p.cargo("run --bin foo")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] no bin target named `foo`.
+[ERROR] no bin target named `foo` in default-run packages.
 
 
 "#]])

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -2716,3 +2716,146 @@ fn nonexistence_package_together_with_workspace() {
 "#]])
         .run();
 }
+
+// See rust-lang/cargo#14544
+#[cargo_test]
+fn print_available_targets_within_virtual_workspace() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+        [workspace]
+        resolver = "3"
+        members = ["crate1", "crate2", "pattern1", "pattern2"]
+
+        default-members = ["crate1"]
+        "#,
+        )
+        .file("crate1/src/main.rs", "fn main(){}")
+        .file(
+            "crate1/Cargo.toml",
+            r#"
+        [package]
+        name = "crate1"
+        version = "0.1.0"
+        edition = "2024"
+    "#,
+        )
+        .file("crate2/src/main.rs", "fn main(){}")
+        .file(
+            "crate2/Cargo.toml",
+            r#"
+        [package]
+        name = "crate2"
+        version = "0.1.0"
+        edition = "2024"
+    "#,
+        )
+        .file("pattern1/src/main.rs", "fn main(){}")
+        .file(
+            "pattern1/Cargo.toml",
+            r#"
+        [package]
+        name = "pattern1"
+        version = "0.1.0"
+        edition = "2024"
+    "#,
+        )
+        .file("pattern2/src/main.rs", "fn main(){}")
+        .file(
+            "pattern2/Cargo.toml",
+            r#"
+        [package]
+        name = "pattern2"
+        version = "0.1.0"
+        edition = "2024"
+    "#,
+        )
+        .file("another/src/main.rs", "fn main(){}")
+        .file(
+            "another/Cargo.toml",
+            r#"
+        [package]
+        name = "another"
+        version = "0.1.0"
+        edition = "2024"
+    "#,
+        );
+
+    let p = p.build();
+    p.cargo("run --bin")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] "--bin" takes one argument.
+Available binaries:
+    crate1
+
+
+"#]])
+        .run();
+
+    p.cargo("run -p crate1 --bin crate2")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] no bin target named `crate2`
+
+[HELP] a target with a similar name exists: `crate1`
+
+"#]])
+        .run();
+
+    p.cargo("check -p crate1 -p pattern1 -p pattern2 --bin crate2")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] no bin target named `crate2`
+
+[HELP] a target with a similar name exists: `crate1`
+
+"#]])
+        .run();
+
+    p.cargo("run --bin crate2")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] no bin target named `crate2`
+
+[HELP] a target with a similar name exists: `crate1`
+
+"#]])
+        .run();
+
+    p.cargo("check --bin pattern*")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] no bin target matches pattern `pattern*`.
+Available bin targets:
+    crate1
+
+
+"#]])
+        .run();
+
+    // This another branch that none of similar name exists, and print available targets in the
+    // default-members.
+    p.change_file(
+        "Cargo.toml",
+        r#"
+        [workspace]
+        resolver = "3"
+        members = ["crate1", "crate2", "another"]
+
+        default-members = ["another"]
+        "#,
+    );
+
+    p.cargo("run --bin crate2")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] no bin target named `crate2`.
+Available bin targets:
+    another
+
+
+"#]])
+        .run();
+}

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -2797,7 +2797,7 @@ Available binaries:
     p.cargo("run -p crate1 --bin crate2")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] no bin target named `crate2`
+[ERROR] no bin target named `crate2` in `crate1` package
 
 [HELP] a target with a similar name exists: `crate1`
 [HELP] Available bin in `crate2` package:
@@ -2809,7 +2809,7 @@ Available binaries:
     p.cargo("check -p crate1 -p pattern1 -p pattern2 --bin crate2")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] no bin target named `crate2`
+[ERROR] no bin target named `crate2` in `crate1`, ... packages
 
 [HELP] a target with a similar name exists: `crate1`
 [HELP] Available bin in `crate2` package:
@@ -2821,7 +2821,7 @@ Available binaries:
     p.cargo("run --bin crate2")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] no bin target named `crate2`
+[ERROR] no bin target named `crate2` in default-run packages
 
 [HELP] a target with a similar name exists: `crate1`
 [HELP] Available bin in `crate2` package:
@@ -2833,7 +2833,7 @@ Available binaries:
     p.cargo("check --bin pattern*")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] no bin target matches pattern `pattern*`.
+[ERROR] no bin target matches pattern `pattern*` in default-run packages.
 [HELP] Available bin in `pattern1` package:
     pattern1
 [HELP] Available bin in `pattern2` package:
@@ -2858,7 +2858,7 @@ Available binaries:
     p.cargo("run --bin crate2")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] no bin target named `crate2`.
+[ERROR] no bin target named `crate2` in default-run packages.
 [HELP] Available bin in `crate2` package:
     crate2
 

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -2800,6 +2800,8 @@ Available binaries:
 [ERROR] no bin target named `crate2`
 
 [HELP] a target with a similar name exists: `crate1`
+[HELP] Available bin in `crate2` package:
+    crate2
 
 "#]])
         .run();
@@ -2810,6 +2812,8 @@ Available binaries:
 [ERROR] no bin target named `crate2`
 
 [HELP] a target with a similar name exists: `crate1`
+[HELP] Available bin in `crate2` package:
+    crate2
 
 "#]])
         .run();
@@ -2820,6 +2824,8 @@ Available binaries:
 [ERROR] no bin target named `crate2`
 
 [HELP] a target with a similar name exists: `crate1`
+[HELP] Available bin in `crate2` package:
+    crate2
 
 "#]])
         .run();
@@ -2828,9 +2834,10 @@ Available binaries:
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] no bin target matches pattern `pattern*`.
-Available bin targets:
-    crate1
-
+[HELP] Available bin in `pattern1` package:
+    pattern1
+[HELP] Available bin in `pattern2` package:
+    pattern2
 
 "#]])
         .run();
@@ -2852,9 +2859,8 @@ Available bin targets:
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] no bin target named `crate2`.
-Available bin targets:
-    another
-
+[HELP] Available bin in `crate2` package:
+    crate2
 
 "#]])
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

The old behavior gets members from `default-members` if specified in a virtual workspace, this PR gets all workspace members for `Available` target hints. 

Fixes https://github.com/rust-lang/cargo/issues/14544

### How should we test and review this PR?

The first commit added the test, the second commit addressed the issue.

### Additional information

