### PR TITLE
Improve error when versions start with `v`

### DIFF
--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -279,7 +279,13 @@ fn parse_semver_flag(v: &str) -> CargoResult<VersionReq> {
             ),
         }
     } else {
-        match v.trim().parse::<semver::Version>() {
+        let trimmed = if v.starts_with('v') {
+            &v[1..].trim()
+        } else {
+            v.trim()
+        };
+
+        match trimmed.parse::<semver::Version>() {
             Ok(v) => Ok(v.to_exact_req()),
             Err(e) => {
                 let mut msg = e.to_string();

--- a/src/bin/cargo/commands/yank.rs
+++ b/src/bin/cargo/commands/yank.rs
@@ -54,14 +54,26 @@ fn resolve_crate<'k>(
             }
 
             match version {
-                None => Ok((Some(name), embedded_version)),
+                None => {
+                    if embedded_version.starts_with('v') {
+                        Ok((Some(name), &embedded_version[1..]))
+                    } else {
+                        Ok((Some(name), embedded_version))
+                    }
+                }
                 Some(_) => {
                     anyhow::bail!("cannot specify both `@{embedded_version}` and `--version`");
                 }
             }
         }
         None => match version {
-            Some(version) => Ok((krate, version)),
+            Some(version) => {
+                if version.starts_with('v') {
+                    Ok((krate, &version[1..]))
+                } else {
+                    Ok((krate, version))
+                }
+            }
             None => {
                 anyhow::bail!("`--version` is required");
             }

--- a/src/cargo/ops/cargo_add/crate_spec.rs
+++ b/src/cargo/ops/cargo_add/crate_spec.rs
@@ -30,14 +30,22 @@ impl CrateSpec {
 
         PackageName::new(name)?;
 
-        if let Some(version) = version {
-            semver::VersionReq::parse(version)
-                .with_context(|| format!("invalid version requirement `{version}`"))?;
+        let trimmed = version.map(|s| {
+            if s.starts_with('v') {
+                s[1..].to_string()
+            } else {
+                s.to_string()
+            }
+        });
+
+        if let Some(trimmed) = &trimmed {
+            semver::VersionReq::parse(trimmed)
+                .with_context(|| format!("invalid version requirement `{trimmed}`"))?;
         }
 
         let id = Self {
             name: name.to_owned(),
-            version_req: version.map(|s| s.to_owned()),
+            version_req: trimmed,
         };
 
         Ok(id)

--- a/src/cargo/ops/registry/yank.rs
+++ b/src/cargo/ops/registry/yank.rs
@@ -3,7 +3,6 @@
 //! [yank]: https://doc.rust-lang.org/nightly/cargo/reference/registry-web-api.html#yank
 //! [unyank]: https://doc.rust-lang.org/nightly/cargo/reference/registry-web-api.html#unyank
 
-use anyhow::bail;
 use anyhow::Context as _;
 use cargo_credential::Operation;
 use cargo_credential::Secret;
@@ -18,7 +17,7 @@ use super::RegistryOrIndex;
 pub fn yank(
     gctx: &GlobalContext,
     krate: Option<String>,
-    version: Option<String>,
+    version: String,
     token: Option<Secret<String>>,
     reg_or_index: Option<RegistryOrIndex>,
     undo: bool,
@@ -30,9 +29,6 @@ pub fn yank(
             let ws = Workspace::new(&manifest_path, gctx)?;
             ws.current()?.package_id().name().to_string()
         }
-    };
-    let Some(version) = version else {
-        bail!("a version must be specified to yank")
     };
 
     let message = if undo {

--- a/tests/testsuite/cargo_add/explicit_version_prefixing_v/in
+++ b/tests/testsuite/cargo_add/explicit_version_prefixing_v/in
@@ -1,0 +1,1 @@
+../add-basic.in

--- a/tests/testsuite/cargo_add/explicit_version_prefixing_v/mod.rs
+++ b/tests/testsuite/cargo_add/explicit_version_prefixing_v/mod.rs
@@ -1,0 +1,29 @@
+use cargo_test_support::compare::assert_ui;
+use cargo_test_support::current_dir;
+use cargo_test_support::file;
+use cargo_test_support::prelude::*;
+use cargo_test_support::str;
+use cargo_test_support::Project;
+
+#[cargo_test]
+fn case() {
+    cargo_test_support::registry::init();
+    for ver in ["0.1.1+my-package", "0.2.0+my-package", "0.2.3+my-package"] {
+        cargo_test_support::registry::Package::new("my-package", ver).publish();
+    }
+
+    let project = Project::from_template(current_dir!().join("in"));
+    let project_root = project.root();
+    let cwd = &project_root;
+
+    snapbox::cmd::Command::cargo_ui()
+        .arg("add")
+        .arg_line("my-package@v0.2.0")
+        .current_dir(cwd)
+        .assert()
+        .failure()
+        .stdout_eq(str![""])
+        .stderr_eq(file!["stderr.term.svg"]);
+
+    assert_ui().subset_matches(current_dir!().join("out"), &project_root);
+}

--- a/tests/testsuite/cargo_add/explicit_version_prefixing_v/mod.rs
+++ b/tests/testsuite/cargo_add/explicit_version_prefixing_v/mod.rs
@@ -21,7 +21,7 @@ fn case() {
         .arg_line("my-package@v0.2.0")
         .current_dir(cwd)
         .assert()
-        .failure()
+        .success()
         .stdout_eq(str![""])
         .stderr_eq(file!["stderr.term.svg"]);
 

--- a/tests/testsuite/cargo_add/explicit_version_prefixing_v/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/explicit_version_prefixing_v/out/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+
+[package]
+name = "cargo-list-test-fixture"
+version = "0.0.0"
+edition = "2015"

--- a/tests/testsuite/cargo_add/explicit_version_prefixing_v/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/explicit_version_prefixing_v/out/Cargo.toml
@@ -4,3 +4,6 @@
 name = "cargo-list-test-fixture"
 version = "0.0.0"
 edition = "2015"
+
+[dependencies]
+my-package = "0.2.0"

--- a/tests/testsuite/cargo_add/explicit_version_prefixing_v/stderr.term.svg
+++ b/tests/testsuite/cargo_add/explicit_version_prefixing_v/stderr.term.svg
@@ -1,0 +1,33 @@
+<svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-red { fill: #AA0000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> invalid version requirement `v0.2.0`</tspan>
+</tspan>
+    <tspan x="10px" y="46px">
+</tspan>
+    <tspan x="10px" y="64px"><tspan>Caused by:</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan>  unexpected character 'v' while parsing major version number</tspan>
+</tspan>
+    <tspan x="10px" y="100px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/testsuite/cargo_add/explicit_version_prefixing_v/stderr.term.svg
+++ b/tests/testsuite/cargo_add/explicit_version_prefixing_v/stderr.term.svg
@@ -1,8 +1,8 @@
-<svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="92px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,15 +18,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> invalid version requirement `v0.2.0`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px">
+    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.2.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Caused by:</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>  unexpected character 'v' while parsing major version number</tspan>
-</tspan>
-    <tspan x="10px" y="100px">
+    <tspan x="10px" y="82px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_add/mod.rs
+++ b/tests/testsuite/cargo_add/mod.rs
@@ -21,6 +21,7 @@ mod dev_existing_path_base;
 mod dev_prefer_existing_version;
 mod dry_run;
 mod empty_dep_name;
+mod explicit_version_prefixing_v;
 mod features;
 mod features_activated_over_limit;
 mod features_deactivated_over_limit;

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -1622,10 +1622,9 @@ fn vers_precise_prefixing_v() {
     pkg("foo", "0.1.2");
 
     cargo_process("install foo --vers v0.1.1")
-        .with_status(1)
-        .with_stdout_data("")
         .with_stderr_data(str![[r#"
-[ERROR] invalid value 'v0.1.1' for '--version <VERSION>': unexpected character 'v' while parsing major version number
+...
+[DOWNLOADED] foo v0.1.1 (registry `dummy-registry`)
 ...
 "#]])
         .run();
@@ -1651,10 +1650,9 @@ fn version_precise_prefixing_v() {
     pkg("foo", "0.1.2");
 
     cargo_process("install foo --version v0.1.1")
-        .with_status(1)
-        .with_stdout_data("")
         .with_stderr_data(str![[r#"
-[ERROR] invalid value 'v0.1.1' for '--version <VERSION>': unexpected character 'v' while parsing major version number
+...
+[DOWNLOADED] foo v0.1.1 (registry `dummy-registry`)
 ...
 "#]])
         .run();
@@ -1680,10 +1678,9 @@ fn inline_version_precise_prefixing_v() {
     pkg("foo", "0.1.2");
 
     cargo_process("install foo@v0.1.1")
-        .with_status(1)
-        .with_stdout_data("")
         .with_stderr_data(str![[r#"
-[ERROR] invalid value 'foo@v0.1.1' for '[CRATE[@<VER>]]...': unexpected character 'v' while parsing major version number
+...
+[DOWNLOADED] foo v0.1.1 (registry `dummy-registry`)
 ...
 "#]])
         .run();
@@ -1719,10 +1716,11 @@ fn inline_version_multiple_prefixing_v() {
     pkg("bar", "0.2.2");
 
     cargo_process("install foo@v0.1.1 bar@v0.2.1")
-        .with_status(1)
-        .with_stdout_data("")
         .with_stderr_data(str![[r#"
-[ERROR] invalid value 'foo@v0.1.1' for '[CRATE[@<VER>]]...': unexpected character 'v' while parsing major version number
+...
+[DOWNLOADED] foo v0.1.1 (registry `dummy-registry`)
+...
+[DOWNLOADED] bar v0.2.1 (registry `dummy-registry`)
 ...
 "#]])
         .run();

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -1617,6 +1617,21 @@ fn vers_precise() {
 }
 
 #[cargo_test]
+fn vers_precise_prefixing_v() {
+    pkg("foo", "0.1.1");
+    pkg("foo", "0.1.2");
+
+    cargo_process("install foo --vers v0.1.1")
+        .with_status(1)
+        .with_stdout_data("")
+        .with_stderr_data(str![[r#"
+[ERROR] invalid value 'v0.1.1' for '--version <VERSION>': unexpected character 'v' while parsing major version number
+...
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn version_precise() {
     pkg("foo", "0.1.1");
     pkg("foo", "0.1.2");
@@ -1625,6 +1640,21 @@ fn version_precise() {
         .with_stderr_data(str![[r#"
 ...
 [DOWNLOADED] foo v0.1.1 (registry `dummy-registry`)
+...
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn version_precise_prefixing_v() {
+    pkg("foo", "0.1.1");
+    pkg("foo", "0.1.2");
+
+    cargo_process("install foo --version v0.1.1")
+        .with_status(1)
+        .with_stdout_data("")
+        .with_stderr_data(str![[r#"
+[ERROR] invalid value 'v0.1.1' for '--version <VERSION>': unexpected character 'v' while parsing major version number
 ...
 "#]])
         .run();
@@ -1645,6 +1675,21 @@ fn inline_version_precise() {
 }
 
 #[cargo_test]
+fn inline_version_precise_prefixing_v() {
+    pkg("foo", "0.1.1");
+    pkg("foo", "0.1.2");
+
+    cargo_process("install foo@v0.1.1")
+        .with_status(1)
+        .with_stdout_data("")
+        .with_stderr_data(str![[r#"
+[ERROR] invalid value 'foo@v0.1.1' for '[CRATE[@<VER>]]...': unexpected character 'v' while parsing major version number
+...
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn inline_version_multiple() {
     pkg("foo", "0.1.0");
     pkg("foo", "0.1.1");
@@ -1659,6 +1704,25 @@ fn inline_version_multiple() {
 [DOWNLOADED] foo v0.1.1 (registry `dummy-registry`)
 ...
 [DOWNLOADED] bar v0.2.1 (registry `dummy-registry`)
+...
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn inline_version_multiple_prefixing_v() {
+    pkg("foo", "0.1.0");
+    pkg("foo", "0.1.1");
+    pkg("foo", "0.1.2");
+    pkg("bar", "0.2.0");
+    pkg("bar", "0.2.1");
+    pkg("bar", "0.2.2");
+
+    cargo_process("install foo@v0.1.1 bar@v0.2.1")
+        .with_status(1)
+        .with_stdout_data("")
+        .with_stderr_data(str![[r#"
+[ERROR] invalid value 'foo@v0.1.1' for '[CRATE[@<VER>]]...': unexpected character 'v' while parsing major version number
 ...
 "#]])
         .run();

--- a/tests/testsuite/yank.rs
+++ b/tests/testsuite/yank.rs
@@ -53,6 +53,41 @@ Caused by:
 }
 
 #[cargo_test]
+fn explicit_version_prefixing_v() {
+    let registry = registry::init();
+    setup("foo", "0.0.1");
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("yank --version v0.0.1")
+        .replace_crates_io(registry.index_url())
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[UPDATING] crates.io index
+[YANK] foo@v0.0.1
+[ERROR] failed to yank from the registry at [ROOTURL]/api
+
+Caused by:
+  [37] Could not read a file:// file (Couldn't open file [ROOT]/api/api/v1/crates/foo/v0.0.1/yank)
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn explicit_version_with_asymmetric() {
     let registry = registry::RegistryBuilder::new()
         .http_api()
@@ -124,6 +159,41 @@ fn inline_version() {
 
 Caused by:
   EOF while parsing a value at line 1 column 0
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn inline_version_prefixing_v() {
+    let registry = registry::init();
+    setup("foo", "0.0.1");
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("yank foo@v0.0.1")
+        .replace_crates_io(registry.index_url())
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[UPDATING] crates.io index
+[YANK] foo@v0.0.1
+[ERROR] failed to yank from the registry at [ROOTURL]/api
+
+Caused by:
+  [37] Could not read a file:// file (Couldn't open file [ROOT]/api/api/v1/crates/foo/v0.0.1/yank)
 
 "#]])
         .run();

--- a/tests/testsuite/yank.rs
+++ b/tests/testsuite/yank.rs
@@ -74,14 +74,18 @@ fn explicit_version_prefixing_v() {
 
     p.cargo("yank --version v0.0.1")
         .replace_crates_io(registry.index_url())
+        .run();
+
+    p.cargo("yank --undo --version v0.0.1")
+        .replace_crates_io(registry.index_url())
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] crates.io index
-[YANK] foo@v0.0.1
-[ERROR] failed to yank from the registry at [ROOTURL]/api
+      Unyank foo@0.0.1
+[ERROR] failed to undo a yank from the registry at [ROOTURL]/api
 
 Caused by:
-  [37] Could not read a file:// file (Couldn't open file [ROOT]/api/api/v1/crates/foo/v0.0.1/yank)
+  EOF while parsing a value at line 1 column 0
 
 "#]])
         .run();
@@ -186,14 +190,18 @@ fn inline_version_prefixing_v() {
 
     p.cargo("yank foo@v0.0.1")
         .replace_crates_io(registry.index_url())
+        .run();
+
+    p.cargo("yank --undo foo@v0.0.1")
+        .replace_crates_io(registry.index_url())
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] crates.io index
-[YANK] foo@v0.0.1
-[ERROR] failed to yank from the registry at [ROOTURL]/api
+      Unyank foo@0.0.1
+[ERROR] failed to undo a yank from the registry at [ROOTURL]/api
 
 Caused by:
-  [37] Could not read a file:// file (Couldn't open file [ROOT]/api/api/v1/crates/foo/v0.0.1/yank)
+  EOF while parsing a value at line 1 column 0
 
 "#]])
         .run();


### PR DESCRIPTION
Fixes #12331

<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
