### PR TITLE
rename the `author` field to be `authors` in book.toml

### DIFF
--- a/src/doc/book.toml
+++ b/src/doc/book.toml
@@ -1,6 +1,6 @@
 [book]
 title = "The Cargo Book"
-author = "Alex Crichton, Steve Klabnik and Carol Nichols, with contributions from the Rust community"
+authors = ["Alex Crichton", "Steve Klabnik", "Carol Nichols", "with contributions from the Rust community"]
 
 [output.html]
 smart-punctuation = true # Enable smart-punctuation feature for more than quotes.


### PR DESCRIPTION
See the [mdbook documentation](https://rust-lang.github.io/mdBook/format/configuration/general.html)
Apparently the `author` was field was [incorrect documentation](https://github.com/rust-lang/mdBook/issues/2623)