### PR TITLE
docs: make it clearer that `rust_version` is enforced during compile

### DIFF
--- a/src/doc/src/reference/rust-version.md
+++ b/src/doc/src/reference/rust-version.md
@@ -19,11 +19,10 @@ identifiers such as -nightly will be ignored while checking the Rust version.
 
 **Diagnostics:**
 
-When your package is compiled on an unsupported toolchain, Cargo will provide
-clearer diagnostics about the insufficient toolchain version by always erroring
-during compilation, rather than reporting invalid syntax or missing functionality
+When your package is compiled on an unsupported toolchain, Cargo will report that as an error to the user. This makes the support expectations clear and avoids reporting a less direct diagnostic like invalid syntax or missing functionality
 in the standard library. This affects all [Cargo targets](cargo-targets.md) in the
 package, including binaries, examples, test suites, benchmarks, etc.
+A user can opt-in to an unsupported build of a package with the `--ignore-rust-version` flag.
 
 
 **Development aid:**

--- a/src/doc/src/reference/rust-version.md
+++ b/src/doc/src/reference/rust-version.md
@@ -19,10 +19,12 @@ identifiers such as -nightly will be ignored while checking the Rust version.
 
 **Diagnostics:**
 
-When your package is compiled on an unsupported toolchain,
-Cargo will provide clearer diagnostics about the insufficient toolchain version rather than reporting invalid syntax or missing functionality in the standard library.
-This affects all [Cargo targets](cargo-targets.md) in the package, including binaries, examples, test suites,
-benchmarks, etc.
+When your package is compiled on an unsupported toolchain, Cargo will provide
+clearer diagnostics about the insufficient toolchain version by always erroring
+during compilation, rather than reporting invalid syntax or missing functionality
+in the standard library. This affects all [Cargo targets](cargo-targets.md) in the
+package, including binaries, examples, test suites, benchmarks, etc.
+
 
 **Development aid:**
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them. -->

### What does this PR try to resolve?

The current wording makes it sound like Cargo will only refuse to compile the package if it encounters any missing functionality in stdlib while compiling the package on an unsupported toolchain. However, cargo will actually refuse to build the package unless overridden or the toolchain is updated.


### How should we test and review this PR?

No tests are required or applicable for this PR unless I am mistaken

### Additional information

