### PR TITLE
Allow `term.progress.when` to default

### DIFF
--- a/src/cargo/util/context/mod.rs
+++ b/src/cargo/util/context/mod.rs
@@ -2830,6 +2830,7 @@ pub struct TermConfig {
 #[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ProgressConfig {
+    #[serde(default)]
     pub when: ProgressWhen,
     pub width: Option<usize>,
 }

--- a/tests/testsuite/progress.rs
+++ b/tests/testsuite/progress.rs
@@ -53,7 +53,7 @@ fn bad_progress_config_missing_width() {
 }
 
 #[cargo_test]
-fn bad_progress_config_missing_when() {
+fn default_progress_is_auto() {
     let p = project()
         .file(
             ".cargo/config.toml",
@@ -65,16 +65,7 @@ fn bad_progress_config_missing_when() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("check")
-        .with_status(101)
-        .with_stderr_data(str![[r#"
-[ERROR] error in [ROOT]/foo/.cargo/config.toml: could not load config key `term.progress`
-
-Caused by:
-  missing field `when`
-
-"#]])
-        .run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]


### PR DESCRIPTION
### What does this PR try to resolve?

The config section `term.progress` contains a collection of options (currently only `when` and `width`). If only `width` is set, Cargo fails with the error: "missing field `when`." This behavior may be surprising and inconvenient for users who want to set the `CARGO_TERM_PROGRESS_WIDTH` environment variable.

### How should we test and review this PR?

The relevant test, `bad_progress_config_missing_when`, has been replaced with `default_progress_is_auto`.

https://github.com/rust-lang/cargo/pull/14615

From https://github.com/rust-lang/cargo/pull/14615#discussion_r1889426752

> I don't recall any particular decisions made regarding bad_progress_config_missing_when. I personally would not object to changing that to allow it to pass. I can't think of a reason it would be required to specify when with width.