### PR TITLE
Bump `cc` to 1.2.16 to fix `x86` windows jobs in rust-lang/rust CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,9 +543,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.13"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",


### PR DESCRIPTION
### What does this PR try to resolve?

GitHub Runner Images 20250224.5.0+ ship Windows 11 SDK 10.0.26100+ compared to the previous Windows 11 SDK 10.0.22621, which bumped the UCRT headers. The new UCRT headers use SSE2 types. However, `cc` versions <= 1.2.15 emit `/arch:IA32` for `x86` Windows targets for `clang-cl`, which causes compilation errors since `clang-cl` can't find SSE2 types without `/arch:SSE2` specified (or defaulted). (Note that MSVC at the time of writing silently accepts and emits instruments for code using SSE2 types, as opposed to `clang-cl` hard error-ing).

`cc` 1.2.16 contains a fix for this problem, https://github.com/rust-lang/cc-rs/pull/1425, to correctly emit `/arch:SSE2` instead of `/arch:IA32` to enable `clang-cl` to find the SSE2 types. However, cargo's `cc` currently is still on 1.2.13.

To fix this for rust-lang/rust CI, we need to bump anything that transitively relies on `cc` and tries to use `clang-cl` on `x86` Windows targets to compile any C/C++ code that transitively use functions or types that require SSE2 types, such as `<wchar.h>`.

### How should we test and review this PR?

The fix was initially intended for `rustc_{codegen_ssa,llvm}` `cc`, and based on testing in https://github.com/rust-lang/rust/pull/137724, I was able to successfully build `rustc_{codegen_ssa,llvm}` with a forked `cc` based on 1.2.15 which contains the fix from https://github.com/rust-lang/cc-rs/pull/1425. Note that in the same PR, while the compiler build succeeded, the build of cargo itself failed since it transitively used a `cc` *without* the fix to build `curl-sys`[^dep-chain], which failed as one might expect (`curl-sys` tries to build C code that uses `<wchar.h>` which runs into the same problem). Hence, this PR is opened to bump cargo's `cc` to a `cc` version containing the fix.

### Additional information

This `x86` Windows CI problem is:

- Discussed in https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/spurious.20.28.3F.29.20i686.20msvc.20errors.
- Tracked by https://github.com/rust-lang/rust/issues/137733.

#### `cc` changelog between 1.2.13 and 1.2.16

<details>
<summary>`cc` changes since 1.2.13 up to and including 1.2.16</summary>

##### [1.2.16](https://github.com/rust-lang/cc-rs/compare/cc-v1.2.15...cc-v1.2.16) - 2025-02-28

###### Fixed

- force windows compiler to run in `out_dir` to prevent artifacts in cwd (#1415)

###### Other

- use `/arch:SSE2` for `x86` target arch (#1425)
- Regenerate windows-sys binding ([#1422](https://github.com/rust-lang/cc-rs/pull/1422))
- Regenerate target info ([#1418](https://github.com/rust-lang/cc-rs/pull/1418))
- Add LIB var when compiling flag_check (#1417)
- Change flag ordering ([#1403](https://github.com/rust-lang/cc-rs/pull/1403))
- Fix archiver detection for musl cross compilation ([#1404](https://github.com/rust-lang/cc-rs/pull/1404))

##### [1.2.15](https://github.com/rust-lang/cc-rs/compare/cc-v1.2.14...cc-v1.2.15) - 2025-02-21

###### Other

- Regenerate target info ([#1406](https://github.com/rust-lang/cc-rs/pull/1406))
- Always read from all `CFLAGS`-style flags ([#1401](https://github.com/rust-lang/cc-rs/pull/1401))
- Simplify the error output on failed `Command` invocation ([#1397](https://github.com/rust-lang/cc-rs/pull/1397))

##### [1.2.14](https://github.com/rust-lang/cc-rs/compare/cc-v1.2.13...cc-v1.2.14) - 2025-02-14

###### Other

- Regenerate target info ([#1398](https://github.com/rust-lang/cc-rs/pull/1398))
- Add support for setting `-gdwarf-{version}` based on RUSTFLAGS ([#1395](https://github.com/rust-lang/cc-rs/pull/1395))
- Add support for alternative network stack io-sock on QNX 7.1 aarch64 and x86_64 ([#1312](https://github.com/rust-lang/cc-rs/pull/1312))

</details>

[^dep-chain]: I think the dep chain is something like git2 -> libgit2-sys -> curl -> curl-sys?