### PR TITLE
fix(install): check if git url contains a rev

### DIFF
--- a/src/workspace/parser/mod.rs
+++ b/src/workspace/parser/mod.rs
@@ -2407,16 +2407,6 @@ fn to_dependency_source_id<P: ResolveToPath + Clone>(
                 .or_else(|| orig.rev.clone().map(GitReference::Rev))
                 .unwrap_or(GitReference::DefaultBranch);
             let loc = git.into_url()?;
-
-            if let Some(fragment) = loc.fragment() {
-                let msg = format!(
-                    "URL fragment `#{fragment}` in git URL is ignored for dependency ({name_in_toml}). \
-                        If you were trying to specify a specific git revision, \
-                        use `rev = \"{fragment}\"` in the dependency declaration.",
-                );
-                manifest_ctx.warnings.push(msg);
-            }
-
             SourceId::for_git(&loc, reference)
         }
         (None, Some(path), _, _) => {

--- a/src/workspace/source_id.rs
+++ b/src/workspace/source_id.rs
@@ -217,7 +217,14 @@ impl SourceId {
 
     /// Creates a `SourceId` from a Git reference.
     pub fn for_git(url: &Url, reference: GitReference) -> CargoResult<SourceId> {
-        SourceId::new(SourceKind::Git(reference), url.clone(), None)
+        if url.fragment().is_some() {
+            Err(anyhow::format_err!(
+                "invalid url `{url}` to create a git reference: URL fragments are not supported\n\n\
+                    help: remove the fragment, or use `--rev`, `--branch`, or `--tag` to select a git reference"
+            ))
+        } else {
+            SourceId::new(SourceKind::Git(reference), url.clone(), None)
+        }
     }
 
     /// Creates a `SourceId` from a remote registry URL when the registry name

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -2397,21 +2397,12 @@ fn fragment_in_git_url() {
         // ...
         // [..]127.0.0.1[..]
         .with_stderr_data(str![[r#"
-[WARNING] Cargo.toml: URL fragment `#foo` in git URL is ignored for dependency (bar). If you were trying to specify a specific git revision, use `rev = "foo"` in the dependency declaration.
-[WARNING] `foo` (manifest) generated 1 warning
-[UPDATING] git repository `http://127.0.0.1/#foo`
-...
-[ERROR] failed to get `bar` as a dependency of package `foo v0.0.0 ([ROOT]/foo)`
+[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
 
 Caused by:
-  failed to load source for dependency `bar`
+  invalid url `http://127.0.0.1/#foo` to create a git reference: URL fragments are not supported
 
-Caused by:
-  unable to update http://127.0.0.1/#foo
-
-Caused by:
-  failed to clone into: [ROOT]/home/.cargo/git/db/_empty-[HASH]
-...
+  [HELP] remove the fragment, or use `--rev`, `--branch`, or `--tag` to select a git reference
 
 "#]])
         .run();

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -2334,6 +2334,32 @@ invalid potential workspace manifest: `[ROOT]/home/.cargo/git/checkouts/foo-[HAS
 }
 
 #[cargo_test]
+fn install_git_with_rev_in_url() {
+    let p = git::repo(&paths::root().join("foo"))
+        .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    let rev = p.revparse_head();
+    // The malformed URL is passed to libgit2 as a path containing `#`.
+    // Create that path so the clone succeeds and the install can be tracked.
+    let fragment_path = paths::root().join(format!("foo#{rev}"));
+    git2::Repository::clone(p.url().as_str(), &fragment_path).unwrap();
+
+    let mut url = p.url().to_string();
+    url.push('#');
+    url.push_str(&rev);
+
+    cargo_process("install --locked --git").arg(url).run();
+    assert_has_installed_exe(paths::cargo_home(), "foo");
+    let crates_toml = fs::read_to_string(paths::home().join(".cargo/.crates.toml")).unwrap();
+    assert!(
+        crates_toml.contains(&format!("git+{}#{rev}#{rev}", p.url())),
+        "{crates_toml}"
+    );
+}
+
+#[cargo_test]
 fn install_git_with_symlink_home() {
     // Ensure that `cargo install` with a git repo is OK when CARGO_HOME is a
     // symlink, and uses an build script.

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -2350,13 +2350,16 @@ fn install_git_with_rev_in_url() {
     url.push('#');
     url.push_str(&rev);
 
-    cargo_process("install --locked --git").arg(url).run();
-    assert_has_installed_exe(paths::cargo_home(), "foo");
-    let crates_toml = fs::read_to_string(paths::home().join(".cargo/.crates.toml")).unwrap();
-    assert!(
-        crates_toml.contains(&format!("git+{}#{rev}#{rev}", p.url())),
-        "{crates_toml}"
-    );
+    cargo_process("install --locked --git")
+        .arg(url)
+        .with_stderr_data(str![[r#"
+[ERROR] invalid url `[ROOTURL]/foo#[..]` to create a git reference: URL fragments are not supported
+
+[HELP] remove the fragment, or use `--rev`, `--branch`, or `--tag` to select a git reference
+
+"#]])
+        .with_status(101)
+        .run();
 }
 
 #[cargo_test]


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/cargo/pull/15489)*

Check if the git url contains a '#' which is likely a sign for the user's desire to specify a rev. Give hint to use `--rev`

Fixes #15336 
