### PR TITLE
feat(tree): Add `--depth public` behind `-Zunstable-options`

### DIFF
--- a/src/cargo/ops/tree/mod.rs
+++ b/src/cargo/ops/tree/mod.rs
@@ -91,6 +91,7 @@ impl FromStr for Prefix {
 #[derive(Clone, Copy)]
 pub enum DisplayDepth {
     MaxDisplayDepth(u32),
+    Public,
     Workspace,
 }
 
@@ -100,6 +101,7 @@ impl FromStr for DisplayDepth {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "workspace" => Ok(Self::Workspace),
+            "public" => Ok(Self::Public),
             s => s.parse().map(Self::MaxDisplayDepth).map_err(|_| {
                 clap::Error::raw(
                     clap::error::ErrorKind::ValueValidation,
@@ -420,6 +422,12 @@ fn print_dependencies<'a>(
     let (max_display_depth, filter_non_workspace_member) = match display_depth {
         DisplayDepth::MaxDisplayDepth(max) => (max, false),
         DisplayDepth::Workspace => (u32::MAX, true),
+        DisplayDepth::Public => {
+            if !ws.gctx().cli_unstable().unstable_options {
+                anyhow::bail!("`--depth public` requires `-Zunstable-options`")
+            }
+            (u32::MAX, false)
+        }
     };
 
     // Current level exceeds maximum display depth. Skip.

--- a/src/cargo/ops/tree/mod.rs
+++ b/src/cargo/ops/tree/mod.rs
@@ -282,7 +282,7 @@ fn print(
             &mut visited_deps,
             &mut levels_continue,
             &mut print_stack,
-        );
+        )?;
     }
 
     Ok(())
@@ -302,7 +302,7 @@ fn print_node<'a>(
     visited_deps: &mut HashSet<NodeId>,
     levels_continue: &mut Vec<(anstyle::Style, bool)>,
     print_stack: &mut Vec<NodeId>,
-) {
+) -> CargoResult<()> {
     let new = no_dedupe || visited_deps.insert(node_index);
 
     match prefix {
@@ -343,7 +343,7 @@ fn print_node<'a>(
     drop_println!(ws.gctx(), "{}{}", format.display(graph, node_index), star);
 
     if !new || in_cycle {
-        return;
+        return Ok(());
     }
     print_stack.push(node_index);
 
@@ -367,9 +367,11 @@ fn print_node<'a>(
             levels_continue,
             print_stack,
             kind,
-        );
+        )?;
     }
     print_stack.pop();
+
+    Ok(())
 }
 
 /// Prints all the dependencies of a package for the given dependency kind.
@@ -387,10 +389,10 @@ fn print_dependencies<'a>(
     levels_continue: &mut Vec<(anstyle::Style, bool)>,
     print_stack: &mut Vec<NodeId>,
     kind: &EdgeKind,
-) {
+) -> CargoResult<()> {
     let deps = graph.edges_of_kind(node_index, kind);
     if deps.is_empty() {
-        return;
+        return Ok(());
     }
 
     let name = match kind {
@@ -422,7 +424,7 @@ fn print_dependencies<'a>(
 
     // Current level exceeds maximum display depth. Skip.
     if levels_continue.len() + 1 > max_display_depth as usize {
-        return;
+        return Ok(());
     }
 
     let mut it = deps
@@ -457,9 +459,11 @@ fn print_dependencies<'a>(
             visited_deps,
             levels_continue,
             print_stack,
-        );
+        )?;
         levels_continue.pop();
     }
+
+    Ok(())
 }
 
 fn edge_line_color(kind: EdgeKind) -> anstyle::Style {

--- a/tests/testsuite/cargo_tree/deps.rs
+++ b/tests/testsuite/cargo_tree/deps.rs
@@ -1901,6 +1901,147 @@ c v0.1.0 ([ROOT]/foo/c) (*)
         .run();
 }
 
+#[cargo_test(nightly, reason = "exported_private_dependencies lint is unstable")]
+fn depth_public() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["diamond", "left-pub", "right-priv", "dep"]
+            "#,
+        )
+        .file(
+            "diamond/Cargo.toml",
+            r#"
+            cargo-features = ["public-dependency"]
+
+            [package]
+            name = "diamond"
+            version = "0.1.0"
+
+            [dependencies]
+            left-pub = { path = "../left-pub", public = true }
+            right-priv = { path = "../right-priv", public = true }
+            "#,
+        )
+        .file("diamond/src/lib.rs", "")
+        .file(
+            "left-pub/Cargo.toml",
+            r#"
+            cargo-features = ["public-dependency"]
+
+            [package]
+            name = "left-pub"
+            version = "0.1.0"
+
+            [dependencies]
+            dep = { path = "../dep", public = true }
+            "#,
+        )
+        .file("left-pub/src/lib.rs", "")
+        .file(
+            "right-priv/Cargo.toml",
+            r#"
+            [package]
+            name = "right-priv"
+            version = "0.1.0"
+
+            [dependencies]
+            dep = { path = "../dep" }
+            "#,
+        )
+        .file("right-priv/src/lib.rs", "")
+        .file(
+            "dep/Cargo.toml",
+            r#"
+            [package]
+            name = "dep"
+            version = "0.1.0"
+            "#,
+        )
+        .file("dep/src/lib.rs", "")
+        .build();
+
+    p.cargo("tree")
+        .masquerade_as_nightly_cargo(&["public-dependency"])
+        .with_stdout_data(str![[r#"
+dep v0.1.0 ([ROOT]/foo/dep)
+
+diamond v0.1.0 ([ROOT]/foo/diamond)
+├── left-pub v0.1.0 ([ROOT]/foo/left-pub)
+│   └── dep v0.1.0 ([ROOT]/foo/dep)
+└── right-priv v0.1.0 ([ROOT]/foo/right-priv)
+    └── dep v0.1.0 ([ROOT]/foo/dep)
+
+left-pub v0.1.0 ([ROOT]/foo/left-pub) (*)
+
+right-priv v0.1.0 ([ROOT]/foo/right-priv) (*)
+
+"#]])
+        .run();
+
+    p.cargo("tree -p left-pub")
+        .masquerade_as_nightly_cargo(&["public-dependency"])
+        .with_stdout_data(str![[r#"
+left-pub v0.1.0 ([ROOT]/foo/left-pub)
+└── dep v0.1.0 ([ROOT]/foo/dep)
+
+"#]])
+        .run();
+
+    p.cargo("tree -p right-priv")
+        .masquerade_as_nightly_cargo(&["public-dependency"])
+        .with_stdout_data(str![[r#"
+right-priv v0.1.0 ([ROOT]/foo/right-priv)
+└── dep v0.1.0 ([ROOT]/foo/dep)
+
+"#]])
+        .run();
+
+    p.cargo("tree -p diamond")
+        .masquerade_as_nightly_cargo(&["public-dependency"])
+        .with_stdout_data(str![[r#"
+diamond v0.1.0 ([ROOT]/foo/diamond)
+├── left-pub v0.1.0 ([ROOT]/foo/left-pub)
+│   └── dep v0.1.0 ([ROOT]/foo/dep)
+└── right-priv v0.1.0 ([ROOT]/foo/right-priv)
+    └── dep v0.1.0 ([ROOT]/foo/dep)
+
+"#]])
+        .run();
+
+    p.cargo("tree")
+        .masquerade_as_nightly_cargo(&["public-dependency"])
+        .with_stdout_data(str![[r#"
+dep v0.1.0 ([ROOT]/foo/dep)
+
+diamond v0.1.0 ([ROOT]/foo/diamond)
+├── left-pub v0.1.0 ([ROOT]/foo/left-pub)
+│   └── dep v0.1.0 ([ROOT]/foo/dep)
+└── right-priv v0.1.0 ([ROOT]/foo/right-priv)
+    └── dep v0.1.0 ([ROOT]/foo/dep)
+
+left-pub v0.1.0 ([ROOT]/foo/left-pub) (*)
+
+right-priv v0.1.0 ([ROOT]/foo/right-priv) (*)
+
+"#]])
+        .run();
+
+    p.cargo("tree --invert dep")
+        .masquerade_as_nightly_cargo(&["public-dependency"])
+        .with_stdout_data(str![[r#"
+dep v0.1.0 ([ROOT]/foo/dep)
+├── left-pub v0.1.0 ([ROOT]/foo/left-pub)
+│   └── diamond v0.1.0 ([ROOT]/foo/diamond)
+└── right-priv v0.1.0 ([ROOT]/foo/right-priv)
+    └── diamond v0.1.0 ([ROOT]/foo/diamond)
+
+"#]])
+        .run();
+}
+
 #[cargo_test]
 fn prune() {
     let p = make_simple_proj();

--- a/tests/testsuite/cargo_tree/deps.rs
+++ b/tests/testsuite/cargo_tree/deps.rs
@@ -1987,7 +1987,6 @@ left-pub v0.1.0 ([ROOT]/foo/left-pub)
         .masquerade_as_nightly_cargo(&["public-dependency", "depth-public"])
         .with_stdout_data(str![[r#"
 right-priv v0.1.0 ([ROOT]/foo/right-priv)
-└── dep v0.1.0 ([ROOT]/foo/dep)
 
 "#]])
         .run();
@@ -2000,7 +1999,6 @@ diamond v0.1.0 ([ROOT]/foo/diamond)
 ├── left-pub v0.1.0 ([ROOT]/foo/left-pub)
 │   └── dep v0.1.0 ([ROOT]/foo/dep)
 └── right-priv v0.1.0 ([ROOT]/foo/right-priv)
-    └── dep v0.1.0 ([ROOT]/foo/dep)
 
 "#]])
         .run();
@@ -2015,7 +2013,6 @@ diamond v0.1.0 ([ROOT]/foo/diamond)
 ├── left-pub v0.1.0 ([ROOT]/foo/left-pub)
 │   └── dep v0.1.0 ([ROOT]/foo/dep)
 └── right-priv v0.1.0 ([ROOT]/foo/right-priv)
-    └── dep v0.1.0 ([ROOT]/foo/dep)
 
 left-pub v0.1.0 ([ROOT]/foo/left-pub) (*)
 
@@ -2029,9 +2026,7 @@ right-priv v0.1.0 ([ROOT]/foo/right-priv) (*)
         .masquerade_as_nightly_cargo(&["public-dependency", "depth-public"])
         .with_stdout_data(str![[r#"
 dep v0.1.0 ([ROOT]/foo/dep)
-├── left-pub v0.1.0 ([ROOT]/foo/left-pub)
-│   └── diamond v0.1.0 ([ROOT]/foo/diamond)
-└── right-priv v0.1.0 ([ROOT]/foo/right-priv)
+└── left-pub v0.1.0 ([ROOT]/foo/left-pub)
     └── diamond v0.1.0 ([ROOT]/foo/diamond)
 
 "#]])

--- a/tests/testsuite/cargo_tree/deps.rs
+++ b/tests/testsuite/cargo_tree/deps.rs
@@ -1963,26 +1963,18 @@ fn depth_public() {
         .file("dep/src/lib.rs", "")
         .build();
 
-    p.cargo("tree")
-        .masquerade_as_nightly_cargo(&["public-dependency"])
-        .with_stdout_data(str![[r#"
-dep v0.1.0 ([ROOT]/foo/dep)
-
-diamond v0.1.0 ([ROOT]/foo/diamond)
-├── left-pub v0.1.0 ([ROOT]/foo/left-pub)
-│   └── dep v0.1.0 ([ROOT]/foo/dep)
-└── right-priv v0.1.0 ([ROOT]/foo/right-priv)
-    └── dep v0.1.0 ([ROOT]/foo/dep)
-
-left-pub v0.1.0 ([ROOT]/foo/left-pub) (*)
-
-right-priv v0.1.0 ([ROOT]/foo/right-priv) (*)
+    p.cargo("tree --depth public")
+        .masquerade_as_nightly_cargo(&["public-dependency", "depth-public"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] `--depth public` requires `-Zunstable-options`
 
 "#]])
         .run();
 
-    p.cargo("tree -p left-pub")
-        .masquerade_as_nightly_cargo(&["public-dependency"])
+    p.cargo("tree --depth public -p left-pub")
+        .arg("-Zunstable-options")
+        .masquerade_as_nightly_cargo(&["public-dependency", "depth-public"])
         .with_stdout_data(str![[r#"
 left-pub v0.1.0 ([ROOT]/foo/left-pub)
 └── dep v0.1.0 ([ROOT]/foo/dep)
@@ -1990,8 +1982,9 @@ left-pub v0.1.0 ([ROOT]/foo/left-pub)
 "#]])
         .run();
 
-    p.cargo("tree -p right-priv")
-        .masquerade_as_nightly_cargo(&["public-dependency"])
+    p.cargo("tree --depth public -p right-priv")
+        .arg("-Zunstable-options")
+        .masquerade_as_nightly_cargo(&["public-dependency", "depth-public"])
         .with_stdout_data(str![[r#"
 right-priv v0.1.0 ([ROOT]/foo/right-priv)
 └── dep v0.1.0 ([ROOT]/foo/dep)
@@ -1999,8 +1992,9 @@ right-priv v0.1.0 ([ROOT]/foo/right-priv)
 "#]])
         .run();
 
-    p.cargo("tree -p diamond")
-        .masquerade_as_nightly_cargo(&["public-dependency"])
+    p.cargo("tree --depth public -p diamond")
+        .arg("-Zunstable-options")
+        .masquerade_as_nightly_cargo(&["public-dependency", "depth-public"])
         .with_stdout_data(str![[r#"
 diamond v0.1.0 ([ROOT]/foo/diamond)
 ├── left-pub v0.1.0 ([ROOT]/foo/left-pub)
@@ -2011,8 +2005,9 @@ diamond v0.1.0 ([ROOT]/foo/diamond)
 "#]])
         .run();
 
-    p.cargo("tree")
-        .masquerade_as_nightly_cargo(&["public-dependency"])
+    p.cargo("tree --depth public")
+        .arg("-Zunstable-options")
+        .masquerade_as_nightly_cargo(&["public-dependency", "depth-public"])
         .with_stdout_data(str![[r#"
 dep v0.1.0 ([ROOT]/foo/dep)
 
@@ -2029,8 +2024,9 @@ right-priv v0.1.0 ([ROOT]/foo/right-priv) (*)
 "#]])
         .run();
 
-    p.cargo("tree --invert dep")
-        .masquerade_as_nightly_cargo(&["public-dependency"])
+    p.cargo("tree --depth public --invert dep")
+        .arg("-Zunstable-options")
+        .masquerade_as_nightly_cargo(&["public-dependency", "depth-public"])
         .with_stdout_data(str![[r#"
 dep v0.1.0 ([ROOT]/foo/dep)
 ├── left-pub v0.1.0 ([ROOT]/foo/left-pub)

--- a/tests/testsuite/cargo_tree/features.rs
+++ b/tests/testsuite/cargo_tree/features.rs
@@ -379,8 +379,6 @@ fn depth_public_no_features() {
         .masquerade_as_nightly_cargo(&["public-dependency", "depth-public"])
         .with_stdout_data(str![[r#"
 foo v0.1.0 ([ROOT]/foo)
-├── priv-defaultdep feature "default"
-│   └── priv-defaultdep v1.0.0
 └── pub-defaultdep feature "default"
     └── pub-defaultdep v1.0.0
 
@@ -432,10 +430,6 @@ fn depth_public_transitive_features() {
 foo v0.1.0 ([ROOT]/foo)
 ├── priv-defaultdep feature "default"
 │   ├── priv-defaultdep v1.0.0
-│   │   └── optdep feature "default"
-│   │       ├── optdep v1.0.0
-│   │       └── optdep feature "f"
-│   │           └── optdep v1.0.0
 │   └── priv-defaultdep feature "f1"
 │       ├── priv-defaultdep v1.0.0 (*)
 │       └── priv-defaultdep feature "f2"
@@ -444,7 +438,10 @@ foo v0.1.0 ([ROOT]/foo)
 │               └── priv-defaultdep v1.0.0 (*)
 └── pub-defaultdep feature "default"
     ├── pub-defaultdep v1.0.0
-    │   └── optdep feature "default" (*)
+    │   └── optdep feature "default"
+    │       ├── optdep v1.0.0
+    │       └── optdep feature "f"
+    │           └── optdep v1.0.0
     └── pub-defaultdep feature "f1"
         ├── pub-defaultdep v1.0.0 (*)
         └── pub-defaultdep feature "f2"
@@ -510,8 +507,6 @@ foo v0.1.0 ([ROOT]/foo)
         .masquerade_as_nightly_cargo(&["public-dependency", "depth-public"])
         .with_stdout_data(str![[r#"
 foo v0.1.0 ([ROOT]/foo)
-└── priv feature "default"
-    └── priv v1.0.0
 
 "#]])
         .run();

--- a/tests/testsuite/cargo_tree/features.rs
+++ b/tests/testsuite/cargo_tree/features.rs
@@ -374,8 +374,9 @@ fn depth_public_no_features() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("tree -e features")
-        .masquerade_as_nightly_cargo(&["public-dependency"])
+    p.cargo("tree -e features --depth public")
+        .arg("-Zunstable-options")
+        .masquerade_as_nightly_cargo(&["public-dependency", "depth-public"])
         .with_stdout_data(str![[r#"
 foo v0.1.0 ([ROOT]/foo)
 ├── priv-defaultdep feature "default"
@@ -424,8 +425,9 @@ fn depth_public_transitive_features() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("tree -e features")
-        .masquerade_as_nightly_cargo(&["public-dependency"])
+    p.cargo("tree -e features --depth public")
+        .arg("-Zunstable-options")
+        .masquerade_as_nightly_cargo(&["public-dependency", "depth-public"])
         .with_stdout_data(str![[r#"
 foo v0.1.0 ([ROOT]/foo)
 ├── priv-defaultdep feature "default"
@@ -483,16 +485,18 @@ fn depth_public_cli() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("tree -e features")
-        .masquerade_as_nightly_cargo(&["public-dependency"])
+    p.cargo("tree -e features --depth public")
+        .arg("-Zunstable-options")
+        .masquerade_as_nightly_cargo(&["public-dependency", "depth-public"])
         .with_stdout_data(str![[r#"
 foo v0.1.0 ([ROOT]/foo)
 
 "#]])
         .run();
 
-    p.cargo("tree -e features --features pub-indirect")
-        .masquerade_as_nightly_cargo(&["public-dependency"])
+    p.cargo("tree -e features --depth public --features pub-indirect")
+        .arg("-Zunstable-options")
+        .masquerade_as_nightly_cargo(&["public-dependency", "depth-public"])
         .with_stdout_data(str![[r#"
 foo v0.1.0 ([ROOT]/foo)
 └── pub feature "default"
@@ -501,8 +505,9 @@ foo v0.1.0 ([ROOT]/foo)
 "#]])
         .run();
 
-    p.cargo("tree -e features --features priv-indirect")
-        .masquerade_as_nightly_cargo(&["public-dependency"])
+    p.cargo("tree -e features --depth public --features priv-indirect")
+        .arg("-Zunstable-options")
+        .masquerade_as_nightly_cargo(&["public-dependency", "depth-public"])
         .with_stdout_data(str![[r#"
 foo v0.1.0 ([ROOT]/foo)
 └── priv feature "default"

--- a/tests/testsuite/cargo_tree/features.rs
+++ b/tests/testsuite/cargo_tree/features.rs
@@ -350,3 +350,164 @@ foo v0.1.0 ([ROOT]/foo)
 "#]])
         .run();
 }
+
+#[cargo_test(nightly, reason = "exported_private_dependencies lint is unstable")]
+fn depth_public_no_features() {
+    Package::new("pub-defaultdep", "1.0.0").publish();
+    Package::new("priv-defaultdep", "1.0.0").publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["public-dependency"]
+
+            [package]
+            name = "foo"
+            version = "0.1.0"
+
+            [dependencies]
+            pub-defaultdep = { version = "1.0.0", public = true }
+            priv-defaultdep = "1.0.0"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("tree -e features")
+        .masquerade_as_nightly_cargo(&["public-dependency"])
+        .with_stdout_data(str![[r#"
+foo v0.1.0 ([ROOT]/foo)
+├── priv-defaultdep feature "default"
+│   └── priv-defaultdep v1.0.0
+└── pub-defaultdep feature "default"
+    └── pub-defaultdep v1.0.0
+
+"#]])
+        .run();
+}
+
+#[cargo_test(nightly, reason = "exported_private_dependencies lint is unstable")]
+fn depth_public_transitive_features() {
+    Package::new("pub-defaultdep", "1.0.0")
+        .feature("default", &["f1"])
+        .feature("f1", &["f2"])
+        .feature("f2", &["optdep"])
+        .add_dep(Dependency::new("optdep", "1.0").optional(true).public(true))
+        .publish();
+    Package::new("priv-defaultdep", "1.0.0")
+        .feature("default", &["f1"])
+        .feature("f1", &["f2"])
+        .feature("f2", &["optdep"])
+        .add_dep(Dependency::new("optdep", "1.0").optional(true))
+        .publish();
+    Package::new("optdep", "1.0.0")
+        .feature("default", &["f"])
+        .feature("f", &[])
+        .publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["public-dependency"]
+
+            [package]
+            name = "foo"
+            version = "0.1.0"
+
+            [dependencies]
+            pub-defaultdep = { version = "1.0.0", public = true }
+            priv-defaultdep = { version = "1.0.0", public = true }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("tree -e features")
+        .masquerade_as_nightly_cargo(&["public-dependency"])
+        .with_stdout_data(str![[r#"
+foo v0.1.0 ([ROOT]/foo)
+├── priv-defaultdep feature "default"
+│   ├── priv-defaultdep v1.0.0
+│   │   └── optdep feature "default"
+│   │       ├── optdep v1.0.0
+│   │       └── optdep feature "f"
+│   │           └── optdep v1.0.0
+│   └── priv-defaultdep feature "f1"
+│       ├── priv-defaultdep v1.0.0 (*)
+│       └── priv-defaultdep feature "f2"
+│           ├── priv-defaultdep v1.0.0 (*)
+│           └── priv-defaultdep feature "optdep"
+│               └── priv-defaultdep v1.0.0 (*)
+└── pub-defaultdep feature "default"
+    ├── pub-defaultdep v1.0.0
+    │   └── optdep feature "default" (*)
+    └── pub-defaultdep feature "f1"
+        ├── pub-defaultdep v1.0.0 (*)
+        └── pub-defaultdep feature "f2"
+            ├── pub-defaultdep v1.0.0 (*)
+            └── pub-defaultdep feature "optdep"
+                └── pub-defaultdep v1.0.0 (*)
+
+"#]])
+        .run();
+}
+
+#[cargo_test(nightly, reason = "exported_private_dependencies lint is unstable")]
+fn depth_public_cli() {
+    Package::new("priv", "1.0.0").feature("f", &[]).publish();
+    Package::new("pub", "1.0.0").feature("f", &[]).publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["public-dependency"]
+
+            [package]
+            name = "foo"
+            version = "0.1.0"
+
+            [features]
+            priv-indirect = ["priv"]
+            priv = ["dep:priv", "priv?/f"]
+            pub-indirect = ["pub"]
+            pub = ["dep:pub", "priv?/f"]
+
+            [dependencies]
+            priv = { version = "1.0.0", optional = true }
+            pub = { version = "1.0.0", optional = true, public = true }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("tree -e features")
+        .masquerade_as_nightly_cargo(&["public-dependency"])
+        .with_stdout_data(str![[r#"
+foo v0.1.0 ([ROOT]/foo)
+
+"#]])
+        .run();
+
+    p.cargo("tree -e features --features pub-indirect")
+        .masquerade_as_nightly_cargo(&["public-dependency"])
+        .with_stdout_data(str![[r#"
+foo v0.1.0 ([ROOT]/foo)
+└── pub feature "default"
+    └── pub v1.0.0
+
+"#]])
+        .run();
+
+    p.cargo("tree -e features --features priv-indirect")
+        .masquerade_as_nightly_cargo(&["public-dependency"])
+        .with_stdout_data(str![[r#"
+foo v0.1.0 ([ROOT]/foo)
+└── priv feature "default"
+    └── priv v1.0.0
+
+"#]])
+        .run();
+}


### PR DESCRIPTION
### What does this PR try to resolve?

I was investigating some issues around public dependency lints and wanted to see the structure of the public dependencies and had the idea to add this with us having added `--depth workspace`.

See https://github.com/rust-lang/rust/issues/119428#issuecomment-2686384070 for some example output (comparing `cargo tree` with `cargo tree --depth public`)

### How should we test and review this PR?



### Additional information

