### PR TITLE
chore: depend on openssl-sys to correctly pin its version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,6 +351,7 @@ dependencies = [
  "memchr",
  "opener",
  "openssl",
+ "openssl-sys",
  "os_info",
  "pasetors",
  "pathdiff",
@@ -2824,18 +2825,18 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.4.1+3.4.0"
+version = "111.28.2+1.1.1w"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
+checksum = "bb1830e20a48a975ca898ca8c1d036a36c3c6c5cb7dabc1c216706587857920f"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.105"
+version = "0.9.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
+checksum = "db7e971c2c2bba161b2d2fdf37080177eff520b3bc044787c7f1f5f9e78d869b"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -234,6 +234,7 @@ cargo-credential-macos-keychain.workspace = true
 
 [target.'cfg(not(windows))'.dependencies]
 openssl = { workspace = true, optional = true }
+openssl-sys = { workspace = true, optional = true } # HACK: for pinning to openssl v1.
 
 [target.'cfg(windows)'.dependencies]
 cargo-credential-wincred.workspace = true


### PR DESCRIPTION
### What does this PR try to resolve?

From https://github.com/rust-lang/cargo/issues/13546#issuecomment-2676629906

> This was an overlook in <https://github.com/rust-lang/cargo/pull/15166> and apparently we forgot to actually add openssl-sys to `cargo` package. The pinned version is [under `workspace.dependencies`](https://github.com/rust-lang/cargo/pull/15166) so it never really affect the dependency resolution.
>
> The bad news is that <https://github.com/rust-lang/cargo/pull/15166> is now in beta toolchain already. If we're going to fix this again we might need to revert it in beta as well.

This PR fixes it. However, I think we should find a way to unpin the version.

### How should we test and review this PR?

If we're going to merge this, we might want to backport to beta

