### PR TITLE
fix(package): Ensure we can package directories ending with '.rs'

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -45,9 +45,10 @@ pub use embedded::ScriptSource;
 /// See also `bin/cargo/commands/run.rs`s `is_manifest_command`
 pub fn is_embedded(path: &Path) -> bool {
     let ext = path.extension();
-    ext == Some(OsStr::new("rs")) ||
+    (ext == Some(OsStr::new("rs")) ||
         // Provide better errors by not considering directories to be embedded manifests
-        (ext.is_none() && path.is_file())
+        ext.is_none())
+        && path.is_file()
 }
 
 /// Loads a `Cargo.toml` from a file on disk.

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -6646,17 +6646,21 @@ fn workspace_with_dot_rs_dir() {
     p.cargo("package -Zpackage-workspace")
         .masquerade_as_nightly_cargo(&["package-workspace"])
         .replace_crates_io(reg.index_url())
-        .with_status(101)
         .with_stderr_data(
             str![[r#"
 [PACKAGING] foo v0.16.2 ([ROOT]/foo/crates/foo.rs)
-[ERROR] failed to prepare local package for uploading
-
-Caused by:
-  Unable to update [ROOT]/foo/crates/foo.rs
-
-Caused by:
-  Single file packages cannot be used as dependencies
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGING] bar v0.16.2 ([ROOT]/foo/crates/bar.rs)
+[UPDATING] crates.io index
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[VERIFYING] foo v0.16.2 ([ROOT]/foo/crates/foo.rs)
+[COMPILING] foo v0.16.2 ([ROOT]/foo/target/package/foo-0.16.2)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[VERIFYING] bar v0.16.2 ([ROOT]/foo/crates/bar.rs)
+[UNPACKING] foo v0.16.2 (registry `[ROOT]/foo/target/package/tmp-registry`)
+[COMPILING] foo v0.16.2
+[COMPILING] bar v0.16.2 ([ROOT]/foo/target/package/bar-0.16.2)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]]
             .unordered(),

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -1358,7 +1358,7 @@ fn cmd_check_with_missing_script_rs() {
         .with_status(101)
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
-[ERROR] manifest path `script.rs` does not exist
+[ERROR] the manifest-path must be a path to a Cargo.toml file
 
 "#]])
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

This likely only affects `-Zpackage-workspace` but it might have also broken dependencies whose path ends with `.rs` as
well

This broke in https://github.com/rust-lang/cargo/pull/14961

### How should we test and review this PR?



### Additional information


