### PR TITLE
use `zlib-rs` for gzip compression in rust code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,12 +1140,12 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
- "libz-sys",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -2598,6 +2598,15 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6489ca9bd760fe9642d7644e827b0c9add07df89857b0416ee15c1cc1a3b8c5a"
+dependencies = [
+ "zlib-rs",
 ]
 
 [[package]]
@@ -4805,3 +4814,9 @@ dependencies = [
  "quote",
  "syn 2.0.98",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "868b928d7949e09af2f6086dfc1e01936064cc7a819253bce650d4e2a2d63ba8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ criterion = { version = "0.5.1", features = ["html_reports"] }
 curl = "0.4.47"
 curl-sys = "0.4.79"
 filetime = "0.2.25"
-flate2 = { version = "1.0.35", default-features = false, features = ["zlib"] }
+flate2 = { version = "1.1.1", default-features = false, features = ["zlib-rs"] }
 git2 = "0.20.0"
 git2-curl = "0.21.0"
 gix = { version = "0.70.0", default-features = false, features = ["blocking-http-transport-curl", "progress-tree", "parallel", "dirwalk"] }

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The build will automatically use vendored versions of the following libraries. H
 * [`libcurl`](https://curl.se/libcurl/) — Used for network transfers.
 * [`libgit2`](https://libgit2.org/) — Used for fetching git dependencies.
 * [`libssh2`](https://www.libssh2.org/) — Used for SSH access to git repositories.
-* [`libz`](https://zlib.net/) (aka zlib) — Used for data compression.
+* [`libz`](https://zlib.net/) (AKA zlib) — Used by the above C libraries for data compression. (Rust code uses [`zlib-rs`](https://github.com/trifectatechfoundation/zlib-rs) instead.)
 
 It is recommended to use the vendored versions as they are the versions that are tested to work with Cargo.
 

--- a/src/doc/src/reference/features.md
+++ b/src/doc/src/reference/features.md
@@ -187,7 +187,7 @@ The [`default` features](#the-default-feature) can be disabled using
 
 ```toml
 [dependencies]
-flate2 = { version = "1.0.3", default-features = false, features = ["zlib"] }
+flate2 = { version = "1.0.3", default-features = false, features = ["zlib-rs"] }
 ```
 
 > **Note**: This may not ensure the default features are disabled. If another


### PR DESCRIPTION
### What does this PR try to resolve?

This PR uses `zlib-rs` via the `flate2` crate. It is used for (de)compressing gzip files (e.g. in `cargo package`). 

Using zlib-rs is significantly faster, and produces output of roughly similar size. For the `windows-bindgen` crate 
(a very large crate), the speedup is over 60%, or about 2 seconds.

```
> time cargo package -p windows-bindgen --no-verify
   Packaging windows-bindgen v0.61.0 (/home/folkertdev/rust/windows-rs/crates/libs/bindgen)
    Updating crates.io index
    Packaged 76 files, 31.2MiB (8.2MiB compressed)

________________________________________________________
Executed in    3.30 secs    fish           external
   usr time    3.19 secs  424.00 micros    3.19 secs
   sys time    0.05 secs   61.00 micros    0.05 secs

> time ~/rust/cargo/target/release/cargo package -p windows-bindgen --no-verify
   Packaging windows-bindgen v0.61.0 (/home/folkertdev/rust/windows-rs/crates/libs/bindgen)
    Updating crates.io index
    Packaged 76 files, 31.2MiB (8.3MiB compressed)

________________________________________________________
Executed in    1.25 secs    fish           external
   usr time    1.15 secs    0.00 micros    1.15 secs
   sys time    0.04 secs  589.00 micros    0.04 secs
```

### How should we test and review this PR?

Generally CI/the test suite should handle correctness.

Something to look out for is zlib-rs producing larger binaries than before. So far we're seeing output sizes that are roughly the same (sometimes a bit better, sometimes a bit worse) as the status quo.

We've not specifically looked at decompression yet, mostly because we could not come up with a good command to benchmark. In general zlib-rs is much faster than stock zlib there too.

### Additional information

For the time being, `cargo` still depends on stock zlib via e.g. `curl` and `git`. As far as I know it is the intention to eventually move away from these C dependencies, at which point the dependency on stock zlib also disappears.