### PR TITLE
Fix some issues with future-incompat report generation

### DIFF
--- a/src/cargo/core/compiler/future_incompat.rs
+++ b/src/cargo/core/compiler/future_incompat.rs
@@ -483,7 +483,7 @@ You may want to consider updating them to a newer version to see if the issue ha
             "
 To solve this problem, you can try the following approaches:
 
-{update_message}
+{update_message}\
 - If the issue is not solved by updating the dependencies, a fix has to be
 implemented by those dependencies. You can help with that by notifying the
 maintainers of this problem (e.g. by creating a bug report) or by proposing a

--- a/src/cargo/core/compiler/future_incompat.rs
+++ b/src/cargo/core/compiler/future_incompat.rs
@@ -485,7 +485,7 @@ fix to the maintainers (e.g. by creating a pull request):
 section in `Cargo.toml` to use your own version of the dependency. For more
 information, see:
 https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section
-        ",
+",
         upstream_info = upstream_info,
         update_message = update_message,
     );

--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -700,9 +700,15 @@ impl<'gctx> DrainState<'gctx> {
                 }
             }
             Message::FutureIncompatReport(id, items) => {
-                let package_id = self.active[&id].pkg.package_id();
+                let unit = &self.active[&id];
+                let package_id = unit.pkg.package_id();
+                let is_local = unit.is_local();
                 self.per_package_future_incompat_reports
-                    .push(FutureIncompatReportPackage { package_id, items });
+                    .push(FutureIncompatReportPackage {
+                        package_id,
+                        is_local,
+                        items,
+                    });
             }
             Message::Token(acquired_token) => {
                 let token = acquired_token.context("failed to acquire jobserver token")?;

--- a/tests/testsuite/future_incompat_report.rs
+++ b/tests/testsuite/future_incompat_report.rs
@@ -553,6 +553,7 @@ fn suggestions_for_updates() {
                 [package]
                 name = "foo"
                 version = "0.1.0"
+                edition = "2015"
 
                 [dependencies]
                 with_updates = "1"
@@ -591,25 +592,111 @@ fn suggestions_for_updates() {
         .masquerade_as_nightly_cargo(&["future-incompat-test"])
         .env("RUSTFLAGS", "-Zfuture-incompat-test")
         .with_stderr_data(str![[r#"
-...
+[DOWNLOADING] crates ...
+[DOWNLOADED] without_updates v1.0.0 (registry `dummy-registry`)
+[DOWNLOADED] with_updates v1.0.0 (registry `dummy-registry`)
+[DOWNLOADED] big_update v1.0.0 (registry `dummy-registry`)
+[CHECKING] with_updates v1.0.0
+[CHECKING] big_update v1.0.0
+[CHECKING] without_updates v1.0.0
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[WARNING] the following packages contain code that will be rejected by a future version of Rust: big_update v1.0.0, with_updates v1.0.0, without_updates v1.0.0
+[NOTE] 
+To solve this problem, you can try the following approaches:
+
+
 - Some affected dependencies have newer versions available.
 You may want to consider updating them to a newer version to see if the issue has been fixed.
 
 big_update v1.0.0 has the following newer versions available: 2.0.0
 with_updates v1.0.0 has the following newer versions available: 1.0.1, 1.0.2, 3.0.1
-...
-"#]])
+
+
+- If the issue is not solved by updating the dependencies, a fix has to be
+implemented by those dependencies. You can help with that by notifying the
+maintainers of this problem (e.g. by creating a bug report) or by proposing a
+fix to the maintainers (e.g. by creating a pull request):
+
+  - big_update@1.0.0
+  - Repository: <not found>
+  - Detailed warning command: `cargo report future-incompatibilities --id 1 --package big_update@1.0.0`
+
+  - with_updates@1.0.0
+  - Repository: <not found>
+  - Detailed warning command: `cargo report future-incompatibilities --id 1 --package with_updates@1.0.0`
+
+  - without_updates@1.0.0
+  - Repository: <not found>
+  - Detailed warning command: `cargo report future-incompatibilities --id 1 --package without_updates@1.0.0`
+
+- If waiting for an upstream fix is not an option, you can use the `[patch]`
+section in `Cargo.toml` to use your own version of the dependency. For more
+information, see:
+https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section
+
+[NOTE] this report can be shown with `cargo report future-incompatibilities --id 1`
+
+"#]].unordered())
         .run();
 
     p.cargo("report future-incompatibilities")
         .with_stdout_data(str![[r#"
-...
+The following warnings were discovered during the build. These warnings are an
+indication that the packages contain code that will become an error in a
+future release of Rust. These warnings typically cover changes to close
+soundness problems, unintended or undocumented behavior, or critical problems
+that cannot be fixed in a backwards-compatible fashion, and are not expected
+to be in wide use.
+
+Each warning should contain a link for more information on what the warning
+means and how to resolve it.
+
+
+To solve this problem, you can try the following approaches:
+
+
 - Some affected dependencies have newer versions available.
 You may want to consider updating them to a newer version to see if the issue has been fixed.
 
 big_update v1.0.0 has the following newer versions available: 2.0.0
 with_updates v1.0.0 has the following newer versions available: 1.0.1, 1.0.2, 3.0.1
+
+
+- If the issue is not solved by updating the dependencies, a fix has to be
+implemented by those dependencies. You can help with that by notifying the
+maintainers of this problem (e.g. by creating a bug report) or by proposing a
+fix to the maintainers (e.g. by creating a pull request):
+
+  - big_update@1.0.0
+  - Repository: <not found>
+  - Detailed warning command: `cargo report future-incompatibilities --id 1 --package big_update@1.0.0`
+
+  - with_updates@1.0.0
+  - Repository: <not found>
+  - Detailed warning command: `cargo report future-incompatibilities --id 1 --package with_updates@1.0.0`
+
+  - without_updates@1.0.0
+  - Repository: <not found>
+  - Detailed warning command: `cargo report future-incompatibilities --id 1 --package without_updates@1.0.0`
+
+- If waiting for an upstream fix is not an option, you can use the `[patch]`
+section in `Cargo.toml` to use your own version of the dependency. For more
+information, see:
+https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section
+
+The package `big_update v1.0.0` currently triggers the following future incompatibility lints:
+> [WARNING] unused variable: `x`
 ...
+
+The package `with_updates v1.0.0` currently triggers the following future incompatibility lints:
+> [WARNING] unused variable: `x`
+...
+
+The package `without_updates v1.0.0` currently triggers the following future incompatibility lints:
+> [WARNING] unused variable: `x`
+...
+
 "#]])
         .run();
 }

--- a/tests/testsuite/future_incompat_report.rs
+++ b/tests/testsuite/future_incompat_report.rs
@@ -149,7 +149,6 @@ fn incompat_in_dependency() {
 [NOTE] 
 To solve this problem, you can try the following approaches:
 
-
 - If the issue is not solved by updating the dependencies, a fix has to be
 implemented by those dependencies. You can help with that by notifying the
 maintainers of this problem (e.g. by creating a bug report) or by proposing a
@@ -183,7 +182,6 @@ means and how to resolve it.
 
 
 To solve this problem, you can try the following approaches:
-
 
 - If the issue is not solved by updating the dependencies, a fix has to be
 implemented by those dependencies. You can help with that by notifying the
@@ -634,7 +632,6 @@ fix to the maintainers (e.g. by creating a pull request):
 section in `Cargo.toml` to use your own version of the dependency. For more
 information, see:
 https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section
-
 [NOTE] this report can be shown with `cargo report future-incompatibilities --id 1`
 
 "#]].unordered())
@@ -661,7 +658,6 @@ You may want to consider updating them to a newer version to see if the issue ha
 
 big_update v1.0.0 has the following newer versions available: 2.0.0
 with_updates v1.0.0 has the following newer versions available: 1.0.1, 1.0.2, 3.0.1
-
 
 - If the issue is not solved by updating the dependencies, a fix has to be
 implemented by those dependencies. You can help with that by notifying the
@@ -724,7 +720,6 @@ fn correct_report_id_when_cached() {
 [NOTE] 
 To solve this problem, you can try the following approaches:
 
-
 - If the issue is not solved by updating the dependencies, a fix has to be
 implemented by those dependencies. You can help with that by notifying the
 maintainers of this problem (e.g. by creating a bug report) or by proposing a
@@ -751,7 +746,6 @@ https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch
 [WARNING] the following packages contain code that will be rejected by a future version of Rust: bar v1.0.0
 [NOTE] 
 To solve this problem, you can try the following approaches:
-
 
 - If the issue is not solved by updating the dependencies, a fix has to be
 implemented by those dependencies. You can help with that by notifying the

--- a/tests/testsuite/future_incompat_report.rs
+++ b/tests/testsuite/future_incompat_report.rs
@@ -102,7 +102,7 @@ fix to the maintainers (e.g. by creating a pull request):
 
   - foo@0.0.0
   - Repository: <not found>
-  - Detailed warning command: `cargo report future-incompatibilities --id 2 --package foo@0.0.0`
+  - Detailed warning command: `cargo report future-incompatibilities --id 1 --package foo@0.0.0`
 
 - If waiting for an upstream fix is not an option, you can use the `[patch]`
 section in `Cargo.toml` to use your own version of the dependency. For more
@@ -192,7 +192,7 @@ fix to the maintainers (e.g. by creating a pull request):
 
   - bar@1.0.0
   - Repository: https://example.com/
-  - Detailed warning command: `cargo report future-incompatibilities --id 2 --package bar@1.0.0`
+  - Detailed warning command: `cargo report future-incompatibilities --id 1 --package bar@1.0.0`
 
 - If waiting for an upstream fix is not an option, you can use the `[patch]`
 section in `Cargo.toml` to use your own version of the dependency. For more
@@ -708,7 +708,7 @@ fix to the maintainers (e.g. by creating a pull request):
 
   - bar@1.0.0
   - Repository: https://example.com/
-  - Detailed warning command: `cargo report future-incompatibilities --id 2 --package bar@1.0.0`
+  - Detailed warning command: `cargo report future-incompatibilities --id 1 --package bar@1.0.0`
 
 - If waiting for an upstream fix is not an option, you can use the `[patch]`
 section in `Cargo.toml` to use your own version of the dependency. For more

--- a/tests/testsuite/future_incompat_report.rs
+++ b/tests/testsuite/future_incompat_report.rs
@@ -91,24 +91,6 @@ fn incompat_in_local_crate() {
 [WARNING] `foo` (lib) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [WARNING] the following packages contain code that will be rejected by a future version of Rust: foo v0.0.0 ([ROOT]/foo)
-[NOTE] 
-To solve this problem, you can try the following approaches:
-
-
-- If the issue is not solved by updating the dependencies, a fix has to be
-implemented by those dependencies. You can help with that by notifying the
-maintainers of this problem (e.g. by creating a bug report) or by proposing a
-fix to the maintainers (e.g. by creating a pull request):
-
-  - foo@0.0.0
-  - Repository: <not found>
-  - Detailed warning command: `cargo report future-incompatibilities --id 1 --package foo@0.0.0`
-
-- If waiting for an upstream fix is not an option, you can use the `[patch]`
-section in `Cargo.toml` to use your own version of the dependency. For more
-information, see:
-https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section
-
 [NOTE] this report can be shown with `cargo report future-incompatibilities --id 1`
 
 "#]])
@@ -126,23 +108,6 @@ to be in wide use.
 Each warning should contain a link for more information on what the warning
 means and how to resolve it.
 
-
-To solve this problem, you can try the following approaches:
-
-
-- If the issue is not solved by updating the dependencies, a fix has to be
-implemented by those dependencies. You can help with that by notifying the
-maintainers of this problem (e.g. by creating a bug report) or by proposing a
-fix to the maintainers (e.g. by creating a pull request):
-
-  - foo@0.0.0
-  - Repository: <not found>
-  - Detailed warning command: `cargo report future-incompatibilities --id 1 --package foo@0.0.0`
-
-- If waiting for an upstream fix is not an option, you can use the `[patch]`
-section in `Cargo.toml` to use your own version of the dependency. For more
-information, see:
-https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section
 
 The package `foo v0.0.0 ([ROOT]/foo)` currently triggers the following future incompatibility lints:
 > [WARNING] unused variable: `x`
@@ -352,7 +317,7 @@ frequency = 'never'
 ...
 [WARNING] the following packages contain code that will be rejected by a future version of Rust: foo v0.0.0 ([ROOT]/foo)
 ...
-  - foo@0.0.0
+[NOTE] this report can be shown with `cargo report future-incompatibilities --id [..]`
 ...
 ")
             .run();

--- a/tests/testsuite/future_incompat_report.rs
+++ b/tests/testsuite/future_incompat_report.rs
@@ -108,7 +108,7 @@ fix to the maintainers (e.g. by creating a pull request):
 section in `Cargo.toml` to use your own version of the dependency. For more
 information, see:
 https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section
-        
+
 [NOTE] this report can be shown with `cargo report future-incompatibilities --id 1`
 
 "#]])
@@ -143,7 +143,7 @@ fix to the maintainers (e.g. by creating a pull request):
 section in `Cargo.toml` to use your own version of the dependency. For more
 information, see:
 https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section
-        
+
 The package `foo v0.0.0 ([ROOT]/foo)` currently triggers the following future incompatibility lints:
 > [WARNING] unused variable: `x`
 ...
@@ -198,7 +198,7 @@ fix to the maintainers (e.g. by creating a pull request):
 section in `Cargo.toml` to use your own version of the dependency. For more
 information, see:
 https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section
-        
+
 [NOTE] this report can be shown with `cargo report future-incompatibilities --id 1`
 
 "#]])
@@ -233,7 +233,7 @@ fix to the maintainers (e.g. by creating a pull request):
 section in `Cargo.toml` to use your own version of the dependency. For more
 information, see:
 https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section
-        
+
 The package `bar v1.0.0` currently triggers the following future incompatibility lints:
 > [WARNING] unused variable: `x`
 ...
@@ -686,7 +686,7 @@ fix to the maintainers (e.g. by creating a pull request):
 section in `Cargo.toml` to use your own version of the dependency. For more
 information, see:
 https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section
-        
+
 [NOTE] this report can be shown with `cargo report future-incompatibilities --id 1`
 
 "#]])
@@ -714,7 +714,7 @@ fix to the maintainers (e.g. by creating a pull request):
 section in `Cargo.toml` to use your own version of the dependency. For more
 information, see:
 https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section
-        
+
 [NOTE] this report can be shown with `cargo report future-incompatibilities --id 1`
 
 "#]])


### PR DESCRIPTION
This fixes various issues with the future-incompat report. In particular, it addresses the off-by-one for the `--id` flag when the report is already cached, and it doesn't recommend updating dependencies when the error comes from a local crate. See each commit for more details.

Fixes #15337