### PR TITLE
fix: deduplicate crate types in cargo rustc command

### DIFF
--- a/src/bin/cargo/commands/rustc.rs
+++ b/src/bin/cargo/commands/rustc.rs
@@ -92,14 +92,17 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
         return Ok(());
     }
 
-    let crate_types = args
-        .get_many::<String>(CRATE_TYPE_ARG_NAME)
-        .into_iter()
-        .flatten()
-        .flat_map(|s| s.split(','))
-        .filter(|s| !s.is_empty())
-        .map(String::from)
-        .collect::<Vec<String>>();
+    let crate_types = {
+        let mut seen = std::collections::HashSet::new();
+        args.get_many::<String>(CRATE_TYPE_ARG_NAME)
+            .into_iter()
+            .flatten()
+            .flat_map(|s| s.split(','))
+            .filter(|s| !s.is_empty())
+            .map(String::from)
+            .filter(|s| seen.insert(s.clone()))
+            .collect::<Vec<String>>()
+    };
 
     compile_opts.target_rustc_crate_types = if crate_types.is_empty() {
         None

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -860,48 +860,20 @@ fn precedence() {
 fn build_with_duplicate_crate_types() {
     let p = project().file("src/lib.rs", "").build();
 
-    p
-        .cargo("rustc -v --crate-type staticlib --crate-type staticlib")
+    p.cargo("rustc -v --crate-type staticlib --crate-type staticlib")
         .with_stderr_data(str![[r#"
-[WARNING] output filename collision.
-The lib target `foo` in package `foo v0.0.1 ([ROOT]/foo)` has the same output filename as the lib target `foo` in package `foo v0.0.1 ([ROOT]/foo)`.
-Colliding filename is: [ROOT]/foo/target/debug/deps/libfoo-[HASH].a
-The targets should have unique names.
-Consider changing their names to be unique or compiling them separately.
-This may become a hard error in the future; see <https://github.com/rust-lang/cargo/issues/6313>.
-[WARNING] output filename collision.
-The lib target `foo` in package `foo v0.0.1 ([ROOT]/foo)` has the same output filename as the lib target `foo` in package `foo v0.0.1 ([ROOT]/foo)`.
-Colliding filename is: [ROOT]/foo/target/debug/libfoo.a
-The targets should have unique names.
-Consider changing their names to be unique or compiling them separately.
-This may become a hard error in the future; see <https://github.com/rust-lang/cargo/issues/6313>.
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc [..]future-incompat --crate-type staticlib --crate-type staticlib --emit[..]
+[RUNNING] `rustc [..] --crate-type staticlib --emit[..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
         .run();
 
     p.cargo("rustc -v --crate-type staticlib --crate-type staticlib")
-            .with_status(101)
-            .with_stderr_data(str![[r#"
-[WARNING] output filename collision.
-The lib target `foo` in package `foo v0.0.1 ([ROOT]/foo)` has the same output filename as the lib target `foo` in package `foo v0.0.1 ([ROOT]/foo)`.
-Colliding filename is: [ROOT]/foo/target/debug/deps/libfoo-[HASH].a
-The targets should have unique names.
-Consider changing their names to be unique or compiling them separately.
-This may become a hard error in the future; see <https://github.com/rust-lang/cargo/issues/6313>.
-[WARNING] output filename collision.
-The lib target `foo` in package `foo v0.0.1 ([ROOT]/foo)` has the same output filename as the lib target `foo` in package `foo v0.0.1 ([ROOT]/foo)`.
-Colliding filename is: [ROOT]/foo/target/debug/libfoo.a
-The targets should have unique names.
-Consider changing their names to be unique or compiling them separately.
-This may become a hard error in the future; see <https://github.com/rust-lang/cargo/issues/6313>.
-
-thread 'main' panicked at src/cargo/core/compiler/fingerprint/mod.rs:1180:13:
-assertion failed: mtimes.insert(output.clone(), mtime).is_none()
-[NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+        .with_stderr_data(str![[r#"
+[FRESH] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
-            .run();
+        .run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?

close: #15312

### How should we test and review this PR?

deduplicate `crate-type` in cargo `rustc` command

