### PR TITLE
fix(tree): Make output more deterministic

### DIFF
--- a/src/cargo/ops/tree/graph.rs
+++ b/src/cargo/ops/tree/graph.rs
@@ -478,7 +478,7 @@ fn add_pkg(
             continue;
         }
 
-        deps.sort_unstable_by_key(|dep| dep.name_in_toml());
+        deps.sort_unstable_by_key(|dep| (dep.kind(), dep.name_in_toml()));
         let dep_pkg = graph.package_map[&dep_id];
 
         for dep in deps {


### PR DESCRIPTION
### What does this PR try to resolve?
When you have a dependency show up in multiple dependency tables, the order they are processed was not deterministic. Its hard to predict the exact effects this was having (e.g. for writing tests for this) but changing this made #15366 not reproduce anymore for me.

I'm going to consier this as fixing #15366 mostly because how difficult it is to debug with the non-determinism.
If someone can find a case where this fails, at least it should now always fail and it should be easier to determine why.

Fixes #15366

### How should we test and review this PR?


### Additional information

