### PR TITLE
cargo vendor: Add context which workspace failed to resolve

### DIFF
--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -144,12 +144,12 @@ fn sync(
     // attempt. If anything fails here we basically just move on to the next
     // crate to work with.
     for ws in workspaces {
-        let (packages, resolve) =
-            ops::resolve_ws(ws, dry_run).context("failed to load pkg lockfile")?;
+        let (packages, resolve) = ops::resolve_ws(ws, dry_run)
+            .with_context(|| format!("failed to load lockfile for {}", ws.root().display()))?;
 
         packages
             .get_many(resolve.iter())
-            .context("failed to download packages")?;
+            .with_context(|| format!("failed to download packages for {}", ws.root().display()))?;
 
         for pkg in resolve.iter() {
             let sid = if opts.respect_source_config {
@@ -187,12 +187,12 @@ fn sync(
     // Next up let's actually download all crates and start storing internal
     // tables about them.
     for ws in workspaces {
-        let (packages, resolve) =
-            ops::resolve_ws(ws, dry_run).context("failed to load pkg lockfile")?;
+        let (packages, resolve) = ops::resolve_ws(ws, dry_run)
+            .with_context(|| format!("failed to load lockfile for {}", ws.root().display()))?;
 
         packages
             .get_many(resolve.iter())
-            .context("failed to download packages")?;
+            .with_context(|| format!("failed to download packages for {}", ws.root().display()))?;
 
         for pkg in resolve.iter() {
             // No need to vendor path crates since they're already in the

--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -2016,7 +2016,7 @@ fn error_loading_which_lock() {
 [ERROR] failed to sync
 
 Caused by:
-  failed to load pkg lockfile
+  failed to load lockfile for [ROOT]/foo/b
 
 Caused by:
   could not execute process `does-not-exist -vV` (never executed)
@@ -2056,7 +2056,7 @@ fn error_downloading() {
 [ERROR] failed to sync
 
 Caused by:
-  failed to download packages
+  failed to download packages for [ROOT]/foo
 
 Caused by:
   failed to download from `[ROOTURL]/dl/bar/1.0.0/download`


### PR DESCRIPTION
This adds some context to the `cargo vendor` command when it fails to resolve or load a workspace. This can be helpful when syncing a large number of workspaces, and it isn't clear which one is causing the problem.
