### PR TITLE
Added `build.build_dir` templating support

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -213,7 +213,6 @@ impl<'gctx> Workspace<'gctx> {
     pub fn new(manifest_path: &Path, gctx: &'gctx GlobalContext) -> CargoResult<Workspace<'gctx>> {
         let mut ws = Workspace::new_default(manifest_path.to_path_buf(), gctx);
         ws.target_dir = gctx.target_dir()?;
-        ws.build_dir = gctx.build_dir()?;
 
         if manifest_path.is_relative() {
             bail!(
@@ -223,6 +222,12 @@ impl<'gctx> Workspace<'gctx> {
         } else {
             ws.root_manifest = ws.find_root(manifest_path)?;
         }
+
+        ws.build_dir = gctx.build_dir(
+            ws.root_manifest
+                .as_ref()
+                .unwrap_or(&manifest_path.to_path_buf()),
+        )?;
 
         ws.custom_metadata = ws
             .load_workspace_config()?

--- a/src/cargo/util/context/mod.rs
+++ b/src/cargo/util/context/mod.rs
@@ -652,13 +652,36 @@ impl GlobalContext {
     /// Falls back to the target directory if not specified.
     ///
     /// Callers should prefer [`Workspace::build_dir`] instead.
-    pub fn build_dir(&self) -> CargoResult<Option<Filesystem>> {
+    pub fn build_dir(&self, workspace_manifest_path: &PathBuf) -> CargoResult<Option<Filesystem>> {
         if !self.cli_unstable().build_dir {
             return self.target_dir();
         }
         if let Some(val) = &self.build_config()?.build_dir {
-            let path = val.resolve_path(self);
+            let replacements = vec![
+                (
+                    "{workspace-root}",
+                    workspace_manifest_path
+                        .parent()
+                        .unwrap()
+                        .to_str()
+                        .context("workspace root was not valid utf-8")?
+                        .to_string(),
+                ),
+                (
+                    "{cargo-cache-home}",
+                    self.home()
+                        .as_path_unlocked()
+                        .to_str()
+                        .context("cargo home was not valid utf-8")?
+                        .to_string(),
+                ),
+                ("{workspace-manifest-path-hash}", {
+                    let hash = crate::util::hex::short_hash(&workspace_manifest_path);
+                    format!("{}{}{}", &hash[0..2], std::path::MAIN_SEPARATOR, &hash[2..])
+                }),
+            ];
 
+            let path = val.resolve_templated_path(self, replacements);
             // Check if the target directory is set to an empty string in the config.toml file.
             if val.raw_value().is_empty() {
                 bail!(

--- a/src/cargo/util/context/mod.rs
+++ b/src/cargo/util/context/mod.rs
@@ -681,7 +681,17 @@ impl GlobalContext {
                 }),
             ];
 
-            let path = val.resolve_templated_path(self, replacements);
+            let path = val
+                .resolve_templated_path(self, replacements)
+                .map_err(|e| match e {
+                    path::ResolveTemplateError::UnexpectedVariable {
+                        variable,
+                        raw_template,
+                    } => anyhow!(
+                        "unexpected variable `{variable}` in build.build-dir path `{raw_template}`"
+                    ),
+                })?;
+
             // Check if the target directory is set to an empty string in the config.toml file.
             if val.raw_value().is_empty() {
                 bail!(

--- a/src/cargo/util/context/path.rs
+++ b/src/cargo/util/context/path.rs
@@ -32,6 +32,25 @@ impl ConfigRelativePath {
         self.0.definition.root(gctx).join(&self.0.val)
     }
 
+    /// Same as [`Self::resolve_path`] but will make string replacements
+    /// before resolving the path.
+    ///
+    /// `replacements` should be an an [`IntoIterator`] of tuples with the "from" and "to" for the
+    /// string replacement
+    pub fn resolve_templated_path(
+        &self,
+        gctx: &GlobalContext,
+        replacements: impl IntoIterator<Item = (impl AsRef<str>, impl AsRef<str>)>,
+    ) -> PathBuf {
+        let mut value = self.0.val.clone();
+
+        for (from, to) in replacements {
+            value = value.replace(from.as_ref(), to.as_ref());
+        }
+
+        self.0.definition.root(gctx).join(&value)
+    }
+
     /// Resolves this configuration-relative path to either an absolute path or
     /// something appropriate to execute from `PATH`.
     ///

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -260,6 +260,13 @@ build-dir = "out"
 
 The path to where internal files used as part of the build are placed.
 
+This option supports path templating.
+
+Avaiable template variables:
+* `{workspace-root}` resolves to root of the current workspace.
+* `{cargo-cache-home}` resolves to `CARGO_HOME`
+* `{workspace-manifest-path-hash}` resolves to a hash of the manifest path
+
 
 ## root-dir
 * Original Issue: [#9887](https://github.com/rust-lang/cargo/issues/9887)

--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -12,7 +12,7 @@
 use std::path::PathBuf;
 
 use cargo_test_support::prelude::*;
-use cargo_test_support::{paths, project};
+use cargo_test_support::{paths, project, str};
 use std::env::consts::{DLL_PREFIX, DLL_SUFFIX, EXE_SUFFIX};
 
 #[cargo_test]
@@ -508,6 +508,11 @@ fn template_should_error_for_invalid_variables() {
     p.cargo("build -Z build-dir")
         .masquerade_as_nightly_cargo(&["build-dir"])
         .enable_mac_dsym()
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] unexpected variable `fake` in build.build-dir path `{fake}/build-dir`
+
+"#]])
         .run();
 }
 

--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -492,6 +492,26 @@ fn future_incompat_should_output_to_build_dir() {
 }
 
 #[cargo_test]
+fn template_should_error_for_invalid_variables() {
+    let p = project()
+        .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [build]
+            build-dir = "{fake}/build-dir"
+            target-dir = "target-dir"
+            "#,
+        )
+        .build();
+
+    p.cargo("build -Z build-dir")
+        .masquerade_as_nightly_cargo(&["build-dir"])
+        .enable_mac_dsym()
+        .run();
+}
+
+#[cargo_test]
 fn template_workspace_root() {
     let p = project()
         .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)

--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -493,20 +493,15 @@ fn future_incompat_should_output_to_build_dir() {
 
 #[cargo_test]
 fn template_workspace_root() {
-    let p = project();
-    let root = p.root();
-    let p = p
+    let p = project()
         .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
         .file(
             ".cargo/config.toml",
-            &format!(
-                r#"
-                [build]
-                build-dir = "{}/build-dir"
-                target-dir = "target-dir"
-                "#,
-                root.display()
-            ),
+            r#"
+            [build]
+            build-dir = "{workspace-root}/build-dir"
+            target-dir = "target-dir"
+            "#,
         )
         .build();
 
@@ -528,14 +523,11 @@ fn template_cargo_cache_home() {
         .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
         .file(
             ".cargo/config.toml",
-            &format!(
-                r#"
-                [build]
-                build-dir = "{}/build-dir"
-                target-dir = "target-dir"
-                "#,
-                paths::home().join(".cargo").display()
-            ),
+            r#"
+            [build]
+            build-dir = "{cargo-cache-home}/build-dir"
+            target-dir = "target-dir"
+            "#,
         )
         .build();
 
@@ -569,7 +561,7 @@ fn template_workspace_manfiest_path_hash() {
             ".cargo/config.toml",
             r#"
             [build]
-            build-dir = "foo/a7/0a942ddb7da6b4/build-dir"
+            build-dir = "foo/{workspace-manifest-path-hash}/build-dir"
             target-dir = "target-dir"
             "#,
         )


### PR DESCRIPTION
### What does this PR try to resolve?

This PR is a follow up on #15104 and and adds support for the path templating in `build.build-dir` as defined in #14125.

Supported templates:
* `{workspace-root}`
* `{cargo-cache}` (pointing to `CARGO_HOME` for now)
* `{workspace-manifest-path-hash}`

#### Unresolved questions

What should we name `{workspace-manifest-path-hash}` and what should it include?  Should we shorten to `{workspace-hash}` or even just `{hash}`?  Should we include the Cargo version so we get unique whole-target directories for easier cleanup (#13136)

How should this handle unknown variables (error) or unclosed `{` / `}` (ignored), see https://github.com/rust-lang/cargo/pull/15236#discussion_r1977898973

When using `{workspace-manifest-path-hash}` this hash will change based on the project path. In the event of a cargo being executed in a symlinked project, the hash will change. 

For example, given the following directory 
```
/Users/
└─ user1/
    └─ projects/
        ├─ actual-crate/
        │  └─ Cargo.toml
        └─ symlink-to-crate/ -> actual-crate/
```

the hash will be unique when running cargo from each of the following directories.
* `/Users/user1/actual-crate`
* `/Users/user1/symlink-to-crate`

Figuring out whether to handle this is deferred out, see
- https://github.com/rust-lang/cargo/pull/15236#discussion_r1971938021
-  https://github.com/poliorcetics/rfcs/blob/cargo-target-directories/text/3371-cargo-target-dir-templates.md#symbolic-links
- https://github.com/rust-lang/cargo/issues/12207#issuecomment-2711402159

### How should we test and review this PR?

This PR is fairly small. I included tests for each template variable.

You can also clone my branch and test it locally with
```console
CARGO_BUILD_BUILD_DIR='{workspace-root}/foo' cargo -Z build-dir build
```

### Additional information

While searching Cargo for any prior art for path templating, I found [`sources/registry/download.rs`](https://github.com/rust-lang/cargo/blob/master/src/cargo/sources/registry/download.rs#L84) doing a simple string replace. Thus I followed the same behavior. 




r? @epage 


