### PR TITLE
feat: add completions for add --path

### DIFF
--- a/src/bin/cargo/commands/add.rs
+++ b/src/bin/cargo/commands/add.rs
@@ -100,7 +100,11 @@ Example uses:
                 .value_name("PATH")
                 .help("Filesystem path to local crate to add")
                 .group("selected")
-                .conflicts_with("git"),
+                .conflicts_with("git")
+                .add(clap_complete::engine::ArgValueCompleter::new(
+                    clap_complete::engine::PathCompleter::any()
+                        .filter(|path| path.join("Cargo.toml").exists()),
+                )),
             clap::Arg::new("base")
                 .long("base")
                 .action(ArgAction::Set)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->

### What does this PR try to resolve?

Related to https://github.com/rust-lang/cargo/issues/14520

This PR introduces auto-completion for the `cargo add --path` option. When a user types `cargo add --path` and presses the TAB key, the system will automatically detect directories in the current path and suggestion prioritizes directory containing a Cargo.toml file.

### How should we test and review this PR?

To verify this feature, follow these steps:

In the terminal, type `cargo add --path`
Press the TAB key.
You should see suggestions only for directories in the current path that contain a Cargo.toml file being prioritized, such as ./src/ (if ./src/Cargo.toml exists).


https://github.com/user-attachments/assets/0620ae5e-abca-425c-ad9a-7004929bb98d

