### PR TITLE
Added validation for unmatched brackets in build-dir template

### DIFF
--- a/src/cargo/util/context/mod.rs
+++ b/src/cargo/util/context/mod.rs
@@ -687,6 +687,16 @@ impl GlobalContext {
                     } => anyhow!(
                         "unexpected variable `{variable}` in build.build-dir path `{raw_template}`"
                     ),
+                    path::ResolveTemplateError::UnexpectedBracket { bracket_type, raw_template } => {
+                        let (btype, literal) = match bracket_type {
+                            path::BracketType::Opening => ("opening", "{"),
+                            path::BracketType::Closing => ("closing", "}"),
+                        };
+
+                        anyhow!(
+                            "unexpected {btype} bracket `{literal}` in build.build-dir path `{raw_template}`"
+                        )
+                    }
                 })?;
 
             // Check if the target directory is set to an empty string in the config.toml file.

--- a/src/cargo/util/context/path.rs
+++ b/src/cargo/util/context/path.rs
@@ -58,6 +58,20 @@ impl ConfigRelativePath {
             });
         };
 
+        if value.contains("{") {
+            return Err(ResolveTemplateError::UnexpectedBracket {
+                bracket_type: BracketType::Opening,
+                raw_template: self.0.val.clone(),
+            });
+        }
+
+        if value.contains("}") {
+            return Err(ResolveTemplateError::UnexpectedBracket {
+                bracket_type: BracketType::Closing,
+                raw_template: self.0.val.clone(),
+            });
+        }
+
         Ok(self.0.definition.root(gctx).join(&value))
     }
 
@@ -139,4 +153,14 @@ pub enum ResolveTemplateError {
         variable: String,
         raw_template: String,
     },
+    UnexpectedBracket {
+        bracket_type: BracketType,
+        raw_template: String,
+    },
+}
+
+#[derive(Debug)]
+pub enum BracketType {
+    Opening,
+    Closing,
 }

--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -685,7 +685,7 @@ fn template_workspace_path_hash_should_handle_symlink() {
 }
 
 #[cargo_test]
-fn template_should_handle_ignore_unmatched_brackets() {
+fn template_should_handle_reject_unmatched_brackets() {
     let p = project()
         .file("src/lib.rs", "")
         .file(
@@ -699,6 +699,11 @@ fn template_should_handle_ignore_unmatched_brackets() {
 
     p.cargo("build -Z build-dir")
         .masquerade_as_nightly_cargo(&["build-dir"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] unexpected opening bracket `{` in build.build-dir path `foo/{bar`
+
+"#]])
         .run();
 
     let p = project()
@@ -714,6 +719,11 @@ fn template_should_handle_ignore_unmatched_brackets() {
 
     p.cargo("build -Z build-dir")
         .masquerade_as_nightly_cargo(&["build-dir"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] unexpected closing bracket `}` in build.build-dir path `foo/}bar`
+
+"#]])
         .run();
 }
 

--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -684,6 +684,39 @@ fn template_workspace_path_hash_should_handle_symlink() {
     }
 }
 
+#[cargo_test]
+fn template_should_handle_ignore_unmatched_brackets() {
+    let p = project()
+        .file("src/lib.rs", "")
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [build]
+            build-dir = "foo/{bar"
+            "#,
+        )
+        .build();
+
+    p.cargo("build -Z build-dir")
+        .masquerade_as_nightly_cargo(&["build-dir"])
+        .run();
+
+    let p = project()
+        .file("src/lib.rs", "")
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [build]
+            build-dir = "foo/}bar"
+            "#,
+        )
+        .build();
+
+    p.cargo("build -Z build-dir")
+        .masquerade_as_nightly_cargo(&["build-dir"])
+        .run();
+}
+
 fn parse_workspace_manifest_path_hash(hash_dir: &PathBuf) -> PathBuf {
     // Since the hash will change between test runs simply find the first directories and assume
     // that is the hash dir. The format is a 2 char directory followed by the remaining hash in the


### PR DESCRIPTION
### What does this PR try to resolve?

This PR adds validation for unmatched brackets (which are used for template variables) in `build.build-dir` paths.

See https://github.com/rust-lang/cargo/issues/14125#issuecomment-2790803287 in  #14125

