### PR TITLE
Added `build_directory` field to cargo metadata output

### DIFF
--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -52,6 +52,11 @@ pub fn output_metadata(ws: &Workspace<'_>, opt: &OutputMetadataOptions) -> Cargo
             .collect(),
         resolve,
         target_directory: ws.target_dir().into_path_unlocked(),
+        build_directory: ws
+            .gctx()
+            .cli_unstable()
+            .build_dir
+            .then(|| ws.build_dir().into_path_unlocked()),
         version: VERSION,
         workspace_root: ws.root().to_path_buf(),
         metadata: ws.custom_metadata().cloned(),
@@ -68,6 +73,8 @@ pub struct ExportInfo {
     workspace_default_members: Vec<PackageIdSpec>,
     resolve: Option<MetadataResolve>,
     target_directory: PathBuf,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    build_directory: Option<PathBuf>,
     version: u32,
     workspace_root: PathBuf,
     metadata: Option<toml::Value>,

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -4312,6 +4312,7 @@ fn build_dir() {
         .with_stdout_data(
             str![[r#"
 {
+  "build_directory": "[ROOT]/foo/build-dir",
   "metadata": null,
   "packages": "{...}",
   "resolve": "{...}",

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -4294,6 +4294,43 @@ fn dep_kinds_workspace() {
         .run();
 }
 
+#[cargo_test]
+fn build_dir() {
+    let p = project()
+        .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [build]
+            build-dir = "build-dir"
+            "#,
+        )
+        .build();
+
+    p.cargo("metadata -Z build-dir")
+        .masquerade_as_nightly_cargo(&["build-dir"])
+        .with_stdout_data(
+            str![[r#"
+{
+  "metadata": null,
+  "packages": "{...}",
+  "resolve": "{...}",
+  "target_directory": "[ROOT]/foo/target",
+  "version": 1,
+  "workspace_default_members": [
+    "path+[ROOTURL]/foo#0.0.1"
+  ],
+  "workspace_members": [
+    "path+[ROOTURL]/foo#0.0.1"
+  ],
+  "workspace_root": "[ROOT]/foo"
+}
+"#]]
+            .is_json(),
+        )
+        .run();
+}
+
 // Creating non-utf8 path is an OS-specific pain, so let's run this only on
 // linux, where arbitrary bytes work.
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->

### What does this PR try to resolve?

This PR continues on the build-dir work laid in #14125. (see [this](https://github.com/rust-lang/cargo/issues/14125#issuecomment-2751658701) comment)

We add a new `build_directory` field to the `cargo metadata` output when the `-Z build-dir` feature flag is enabled.

### How should we test and review this PR?

I added a test for metadata output when build-dir is set. There are already many existing tests that verify that build-dir is not included if `-Z build-dir` is not passed.

### Additional information

NOTE: I use `build_directory` instead of `build-dir` to match the existing `target_directory` field in the metadata output

r? @epage 