### PR TITLE
Replace unmaintained humantime crate with jiff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,11 +332,11 @@ dependencies = [
  "hmac",
  "home 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "http-auth",
- "humantime",
  "ignore",
  "im-rc",
  "indexmap",
  "itertools 0.14.0",
+ "jiff 0.2.3",
  "jobserver",
  "lazycell",
  "libc",
@@ -1438,7 +1438,7 @@ checksum = "c57c477b645ee248b173bb1176b52dd528872f12c50375801a58aaf5ae91113f"
 dependencies = [
  "bstr",
  "itoa 1.0.14",
- "jiff",
+ "jiff 0.1.29",
  "thiserror 2.0.11",
 ]
 
@@ -2175,12 +2175,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "icu_collections"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2436,6 +2430,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "jiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c163c633eb184a4ad2a5e7a5dacf12a58c830d717a7963563d4eceb4ced079f"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc3e0019b0f5f43038cf46471b1312136f29e36f54436c6042c8f155fec8789"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "jiff-tzdb"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2533,7 +2551,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4443,7 +4461,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,11 +55,11 @@ hex = "0.4.3"
 hmac = "0.12.1"
 home = "0.5.11"
 http-auth = { version = "0.1.10", default-features = false }
-humantime = "2.1.0"
 ignore = "0.4.23"
 im-rc = "15.1.0"
 indexmap = "2.7.1"
 itertools = "0.14.0"
+jiff = { version = "0.2.3", default-features = false, features = [ "std" ] }
 jobserver = "0.1.32"
 lazycell = "1.3.0"
 libc = "0.2.169"
@@ -176,11 +176,11 @@ hex.workspace = true
 hmac.workspace = true
 home.workspace = true
 http-auth.workspace = true
-humantime.workspace = true
 ignore.workspace = true
 im-rc.workspace = true
 indexmap.workspace = true
 itertools.workspace = true
+jiff.workspace = true
 jobserver.workspace = true
 lazycell.workspace = true
 libgit2-sys.workspace = true

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -79,7 +79,7 @@ fn setup_logger() -> Option<ChromeFlushGuard> {
         .with(fmt_layer)
         .with(profile_layer);
     registry.init();
-    tracing::trace!(start = humantime::format_rfc3339(std::time::SystemTime::now()).to_string());
+    tracing::trace!(start = jiff::Timestamp::now().to_string());
     profile_guard
 }
 

--- a/src/cargo/core/compiler/fingerprint/dirty_reason.rs
+++ b/src/cargo/core/compiler/fingerprint/dirty_reason.rs
@@ -102,12 +102,9 @@ impl fmt::Display for FileTimeDiff {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s_diff = self.new_time.seconds() - self.old_time.seconds();
         if s_diff >= 1 {
-            fmt::Display::fmt(
-                &humantime::Duration::from(std::time::Duration::from_secs(s_diff as u64)),
-                f,
-            )
+            write!(f, "{:#}", jiff::SignedDuration::from_secs(s_diff))
         } else {
-            // format nanoseconds as it is, humantime would display ms, us and ns
+            // format nanoseconds as it is, jiff would display ms, us and ns
             let ns_diff = self.new_time.nanoseconds() - self.old_time.nanoseconds();
             write!(f, "{ns_diff}ns")
         }

--- a/src/cargo/core/compiler/timings.rs
+++ b/src/cargo/core/compiler/timings.rs
@@ -15,7 +15,7 @@ use cargo_util::paths;
 use std::collections::HashMap;
 use std::io::{BufWriter, Write};
 use std::thread::available_parallelism;
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Duration, Instant};
 
 /// Tracking information for the entire build.
 ///
@@ -117,7 +117,7 @@ impl<'gctx> Timings<'gctx> {
                 (pkg_desc, targets)
             })
             .collect();
-        let start_str = humantime::format_rfc3339_seconds(SystemTime::now()).to_string();
+        let start_str = jiff::Timestamp::now().to_string();
         let profile = bcx.build_config.requested_profile.to_string();
         let last_cpu_state = if enabled {
             match State::current() {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->

The crate [`humantime`](https://crates.io/crates/humantime) appears to be unmaintained. There's open PR in RustSec's advisory-db about this: https://github.com/rustsec/advisory-db/pull/2249

The crates [`clap`](https://crates.io/crates/clap) and [`env_logger`](https://crates.io/crates/env_logger) have already made the switch from `humantime` to [`jiff`](https://crates.io/crates/jiff):

 * https://github.com/clap-rs/clap/pull/5944
 * https://github.com/rust-cli/env_logger/pull/352

The `jiff` crate is already dependency on `cargo` via `gix` (albeit old 0.1 version, but that's probably fixed in [next gix release](https://github.com/GitoxideLabs/gitoxide/commit/3ae99a42f51cd2d6c55c6abbd1ead86bf8bf2e1f)):

```
jiff v0.1.29
└── gix-date v0.9.3
    ├── gix v0.70.0
    │   └── cargo v0.88.0 (/Users/oherrala/rust/cargo)
```

This PR shouldn't have any functional change to cargo itself.