### PR TITLE
Added tracing spans for rustc invocations

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -67,7 +67,7 @@ use std::sync::Arc;
 
 use anyhow::{Context as _, Error};
 use lazycell::LazyCell;
-use tracing::{debug, trace};
+use tracing::{debug, instrument, trace};
 
 pub use self::build_config::{BuildConfig, CompileMode, MessageFormat, TimingOutput};
 pub use self::build_context::{
@@ -140,10 +140,11 @@ pub trait Executor: Send + Sync + 'static {
 pub struct DefaultExecutor;
 
 impl Executor for DefaultExecutor {
+    #[instrument(name = "rustc", skip_all, fields(package = id.name().as_str(), process = cmd.to_string()))]
     fn exec(
         &self,
         cmd: &ProcessBuilder,
-        _id: PackageId,
+        id: PackageId,
         _target: &Target,
         _mode: CompileMode,
         on_stdout_line: &mut dyn FnMut(&str) -> CargoResult<()>,


### PR DESCRIPTION
### What does this PR try to resolve?

While doing some investigation on the theoretical performance implications of #4282 (and #15010 by extension) I was profiling cargo with some experimental changes. (Still a work in progress)

But in the mean time, noticed that we do not have spans for rustc invocations. I think these would be useful when profiling `cargo build`. (`cargo build --timing` exists but is more geared towards debugging a slow building project, not cargo itself)

For reference below is an example before/after of a profile run of a dummy crate with a few random dependencies.

#### Before

![image](https://github.com/user-attachments/assets/710d1b93-133d-4826-9e7a-2deed876dbfa)

#### After

![image](https://github.com/user-attachments/assets/0f0ccad4-82b5-42ad-8762-6bd1dacecab4)

