### PR TITLE
chore(triagebot): add `[no-mentions]` and `[note]`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -26,7 +26,16 @@ label = "O-windows"
 
 [shortcut]
 
+# Enable issue transfers within the org
+# Documentation at: https://forge.rust-lang.org/triagebot/transfer.html
 [transfer]
+
+# Prevents mentions in commits to avoid users being spammed
+[no-mentions]
+
+# Enable `@rustbot note` functionality
+# Documentation at: https://forge.rust-lang.org/triagebot/note.html
+[note]
 
 [merge-conflicts]
 remove = []


### PR DESCRIPTION
`[no-mentions]` is for preventing something like <https://github.com/rust-lang/cargo/pull/15378#issuecomment-2855248173>. Well, maybe not working for PR description, I don't know.

`[note]` is for somebody else wanting to help summarize but having no permission to edit top-level comments.

See docs for more:

* https://forge.rust-lang.org/triagebot/note.html
* https://forge.rust-lang.org/triagebot/no-mentions.html