### PR TITLE
feat: show extra build description from bootstrap

### DIFF
--- a/src/cargo/version.rs
+++ b/src/cargo/version.rs
@@ -21,6 +21,18 @@ pub struct VersionInfo {
     ///
     /// `None` if not built from a git repo.
     pub commit_info: Option<CommitInfo>,
+
+    /// A descriptive string to be appended to version output.
+    ///
+    /// This is usually set by the bootstrap in rust-lang/rust
+    /// via the `CFG_VER_DESCRIPTION` environment variable.
+    /// Useful for showing vendor build information.
+    /// For example,
+    ///
+    /// ```text
+    /// cargo 1.85.0 (d73d2caf9 2024-12-31) (MyCustomBuild 1.85.0-3)
+    /// ```
+    pub description: Option<String>,
 }
 
 impl fmt::Display for VersionInfo {
@@ -29,6 +41,10 @@ impl fmt::Display for VersionInfo {
 
         if let Some(ref ci) = self.commit_info {
             write!(f, " ({} {})", ci.short_commit_hash, ci.commit_date)?;
+        };
+
+        if let Some(description) = self.description.as_ref().filter(|d| !d.is_empty()) {
+            write!(f, " ({description})")?;
         };
         Ok(())
     }
@@ -71,10 +87,12 @@ pub fn version() -> VersionInfo {
         commit_hash,
         commit_date: option_env_str!("CARGO_COMMIT_DATE").unwrap(),
     });
+    let description = option_env_str!("CFG_VER_DESCRIPTION");
 
     VersionInfo {
         version,
         release_channel,
         commit_info,
+        description,
     }
 }


### PR DESCRIPTION


### What does this PR try to resolve?

`CFG_VER_DESCRIPTION` is descriptive string to be appended to version output.

This is usually set by the bootstrap in rust-lang/rust. Useful for showing vendor build information.

See <https://github.com/rust-lang/rust/pull/137723>.

### How should we test and review this PR?

```bash
CFG_VER_DESCRIPTION="My Awesome Rust Distribution" cargo b 
target/debug/cargo version
```