### PR TITLE
test(build-std): address overly-matched snapshot

### DIFF
--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -159,7 +159,7 @@ fn basic() {
         .build_std_isolated()
         .target_host()
         .with_stderr_data(str![[r#"
-[COMPILING] rustc-std-workspace-std [..]
+[COMPILING] [..]
 ...
 [COMPILING] test v0.0.0 ([..])
 [COMPILING] foo v0.0.1 ([ROOT]/foo)


### PR DESCRIPTION
Still trying to bisect what went wrong,
but this should be fairly safe to merge.

Failed on nightly-2025-03-18 but not nightly-2025-03-17 btw.