### PR TITLE
test: redact host target when comparing CARGO_ENV path

### DIFF
--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -10,6 +10,7 @@ use std::str;
 use cargo_test_support::basic_manifest;
 use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
+use cargo_test_support::rustc_host;
 use cargo_test_support::str;
 use cargo_test_support::tools::echo_subcommand;
 use cargo_test_support::{
@@ -576,6 +577,7 @@ fn full_did_you_mean() {
 
 #[cargo_test]
 fn overwrite_cargo_environment_variable() {
+    let rustc_host = rustc_host();
     // If passed arguments `arg1 arg2 ...`, this program runs them as a command.
     // If passed no arguments, this program simply prints `$CARGO`.
     let p = project()
@@ -626,6 +628,7 @@ fn overwrite_cargo_environment_variable() {
             .with_extension("")
             .to_str()
             .unwrap()
+            .replace(rustc_host, "[HOST_TARGET]")
     );
 
     for cmd in [


### PR DESCRIPTION
This was found when updating git submodule in rust-lang/rust

```
---- cargo_command::overwrite_cargo_environment_variable stdout ----
running `/projects/rust/build/aarch64-apple-darwin/stage1-tools/aarch64-apple-darwin/release/cargo run`

thread 'cargo_command::overwrite_cargo_environment_variable' panicked at src/tools/cargo/tests/testsuite/cargo_command.rs:636:58:

test failed running `/projects/rust/build/aarch64-apple-darwin/stage1-tools/aarch64-apple-darwin/release/cargo run`
error: expected to find:
/projects/rust/build/aarch64-apple-darwin/stage1-tools/aarch64-apple-darwin/release/cargo

did not find in output:
[COMPILING] foo v1.0.0 ([ROOT]/foo)
[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
[RUNNING] `target/debug/foo`
```