### PR TITLE
docs: Remove statement that dep features are optional

### DIFF
--- a/src/doc/src/reference/registry-index.md
+++ b/src/doc/src/reference/registry-index.md
@@ -139,7 +139,6 @@ explaining the format of the entry.
             // https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html.
             "req": "^0.6",
             // Array of features (as strings) enabled for this dependency.
-            // May be omitted since Cargo 1.84.
             "features": ["i128_support"],
             // Boolean of whether or not this is an optional dependency.
             // Since Cargo 1.84, defaults to `false` if not specified.


### PR DESCRIPTION
I created my own registry by using a git repo and found that leaving the `features` in the dependencies in an index entry does not work. When a crate A has dependencies with features and you try to use it via the registry in crate B the build fails when A uses symbols only available by said features. 