### PR TITLE
Don't canonicalize executable path in `cargo_exe`

### DIFF
--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -181,12 +181,9 @@ fn custom_build_env_vars() {
         )
         .file("bar/src/lib.rs", "pub fn hello() {}");
 
-    let cargo = cargo_exe().canonicalize().unwrap();
+    let cargo = cargo_exe();
     let cargo = cargo.to_str().unwrap();
-    let rustc = paths::resolve_executable("rustc".as_ref())
-        .unwrap()
-        .canonicalize()
-        .unwrap();
+    let rustc = paths::resolve_executable("rustc".as_ref()).unwrap();
     let rustc = rustc.to_str().unwrap();
     let file_content = format!(
         r##"

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -375,7 +375,7 @@ fn cargo_subcommand_env() {
     p.cargo("build").run();
     assert!(p.bin("cargo-envtest").is_file());
 
-    let cargo = cargo_exe().canonicalize().unwrap();
+    let cargo = cargo_exe();
     let mut path = path();
     path.push(target_dir.clone());
     let path = env::join_paths(path.iter()).unwrap();
@@ -388,9 +388,7 @@ fn cargo_subcommand_env() {
     // Check that subcommands inherit an overridden $CARGO
     let envtest_bin = target_dir
         .join("cargo-envtest")
-        .with_extension(std::env::consts::EXE_EXTENSION)
-        .canonicalize()
-        .unwrap();
+        .with_extension(std::env::consts::EXE_EXTENSION);
     let envtest_bin = envtest_bin.to_str().unwrap();
     // Previously, `$CARGO` would be left at `envtest_bin`. However, with the
     // fix for #15099, `$CARGO` is now overwritten with the path to the current
@@ -623,8 +621,6 @@ fn overwrite_cargo_environment_variable() {
     let stderr_cargo = format!(
         "{}[EXE]\n",
         cargo_exe
-            .canonicalize()
-            .unwrap()
             .with_extension("")
             .to_str()
             .unwrap()
@@ -648,8 +644,6 @@ fn overwrite_cargo_environment_variable() {
     let stderr_other_cargo = format!(
         "{}[EXE]\n",
         other_cargo_path
-            .canonicalize()
-            .unwrap()
             .with_extension("")
             .to_str()
             .unwrap()

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -3890,8 +3890,6 @@ fn cargo_test_env() {
     let cargo = format!(
         "{}[EXE]",
         cargo_exe()
-            .canonicalize()
-            .unwrap()
             .with_extension("")
             .to_str()
             .unwrap()
@@ -3913,8 +3911,6 @@ test env_test ... ok
     let stderr_other_cargo = format!(
         "{}[EXE]",
         other_cargo_path
-            .canonicalize()
-            .unwrap()
             .with_extension("")
             .to_str()
             .unwrap()


### PR DESCRIPTION
### What does this PR try to resolve?

Follow up to #9991. The issue explains why but in short canonicalising executable paths causes issues for symlinks. It seems this was missed in #9991.

### How should we test and review this PR?

Note that the comment I deleted is wrong since #9991.

Running existing test should ensure this doesn't break anything.