### PR TITLE
chore: Bump cargo-util-schemas to 0.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util-schemas"
-version = "0.7.5"
+version = "0.8.0"
 dependencies = [
  "schemars",
  "semver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util-schemas"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "schemars",
  "semver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util-schemas"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "schemars",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ cargo-platform = { path = "crates/cargo-platform", version = "0.2.0" }
 cargo-test-macro = { version = "0.4.2", path = "crates/cargo-test-macro" }
 cargo-test-support = { version = "0.7.1", path = "crates/cargo-test-support" }
 cargo-util = { version = "0.2.20", path = "crates/cargo-util" }
-cargo-util-schemas = { version = "0.8.1", path = "crates/cargo-util-schemas" }
+cargo-util-schemas = { version = "0.8.2", path = "crates/cargo-util-schemas" }
 cargo_metadata = "0.19.1"
 clap = "4.5.28"
 clap_complete = { version = "4.5.44", features = ["unstable-dynamic"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ cargo-platform = { path = "crates/cargo-platform", version = "0.2.0" }
 cargo-test-macro = { version = "0.4.2", path = "crates/cargo-test-macro" }
 cargo-test-support = { version = "0.7.1", path = "crates/cargo-test-support" }
 cargo-util = { version = "0.2.20", path = "crates/cargo-util" }
-cargo-util-schemas = { version = "0.8.0", path = "crates/cargo-util-schemas" }
+cargo-util-schemas = { version = "0.8.1", path = "crates/cargo-util-schemas" }
 cargo_metadata = "0.19.1"
 clap = "4.5.28"
 clap_complete = { version = "4.5.44", features = ["unstable-dynamic"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ cargo-platform = { path = "crates/cargo-platform", version = "0.2.0" }
 cargo-test-macro = { version = "0.4.2", path = "crates/cargo-test-macro" }
 cargo-test-support = { version = "0.7.1", path = "crates/cargo-test-support" }
 cargo-util = { version = "0.2.20", path = "crates/cargo-util" }
-cargo-util-schemas = { version = "0.7.4", path = "crates/cargo-util-schemas" }
+cargo-util-schemas = { version = "0.8.0", path = "crates/cargo-util-schemas" }
 cargo_metadata = "0.19.1"
 clap = "4.5.28"
 clap_complete = { version = "4.5.44", features = ["unstable-dynamic"] }

--- a/crates/cargo-util-schemas/Cargo.toml
+++ b/crates/cargo-util-schemas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-util-schemas"
-version = "0.7.5"
+version = "0.8.0"
 rust-version = "1.86"  # MSRV:1
 edition.workspace = true
 license.workspace = true

--- a/crates/cargo-util-schemas/Cargo.toml
+++ b/crates/cargo-util-schemas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-util-schemas"
-version = "0.8.1"
+version = "0.8.2"
 rust-version = "1.86"  # MSRV:1
 edition.workspace = true
 license.workspace = true

--- a/crates/cargo-util-schemas/Cargo.toml
+++ b/crates/cargo-util-schemas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-util-schemas"
-version = "0.8.0"
+version = "0.8.1"
 rust-version = "1.86"  # MSRV:1
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
### What does this PR try to resolve?

This is required due to a SemVer breaking change introduced in 0.7.3.

See

* <https://github.com/rust-lang/cargo/issues/15387>
* <https://github.com/rust-lang/cargo/pull/15397>
* <https://github.com/rust-lang/cargo/pull/15402>