### PR TITLE
Update fingerprint footnote

### DIFF
--- a/src/cargo/core/compiler/fingerprint/mod.rs
+++ b/src/cargo/core/compiler/fingerprint/mod.rs
@@ -89,7 +89,7 @@
 //! `[lints]` table[^6]                        | ✓           |                     |                        |
 //! `[lints.rust.unexpected_cfgs.check-cfg]`   | ✓           |                     |                        |
 //!
-//! [^1]: Build script and bin dependencies are not included.
+//! [^1]: Bin dependencies are not included.
 //!
 //! [^3]: See below for details on mtime tracking.
 //!


### PR DESCRIPTION
This was noted in https://github.com/rust-lang/cargo/issues/8140#issuecomment-2845741150 that it appeared outdated, and indeed this was changed in https://github.com/rust-lang/cargo/pull/6832.
