### PR TITLE
feat(package): add --exclude-lockfile flag

### DIFF
--- a/src/bin/cargo/commands/package.rs
+++ b/src/bin/cargo/commands/package.rs
@@ -26,6 +26,10 @@ pub fn cli() -> Command {
             "allow-dirty",
             "Allow dirty working directories to be packaged",
         ))
+        .arg(flag(
+            "exclude-lockfile",
+            "Don't include the lock file when packaging",
+        ))
         .arg_silent_suggestion()
         .arg_package_spec_no_all(
             "Package(s) to assemble",
@@ -79,6 +83,7 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
             list: args.flag("list"),
             check_metadata: !args.flag("no-metadata"),
             allow_dirty: args.flag("allow-dirty"),
+            include_lockfile: !args.flag("exclude-lockfile"),
             to_package: specs,
             targets: args.targets()?,
             jobs: args.jobs()?,

--- a/src/cargo/ops/registry/publish.rs
+++ b/src/cargo/ops/registry/publish.rs
@@ -146,6 +146,7 @@ pub fn publish(ws: &Workspace<'_>, opts: &PublishOpts<'_>) -> CargoResult<()> {
             list: false,
             check_metadata: true,
             allow_dirty: opts.allow_dirty,
+            include_lockfile: true,
             // `package_with_dep_graph` ignores this field in favor of
             // the already-resolved list of packages
             to_package: ops::Packages::Default,

--- a/src/doc/man/cargo-package.md
+++ b/src/doc/man/cargo-package.md
@@ -27,8 +27,8 @@ stored in the `target/package` directory. This performs the following steps:
     - `[patch]`, `[replace]`, and `[workspace]` sections are removed from the
       manifest.
     - `Cargo.lock` is always included. When missing, a new lock file will be
-      generated. {{man "cargo-install" 1}} will use the packaged lock file if
-      the `--locked` flag is used.
+      generated unless the `--exclude-lockfile` flag is used. {{man "cargo-install" 1}}
+      will use the packaged lock file if the `--locked` flag is used.
     - A `.cargo_vcs_info.json` file is included that contains information
       about the current VCS checkout hash if available, as well as a flag if the
       worktree is dirty.
@@ -96,6 +96,14 @@ or the license).
 
 {{#option "`--allow-dirty`" }}
 Allow working directories with uncommitted VCS changes to be packaged.
+{{/option}}
+
+{{#option "`--exclude-lockfile`" }}
+Don't include the lock file when packaging.
+
+This flag is not for general use.
+Some tools may expect a lock file to be present (e.g. `cargo install --locked`).
+Consider other options before using this.
 {{/option}}
 
 {{> options-index }}

--- a/src/doc/man/generated_txt/cargo-package.txt
+++ b/src/doc/man/generated_txt/cargo-package.txt
@@ -27,8 +27,9 @@ DESCRIPTION
              manifest.
 
           o  Cargo.lock is always included. When missing, a new lock file will
-             be generated. cargo-install(1) will use the packaged lock file if
-             the --locked flag is used.
+             be generated unless the --exclude-lockfile flag is used.
+             cargo-install(1) will use the packaged lock file if the --locked
+             flag is used.
 
           o  A .cargo_vcs_info.json file is included that contains information
              about the current VCS checkout hash if available, as well as a
@@ -95,6 +96,13 @@ OPTIONS
        --allow-dirty
            Allow working directories with uncommitted VCS changes to be
            packaged.
+
+       --exclude-lockfile
+           Don’t include the lock file when packaging.
+
+           This flag is not for general use. Some tools may expect a lock file
+           to be present (e.g. cargo install --locked). Consider other options
+           before using this.
 
        --index index
            The URL of the registry index to use.

--- a/src/doc/src/commands/cargo-package.md
+++ b/src/doc/src/commands/cargo-package.md
@@ -22,8 +22,8 @@ stored in the `target/package` directory. This performs the following steps:
     - `[patch]`, `[replace]`, and `[workspace]` sections are removed from the
       manifest.
     - `Cargo.lock` is always included. When missing, a new lock file will be
-      generated. [cargo-install(1)](cargo-install.html) will use the packaged lock file if
-      the `--locked` flag is used.
+      generated unless the `--exclude-lockfile` flag is used. [cargo-install(1)](cargo-install.html)
+      will use the packaged lock file if the `--locked` flag is used.
     - A `.cargo_vcs_info.json` file is included that contains information
       about the current VCS checkout hash if available, as well as a flag if the
       worktree is dirty.
@@ -92,6 +92,13 @@ or the license).</dd>
 
 <dt class="option-term" id="option-cargo-package---allow-dirty"><a class="option-anchor" href="#option-cargo-package---allow-dirty"></a><code>--allow-dirty</code></dt>
 <dd class="option-desc">Allow working directories with uncommitted VCS changes to be packaged.</dd>
+
+
+<dt class="option-term" id="option-cargo-package---exclude-lockfile"><a class="option-anchor" href="#option-cargo-package---exclude-lockfile"></a><code>--exclude-lockfile</code></dt>
+<dd class="option-desc">Don’t include the lock file when packaging.</p>
+<p>This flag is not for general use.
+Some tools may expect a lock file to be present (e.g. <code>cargo install --locked</code>).
+Consider other options before using this.</dd>
 
 
 <dt class="option-term" id="option-cargo-package---index"><a class="option-anchor" href="#option-cargo-package---index"></a><code>--index</code> <em>index</em></dt>

--- a/src/etc/man/cargo-package.1
+++ b/src/etc/man/cargo-package.1
@@ -36,8 +36,8 @@ manifest.
 .sp
 .RS 4
 \h'-04'\(bu\h'+03'\fBCargo.lock\fR is always included. When missing, a new lock file will be
-generated. \fBcargo\-install\fR(1) will use the packaged lock file if
-the \fB\-\-locked\fR flag is used.
+generated unless the \fB\-\-exclude\-lockfile\fR flag is used. \fBcargo\-install\fR(1)
+will use the packaged lock file if the \fB\-\-locked\fR flag is used.
 .RE
 .sp
 .RS 4
@@ -125,6 +125,15 @@ or the license).
 \fB\-\-allow\-dirty\fR
 .RS 4
 Allow working directories with uncommitted VCS changes to be packaged.
+.RE
+.sp
+\fB\-\-exclude\-lockfile\fR
+.RS 4
+Don\[cq]t include the lock file when packaging.
+.sp
+This flag is not for general use.
+Some tools may expect a lock file to be present (e.g. \fBcargo install \-\-locked\fR).
+Consider other options before using this.
 .RE
 .sp
 \fB\-\-index\fR \fIindex\fR

--- a/tests/testsuite/cargo_package/help/stdout.term.svg
+++ b/tests/testsuite/cargo_package/help/stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="827px" height="812px" xmlns="http://www.w3.org/2000/svg">
+<svg width="827px" height="830px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -41,71 +41,73 @@
 </tspan>
     <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-cyan bold">--allow-dirty</tspan><tspan>              Allow dirty working directories to be packaged</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-cyan bold">--exclude-lockfile</tspan><tspan>         Don't include the lock file when packaging</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring: auto, always, never</tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring: auto, always, never</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>                                 details</tspan>
+    <tspan x="10px" y="316px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="334px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="352px">
+    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan class="fg-green bold">Package Selection:</tspan>
+    <tspan x="10px" y="370px">
 </tspan>
-    <tspan x="10px" y="388px"><tspan>  </tspan><tspan class="fg-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package(s) to assemble</tspan>
+    <tspan x="10px" y="388px"><tspan class="fg-green bold">Package Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--workspace</tspan><tspan>         Assemble all packages in the workspace</tspan>
+    <tspan x="10px" y="406px"><tspan>  </tspan><tspan class="fg-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package(s) to assemble</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--exclude</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>    Don't assemble specified packages</tspan>
+    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--workspace</tspan><tspan>         Assemble all packages in the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="442px">
+    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--exclude</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>    Don't assemble specified packages</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan class="fg-green bold">Feature Selection:</tspan>
+    <tspan x="10px" y="460px">
 </tspan>
-    <tspan x="10px" y="478px"><tspan>  </tspan><tspan class="fg-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
+    <tspan x="10px" y="478px"><tspan class="fg-green bold">Feature Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
+    <tspan x="10px" y="496px"><tspan>  </tspan><tspan class="fg-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
+    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
 </tspan>
-    <tspan x="10px" y="532px">
+    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan class="fg-green bold">Compilation Options:</tspan>
+    <tspan x="10px" y="550px">
 </tspan>
-    <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Build for the target triple</tspan>
+    <tspan x="10px" y="568px"><tspan class="fg-green bold">Compilation Options:</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
+    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Build for the target triple</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>  </tspan><tspan class="fg-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
+    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
+    <tspan x="10px" y="622px"><tspan>  </tspan><tspan class="fg-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
 </tspan>
-    <tspan x="10px" y="640px">
+    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="658px">
 </tspan>
-    <tspan x="10px" y="676px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="676px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
+    <tspan x="10px" y="694px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="748px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="748px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="766px">
+    <tspan x="10px" y="766px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help package</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="784px">
 </tspan>
-    <tspan x="10px" y="802px">
+    <tspan x="10px" y="802px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help package</tspan><tspan class="bold">` for more detailed information.</tspan>
+</tspan>
+    <tspan x="10px" y="820px">
 </tspan>
   </text>
 


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes #15059
Fixes #15159

This provides an escape hatch `--exclude-lockfile`for uncommon workflows
that don't verify (`--no-verify` is passed) the build with their unpublished packages
In effect, this takes the heuristic removed in #14815 and replaces it with a flag

When `--exclude-lockfile` is enabled,
`cargo package` will not verify the lock file if present,
nor will it generate a new one if absent.
Cargo.lock will not be included in the resulting tarball.

Together with `--no-verify`,
this flag decouples packaging from checking the registry index.
While this is useful for some non-normal workflows that requires
to assemble packages having unpublished dependencies.
It is recommended to use `-Zpackage-workspace` to package the entire
workspace, instead of opting out lockfile.

### How should we test and review this PR?

The first commit was stolen from <https://github.com/NoisyCoil/cargo/commit/1a104b544445b11044f095705ed6dd45f8a60b15> (credit to @NoisyCoil!)

The second added two failing cases we observed in #15059.

### Additional information

