### PR TITLE
Make cargo script ignore workspaces

### DIFF
--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -1923,19 +1923,17 @@ members = [
 
     p.cargo("-Zscript -v script/echo.rs")
         .masquerade_as_nightly_cargo(&["script"])
-        .with_stdout_data(str![[r#""#]])
-        .with_stderr_data(str![[r#"
-[WARNING] `package.edition` is unspecified, defaulting to `2024`
-[ERROR] failed to load manifest for workspace member `[ROOT]/foo/inner`
-referenced by workspace at `[ROOT]/foo/Cargo.toml`
-
-Caused by:
-  failed to parse manifest at `[ROOT]/foo/inner/Cargo.toml`
-
-Caused by:
-  registry index was not found in any configuration: `test-reg`
+        .with_stdout_data(str![[r#"
+bin: [ROOT]/home/.cargo/target/[HASH]/debug/echo[EXE]
+args: []
 
 "#]])
-        .with_status(101)
+        .with_stderr_data(str![[r#"
+[WARNING] `package.edition` is unspecified, defaulting to `2024`
+[COMPILING] echo v0.0.0 ([ROOT]/foo/script/echo.rs)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[RUNNING] `[ROOT]/home/.cargo/target/[HASH]/debug/echo[EXE]`
+
+"#]])
         .run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?

Cargo script considers itself part of the workspace if the script is located in a sub-directory of a workspace (presumably since https://github.com/rust-lang/cargo/pull/15168). This becomes an issue when using a custom registry that is defined in the `.cargo/config.toml` within the workspace. Cargo script does not take that file into account and fails with ``registry index was not found in any configuration: `test-reg` ``.

### How should we test and review this PR?

This PR adds a regression test and makes cargo script ignore the surrounding workspace.
The test ~~will fail without the fix in the second commit and~~ can be used to reproduce the issue.

### Additional information

The issue started occurring with `nightly-2025-02-16`.
Related to https://github.com/rust-lang/cargo/issues/12207.

<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.


Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
