### PR TITLE
fix(package): detect dirtiness for symlinks to submodule 

### DIFF
--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1463,13 +1463,16 @@ fn dirty_file_outside_pkg_root_inside_submodule() {
     p.symlink("submodule/file.txt", "isengard/src/file.txt");
     git::add(&repo);
     git::commit(&repo);
-    // This dirtyness should be detected in the future.
     p.change_file("submodule/file.txt", "changed");
 
     p.cargo("package --workspace --no-verify")
+        .with_status(101)
         .with_stderr_data(str![[r#"
-[PACKAGING] isengard v0.0.0 ([ROOT]/foo/isengard)
-[PACKAGED] 6 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[ERROR] 1 files in the working directory contain changes that were not yet committed into git:
+
+submodule/file.txt
+
+to proceed despite this and include the uncommitted changes, pass the `--allow-dirty` flag
 
 "#]])
         .run();

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1426,6 +1426,56 @@ edition = "2021"
 }
 
 #[cargo_test]
+fn dirty_file_outside_pkg_root_inside_submodule() {
+    if !symlink_supported() {
+        return;
+    }
+    let (p, repo) = git::new_repo("foo", |p| {
+        p.file(
+            "Cargo.toml",
+            r#"
+                [workspace]
+                members = ["isengard"]
+                resolver = "2"
+            "#,
+        )
+        .file(
+            "isengard/Cargo.toml",
+            r#"
+                [package]
+                name = "isengard"
+                edition = "2015"
+                homepage = "saruman"
+                description = "saruman"
+                license = "ISC"
+            "#,
+        )
+        .file("isengard/src/lib.rs", "")
+    });
+    let submodule = git::new("submodule", |p| {
+        p.no_manifest().file("file.txt", "from-submodule")
+    });
+    git::add_submodule(
+        &repo,
+        &submodule.root().to_url().to_string(),
+        Path::new("submodule"),
+    );
+    p.symlink("submodule/file.txt", "isengard/src/file.txt");
+    git::add(&repo);
+    git::commit(&repo);
+    // This dirtyness should be detected in the future.
+    p.change_file("submodule/file.txt", "changed");
+
+    p.cargo("package --workspace --no-verify")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] attempt to get status of nonexistent file 'submodule/file.txt'; class=Invalid (3); code=NotFound (-3)
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn issue_13695_allow_dirty_vcs_info() {
     let p = project()
         .file(

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1467,9 +1467,9 @@ fn dirty_file_outside_pkg_root_inside_submodule() {
     p.change_file("submodule/file.txt", "changed");
 
     p.cargo("package --workspace --no-verify")
-        .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] attempt to get status of nonexistent file 'submodule/file.txt'; class=Invalid (3); code=NotFound (-3)
+[PACKAGING] isengard v0.0.0 ([ROOT]/foo/isengard)
+[PACKAGED] 6 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 
 "#]])
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

If a there is a symlink into a git repository/submodule,
when checking its git status with the wrong outer repo,
we'll get an NotFound error,
as the object doesn't belong to the outer repository.
This kind of error blocked the entire `cargo package` operation.

This fix additionally discovers the nearest Git repository,
and then checks status with that,
assuming the repo is the parent of the source file of the symlink.
This is a best effort solution, so if the check fails we ignore.

### How should we test and review this PR?

If we don't want the complication,
we could drop the last commit, ignore the error, and forget about handling submodules

fixes #15384
fixes #15413
