### PR TITLE
Remove `Cargo.toml` from `package.include` in example

### DIFF
--- a/src/doc/src/reference/publishing.md
+++ b/src/doc/src/reference/publishing.md
@@ -114,7 +114,6 @@ If you’d rather explicitly list the files to include, Cargo also supports an
 # ...
 include = [
     "**/*.rs",
-    "Cargo.toml",
 ]
 ```
 

--- a/src/doc/src/reference/publishing.md
+++ b/src/doc/src/reference/publishing.md
@@ -107,7 +107,7 @@ exclude = [
 ```
 
 If you’d rather explicitly list the files to include, Cargo also supports an
-`include` key, which if set, overrides the `exclude` key:
+[`include` key](manifest.md#the-exclude-and-include-fields), which if set, overrides the `exclude` key:
 
 ```toml
 [package]


### PR DESCRIPTION
https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields

>The following files are always included:
>
>* The `Cargo.toml` file of the package itself is always included, it does not need to be listed in `include`.