### PR TITLE
fix grammar, and remove confusing example

### DIFF
--- a/src/doc/src/reference/source-replacement.md
+++ b/src/doc/src/reference/source-replacement.md
@@ -27,10 +27,13 @@ dependencies], and private registry support is described in [the Registries
 chapter][registries].
 
 When using source replacement, running commands that need to
-contact the registry requires passing the `--registry` option. This helps avoid
+contact the registry directly[^1] requires passing the `--registry` option. This helps avoid
 any ambiguity about which registry to contact, and will use the authentication
 token for the specified registry.
 
+[^1]: Examples of such commands are in [Publishing Commands].
+
+[Publishing Commands]: ../commands/publishing-commands.md
 [overriding dependencies]: overriding-dependencies.md
 [registries]: registries.md
 

--- a/src/doc/src/reference/source-replacement.md
+++ b/src/doc/src/reference/source-replacement.md
@@ -26,7 +26,7 @@ dependencies through the usage of [the `[patch]` key][overriding
 dependencies], and private registry support is described in [the Registries
 chapter][registries].
 
-When using source replacement, running commands like `cargo publish` that need to
+When using source replacement, running commands that need to
 contact the registry requires passing the `--registry` option. This helps avoid
 any ambiguity about which registry to contact, and will use the authentication
 token for the specified registry.


### PR DESCRIPTION
Also, lots of commands need to contact the registry, so seeing an example gives me doubt.