### PR TITLE
docs(ref): Shift focus to resolver v3

### DIFF
--- a/src/doc/src/reference/workspaces.md
+++ b/src/doc/src/reference/workspaces.md
@@ -67,7 +67,7 @@ you want to keep all the packages organized in separate directories.
 # [PROJECT_DIR]/Cargo.toml
 [workspace]
 members = ["hello_world"]
-resolver = "2"
+resolver = "3"
 ```
 
 ```toml


### PR DESCRIPTION
### What does this PR try to resolve?

We have the `resolver` field in their as subtle nod to encourage people to explicitly set it in workspaces.  With `resolver = "3"` being out for a couple releases (at the time this hits stable), it seems appropriate for us to bump this value.

### How should we test and review this PR?



### Additional information

