### PR TITLE
Improved error message when build-dir template var is invalid

### DIFF
--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -512,6 +512,8 @@ fn template_should_error_for_invalid_variables() {
         .with_stderr_data(str![[r#"
 [ERROR] unexpected variable `fake` in build.build-dir path `{fake}/build-dir`
 
+[HELP] available template variables are `{workspace-root}`, `{cargo-cache-home}`, `{workspace-path-hash}`
+
 "#]])
         .run();
 }
@@ -534,6 +536,8 @@ fn template_should_suggest_nearest_variable() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] unexpected variable `workspace-ro` in build.build-dir path `{workspace-ro}/build-dir`
+
+[HELP] a template variable with a similar name exists: `workspace-root`
 
 "#]])
         .run();

--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -517,6 +517,29 @@ fn template_should_error_for_invalid_variables() {
 }
 
 #[cargo_test]
+fn template_should_suggest_nearest_variable() {
+    let p = project()
+        .file("src/lib.rs", "")
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [build]
+            build-dir = "{workspace-ro}/build-dir"
+            "#,
+        )
+        .build();
+
+    p.cargo("build -Z build-dir")
+        .masquerade_as_nightly_cargo(&["build-dir"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] unexpected variable `workspace-ro` in build.build-dir path `{workspace-ro}/build-dir`
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn template_workspace_root() {
     let p = project()
         .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)


### PR DESCRIPTION
### What does this PR try to resolve?

This PR improves the error message when an invalid template variable is used in the `build.build-dir` config.
I am using `closest_msg` to find a close match. If there are no close matches, we simply print the available template variables list. 

See #14125

r? @epage 