### PR TITLE
Add $CARGO_PKG_AUTHORZ that separates the entries with \x01 instead of :

### DIFF
--- a/crates/build-rs-test-lib/build.rs
+++ b/crates/build-rs-test-lib/build.rs
@@ -50,6 +50,7 @@ fn smoke_test_inputs() {
     dbg!(cargo_manifest_path());
     dbg!(cargo_manifest_links());
     dbg!(cargo_pkg_authors());
+    dbg!(cargo_pkg_authorz());
     dbg!(cargo_pkg_description());
     dbg!(cargo_pkg_homepage());
     dbg!(cargo_pkg_license());

--- a/crates/build-rs/src/input.rs
+++ b/crates/build-rs/src/input.rs
@@ -568,6 +568,12 @@ pub fn cargo_pkg_authors() -> Vec<String> {
     to_strings(var_or_panic("CARGO_PKG_AUTHORS"), ':')
 }
 
+/// The authors from the manifest of your package.
+#[track_caller]
+pub fn cargo_pkg_authorz() -> Vec<String> {
+    to_strings(var_or_panic("CARGO_PKG_AUTHORS"), '\x01')
+}
+
 /// The name of your package.
 #[track_caller]
 pub fn cargo_pkg_name() -> String {

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -207,6 +207,7 @@ metadata_envs! {
     (license, "CARGO_PKG_LICENSE"),
     (license_file, "CARGO_PKG_LICENSE_FILE"),
     (authors, "CARGO_PKG_AUTHORS", |m: &ManifestMetadata| m.authors.join(":")),
+    (authors, "CARGO_PKG_AUTHORZ", |m: &ManifestMetadata| m.authors.join("\x01")),
     (rust_version, "CARGO_PKG_RUST_VERSION", |m: &ManifestMetadata| m.rust_version.as_ref().map(ToString::to_string).unwrap_or_default()),
     (readme, "CARGO_PKG_README"),
 }

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -235,6 +235,7 @@ corresponding environment variable is set to the empty string, `""`.
 * `CARGO_PKG_VERSION_PATCH` --- The patch version of your package.
 * `CARGO_PKG_VERSION_PRE` --- The pre-release version of your package.
 * `CARGO_PKG_AUTHORS` --- Colon separated list of authors from the manifest of your package.
+* `CARGO_PKG_AUTHORZ` --- `\x01` separated list of authors from the manifest of your package.
 * `CARGO_PKG_NAME` --- The name of your package.
 * `CARGO_PKG_DESCRIPTION` --- The description from the manifest of your package.
 * `CARGO_PKG_HOMEPAGE` --- The home page from the manifest of your package.

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -1789,12 +1789,18 @@ fn crate_authors_env_vars() {
                 extern crate foo;
 
                 static AUTHORS: &'static str = env!("CARGO_PKG_AUTHORS");
+                static AUTHORZ: &'static str = env!("CARGO_PKG_AUTHORZ");
 
                 fn main() {
                     let s = "wycats@example.com:neikos@example.com";
                     assert_eq!(AUTHORS, foo::authors());
                     println!("{}", AUTHORS);
                     assert_eq!(s, AUTHORS);
+
+                    let s = "wycats@example.com\x01neikos@example.com";
+                    assert_eq!(AUTHORZ, foo::authorz());
+                    println!("{}", AUTHORZ);
+                    assert_eq!(s, AUTHORZ);
                 }
             "#,
         )
@@ -1803,6 +1809,9 @@ fn crate_authors_env_vars() {
             r#"
                 pub fn authors() -> String {
                     format!("{}", env!("CARGO_PKG_AUTHORS"))
+                }
+                pub fn authorz() -> String {
+                    format!("{}", env!("CARGO_PKG_AUTHORZ"))
                 }
             "#,
         )


### PR DESCRIPTION
### What does this PR try to resolve?

Valid and reasonable authors entries like
```toml
authors = ["наб <nabijaczleweli@nabijaczleweli.xyz>",
           "nevsal",
           "Lynnesbian <https://fedi.lynnesbian.space/@lynnesbian>"]
```
become
```
наб <nabijaczleweli@nabijaczleweli.xyz>
nevsal
Lynnesbian <https
//fedi.lynnesbian.space/@lynnesbian>
```
with the standard `.replace(':', "\n")` treatment.

There's no reason to use `:` instead of something that's guaranteed to never be in the string. `\0` is unusable, so use `\1`.

### How should we test and review this PR?

```
$ cat src/main.rs
#[macro_use]
extern crate clap;
fn main() {
    println!("{}", env!("CARGO_PKG_AUTHORS"));
    println!("{}", env!("CARGO_PKG_AUTHORZ"));
    println!("{}", crate_authors!("\n"));
    println!("{}", env!("CARGO_PKG_AUTHORZ").replace('\x01', "\n"));
}

$ cat Cargo.toml
[package]
name = "b"
version = "0.1.0"
authors = ["наб <nabijaczleweli@nabijaczleweli.xyz>",
           "nevsal",
           "Lynnesbian <https://fedi.lynnesbian.space/@lynnesbian>"]

[dependencies.clap]
version = "3.2"
features = ["cargo"]

$ ../cargo/target/debug/cargo run
наб <nabijaczleweli@nabijaczleweli.xyz>:nevsal:Lynnesbian <https://fedi.lynnesbian.space/@lynnesbian>
наб <nabijaczleweli@nabijaczleweli.xyz>nevsalLynnesbian <https://fedi.lynnesbian.space/@lynnesbian>
наб <nabijaczleweli@nabijaczleweli.xyz>
nevsal
Lynnesbian <https
//fedi.lynnesbian.space/@lynnesbian>
наб <nabijaczleweli@nabijaczleweli.xyz>
nevsal
Lynnesbian <https://fedi.lynnesbian.space/@lynnesbian>

$ ../cargo/target/debug/cargo run | cat -A
warning: no edition set: defaulting to the 2015 edition while the latest is 2024
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.21s
     Running `target/debug/b`
M-PM-=M-PM-0M-PM-1 <nabijaczleweli@nabijaczleweli.xyz>:nevsal:Lynnesbian <https://fedi.lynnesbian.space/@lynnesbian>$
M-PM-=M-PM-0M-PM-1 <nabijaczleweli@nabijaczleweli.xyz>^Anevsal^ALynnesbian <https://fedi.lynnesbian.space/@lynnesbian>$
M-PM-=M-PM-0M-PM-1 <nabijaczleweli@nabijaczleweli.xyz>$
nevsal$
Lynnesbian <https$
//fedi.lynnesbian.space/@lynnesbian>$
M-PM-=M-PM-0M-PM-1 <nabijaczleweli@nabijaczleweli.xyz>$
nevsal$
Lynnesbian <https://fedi.lynnesbian.space/@lynnesbian>$
```

### Additional information

Downstream report: https://github.com/nabijaczleweli/cargo-update/issues/294