### PR TITLE
feat(cli): forward bash completions of third party subcommands

### DIFF
--- a/src/etc/cargo.bashcomp.sh
+++ b/src/etc/cargo.bashcomp.sh
@@ -154,8 +154,15 @@ _cargo()
 					local opt_var=opt__${cmd//-/_}
 				fi
 				if [[ -z "${!opt_var-}" ]]; then
-					# Fallback to filename completion.
-					_filedir
+					# Forward to subcommands completion if bash-completion >= 2.12 is available
+					if [[ $BASH_COMPLETION_VERSINFO && (${BASH_COMPLETION_VERSINFO[0]} -gt 2 || (${BASH_COMPLETION_VERSINFO[0]} -eq 2 && ${BASH_COMPLETION_VERSINFO[1]} -ge 12)) ]]; then
+						COMP_WORDS[cmd_i]="cargo-$cmd"
+						_comp_command_offset "$cmd_i"
+						COMP_WORDS[cmd_i]="$cmd"
+					else
+						# Fallback to filename completion.
+						_filedir
+					fi
 				else
 					COMPREPLY=( $( compgen -W "${!opt_var}" -- "$cur" ) )
 				fi


### PR DESCRIPTION
# What does this PR try to resolve?

Currently third party subcommands like `cargo asm` from [`cargo-show-asm`] don't
support shell completions, even when the corresponding `cargo-<cmd>` command *does*.
(I'm using `cargo asm` as example because it was the first subcommand that came
into mind that provides completions)

This PR fixes this for `bash` by using [`bash-completion`]'s
[`_comp_command_offset`] function to generate these completions.
(Assuming these completions are available to [`bash-completion`])

[`bash-completion`] is the package that is used by all major unix-like operating
systems to provide bash completions.

If the subcommand has no completion, that falls back to the default bash.
(That might not be *exactly* the same as `_filedir`, but should be correct anyway)

**Note** that [`_comp_command_offset`] is only supported since [`bash-completion`] >= `2.12.0`,
which requires `bash` >= `4.2.0`, which means that the default
`bash` version shipped with MacOs is **not** supported. \
In that case we fall back to the previous behavior with `_filedir`.

# How should we test and review this PR?

I'm not sure if there is any testing setup for shell completions for `cargo`.
I have just tested it manually by running these commands:
(In the working directory of this PR)

```bash
#!/usr/bin/env bash

# Install the subcommand
cargo install cargo-show-asm
# Load the completions for `cargo-asm`
eval "$(cargo-asm --bpaf-complete-style-bash)"
# (Re)source the new cargo completions
source src/etc/cargo.bashcomp.sh
```

and then tab-completing from `cargo asm <TAB>`.

# Additional information

## Further Possibilities

The same trick with [`_comp_command_offset`] could be used to get completions
for the command run with `cargo run -- `, assuming there is an easy way to get
the name of the binary that would be run. (And maybe something to dynamically (re)-load the completions.)

## Prior Art

The `zsh`-completions already support the `zsh`-equivalent of this with <https://github.com/rust-lang/cargo/blob/58cfd96b59fa1406e8af7bca968fc465b003d8c7/src/etc/_cargo#L368-L372>

[`cargo-show-asm`]: https://docs.rs/cargo-show-asm
[`bash-completion`]: https://github.com/scop/bash-completion/
[`_comp_command_offset`]: https://github.com/scop/bash-completion/blob/92f558d582c452e96872f480ebf86cc3c08f0a87/bash_completion#L2816-L2821
