### PR TITLE
[stable-1.86] chore: bump cargo-util-schemas to 0.8.0 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Install cargo-semver-checks
         run: |
           mkdir installed-bins
-          curl -Lf https://github.com/obi1kenobi/cargo-semver-checks/releases/download/v0.36.0/cargo-semver-checks-x86_64-unknown-linux-gnu.tar.gz \
+          curl -Lf https://github.com/obi1kenobi/cargo-semver-checks/releases/download/v0.39.0/cargo-semver-checks-x86_64-unknown-linux-gnu.tar.gz \
             | tar -xz --directory=./installed-bins
           echo `pwd`/installed-bins >> $GITHUB_PATH
       - run: ci/validate-version-bump.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Install cargo-semver-checks
         run: |
           mkdir installed-bins
-          curl -Lf https://github.com/obi1kenobi/cargo-semver-checks/releases/download/v0.39.0/cargo-semver-checks-x86_64-unknown-linux-gnu.tar.gz \
+          curl -Lf https://github.com/obi1kenobi/cargo-semver-checks/releases/download/v0.40.0/cargo-semver-checks-x86_64-unknown-linux-gnu.tar.gz \
             | tar -xz --directory=./installed-bins
           echo `pwd`/installed-bins >> $GITHUB_PATH
       - run: ci/validate-version-bump.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cargo"
-version = "0.87.0"
+version = "0.87.1"
 dependencies = [
  "annotate-snippets",
  "anstream",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util-schemas"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "schemars",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ cargo-platform = { path = "crates/cargo-platform", version = "0.2.0" }
 cargo-test-macro = { version = "0.4.1", path = "crates/cargo-test-macro" }
 cargo-test-support = { version = "0.7.1", path = "crates/cargo-test-support" }
 cargo-util = { version = "0.2.19", path = "crates/cargo-util" }
-cargo-util-schemas = { version = "0.7.3", path = "crates/cargo-util-schemas" }
+cargo-util-schemas = { version = "0.8.0", path = "crates/cargo-util-schemas" }
 cargo_metadata = "0.19.1"
 clap = "4.5.28"
 clap_complete = { version = "4.5.44", features = ["unstable-dynamic"] }
@@ -135,7 +135,7 @@ self_named_module_files = "warn"
 
 [package]
 name = "cargo"
-version = "0.87.0"
+version = "0.87.1"
 edition.workspace = true
 license.workspace = true
 rust-version = "1.84"  # MSRV:1

--- a/crates/cargo-util-schemas/Cargo.toml
+++ b/crates/cargo-util-schemas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-util-schemas"
-version = "0.7.3"
+version = "0.8.0"
 rust-version = "1.84"  # MSRV:1
 edition.workspace = true
 license.workspace = true

--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -1341,7 +1341,7 @@ struct Foo;
 impl Trait for Foo {}
 
 fn main() {
-    let obj: Box<dyn Trait> = Box::new(Foo); // Error: cannot be made into an object
+    let obj: Box<dyn Trait> = Box::new(Foo); // Error: the trait `Trait` is not dyn compatible
 }
 ```
 


### PR DESCRIPTION
### What does this PR try to resolve?

This is needed because a type of public field has changed
but was overlooked and was SemVer breaking.

See also

* https://github.com/rust-lang/cargo/issues/15387#issuecomment-2779294952
* [#t-cargo > cargo-util-schemas@0.7.3 SemVer Violations](https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/cargo-util-schemas.400.2E7.2E3.20SemVer.20Violations)


These commit are cherry-picked in order to make CI happy:

* 62bd1ad4bd593d71cd6fd4abd244743af0077955
* 9946566ce4602685e0e10300f26efd905e7114b5
* 251a078d4dbefac5b23aa8de82529e56f6c5cda4
