### PR TITLE
feat: add completions for `--manifest-path`

### DIFF
--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -335,9 +335,6 @@ pub trait CommandExt: Sized {
                         if is_embedded(path) {
                             return true;
                         }
-                        if path.is_file() && path.extension().is_none() {
-                            return true;
-                        }
                         false
                     }),
                 )),

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -10,6 +10,7 @@ use crate::util::important_paths::find_root_manifest_for_wd;
 use crate::util::interning::InternedString;
 use crate::util::is_rustup;
 use crate::util::restricted_names;
+use crate::util::toml::is_embedded;
 use crate::util::{
     print_available_benches, print_available_binaries, print_available_examples,
     print_available_packages, print_available_tests,
@@ -325,7 +326,21 @@ pub trait CommandExt: Sized {
         self._arg(
             opt("manifest-path", "Path to Cargo.toml")
                 .value_name("PATH")
-                .help_heading(heading::MANIFEST_OPTIONS),
+                .help_heading(heading::MANIFEST_OPTIONS)
+                .add(clap_complete::engine::ArgValueCompleter::new(
+                    clap_complete::engine::PathCompleter::any().filter(|path: &Path| {
+                        if path.file_name() == Some(OsStr::new("Cargo.toml")) {
+                            return true;
+                        }
+                        if is_embedded(path) {
+                            return true;
+                        }
+                        if path.is_file() && path.extension().is_none() {
+                            return true;
+                        }
+                        false
+                    }),
+                )),
         )
     }
 


### PR DESCRIPTION
### What does this PR try to resolve?

Add auto completion for `cargo build --manifest-path <TAB>`

Related to #14520 

Ways this could be handled:
1. Complete nothing **(current nightly behavior)**: users must manually type every character of the path.
2. Complete all files **(current stable behavior)**: users see every file, more than this PR
3. Complete every file name that is accepted by `--manifest-path` **(this PR)**: this may match files that don't have a manifest inside them, implicit or explicit
4. Complete only `Cargo.toml`: Cargo script users will have to manually type in every of the path

Generally, completions should err on the side of being overly broad, rather than less, because otherwise users will have to manually type things out

This is still an improvement over the stable behavior because you don't have
1. `foo/C[TAB]`, see `Cargo.toml` and `Cargo.lock`
2. `foo/Ca[TAB]`, get `foo/Cargo.toml`

### How should we test and review this PR?

[Screencast from 23-02-25 04:09:17 PM IST.webm](https://github.com/user-attachments/assets/6290801c-85bf-4b44-9dcd-6cc431891897)


