### PR TITLE
chore: dont check cargo-util semver until 1.86 is released

### DIFF
--- a/crates/xtask-bump-check/src/xtask.rs
+++ b/crates/xtask-bump-check/src/xtask.rs
@@ -206,7 +206,18 @@ fn bump_check(args: &clap::ArgMatches, gctx: &cargo::util::GlobalContext) -> Car
     let mut cmd = ProcessBuilder::new("cargo");
     cmd.arg("semver-checks")
         .arg("check-release")
+        // Don't check cargo-util util 1.86 is released.
+        // While it does have a SemVer breakage,
+        // it is unlikely people use it with turbo-fish syntax.
+        // And cargo-util is essentially for internal use.
+        //
+        // See:
+        //
+        // * https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/check-version-bump.20failure
+        // * https://forge.rust-lang.org/policies/crate-ownership.html#internal-use
+        .args(&["--exclude", "cargo-util"])
         .arg("--workspace");
+
     gctx.shell().status("Running", &cmd)?;
     cmd.exec()?;
     if github {


### PR DESCRIPTION

### What does this PR try to resolve

This fixes the current confusing failures in our CI pipeline:

* https://github.com/rust-lang/cargo/actions/runs/13465687015/job/37630870984
* https://github.com/rust-lang/cargo/actions/runs/13469881475/job/37642079118?pr=15104

CI job failed because of this major SemVer breakage:

```diff
-pub fn strip_prefix_canonical<P: AsRef<Path>>(
-    path: P,
-    base: P,
+pub fn strip_prefix_canonical(
+    path: impl AsRef<Path>,
+    base: impl AsRef<Path>,
 ) -> Result<PathBuf, std::path::StripPrefixError> {
```

While cargo-util does have that change violating SemVer,
it is unlikely people use it with turbo-fish syntax.
And cargo-util is essentially for internal use.


See:

* https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/check-version-bump.20failure
* https://forge.rust-lang.org/policies/crate-ownership.html#internal-use


### How should we test and review this PR?

CI passes and we're all good, though we are violating SemVer policy 😬.