### PR TITLE
suggest workspace hints for boolean dependencies

### DIFF
--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -2642,6 +2642,39 @@ fn bad_dependency() {
 }
 
 #[cargo_test]
+fn bad_boolean_dependency() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                edition = "2015"
+                authors = []
+
+                [dependencies]
+                bar = true
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] invalid type: boolean `true`, expected a version string like "0.9.8" or a detailed dependency like { version = "0.9.8" }
+ --> Cargo.toml:9:23
+  |
+9 |                 bar = true
+  |                       ^^^^
+  |
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn bad_debuginfo() {
     let p = project()
         .file(

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -2642,7 +2642,7 @@ fn bad_dependency() {
 }
 
 #[cargo_test]
-fn bad_boolean_dependency() {
+fn bad_dependency_true_literal() {
     let p = project()
         .file(
             "Cargo.toml",
@@ -2664,6 +2664,8 @@ fn bad_boolean_dependency() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] invalid type: boolean `true`, expected a version string like "0.9.8" or a detailed dependency like { version = "0.9.8" }
+[NOTE] if you meant to use a workspace member, you can write
+ dep.workspace = true
  --> Cargo.toml:9:23
   |
 9 |                 bar = true


### PR DESCRIPTION

### What does this PR try to resolve?
via issue #15505, Cargo currently errors on  
```toml
[dependencies]
crc32fast = true
```
with a message about `expected a version string or a detailed dependency` It doesn’t hint that you can depend on a workspace member. This PR updates `cargo` so that when you write dep = true, the error also suggests:
```toml
dep = { workspace = true }
dep.workspace = true
```

### How should we test and review this PR?
In a workspace crate’s Cargo.toml, add
```toml
[dependencies]
crc32fast = true
```
Run `cargo build` and you should see the enhanced error with the two workspace hints.

### Additional information

Regarding support for int/float, we only need a special case for boolean because they’re the only values that get the `workspace hint`. Everything else just uses the normal detailed dependency error
