### PR TITLE
Update doctest xcompile flags

### DIFF
--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -238,12 +238,10 @@ fn run_doc_tests(
         }
 
         if doctest_xcompile {
-            p.arg("-Zunstable-options");
-            p.arg("--enable-per-target-ignores");
             if let Some((runtool, runtool_args)) = compilation.target_runner(unit.kind) {
-                p.arg("--runtool").arg(runtool);
+                p.arg("--test-runtool").arg(runtool);
                 for arg in runtool_args {
-                    p.arg("--runtool-arg").arg(arg);
+                    p.arg("--test-runtool-arg").arg(arg);
                 }
             }
             if let Some(linker) = linker {

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -285,8 +285,7 @@ This flag changes `cargo test`'s behavior when handling doctests when
 a target is passed. Currently, if a target is passed that is different
 from the host cargo will simply skip testing doctests. If this flag is
 present, cargo will continue as normal, passing the tests to doctest,
-while also passing it a `--target` option, as well as enabling
-`-Zunstable-features --enable-per-target-ignores` and passing along
+while also passing it a `--target` option, as well as passing along
 information from `.cargo/config.toml`. See the rustc issue for more information.
 
 ```sh

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -4738,8 +4738,7 @@ fn test_dep_with_dev() {
 
 #[cargo_test(nightly, reason = "-Zdoctest-xcompile is unstable")]
 fn cargo_test_doctest_xcompile_ignores() {
-    // -Zdoctest-xcompile also enables --enable-per-target-ignores which
-    // allows the ignore-TARGET syntax.
+    // Test for `ignore-...` syntax with -Zdoctest-xcompile.
     let p = project()
         .file("Cargo.toml", &basic_lib_manifest("foo"))
         .file(
@@ -4766,15 +4765,15 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
         .run();
     #[cfg(target_arch = "x86_64")]
     p.cargo("test")
-        .with_status(101)
         .with_stdout_data(str![[r#"
 ...
-test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in [ELAPSED]s
+test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in [ELAPSED]s
 ...
-"#]],
-        )
+"#]])
         .run();
 
+    // Should be the same with or without -Zdoctest-xcompile because `ignore-`
+    // syntax is always enabled.
     #[cfg(not(target_arch = "x86_64"))]
     p.cargo("test -Zdoctest-xcompile")
         .masquerade_as_nightly_cargo(&["doctest-xcompile"])


### PR DESCRIPTION
This updates the flags used for doctest xcompile to match the upstream changes in https://github.com/rust-lang/rust/pull/137096 which renamed and stabilized the flags.

This cannot be merged until after nightly is published tonight.