### PR TITLE
Trivial tweaks to 'target_short_hash'

### DIFF
--- a/src/cargo/core/compiler/build_runner/compilation_files.rs
+++ b/src/cargo/core/compiler/build_runner/compilation_files.rs
@@ -199,8 +199,8 @@ impl<'a, 'gctx: 'a> CompilationFiles<'a, 'gctx> {
     }
 
     /// Gets the short hash based only on the `PackageId`.
-    /// Used for the metadata when `metadata` returns `None`.
-    pub fn target_short_hash(&self, unit: &Unit) -> String {
+    /// Used for the metadata when `c_extra_filename` returns `None`.
+    fn target_short_hash(&self, unit: &Unit) -> String {
         let hashable = unit.pkg.package_id().stable_hash(self.ws.root());
         util::short_hash(&(METADATA_VERSION, hashable))
     }


### PR DESCRIPTION
### What does this PR try to resolve?

The `target_short_hash` function is a fallback used by the `pkg_dir` function for units that should not generate `-C extra-filename`.

This makes the function private since it would be easy to misuse and fixes an outdated method name in the doc comment.

### How should we test and review this PR?

Trivial.
