### PR TITLE
docs(contrib): Expand the description of team meetings

### DIFF
--- a/src/doc/contrib/src/team.md
+++ b/src/doc/contrib/src/team.md
@@ -58,12 +58,28 @@ Members are given privileges, such as:
 
 ### Meetings
 
-The team meets on a weekly basis on a video chat.
-If you are interested in participating, feel free to contact us on [Zulip].
+The primary focus of team meetings is for unblocking designs, including discussing
+- [RFCs][t-cargo-rfcs]
+- [FCPs][cargo-status-tracker]
+- [Items marked **I-nominated-to-discuss**][i-nominated]
+- [Items marked **S-needs-team-input**][s-team-input]
+- Topics proposed on [Zulip][zulip-meeting], subject to availability
 
+Generally, topics for the agenda should be posted a day in advance to give people the opportunity to review them before the meeting.
+
+The team meets on a weekly basis ([ics][meeting-ics]) on a video chat.
+Members of the community are welcome to attend.
 Minutes for all meetings are recorded on [HackMD][meeting-minutes].
 
+For discussing contributions, [Office Hours](../process/index.md#mentorship) would be more appropriate venue.
+
+[t-cargo-rfcs]: https://github.com/rust-lang/rfcs/pulls?q=is%3Apr+is%3Aopen+label%3AT-cargo
+[cargo-status-tracker]: https://github.com/orgs/rust-lang/projects/47
+[i-nominated]: https://github.com/rust-lang/cargo/labels/I-nominated-to-discuss
+[s-team-input]: https://github.com/rust-lang/cargo/labels/S-needs-team-input
+[meeting-ics]: https://rust-lang.github.io/calendar/cargo/team-meeting.ics
 [meeting-minutes]: https://hackmd.io/@rust-cargo-team?tags=%5B%22meetings%22%5D
+[zulip-meeting]: https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/Cargo.20meeting
 
 ### Becoming a member
 


### PR DESCRIPTION
### What does this PR try to resolve?

The goal is to make Cargo team meetings more inviting.  This PR includes both the information for more people to attend while framing the purpose of the meeting to set appropriate expectations.

### How should we test and review this PR?



### Additional information

