### PR TITLE
fix(vendor): dont remove non-cached source 

### DIFF
--- a/src/bin/cargo/commands/vendor.rs
+++ b/src/bin/cargo/commands/vendor.rs
@@ -60,7 +60,8 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
     // to respect any of the `source` configuration in Cargo itself. That's
     // intended for other consumers of Cargo, but we want to go straight to the
     // source, e.g. crates.io, to fetch crates.
-    if !args.flag("respect-source-config") {
+    let respect_source_config = args.flag("respect-source-config");
+    if !respect_source_config {
         gctx.values_mut()?.remove("source");
     }
 
@@ -80,6 +81,7 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
                 .unwrap_or_default()
                 .cloned()
                 .collect(),
+            respect_source_config,
         },
     )?;
     Ok(())

--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -1965,17 +1965,18 @@ fn dont_delete_non_registry_sources_with_respect_source_config() {
 
     add_crates_io_vendor_config(&p);
     p.cargo("vendor --respect-source-config new-vendor-dir")
-        .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to sync
+   Vendoring log v0.3.5 ([ROOT]/foo/vendor/log) to new-vendor-dir/log
+To use vendored sources, add this to your .cargo/config.toml for this project:
 
-Caused by:
-  failed to load pkg lockfile
 
-Caused by:
-  no matching package named `log` found
-  location searched: directory source `[ROOT]/foo/vendor` (which is replacing registry `crates-io`)
-  required by package `foo v0.1.0 ([ROOT]/foo)`
+"#]])
+        .with_stdout_data(str![[r#"
+[source.crates-io]
+replace-with = "vendored-sources"
+
+[source.vendored-sources]
+directory = "new-vendor-dir"
 
 "#]])
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes #15244

With this fix,
`cargo vendor` will not delete original sources,
if you want to vendor things from one directory sources to the other

#### Background

cargo-vendor has a workaround that to mitigate #5956:
it removes all cached sources in order to trigger a re-unpack.
It was meant for dealing with registry sources only,
but accidentally applied to directory source kind.

While directory source kind was invented for vendoring,
and vendoring from one vendored directory to the other seems unusual,
Cargo IMO should not delete any real sources.

It does not mean that registry sources are okay to delete,
In long term, we should explore a way that unpacks `.crate` files
directly, without any removal. See
https://github.com/rust-lang/cargo/pull/12509#issuecomment-1732415990

### How should we test and review this PR?

The added test should suffice.

Also, although this is for fixing #15244,
`cargo vendor` still doesn't support vendor from and to the same location.
Unless we figure out an `rsync`-like solutin to update vendor sources,
it is not going to support in short term.
(And I also doubt the real world use case of it)


### Additional information
