### PR TITLE
fix: build warning in windows_reserved_names_are_allowed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,7 +457,7 @@ version = "0.4.1"
 
 [[package]]
 name = "cargo-test-support"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anstream",
  "anstyle",

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-test-support"
-version = "0.7.1"
+version = "0.7.2"
 edition.workspace = true
 rust-version = "1.84"  # MSRV:1
 license.workspace = true

--- a/crates/cargo-test-support/src/paths.rs
+++ b/crates/cargo-test-support/src/paths.rs
@@ -371,8 +371,6 @@ pub fn sysroot() -> String {
 /// determines whether we are running in a mode that allows Windows reserved names.
 #[cfg(windows)]
 pub fn windows_reserved_names_are_allowed() -> bool {
-    use cargo_util::is_ci;
-
     use std::ffi::OsStr;
     use std::os::windows::ffi::OsStrExt;
     use std::ptr;


### PR DESCRIPTION
A recent change removed use of the `is_ci` function, but didn't remove the `use` statement.