### PR TITLE
docs(refs): Add `unsafe` to `extern` while using build scripts in Cargo Book

### DIFF
--- a/src/doc/src/reference/build-script-examples.md
+++ b/src/doc/src/reference/build-script-examples.md
@@ -252,7 +252,7 @@ void hello() {
 // Note the lack of the `#[link]` attribute. We’re delegating the responsibility
 // of selecting what to link over to the build script rather than hard-coding
 // it in the source file.
-extern { fn hello(); }
+unsafe extern { fn hello(); }
 
 fn main() {
     unsafe { hello(); }
@@ -327,7 +327,7 @@ Let's round out the example with a basic FFI binding:
 
 use std::os::raw::{c_uint, c_ulong};
 
-extern "C" {
+unsafe extern "C" {
     pub fn crc32(crc: c_ulong, buf: *const u8, len: c_uint) -> c_ulong;
 }
 

--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -766,7 +766,7 @@ pub struct SpecificLayout {
 // Example usage that will break.
 use updated_crate::SpecificLayout;
 
-extern "C" {
+unsafe extern "C" {
     // This C function is assuming a specific layout defined in a C header.
     fn c_fn_get_b(x: &SpecificLayout) -> u32;
 }
@@ -820,7 +820,7 @@ pub struct SpecificLayout {
 // Example usage that will break.
 use updated_crate::SpecificLayout;
 
-extern "C" {
+unsafe extern "C" {
     // This C function is assuming a specific layout defined in a C header.
     fn c_fn_get_b(x: &SpecificLayout) -> u32; // Error: is not FFI-safe
 }
@@ -941,7 +941,7 @@ pub struct Transparent<T>(T);
 #![deny(improper_ctypes)]
 use updated_crate::Transparent;
 
-extern "C" {
+unsafe extern "C" {
     fn c_fn() -> Transparent<f64>; // Error: is not FFI-safe
 }
 


### PR DESCRIPTION
### What does this PR try to resolve?

Since `rust 1.85.0`, It is no longer sufficient to use the `unsafe` keyword only at the call site. It must also be applied to the `extern` statement, hence, Cargo Book must be updated

- closes https://github.com/rust-lang/cargo/issues/15289

and also update some more related content

### How should we test and review this PR?

Run `mdbook build`. The `unsafe extern` should be seen at `cargo/reference/build-script-examples.html#linking-to-system-libraries` , `cargo/reference/build-script-examples.html#building-a-native-library` , `cargo/reference/semver.html#repr-c-shuffle` , `cargo/reference/semver.html#repr-c-remove` and `cargo/reference/semver.html#repr-transparent-remove` 

### Additional information
