### PR TITLE
Temporarily ignore cargo_test_doctest_xcompile_ignores

### DIFF
--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -4740,7 +4740,9 @@ fn test_dep_with_dev() {
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zdoctest-xcompile is unstable")]
+// #[cargo_test(nightly, reason = "-Zdoctest-xcompile is unstable")]
+#[cargo_test]
+#[ignore = "waiting for https://github.com/rust-lang/rust/pull/138877"]
 fn cargo_test_doctest_xcompile_ignores() {
     // -Zdoctest-xcompile also enables --enable-per-target-ignores which
     // allows the ignore-TARGET syntax.


### PR DESCRIPTION
This was broken due to a change in
https://github.com/rust-lang/rust/pull/138535. There is an approved PR in https://github.com/rust-lang/rust/pull/138877 to fix it, but it may take a day or two for it to make its way to nightly. This should be reverted after it hits nightly.
