### PR TITLE
[beta-1.86] depend on openssl-sys to correctly pin its version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,6 +351,7 @@ dependencies = [
  "memchr",
  "opener",
  "openssl",
+ "openssl-sys",
  "os_info",
  "pasetors",
  "pathdiff",
@@ -2824,18 +2825,18 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.4.1+3.4.0"
+version = "111.28.2+1.1.1w"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
+checksum = "bb1830e20a48a975ca898ca8c1d036a36c3c6c5cb7dabc1c216706587857920f"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.105"
+version = "0.9.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
+checksum = "db7e971c2c2bba161b2d2fdf37080177eff520b3bc044787c7f1f5f9e78d869b"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -234,6 +234,7 @@ cargo-credential-macos-keychain.workspace = true
 
 [target.'cfg(not(windows))'.dependencies]
 openssl = { workspace = true, optional = true }
+openssl-sys = { workspace = true, optional = true } # HACK: for pinning to openssl v1.
 
 [target.'cfg(windows)'.dependencies]
 cargo-credential-wincred.workspace = true

--- a/tests/testsuite/global_cache_tracker.rs
+++ b/tests/testsuite/global_cache_tracker.rs
@@ -2004,16 +2004,7 @@ fn compatible_with_older_cargo() {
     assert_eq!(get_registry_names("src"), ["middle-1.0.0", "new-1.0.0"]);
     assert_eq!(
         get_registry_names("cache"),
-        // Duplicate crates from two different cache location
-        // because we're changing how SourceId is hashed.
-        // This change should be reverted once rust-lang/cargo#14917 lands.
-        [
-            "middle-1.0.0.crate",
-            "middle-1.0.0.crate",
-            "new-1.0.0.crate",
-            "new-1.0.0.crate",
-            "old-1.0.0.crate"
-        ]
+        ["middle-1.0.0.crate", "new-1.0.0.crate", "old-1.0.0.crate"]
     );
 
     // T-0 months: Current version, make sure it can read data from stable,
@@ -2036,10 +2027,7 @@ fn compatible_with_older_cargo() {
     assert_eq!(get_registry_names("src"), ["new-1.0.0"]);
     assert_eq!(
         get_registry_names("cache"),
-        // Duplicate crates from two different cache location
-        // because we're changing how SourceId is hashed.
-        // This change should be reverted once rust-lang/cargo#14917 lands.
-        ["middle-1.0.0.crate", "new-1.0.0.crate", "new-1.0.0.crate"]
+        ["middle-1.0.0.crate", "new-1.0.0.crate"]
     );
 }
 


### PR DESCRIPTION
Beta backports

* #15224

In order to make CI pass, the following PRs are also cherry-picked:

* https://github.com/rust-lang/cargo/commit/7e0da417c071568f51bc5463f46981ce5b87112d
