### PR TITLE
[beta 1.86] test(gc): Update tests for latest stable

### DIFF
--- a/tests/testsuite/global_cache_tracker.rs
+++ b/tests/testsuite/global_cache_tracker.rs
@@ -2004,16 +2004,7 @@ fn compatible_with_older_cargo() {
     assert_eq!(get_registry_names("src"), ["middle-1.0.0", "new-1.0.0"]);
     assert_eq!(
         get_registry_names("cache"),
-        // Duplicate crates from two different cache location
-        // because we're changing how SourceId is hashed.
-        // This change should be reverted once rust-lang/cargo#14917 lands.
-        [
-            "middle-1.0.0.crate",
-            "middle-1.0.0.crate",
-            "new-1.0.0.crate",
-            "new-1.0.0.crate",
-            "old-1.0.0.crate"
-        ]
+        ["middle-1.0.0.crate", "new-1.0.0.crate", "old-1.0.0.crate"]
     );
 
     // T-0 months: Current version, make sure it can read data from stable,
@@ -2036,10 +2027,7 @@ fn compatible_with_older_cargo() {
     assert_eq!(get_registry_names("src"), ["new-1.0.0"]);
     assert_eq!(
         get_registry_names("cache"),
-        // Duplicate crates from two different cache location
-        // because we're changing how SourceId is hashed.
-        // This change should be reverted once rust-lang/cargo#14917 lands.
-        ["middle-1.0.0.crate", "new-1.0.0.crate", "new-1.0.0.crate"]
+        ["middle-1.0.0.crate", "new-1.0.0.crate"]
     );
 }
 


### PR DESCRIPTION
This fixes the `global_cache_tracker::compatible_with_older_cargo` test to work now that stable has been updated. Cherry-picks the fix from https://github.com/rust-lang/cargo/pull/15211