### PR TITLE
Prevent undeclared public network access

### DIFF
--- a/tests/testsuite/cargo_add/add_no_vendored_package_with_vendor/mod.rs
+++ b/tests/testsuite/cargo_add/add_no_vendored_package_with_vendor/mod.rs
@@ -7,6 +7,7 @@ use cargo_test_support::Project;
 
 #[cargo_test]
 fn case() {
+    cargo_test_support::registry::init();
     let project = Project::from_template(current_dir!().join("in"));
     let project_root = project.root();
     let cwd = &project_root;

--- a/tests/testsuite/cargo_add/add_toolchain/mod.rs
+++ b/tests/testsuite/cargo_add/add_toolchain/mod.rs
@@ -7,6 +7,7 @@ use cargo_test_support::Project;
 
 #[cargo_test]
 fn case() {
+    cargo_test_support::registry::init();
     let project = Project::from_template(current_dir!().join("in"));
     let project_root = project.root();
     let cwd = &project_root;

--- a/tests/testsuite/cargo_add/dev_existing_path_base/mod.rs
+++ b/tests/testsuite/cargo_add/dev_existing_path_base/mod.rs
@@ -7,6 +7,7 @@ use cargo_test_support::Project;
 
 #[cargo_test]
 fn case() {
+    cargo_test_support::registry::init();
     let project = Project::from_template(current_dir!().join("in"));
     let project_root = project.root();
     let cwd = project_root.join("primary");

--- a/tests/testsuite/cargo_add/invalid_key_inherit_dependency/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_key_inherit_dependency/mod.rs
@@ -7,6 +7,7 @@ use cargo_test_support::Project;
 
 #[cargo_test]
 fn case() {
+    cargo_test_support::registry::init();
     let project = Project::from_template(current_dir!().join("in"));
     let project_root = project.root();
     let cwd = &project_root;

--- a/tests/testsuite/cargo_add/invalid_key_overwrite_inherit_dependency/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_key_overwrite_inherit_dependency/mod.rs
@@ -7,6 +7,7 @@ use cargo_test_support::Project;
 
 #[cargo_test]
 fn case() {
+    cargo_test_support::registry::init();
     let project = Project::from_template(current_dir!().join("in"));
     let project_root = project.root();
     let cwd = &project_root;

--- a/tests/testsuite/cargo_add/invalid_key_rename_inherit_dependency/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_key_rename_inherit_dependency/mod.rs
@@ -7,6 +7,7 @@ use cargo_test_support::Project;
 
 #[cargo_test]
 fn case() {
+    cargo_test_support::registry::init();
     let project = Project::from_template(current_dir!().join("in"));
     let project_root = project.root();
     let cwd = &project_root;

--- a/tests/testsuite/cargo_add/merge_activated_features/mod.rs
+++ b/tests/testsuite/cargo_add/merge_activated_features/mod.rs
@@ -7,6 +7,7 @@ use cargo_test_support::Project;
 
 #[cargo_test]
 fn case() {
+    cargo_test_support::registry::init();
     let project = Project::from_template(current_dir!().join("in"));
     let project_root = project.root();
     let cwd = &project_root;

--- a/tests/testsuite/cargo_add/normalize_name_path_existing/mod.rs
+++ b/tests/testsuite/cargo_add/normalize_name_path_existing/mod.rs
@@ -7,6 +7,7 @@ use cargo_test_support::Project;
 
 #[cargo_test]
 fn case() {
+    cargo_test_support::registry::init();
     let project = Project::from_template(current_dir!().join("in"));
     let project_root = project.root();
     let cwd = &project_root;

--- a/tests/testsuite/cargo_add/normalize_name_path_existing/stderr.term.svg
+++ b/tests/testsuite/cargo_add/normalize_name_path_existing/stderr.term.svg
@@ -19,7 +19,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> crates.io index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the crate `fuzzy-name` could not be found in registry index.</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/path_base/mod.rs
+++ b/tests/testsuite/cargo_add/path_base/mod.rs
@@ -7,6 +7,7 @@ use cargo_test_support::Project;
 
 #[cargo_test]
 fn case() {
+    cargo_test_support::registry::init();
     let project = Project::from_template(current_dir!().join("in"));
     let project_root = project.root();
     let cwd = project_root.join("primary");

--- a/tests/testsuite/cargo_add/path_base_inferred_name/mod.rs
+++ b/tests/testsuite/cargo_add/path_base_inferred_name/mod.rs
@@ -7,6 +7,7 @@ use cargo_test_support::Project;
 
 #[cargo_test]
 fn case() {
+    cargo_test_support::registry::init();
     let project = Project::from_template(current_dir!().join("in"));
     let project_root = project.root();
     let cwd = project_root.join("primary");

--- a/tests/testsuite/cargo_add/path_base_missing_base_path/mod.rs
+++ b/tests/testsuite/cargo_add/path_base_missing_base_path/mod.rs
@@ -7,6 +7,7 @@ use cargo_test_support::Project;
 
 #[cargo_test]
 fn case() {
+    cargo_test_support::registry::init();
     let project = Project::from_template(current_dir!().join("in"));
     let project_root = project.root();
     let cwd = project_root.join("primary");

--- a/tests/testsuite/cargo_add/path_base_unstable/mod.rs
+++ b/tests/testsuite/cargo_add/path_base_unstable/mod.rs
@@ -7,6 +7,7 @@ use cargo_test_support::Project;
 
 #[cargo_test]
 fn case() {
+    cargo_test_support::registry::init();
     let project = Project::from_template(current_dir!().join("in"));
     let project_root = project.root();
     let cwd = project_root.join("primary");

--- a/tests/testsuite/cargo_add/unknown_inherited_feature/mod.rs
+++ b/tests/testsuite/cargo_add/unknown_inherited_feature/mod.rs
@@ -7,6 +7,7 @@ use cargo_test_support::Project;
 
 #[cargo_test]
 fn case() {
+    cargo_test_support::registry::init();
     let project = Project::from_template(current_dir!().join("in"));
     let project_root = project.root();
     let cwd = &project_root;

--- a/tests/testsuite/cargo_info/specify_empty_version_with_url/mod.rs
+++ b/tests/testsuite/cargo_info/specify_empty_version_with_url/mod.rs
@@ -1,8 +1,11 @@
 use cargo_test_support::prelude::*;
 use cargo_test_support::{file, registry::RegistryBuilder};
 
+use super::init_registry_without_token;
+
 #[cargo_test]
 fn case() {
+    init_registry_without_token();
     let _ = RegistryBuilder::new()
         .alternative()
         .no_configure_token()

--- a/tests/testsuite/cargo_info/specify_version_with_url_but_registry_is_not_matched/mod.rs
+++ b/tests/testsuite/cargo_info/specify_version_with_url_but_registry_is_not_matched/mod.rs
@@ -1,8 +1,11 @@
 use cargo_test_support::prelude::*;
 use cargo_test_support::{file, registry::RegistryBuilder};
 
+use super::init_registry_without_token;
+
 #[cargo_test]
 fn case() {
+    init_registry_without_token();
     let _ = RegistryBuilder::new()
         .alternative()
         .no_configure_token()

--- a/tests/testsuite/cargo_info/within_ws_with_alternative_registry/mod.rs
+++ b/tests/testsuite/cargo_info/within_ws_with_alternative_registry/mod.rs
@@ -2,8 +2,11 @@ use cargo_test_support::prelude::*;
 use cargo_test_support::{compare::assert_ui, registry::RegistryBuilder, Project};
 use cargo_test_support::{current_dir, file};
 
+use super::init_registry_without_token;
+
 #[cargo_test]
 fn case() {
+    init_registry_without_token();
     let _ = RegistryBuilder::new()
         .alternative()
         .no_configure_token()

--- a/tests/testsuite/cargo_info/within_ws_with_alternative_registry/stderr.term.svg
+++ b/tests/testsuite/cargo_info/within_ws_with_alternative_registry/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> crates.io index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">    Updating</tspan><tspan> `alternative` index</tspan>
 </tspan>

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -6065,6 +6065,7 @@ src/main.rs
 
 #[cargo_test]
 fn workspace_with_local_deps_index_mismatch() {
+    registry::init();
     let alt_reg = registry::RegistryBuilder::new()
         .http_api()
         .http_index()
@@ -6123,12 +6124,12 @@ fn workspace_with_local_deps_index_mismatch() {
 [PACKAGING] level2 v0.0.1 ([ROOT]/foo/level2)
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [PACKAGING] level1 v0.0.1 ([ROOT]/foo/level1)
-[UPDATING] crates.io index
+[UPDATING] `dummy-registry` index
 [ERROR] failed to prepare local package for uploading
 
 Caused by:
   no matching package named `level2` found
-  location searched: crates.io index
+  location searched: `dummy-registry` index (which is replacing registry `crates-io`)
   required by package `level1 v0.0.1 ([ROOT]/foo/level1)`
 
 "#]])


### PR DESCRIPTION
Stop a few tests which aren't marked with `public_network_test` from trying to access crates.io.
