### PR TITLE
feat: add completions for `--lockfile-path`

### DIFF
--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -353,10 +353,6 @@ pub trait CommandExt: Sized {
                             None => return false,
                         };
 
-                        // allow directories
-                        if path.is_dir() {
-                            return true;
-                        }
                         // allow `Cargo.lock` file
                         file_name == OsStr::new("Cargo.lock")
                     }),


### PR DESCRIPTION
### What does this PR try to resolve?

Add auto completion for `cargo build --lockfile-path <TAB>`

Related to #14520 

### How should we test and review this PR?

![Screenshot from 2025-02-27 18-38-21](https://github.com/user-attachments/assets/36ae3584-8e1a-4e9e-bab8-fe239c03bb82)
