### PR TITLE
Revert "doc: Mention `XDG_DATA_HOME`"

### DIFF
--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1817,7 +1817,7 @@ When in doubt, you can discuss this in [#14520](https://github.com/rust-lang/car
 
 ### How to use native-completions feature:
 - bash:
-  Add `source <(CARGO_COMPLETE=bash cargo +nightly)` to `$XDG_DATA_HOME/bash-completion/completions/cargo`, or `~/.local/share/bash-completion/completions/cargo` if `XDG_DATA_HOME` is not set.
+  Add `source <(CARGO_COMPLETE=bash cargo +nightly)` to `~/.local/share/bash-completion/completions/cargo`.
 
 - zsh:
   Add `source <(CARGO_COMPLETE=zsh cargo +nightly)` to your `.zshrc`.


### PR DESCRIPTION
This reverts commit 15a7672dde9853a8b15b545a1e5da5bbee7244c9.

### What does this PR try to resolve?

There was a miscommunication about some outstanding concerns with #15480 and it got merged before we were ready.

Specifically
- How important is this for unstable docs?
- How universal is the use of `bash-completions` and what should we do for people who don't have it?
- How likely is someone to catch that they don't have `XDG_DATA_HOME` set and get tripped up over this documentation
- Should we be aligned with upstream clap?

### How should we test and review this PR?



### Additional information

