### PR TITLE
docs: fix typo in the "Shared cache" section

### DIFF
--- a/src/doc/src/reference/build-cache.md
+++ b/src/doc/src/reference/build-cache.md
@@ -83,7 +83,7 @@ A third party tool, [sccache], can be used to share built dependencies across
 different workspaces.
 
 To setup `sccache`, install it with `cargo install sccache` and set
-`RUSTC_WRAPPER` environmental variable to `sccache` before invoking Cargo. If
+`RUSTC_WRAPPER` environment variable to `sccache` before invoking Cargo. If
 you use bash, it makes sense to add `export RUSTC_WRAPPER=sccache` to
 `.bashrc`. Alternatively, you can set [`build.rustc-wrapper`] in the [Cargo
 configuration][config]. Refer to sccache documentation for more details.


### PR DESCRIPTION
### What does this PR try to resolve?  
This PR addresses a typo in the "Shared cache" section. The word "environmental" has been corrected to "environment" for proper grammar in the phrase:  
- "set `RUSTC_WRAPPER` environmental variable to `sccache`" → "set `RUSTC_WRAPPER` environment variable to `sccache`".

### How should we test and review this PR?  
Review the change in the relevant documentation section and verify that the typo has been corrected. No functional changes are involved.

### Additional information  
This is a simple grammar fix to ensure clarity in the documentation.