### PR TITLE
fix(build-dir): Renamed workspace-manifest-path-hash to workspace-path-hash

### DIFF
--- a/src/cargo/util/context/mod.rs
+++ b/src/cargo/util/context/mod.rs
@@ -675,7 +675,7 @@ impl GlobalContext {
                         .context("cargo home was not valid utf-8")?
                         .to_string(),
                 ),
-                ("{workspace-manifest-path-hash}", {
+                ("{workspace-path-hash}", {
                     let hash = crate::util::hex::short_hash(&workspace_manifest_path);
                     format!("{}{}{}", &hash[0..2], std::path::MAIN_SEPARATOR, &hash[2..])
                 }),

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -265,7 +265,7 @@ This option supports path templating.
 Avaiable template variables:
 * `{workspace-root}` resolves to root of the current workspace.
 * `{cargo-cache-home}` resolves to `CARGO_HOME`
-* `{workspace-manifest-path-hash}` resolves to a hash of the manifest path
+* `{workspace-path-hash}` resolves to a hash of the manifest path
 
 
 ## root-dir

--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -586,7 +586,7 @@ fn template_workspace_manfiest_path_hash() {
             ".cargo/config.toml",
             r#"
             [build]
-            build-dir = "foo/{workspace-manifest-path-hash}/build-dir"
+            build-dir = "foo/{workspace-path-hash}/build-dir"
             target-dir = "target-dir"
             "#,
         )


### PR DESCRIPTION
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->

### What does this PR try to resolve?

Small PR to rename `workspace-manifest-path-hash` to `workspace-path-hash` in the build-dir template as mentioned [here](https://github.com/rust-lang/cargo/issues/14125#issuecomment-2733611870) (cc: #14125)


r? @epage 
