### PR TITLE
refactor: control byte display precision with std::fmt options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,12 +280,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
-name = "bytesize"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
-
-[[package]]
 name = "camino"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,7 +308,6 @@ dependencies = [
  "anyhow",
  "base64",
  "blake3",
- "bytesize",
  "cargo-credential",
  "cargo-credential-libsecret",
  "cargo-credential-macos-keychain",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ anyhow = "1.0.95"
 base64 = "0.22.1"
 blake3 = "1.5.5"
 build-rs = { version = "0.3.0", path = "crates/build-rs" }
-bytesize = "1.3"
 cargo = { path = "" }
 cargo-credential = { version = "0.4.2", path = "credential/cargo-credential" }
 cargo-credential-libsecret = { version = "0.4.13", path = "credential/cargo-credential-libsecret" }
@@ -157,7 +156,6 @@ anstyle.workspace = true
 anyhow.workspace = true
 base64.workspace = true
 blake3.workspace = true
-bytesize.workspace = true
 cargo-credential.workspace = true
 cargo-platform.workspace = true
 cargo-util-schemas.workspace = true

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -5,7 +5,8 @@ use crate::ops;
 use crate::util::edit_distance;
 use crate::util::errors::CargoResult;
 use crate::util::interning::InternedString;
-use crate::util::{human_readable_bytes, GlobalContext, Progress, ProgressStyle};
+use crate::util::HumanBytes;
+use crate::util::{GlobalContext, Progress, ProgressStyle};
 use anyhow::bail;
 use cargo_util::paths;
 use std::collections::{HashMap, HashSet};
@@ -457,13 +458,8 @@ impl<'gctx> CleanContext<'gctx> {
         let byte_count = if self.total_bytes_removed == 0 {
             String::new()
         } else {
-            // Don't show a fractional number of bytes.
-            if self.total_bytes_removed < 1024 {
-                format!(", {}B total", self.total_bytes_removed)
-            } else {
-                let (bytes, unit) = human_readable_bytes(self.total_bytes_removed);
-                format!(", {bytes:.1}{unit} total")
-            }
+            let bytes = HumanBytes(self.total_bytes_removed);
+            format!(", {bytes:.1} total")
         };
         // I think displaying the number of directories removed isn't
         // particularly interesting to the user. However, if there are 0

--- a/src/cargo/ops/cargo_package/mod.rs
+++ b/src/cargo/ops/cargo_package/mod.rs
@@ -22,13 +22,13 @@ use crate::sources::{PathSource, CRATES_IO_REGISTRY};
 use crate::util::cache_lock::CacheLockMode;
 use crate::util::context::JobsConfig;
 use crate::util::errors::CargoResult;
-use crate::util::human_readable_bytes;
 use crate::util::restricted_names;
 use crate::util::toml::prepare_for_publish;
 use crate::util::FileLock;
 use crate::util::Filesystem;
 use crate::util::GlobalContext;
 use crate::util::Graph;
+use crate::util::HumanBytes;
 use crate::{drop_println, ops};
 use anyhow::{bail, Context as _};
 use cargo_util::paths;
@@ -129,13 +129,10 @@ fn create_package(
         .with_context(|| format!("could not learn metadata for: `{}`", dst_path.display()))?;
     let compressed_size = dst_metadata.len();
 
-    let uncompressed = human_readable_bytes(uncompressed_size);
-    let compressed = human_readable_bytes(compressed_size);
+    let uncompressed = HumanBytes(uncompressed_size);
+    let compressed = HumanBytes(compressed_size);
 
-    let message = format!(
-        "{} files, {:.1}{} ({:.1}{} compressed)",
-        filecount, uncompressed.0, uncompressed.1, compressed.0, compressed.1,
-    );
+    let message = format!("{filecount} files, {uncompressed:.1} ({compressed:.1} compressed)");
     // It doesn't really matter if this fails.
     drop(gctx.shell().status("Packaged", message));
 

--- a/src/cargo/sources/git/oxide.rs
+++ b/src/cargo/sources/git/oxide.rs
@@ -2,7 +2,8 @@
 //! `utils` closely for now. One day it can be renamed into `utils` once `git2` isn't required anymore.
 
 use crate::util::network::http::HttpTimeout;
-use crate::util::{human_readable_bytes, network, MetricsCounter, Progress};
+use crate::util::HumanBytes;
+use crate::util::{network, MetricsCounter, Progress};
 use crate::{CargoResult, GlobalContext};
 use cargo_util::paths;
 use gix::bstr::{BString, ByteSlice};
@@ -148,8 +149,8 @@ fn translate_progress_to_bar(
                 counter.add(received_bytes, now);
                 last_percentage_update = now;
             }
-            let (rate, unit) = human_readable_bytes(counter.rate() as u64);
-            let msg = format!(", {rate:.2}{unit}/s");
+            let rate = HumanBytes(counter.rate() as u64);
+            let msg = format!(", {rate:.2}/s");
 
             progress_bar.tick(
                 (total_objects * (num_phases - 2)) + objects,

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -6,9 +6,8 @@ use crate::sources::git::fetch::RemoteKind;
 use crate::sources::git::oxide;
 use crate::sources::git::oxide::cargo_config_to_gitoxide_overrides;
 use crate::util::errors::CargoResult;
-use crate::util::{
-    human_readable_bytes, network, GlobalContext, IntoUrl, MetricsCounter, Progress,
-};
+use crate::util::HumanBytes;
+use crate::util::{network, GlobalContext, IntoUrl, MetricsCounter, Progress};
 use anyhow::{anyhow, Context as _};
 use cargo_util::{paths, ProcessBuilder};
 use curl::easy::List;
@@ -914,8 +913,8 @@ pub fn with_fetch_options(
                         counter.add(stats.received_bytes(), now);
                         last_update = now;
                     }
-                    let (rate, unit) = human_readable_bytes(counter.rate() as u64);
-                    format!(", {:.2}{}/s", rate, unit)
+                    let rate = HumanBytes(counter.rate() as u64);
+                    format!(", {rate:.2}/s")
                 };
                 progress
                     .tick(stats.indexed_objects(), stats.total_objects(), &msg)

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -3424,7 +3424,7 @@ fn verify_packaged_status_line(
     uncompressed_size: u64,
     compressed_size: u64,
 ) {
-    use cargo::util::human_readable_bytes;
+    use cargo::util::HumanBytes;
 
     let stderr = String::from_utf8(output.stderr).unwrap();
     let mut packaged_lines = stderr
@@ -3438,12 +3438,9 @@ fn verify_packaged_status_line(
         "Only one `Packaged` status line should appear in stderr"
     );
     let size_info = packaged_line.trim().trim_start_matches("Packaged").trim();
-    let uncompressed = human_readable_bytes(uncompressed_size);
-    let compressed = human_readable_bytes(compressed_size);
-    let expected = format!(
-        "{} files, {:.1}{} ({:.1}{} compressed)",
-        num_files, uncompressed.0, uncompressed.1, compressed.0, compressed.1
-    );
+    let uncompressed = HumanBytes(uncompressed_size);
+    let compressed = HumanBytes(compressed_size);
+    let expected = format!("{num_files} files, {uncompressed:.1} ({compressed:.1} compressed)");
     assert_eq!(size_info, expected);
 }
 

--- a/tests/testsuite/progress.rs
+++ b/tests/testsuite/progress.rs
@@ -114,8 +114,8 @@ fn always_shows_progress() {
     p.cargo("check")
         .with_stderr_data(
             str![[r#"
-[DOWNLOADING] [..] crate                                                                              
-[DOWNLOADED] 3 crates ([..]KB) in [..]s
+[DOWNLOADING] [..] crate [..]
+[DOWNLOADED] 3 crates ([..]) in [..]s
 [BUILDING] [..] [..]/4: [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 ...


### PR DESCRIPTION
### What does this PR try to resolve?

Just found we can simplify `human_readable_bytes` a bit.
This also remove the `bytesize` dependency,
since we already have a hand-rolled function.
(It is a good crate, though)

### How should we test and review this PR?

Should have no real functional difference.
`cargo package` starts reporting IEC (KiB) instead of SI (KB).
So do some thresholds of `cargo package`.

Could also switch entirely to `bytesize` if that is preferred.

### Additional information