### PR TITLE
chore: semver-check build-rs against beta channel

### DIFF
--- a/crates/xtask-bump-check/src/xtask.rs
+++ b/crates/xtask-bump-check/src/xtask.rs
@@ -184,7 +184,6 @@ fn bump_check(args: &clap::ArgMatches, gctx: &cargo::util::GlobalContext) -> Car
         let mut cmd = ProcessBuilder::new("cargo");
         cmd.arg("semver-checks")
             .arg("--workspace")
-            .args(&["--exclude", "build-rs"]) // FIXME: Remove once 1.84 is stable.
             .arg("--baseline-rev")
             .arg(referenced_commit.id().to_string());
         for krate in crates_not_check_against_channels {


### PR DESCRIPTION
### What does this PR try to resolve?

This should have been restored when 1.84 was out,
but nobody remembered.

