### PR TITLE
fix(unit-graph): switch to Package ID Spec

### DIFF
--- a/src/cargo/core/compiler/unit_graph.rs
+++ b/src/cargo/core/compiler/unit_graph.rs
@@ -2,10 +2,12 @@
 //!
 //! [`--unit-graph`]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#unit-graph
 
+use cargo_util_schemas::core::PackageIdSpec;
+
 use crate::core::compiler::Unit;
 use crate::core::compiler::{CompileKind, CompileMode};
 use crate::core::profiles::{Profile, UnitFor};
-use crate::core::{PackageId, Target};
+use crate::core::Target;
 use crate::util::interning::InternedString;
 use crate::util::CargoResult;
 use crate::GlobalContext;
@@ -47,7 +49,7 @@ struct SerializedUnitGraph<'a> {
 
 #[derive(serde::Serialize)]
 struct SerializedUnit<'a> {
-    pkg_id: PackageId,
+    pkg_id: PackageIdSpec,
     target: &'a Target,
     profile: &'a Profile,
     platform: CompileKind,
@@ -109,7 +111,7 @@ pub fn emit_serialized_unit_graph(
                 })
                 .collect();
             SerializedUnit {
-                pkg_id: unit.pkg.package_id(),
+                pkg_id: unit.pkg.package_id().to_spec(),
                 target: &unit.target,
                 profile: &unit.profile,
                 platform: unit.kind,

--- a/tests/testsuite/unit_graph.rs
+++ b/tests/testsuite/unit_graph.rs
@@ -68,7 +68,7 @@ fn simple() {
         "feata"
       ],
       "mode": "build",
-      "pkg_id": "a 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+      "pkg_id": "registry+https://github.com/rust-lang/crates.io-index#a@1.0.0",
       "platform": null,
       "profile": {
         "codegen_backend": null,
@@ -113,7 +113,7 @@ fn simple() {
         "featb"
       ],
       "mode": "build",
-      "pkg_id": "b 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+      "pkg_id": "registry+https://github.com/rust-lang/crates.io-index#b@1.0.0",
       "platform": null,
       "profile": {
         "codegen_backend": null,
@@ -151,7 +151,7 @@ fn simple() {
         "featc"
       ],
       "mode": "build",
-      "pkg_id": "c 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+      "pkg_id": "registry+https://github.com/rust-lang/crates.io-index#c@1.0.0",
       "platform": null,
       "profile": {
         "codegen_backend": null,
@@ -194,7 +194,7 @@ fn simple() {
       ],
       "features": [],
       "mode": "build",
-      "pkg_id": "foo 0.1.0 (path+[ROOTURL]/foo)",
+      "pkg_id": "path+[ROOTURL]/foo#0.1.0",
       "platform": null,
       "profile": {
         "codegen_backend": null,


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes #15445, where there were still differences between the format of package ids of "`cargo metadata` and build JSON messages", and `--unit-graph` package ids.

### How should we test and review this PR?

Everything compiles correctly (and outputs what's expected). I also fixed the testcases


