### PR TITLE
Rename the gc config table

### DIFF
--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1601,7 +1601,7 @@ cargo build -Zgc
 Automatic deletion happens on commands that are already doing a significant amount of work,
 such as all of the build commands (`cargo build`, `cargo test`, `cargo check`, etc.), and `cargo fetch`.
 The deletion happens just after resolution and packages have been downloaded.
-Automatic deletion is only done once per day (see `gc.auto.frequency` to configure).
+Automatic deletion is only done once per day (see `cache.auto-clean-frequency` to configure).
 Automatic deletion is disabled if cargo is offline such as with `--offline` or `--frozen` to avoid deleting artifacts that may need to be used if you are offline for a long period of time.
 
 #### Automatic gc configuration
@@ -1612,11 +1612,14 @@ The settings available are:
 ```toml
 # Example config.toml file.
 
-# This table defines the behavior for automatic garbage collection.
-[gc.auto]
-# The maximum frequency that automatic garbage collection happens.
-# Can be "never" to disable automatic-gc, or "always" to run on every command.
-frequency = "1 day"
+# This table defines settings for cargo's caches.
+[cache]
+# The maximum frequency that automatic cleaning of the cache happens.
+# Can be "never" to disable, or "always" to run on every command.
+auto-clean-frequency = "1 day"
+
+# Sub-table for defining specific settings for cleaning the global cache.
+[cache.global-clean]
 # Anything older than this duration will be deleted in the source cache.
 max-src-age = "1 month"
 # Anything older than this duration will be deleted in the compressed crate cache.

--- a/tests/testsuite/global_cache_tracker.rs
+++ b/tests/testsuite/global_cache_tracker.rs
@@ -338,8 +338,9 @@ fn auto_gc_config() {
         .file(
             ".cargo/config.toml",
             r#"
-                [gc.auto]
-                frequency = "always"
+                [cache]
+                auto-clean-frequency = "always"
+                [cache.global-clean]
                 max-src-age = "1 day"
                 max-crate-age = "3 days"
                 max-index-age = "3 days"
@@ -407,13 +408,13 @@ fn auto_gc_config() {
 
 #[cargo_test]
 fn frequency() {
-    // gc.auto.frequency settings
+    // cache.auto-clean-frequency settings
     let p = basic_foo_bar_project();
     p.change_file(
         ".cargo/config.toml",
         r#"
-            [gc.auto]
-            frequency = "never"
+            [cache]
+            auto-clean-frequency = "never"
         "#,
     );
     // Populate data in the past.
@@ -437,7 +438,7 @@ fn frequency() {
 
     // Try again with a setting that allows it to run.
     p.cargo("check -Zgc")
-        .env("CARGO_GC_AUTO_FREQUENCY", "1 day")
+        .env("CARGO_CACHE_AUTO_CLEAN_FREQUENCY", "1 day")
         .masquerade_as_nightly_cargo(&["gc"])
         .run();
     assert_eq!(get_index_names().len(), 0);
@@ -1258,7 +1259,7 @@ fn package_cache_lock_during_build() {
     p_foo2
         .cargo("check -Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
-        .env("CARGO_GC_AUTO_FREQUENCY", "always")
+        .env("CARGO_CACHE_AUTO_CLEAN_FREQUENCY", "always")
         .env("CARGO_LOG", "gc=debug")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index


### PR DESCRIPTION
This renames the gc config table to `[cache]` to help avoid some confusion, and to set up a namespace for possible expansion in the future for different kind of cache controls.

Low-level settings are stuffed into the `[cache.global-clean]` table, but we do not expect to stabilize these at this time. Only the top-level `cache.auto-clean-frequency` setting is expected to be stabilized.

Closes https://github.com/rust-lang/cargo/issues/14292
