### PR TITLE
Add `http.proxy-cainfo` config for proxy certs

### DIFF
--- a/src/cargo/util/context/mod.rs
+++ b/src/cargo/util/context/mod.rs
@@ -2608,6 +2608,7 @@ pub struct CargoHttpConfig {
     pub low_speed_limit: Option<u32>,
     pub timeout: Option<u64>,
     pub cainfo: Option<ConfigRelativePath>,
+    pub proxy_cainfo: Option<ConfigRelativePath>,
     pub check_revoke: Option<bool>,
     pub user_agent: Option<String>,
     pub debug: Option<bool>,

--- a/src/cargo/util/network/http.rs
+++ b/src/cargo/util/network/http.rs
@@ -61,6 +61,10 @@ pub fn configure_http_handle(gctx: &GlobalContext, handle: &mut Easy) -> CargoRe
         let cainfo = cainfo.resolve_path(gctx);
         handle.cainfo(&cainfo)?;
     }
+    if let Some(proxy_cainfo) = &http.proxy_cainfo {
+        let proxy_cainfo = proxy_cainfo.resolve_path(gctx);
+        handle.proxy_cainfo(&format!("{}", proxy_cainfo.display()))?;
+    }
     if let Some(check) = http.check_revoke {
         handle.ssl_options(SslOpt::new().no_revoke(!check))?;
     }

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -107,6 +107,7 @@ ssl-version.min = "tlsv1.1" # minimum TLS version
 timeout = 30                # timeout for each HTTP request, in seconds
 low-speed-limit = 10        # network timeout threshold (bytes/sec)
 cainfo = "cert.pem"         # path to Certificate Authority (CA) bundle
+proxy-cainfo = "cert.pem"   # path to proxy Certificate Authority (CA) bundle
 check-revoke = true         # check for SSL certificate revocation
 multiplexing = true         # HTTP/2 multiplexing
 user-agent = "…"            # the user-agent header
@@ -707,6 +708,14 @@ Sets the timeout for each HTTP request, in seconds.
 
 Path to a Certificate Authority (CA) bundle file, used to verify TLS
 certificates. If not specified, Cargo attempts to use the system certificates.
+
+#### `http.proxy-cainfo`
+* Type: string (path)
+* Default: none
+* Environment: `CARGO_HTTP_PROXY_CAINFO`
+
+Path to a Certificate Authority (CA) bundle file, used to verify proxy TLS
+certificates.
 
 #### `http.check-revoke`
 * Type: boolean

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -105,6 +105,7 @@ In summary, the supported environment variables are:
 * `CARGO_HTTP_PROXY` --- Enables HTTP proxy, see [`http.proxy`].
 * `CARGO_HTTP_TIMEOUT` --- The HTTP timeout, see [`http.timeout`].
 * `CARGO_HTTP_CAINFO` --- The TLS certificate Certificate Authority file, see [`http.cainfo`].
+* `CARGO_HTTP_PROXY_CAINFO` --- The proxy TLS certificate Certificate Authority file, see [`http.proxy-cainfo`].
 * `CARGO_HTTP_CHECK_REVOKE` --- Disables TLS certificate revocation checks, see [`http.check-revoke`].
 * `CARGO_HTTP_SSL_VERSION` --- The TLS version to use, see [`http.ssl-version`].
 * `CARGO_HTTP_LOW_SPEED_LIMIT` --- The HTTP low-speed limit, see [`http.low-speed-limit`].
@@ -171,6 +172,7 @@ In summary, the supported environment variables are:
 [`http.proxy`]: config.md#httpproxy
 [`http.timeout`]: config.md#httptimeout
 [`http.cainfo`]: config.md#httpcainfo
+[`http.proxy-cainfo`]: config.md#httpproxy-cainfo
 [`http.check-revoke`]: config.md#httpcheck-revoke
 [`http.ssl-version`]: config.md#httpssl-version
 [`http.low-speed-limit`]: config.md#httplow-speed-limit


### PR DESCRIPTION
This adds a `http.proxy-cainfo` option to Cargo which reads CA information from a bundle to pass through to the underlying `libcurl` call. This should allow configuration of Cargo in situations where SSL proxy is used.

Similar to https://github.com/rust-lang/cargo/pull/2917.