### PR TITLE
docs: update version notice for deprecation removal

### DIFF
--- a/crates/home/README.md
+++ b/crates/home/README.md
@@ -18,7 +18,7 @@ use the standard library's definition - they use the definition here.
 environment variable on Windows. If you are still using this crate for the
 purpose of getting a home directory, you are strongly encouraged to switch to
 using the standard library's [`home_dir`] instead. It is planned to have the
-deprecation notice removed in 1.86.
+deprecation notice removed in 1.87.
 
 This crate further provides two functions, `cargo_home` and
 `rustup_home`, which are the canonical way to determine the location


### PR DESCRIPTION
Thank you for always maintaining cargo.

### What does this PR try to resolve?
`std::env::home_dir` is still deprecated in [v1.86.0](https://doc.rust-lang.org/1.86.0/src/std/env.rs.html#644-648).

However, it has been undeprecated in the current [nightly](https://doc.rust-lang.org/nightly/src/std/env.rs.html#651).

Therefore, I propose updating the notice for avoiding confusion.