### PR TITLE
feat: add completions for install --path

### DIFF
--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -65,7 +65,11 @@ pub fn cli() -> Command {
         .arg(
             opt("path", "Filesystem path to local crate to install from")
                 .value_name("PATH")
-                .conflicts_with_all(&["git", "index", "registry"]),
+                .conflicts_with_all(&["git", "index", "registry"])
+                .add(clap_complete::engine::ArgValueCompleter::new(
+                    clap_complete::engine::PathCompleter::any()
+                        .filter(|path| path.join("Cargo.toml").exists()),
+                )),
         )
         .arg(opt("root", "Directory to install packages into").value_name("DIR"))
         .arg(flag("force", "Force overwriting existing crates or binaries").short('f'))


### PR DESCRIPTION
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.


### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->

### What does this PR try to resolve?

Related to https://github.com/rust-lang/cargo/issues/14520

This PR introduces auto-completion for the cargo install --path option. When a user types cargo install --path  and presses the TAB key, the system will automatically detect directories in the current path and suggestion prioritizes directory containing a Cargo.toml file. 

### How should we test and review this PR?

To verify this feature, follow these steps:
1. In the terminal, type `cargo install --path`
2. Press the TAB key.
3. You should see suggestions only for directories in the current path that contain a `Cargo.toml` file being prioritized, such as `./src/` (if `./src/Cargo.toml` exists). 

https://github.com/user-attachments/assets/281706c0-7956-4551-a22b-125dadccd12e

### Additional information

There's a [discussion in Zulip](https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/PR15266.3A.20completions.20for.20install.20--path)  and here're some relevant information from it
1. directories are always shown so that a completer doesn't have to recurse through a directory tree to determine what directories may be relevant. The difference marking a directory as accepted does it sorts it first.
2. A user / config setting might override a sort order over native completion. Try disable it manually if native completion is not there.