### PR TITLE
docs: mention wrong URLs as a cause of git authentication errors

### DIFF
--- a/src/doc/src/appendix/git-authentication.md
+++ b/src/doc/src/appendix/git-authentication.md
@@ -10,6 +10,10 @@ handle fetching remote repositories instead of using the built-in support.
 This can be enabled with the `CARGO_NET_GIT_FETCH_WITH_CLI=true` environment
 variable.
 
+> **Note:** Cargo does not require authentication for public git dependencies
+> so if you see an authentication failure in that context, ensure that the
+> URL is correct.
+
 ## HTTPS authentication
 
 HTTPS authentication requires the [`credential.helper`] mechanism. There are


### PR DESCRIPTION
I was seeing an error like the following in my `rust-analyzer` output.

```
error: failed to load source for dependency `fontdue`

Caused by:
  Unable to update https://github.com/xiphseer/fontdue.git?rev=67b963af0d5ca9e09bfeb0b5a9adf85c302d0a67

Caused by:
  failed to fetch into: /home/daniel/.local/share/cargo/git/db/fontdue-4d0b06b88bb2e092

Caused by:
  revision 67b963af0d5ca9e09bfeb0b5a9adf85c302d0a67 not found

Caused by:
  failed to authenticate when downloading repository

  * attempted to find username/password via git's `credential.helper` support, but failed

  if the git CLI succeeds then `net.git-fetch-with-cli` may help here
  https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli

Caused by:
  failed to acquire username/password from local configuration
```

I spent about 10 minutes reading the docs on *git authentication*, before realizing I had just typo'ed my own GitHub username. This PR adds a note to the reference that explicitly mentions wrong (not malformed) URLs as a cause of authentication errors.

It's not directly on the linked <https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli> mainly because *Git Authentication* is already linked there, so it may catch more people and that's meant as the more detailed explanation anyway.