### PR TITLE
CI: Require schema job to pass

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
       - lockfile
       - resolver
       - rustfmt
+      - schema
       - test
       - test_gitoxide
     permissions:


### PR DESCRIPTION
I'm not certain, but I do not believe it was intentional in https://github.com/rust-lang/cargo/pull/15000 to allow the `schema` job to fail. This adds it to the required passing list.
