### PR TITLE
Don't use `$CARGO_BUILD_TARGET` in `cargo metadata`

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -76,7 +76,7 @@ pub use self::build_context::{
 use self::build_plan::BuildPlan;
 pub use self::build_runner::{BuildRunner, Metadata, UnitHash};
 pub use self::compilation::{Compilation, Doctest, UnitOutput};
-pub use self::compile_kind::{CompileKind, CompileTarget};
+pub use self::compile_kind::{CompileKind, CompileKindFallback, CompileTarget};
 pub use self::crate_type::CrateType;
 pub use self::custom_build::LinkArgTarget;
 pub use self::custom_build::{BuildOutput, BuildScriptOutputs, BuildScripts};

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -1224,7 +1224,7 @@ fn workspace_metadata_with_dependencies_no_deps() {
                 name = "bar"
                 version = "0.5.0"
                 authors = ["wycats@example.com"]
-                
+
                 [dependencies]
                 baz = { path = "../baz/" }
                 artifact = { path = "../artifact/", artifact = "bin" }
@@ -1474,13 +1474,13 @@ fn workspace_metadata_with_dependencies_and_resolve() {
                 name = "artifact"
                 version = "0.5.0"
                 authors = []
-                
+
                 [lib]
                 crate-type = ["staticlib", "cdylib", "rlib"]
-                
+
                 [[bin]]
                 name = "bar-name"
-                
+
                 [[bin]]
                 name = "baz-name"
             "#,
@@ -1494,10 +1494,10 @@ fn workspace_metadata_with_dependencies_and_resolve() {
                 name = "bin-only-artifact"
                 version = "0.5.0"
                 authors = []
-                
+
                 [[bin]]
                 name = "a-name"
-                
+
                 [[bin]]
                 name = "b-name"
             "#,
@@ -4343,7 +4343,7 @@ fn workspace_metadata_with_dependencies_no_deps_artifact() {
                 name = "bar"
                 version = "0.5.0"
                 authors = ["wycats@example.com"]
-                
+
                 [dependencies]
                 baz = { path = "../baz/" }
                 baz-renamed = { path = "../baz/" }

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -4980,8 +4980,8 @@ fn metadata_ignores_build_target_configuration() -> anyhow::Result<()> {
         .env("CARGO_BUILD_TARGET", rustc_host())
         .exec_with_output()?;
     assert!(
-        output1.stdout != output2.stdout,
-        "metadata should change when `CARGO_BUILD_TARGET` is set",
+        output1.stdout == output2.stdout,
+        "metadata should not change when `CARGO_BUILD_TARGET` is set",
     );
     Ok(())
 }


### PR DESCRIPTION
This commit fixes a (five year old!) regression in `cargo metadata` where if `--filter-platform` isn't explicitly specified it will accidentally read `$CARGO_BUILD_TARGET` (or `build.target` configuration) and use that as the default `--filter-platform`. The reason for this is that the calculation for targets changed in #8167 and while the shared function makes sense for other commands such as `cargo build` the targets have a different meaning in `cargo metadata` so a slightly different set of functionality is desired.

This commit fixes the issue by introducing a new constructor for the list of `CompileKind` variants where the fallback of "if nothing is specified" is explicitly chosen.

Closes #15270

<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
