### PR TITLE
feat(build-dir): Added the Cargo version to the inputs of `workspace-path-hash`

### DIFF
--- a/src/cargo/util/context/mod.rs
+++ b/src/cargo/util/context/mod.rs
@@ -676,7 +676,16 @@ impl GlobalContext {
                         .to_string(),
                 ),
                 ("{workspace-path-hash}", {
-                    let hash = crate::util::hex::short_hash(&workspace_manifest_path);
+                    // We include the version in the hash to prevent external tools from relying on
+                    // our hash implmentation. Note that we explictly do not include the prerelease
+                    // and build parts of the semver to avoid a new hash for every nightly version.
+                    let version = crate::version::version().semver();
+                    let hash = crate::util::hex::short_hash(&(
+                        version.major,
+                        version.minor,
+                        version.patch,
+                        workspace_manifest_path,
+                    ));
                     format!("{}{}{}", &hash[0..2], std::path::MAIN_SEPARATOR, &hash[2..])
                 }),
             ];

--- a/src/cargo/version.rs
+++ b/src/cargo/version.rs
@@ -35,6 +35,13 @@ pub struct VersionInfo {
     pub description: Option<String>,
 }
 
+impl VersionInfo {
+    /// The Cargo version as a [`semver::Version`].
+    pub fn semver(&self) -> semver::Version {
+        semver::Version::parse(&self.version).expect("Cargo version was not a valid semver version")
+    }
+}
+
 impl fmt::Display for VersionInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.version)?;

--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -569,7 +569,7 @@ fn template_cargo_cache_home() {
 }
 
 #[cargo_test]
-fn template_workspace_manfiest_path_hash() {
+fn template_workspace_path_hash() {
     let p = project()
         .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
         .file(

--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -610,7 +610,7 @@ fn template_workspace_path_hash() {
 }
 
 #[cargo_test]
-fn template_workspace_path_hash_should_not_change_between_cargo_versions() {
+fn template_workspace_path_hash_should_change_between_cargo_versions() {
     let p = project()
         .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
         .file(
@@ -661,10 +661,10 @@ fn template_workspace_path_hash_should_not_change_between_cargo_versions() {
     let second_run_build_dir = hash_dir.as_path().join("build-dir");
     assert_build_dir_layout(second_run_build_dir.clone(), "debug");
 
-    // Finally check that the build-dir is in the same location between both Cargo versions
-    assert_eq!(
+    // Finally check that the build-dir is in different location between both Cargo versions
+    assert_ne!(
         first_run_build_dir, second_run_build_dir,
-        "The workspace path hash generated between 2 Cargo versions did not match"
+        "The workspace path hash generated between 2 Cargo versions matched when it should not"
     );
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->

### What does this PR try to resolve?

This PR adds the Cargo version to the hash inputs of `workspace-path-hash` build-dir template variable.
We only include the major, minor, and patch parts of the version in the hash inputs to avoid including the release channel causing new nightly's from creating many new build-dirs.

See this [comment](https://github.com/rust-lang/cargo/issues/14125#issuecomment-2733611870) in  #14125

### How should we test and review this PR?

I added a test for this change. 
The testing approach is to run `cargo build` twice changing the versions between runs and then validating the build-dir changed between runs.

### Additional information

For testing I had to add a `__CARGO_TEST_CARGO_VERSION` variable as that seemed to be the easiest way to test this. 
Adding `__CARGO_TEST_` env vars for testing purposes appears to be an established pattern (ie. `__CARGO_TESTS_ONLY_SRC_ROOT`, `__CARGO_TEST_MAX_UNPACK_SIZE`, etc)


r? @epage 