### PR TITLE
Upgrade to `rustc-stable-hash v0.1.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3398,9 +3398,9 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc-stable-hash"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2febf9acc5ee5e99d1ad0afcdbccc02d87aa3f857a1f01f825b80eacf8edfcd1"
+checksum = "781442f29170c5c93b7185ad559492601acdc71d5bb0706f5868094f45cfcd08"
 
 [[package]]
 name = "rustfix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ rand = "0.9.0"
 regex = "1.11.1"
 rusqlite = { version = "0.33.0", features = ["bundled"] }
 rustc-hash = "2.1.1"
-rustc-stable-hash = "0.1.1"
+rustc-stable-hash = "0.1.2"
 rustfix = { version = "0.9.0", path = "crates/rustfix" }
 same-file = "1.0.6"
 schemars = "1.0.0-alpha.17"


### PR DESCRIPTION
This update makes the stable hasher consistent across endianness, fixing cargo's `test_stable_hash` on big-endian targets to match the little-endian expected values.

Fixes #15265 