### PR TITLE
fix(vendor)!: direct extraction for registry sources

### DIFF
--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -647,9 +647,6 @@ fn vendor_this(relative: &Path) -> bool {
         // Temporary Cargo files
         Some(".cargo-ok") => false,
 
-        // Explicitly exclude .cargo_vcs_info.json to keep the old behavior.
-        Some(".cargo_vcs_info.json") => false,
-
         // Skip patch-style orig/rej files. Published crates on crates.io
         // have `Cargo.toml.orig` which we don't want to use here and
         // otherwise these are rarely used as part of the build process.

--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -4,13 +4,18 @@ use crate::core::{GitReference, Package, Workspace};
 use crate::ops;
 use crate::sources::path::PathSource;
 use crate::sources::PathEntry;
+use crate::sources::RegistrySource;
 use crate::sources::SourceConfigMap;
 use crate::sources::CRATES_IO_REGISTRY;
 use crate::util::cache_lock::CacheLockMode;
 use crate::util::{try_canonicalize, CargoResult, GlobalContext};
+
 use anyhow::{bail, Context as _};
 use cargo_util::{paths, Sha256};
+use cargo_util_schemas::core::SourceKind;
 use serde::Serialize;
+use walkdir::WalkDir;
+
 use std::collections::HashSet;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::ffi::OsStr;
@@ -86,9 +91,16 @@ struct SourceReplacementCache<'gctx> {
 }
 
 impl SourceReplacementCache<'_> {
-    fn new(gctx: &GlobalContext) -> CargoResult<SourceReplacementCache<'_>> {
+    fn new(
+        gctx: &GlobalContext,
+        respect_source_config: bool,
+    ) -> CargoResult<SourceReplacementCache<'_>> {
         Ok(SourceReplacementCache {
-            map: SourceConfigMap::new(gctx)?,
+            map: if respect_source_config {
+                SourceConfigMap::new(gctx)
+            } else {
+                SourceConfigMap::empty(gctx)
+            }?,
             cache: Default::default(),
         })
     }
@@ -130,7 +142,8 @@ fn sync(
         }
     }
 
-    let mut source_replacement_cache = SourceReplacementCache::new(gctx)?;
+    let mut source_replacement_cache =
+        SourceReplacementCache::new(gctx, opts.respect_source_config)?;
 
     // First up attempt to work around rust-lang/cargo#5956. Apparently build
     // artifacts sprout up in Cargo's global cache for whatever reason, although
@@ -263,11 +276,69 @@ fn sync(
         )?;
 
         let _ = fs::remove_dir_all(&dst);
-        let pathsource = PathSource::new(src, id.source_id(), gctx);
-        let paths = pathsource.list_files(pkg)?;
+
         let mut file_cksums = BTreeMap::new();
-        cp_sources(pkg, src, &paths, &dst, &mut file_cksums, &mut tmp_buf, gctx)
-            .with_context(|| format!("failed to copy over vendored sources for: {}", id))?;
+
+        // Need this mapping anyway because we will directly consult registry sources,
+        // otherwise builtin source replacement (sparse registry) won't be respected.
+        let sid = source_replacement_cache.get(id.source_id())?;
+
+        if sid.is_registry() {
+            // To keep the unpacked source from registry in a pristine state,
+            // we'll do a direct extraction into the vendor directory.
+            let registry = match sid.kind() {
+                SourceKind::Registry | SourceKind::SparseRegistry => {
+                    RegistrySource::remote(sid, &Default::default(), gctx)?
+                }
+                SourceKind::LocalRegistry => {
+                    let path = sid.url().to_file_path().expect("local path");
+                    RegistrySource::local(sid, &path, &Default::default(), gctx)
+                }
+                _ => unreachable!("not registry source: {sid}"),
+            };
+
+            let mut compute_file_cksums = |root| {
+                let walkdir = WalkDir::new(root)
+                    .into_iter()
+                    // It is safe to skip errors,
+                    // since we'll hit them during copying/reading later anyway.
+                    .filter_map(|e| e.ok())
+                    // There should be no symlink in tarballs on crates.io,
+                    // but might be wrong for local registries.
+                    // Hence here be conservative and include symlinks.
+                    .filter(|e| e.file_type().is_file() || e.file_type().is_symlink());
+                for e in walkdir {
+                    let path = e.path();
+                    let relative = path.strip_prefix(&dst).unwrap();
+                    let cksum = Sha256::new()
+                        .update_path(path)
+                        .map(Sha256::finish_hex)
+                        .with_context(|| format!("failed to checksum `{}`", path.display()))?;
+                    file_cksums.insert(relative.to_str().unwrap().replace("\\", "/"), cksum);
+                }
+                Ok::<_, anyhow::Error>(())
+            };
+            if dir_has_version_suffix {
+                registry.unpack_package_in(id, &vendor_dir, &vendor_this)?;
+                compute_file_cksums(&dst)?;
+            } else {
+                // Due to the extra sanity check in registry unpack
+                // (ensure it contain only one top-level directory with name `pkg-version`),
+                // we can only unpack a directory with version suffix,
+                // and move it to the no suffix directory.
+                let staging_dir = tempfile::Builder::new()
+                    .prefix(".vendor-staging")
+                    .tempdir_in(vendor_dir)?;
+                let unpacked_src =
+                    registry.unpack_package_in(id, staging_dir.path(), &vendor_this)?;
+                fs::rename(&unpacked_src, &dst)?;
+                compute_file_cksums(&dst)?;
+            }
+        } else {
+            let paths = PathSource::new(src, sid, gctx).list_files(pkg)?;
+            cp_sources(pkg, src, &paths, &dst, &mut file_cksums, &mut tmp_buf, gctx)
+                .with_context(|| format!("failed to copy vendored sources for {id}"))?;
+        }
 
         // Finally, emit the metadata about this package
         let json = serde_json::json!({
@@ -575,6 +646,9 @@ fn vendor_this(relative: &Path) -> bool {
 
         // Temporary Cargo files
         Some(".cargo-ok") => false,
+
+        // Explicitly exclude .cargo_vcs_info.json to keep the old behavior.
+        Some(".cargo_vcs_info.json") => false,
 
         // Skip patch-style orig/rej files. Published crates on crates.io
         // have `Cargo.toml.orig` which we don't want to use here and

--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -417,7 +417,7 @@ fn cp_sources(
                 &dst,
                 &mut dst_opts,
                 &mut contents.as_bytes(),
-                "Generated Cargo.toml",
+                Path::new("Generated Cargo.toml"),
                 tmp_buf,
             )?
         } else {
@@ -430,13 +430,7 @@ fn cp_sources(
                     .with_context(|| format!("failed to stat {:?}", p))?;
                 dst_opts.mode(src_metadata.mode());
             }
-            copy_and_checksum(
-                &dst,
-                &mut dst_opts,
-                &mut src,
-                &p.display().to_string(),
-                tmp_buf,
-            )?
+            copy_and_checksum(&dst, &mut dst_opts, &mut src, &p, tmp_buf)?
         };
 
         cksums.insert(relative.to_str().unwrap().replace("\\", "/"), cksum);
@@ -562,7 +556,7 @@ fn copy_and_checksum<T: Read>(
     dst_path: &Path,
     dst_opts: &mut OpenOptions,
     contents: &mut T,
-    contents_path: &str,
+    contents_path: &Path,
     buf: &mut [u8],
 ) -> CargoResult<String> {
     let mut dst = dst_opts

--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -1096,7 +1096,7 @@ fn ignore_files() {
     p.cargo("vendor --respect-source-config").run();
     let csum = p.read_file("vendor/url/.cargo-checksum.json");
     assert!(!csum.contains("foo.orig"));
-    assert!(!csum.contains(".cargo_vcs_info.json"));
+    assert!(csum.contains(".cargo_vcs_info.json"));
     assert!(!csum.contains(".gitignore"));
     assert!(!csum.contains(".gitattributes"));
     assert!(!csum.contains(".cargo-ok"));

--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -213,12 +213,13 @@ fn package_exclude() {
 
     p.cargo("vendor --respect-source-config").run();
     let csum = p.read_file("vendor/bar/.cargo-checksum.json");
+    // Everything is included because `cargo-vendor`
+    // do direct extractions from tarballs
+    // (Some are excluded like `.git` or `.cargo-ok` though.)
     assert!(csum.contains(".include"));
-    assert!(!csum.contains(".exclude"));
-    assert!(!csum.contains(".dotdir/exclude"));
-    // Gitignore doesn't re-include a file in an excluded parent directory,
-    // even if negating it explicitly.
-    assert!(!csum.contains(".dotdir/include"));
+    assert!(csum.contains(".exclude"));
+    assert!(csum.contains(".dotdir/exclude"));
+    assert!(csum.contains(".dotdir/include"));
 }
 
 #[cargo_test]

--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -1086,6 +1086,7 @@ fn ignore_files() {
     Package::new("url", "1.4.1")
         .file("src/lib.rs", "")
         .file("foo.orig", "")
+        .file(".cargo_vcs_info.json", "")
         .file(".gitignore", "")
         .file(".gitattributes", "")
         .file("foo.rej", "")
@@ -1094,6 +1095,7 @@ fn ignore_files() {
     p.cargo("vendor --respect-source-config").run();
     let csum = p.read_file("vendor/url/.cargo-checksum.json");
     assert!(!csum.contains("foo.orig"));
+    assert!(!csum.contains(".cargo_vcs_info.json"));
     assert!(!csum.contains(".gitignore"));
     assert!(!csum.contains(".gitattributes"));
     assert!(!csum.contains(".cargo-ok"));


### PR DESCRIPTION
### What does this PR try to resolve?

`PathSource::list_files` has some heurstic rules for listing files. Those rules are mainly designed for `cargo package`.

Previously, cargo-vendor relies on those rules to understand what files to vendor. However, it shouldn't use those rules because:

* Package extracted from a `.crate` tarball isn't Git-controlled, some rules may apply differently.
* The extracted package already went through `PathSource::list_files` during packaging. It should be clean enough.
* Should keep crate sources from registry sources in a pristine state, which is exactly what vendoring is meant for.

Instead, we switch to direct extraction into the vendor directory
to ensure source code is the same as in the `.crate` tarball.

### How should we test and review this PR?

There is already a test `vendor::package_exclude` for the fix of #9054,
though now I think it is not a good fix. The test change shows the correct behavior change.

I am not sure if we want more tests.


Also, there are some caveats with this fix:

* The overwrite protection in `unpack_package` assumes the unpack
  directory is always `<pkg>-<version`>.
  We don't want to remove this,
  but for cargo-vendor supports vendoring without version suffix.
  For that case, we need a temporary staging area,
  and move the unpacked source then.
* The heurstic in `PathSource::list_files` did something "good" in
  general cases, like excluding hidden directories. That means
  common directories like `.github` or `.config` won't be vendored.
  After this, those get included. This is another round of churns.
  We might want to get other `cargo-vendor` changes along with this
  in one single release.

### Additional information

* Fixes #9054
* Fixes #9555
* Fixes #9575
* Fixes #11000
* Fixes #14034 
* Fixes #15080 
* Fixes #15090

This also opens a door for

* #10310
* #13191


Since we are changing vendored source (again), we might want to remove the `.rej`/`.orig` special rules in cargo-vendor, as well as look into the new source-dedup vendor dir layout.

<!-- TRIAGEBOT_START -->

<!-- TRIAGEBOT_SUMMARY_START -->

### Summary Notes

- [benchmark-result](https://github.com/rust-lang/cargo/pull/15514#issuecomment-2870275766) by [weihanglo](https://github.com/weihanglo)

Generated by triagebot, see [help](https://forge.rust-lang.org/triagebot/note.html) for how to add more
<!-- TRIAGEBOT_SUMMARY_DATA_START$${"entries_by_url":{"https://github.com/rust-lang/cargo/pull/15514#issuecomment-2870275766":{"title":"benchmark-result","comment_url":"https://github.com/rust-lang/cargo/pull/15514#issuecomment-2870275766","author":"weihanglo"}}}$$TRIAGEBOT_SUMMARY_DATA_END -->

<!-- TRIAGEBOT_SUMMARY_END -->
<!-- TRIAGEBOT_END -->