### PR TITLE
feat: Add custom completer for cargo <TAB> to complete aliases defined in config.toml

### DIFF
--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -1341,7 +1341,7 @@ fn get_packages() -> CargoResult<Vec<Package>> {
     Ok(packages)
 }
 
-fn new_gctx_for_completions() -> CargoResult<GlobalContext> {
+pub fn new_gctx_for_completions() -> CargoResult<GlobalContext> {
     let cwd = std::env::current_dir()?;
     let mut gctx = GlobalContext::new(shell::Shell::new(), cwd.clone(), cargo_home_with_cwd(&cwd)?);
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->

### What does this PR try to resolve?

Related to https://github.com/rust-lang/cargo/issues/14520

This PR introduces auto-completion for the `cargo <TAB>` option. When a user types `cargo <TAB>` and presses the TAB key, the system will automatically suggest aliases defined in `config.toml`

### How should we test and review this PR?

To verify this feature, follow these steps:
1. In the terminal, type `cargo <TAB>`
2. Press the TAB key.
3. You should see aliases suggestions


https://github.com/user-attachments/assets/d8a265e8-bbd9-4f58-8121-80caf142d8a6




