### PR TITLE
chore: bump to 0.90.0; update changelog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "cargo"
-version = "0.89.0"
+version = "0.90.0"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,7 @@ self_named_module_files = "warn"
 
 [package]
 name = "cargo"
-version = "0.89.0"
+version = "0.90.0"
 edition.workspace = true
 license.workspace = true
 rust-version = "1.86"  # MSRV:1

--- a/src/doc/src/CHANGELOG.md
+++ b/src/doc/src/CHANGELOG.md
@@ -1,5 +1,70 @@
 # Changelog
 
+## Cargo 1.89 (2025-08-07)
+[873a0649...HEAD](https://github.com/rust-lang/cargo/compare/873a0649...HEAD)
+
+### Added
+
+- Add `*` and `?` pattern support for SSH known hosts matching.
+  [#15508](https://github.com/rust-lang/cargo/pull/15508)
+
+### Changed
+
+- ❗️ `cargo fix` and `cargo clippy --fix` now run only on the default Cargo
+  targets by default, matching the behavior of `cargo check`. To run on all
+  Cargo targets, use the `--all-targets` flag. This change aligns the behavior
+  with other commands. Edition flags like `--edition` and `--edition-idioms`
+  remain implying `--all-targets` by default.
+  [#15192](https://github.com/rust-lang/cargo/pull/15192)
+- Respect `Retry-After` header for HTTP 429 responses when talking to registries.
+  [#15463](https://github.com/rust-lang/cargo/pull/15463)
+- Improved error message for the `CRATE[@<VER>]` argument prefixed with `v`.
+  [#15484](https://github.com/rust-lang/cargo/pull/15484)
+- Improved error message for the `CRATE[@<VER>]` argument with invalid package
+  name characters.
+  [#15441](https://github.com/rust-lang/cargo/pull/15441)
+- cargo-add: suggest similarly named features 
+  [#15438](https://github.com/rust-lang/cargo/pull/15438)
+
+### Fixed
+
+### Nightly only
+
+- 🔥 `-Zno-embed-metadata`: This tells Cargo to pass the `-Zembed-metadata=no`
+  flag to the compiler, which instructs it not to embed metadata within rlib
+  and dylib artifacts. In this case, the metadata will only be stored in
+  `.rmeta` files.
+  ([docs](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#no-embed-metadata))
+  [#15378](https://github.com/rust-lang/cargo/pull/15378)
+- `-Zscript`: Make cargo script ignore workspaces.
+  [#15496](https://github.com/rust-lang/cargo/pull/15496)
+- `-Zpackage-workspace`: keep dev-dependencies if they have a version.
+  [#15470](https://github.com/rust-lang/cargo/pull/15470)
+
+### Documentation
+
+- Clarify what commands need and remove confusing example
+  [#15457](https://github.com/rust-lang/cargo/pull/15457)
+- Update fingerprint footnote
+  [#15478](https://github.com/rust-lang/cargo/pull/15478)
+- home: update version notice for deprecation removal 
+  [#15511](https://github.com/rust-lang/cargo/pull/15511)
+
+### Internal
+
+- Refactor artifact deps in FeatureResolver::deps
+  [#15492](https://github.com/rust-lang/cargo/pull/15492)
+- Added tracing spans for rustc invocations
+  [#15464](https://github.com/rust-lang/cargo/pull/15464)
+- ci: migrate renovate config 
+  [#15501](https://github.com/rust-lang/cargo/pull/15501)
+- ci: Require schema job to pass
+  [#15504](https://github.com/rust-lang/cargo/pull/15504)
+- test: Remove unused nightly requirements
+  [#15498](https://github.com/rust-lang/cargo/pull/15498)
+- Update dependencies.
+  [#15456](https://github.com/rust-lang/cargo/pull/15456)
+
 ## Cargo 1.88 (2025-06-26)
 [a6c604d1...rust-1.88.0](https://github.com/rust-lang/cargo/compare/a6c604d1...rust-1.88.0)
 

--- a/src/doc/src/CHANGELOG.md
+++ b/src/doc/src/CHANGELOG.md
@@ -63,6 +63,7 @@
   [#15193](https://github.com/rust-lang/cargo/pull/15193)
 - Include the package name also in the target hint message.
   [#15199](https://github.com/rust-lang/cargo/pull/15199)
+  [#15497](https://github.com/rust-lang/cargo/pull/15497)
 - cargo-add: collapse large feature lists
   [#15200](https://github.com/rust-lang/cargo/pull/15200)
 - cargo-vendor: Add context which workspace failed to resolve

--- a/src/doc/src/CHANGELOG.md
+++ b/src/doc/src/CHANGELOG.md
@@ -1,19 +1,57 @@
 # Changelog
 
 ## Cargo 1.88 (2025-06-26)
-[a6c604d1...HEAD](https://github.com/rust-lang/cargo/compare/a6c604d1...HEAD)
+[a6c604d1...rust-1.88.0](https://github.com/rust-lang/cargo/compare/a6c604d1...rust-1.88.0)
 
 ### Added
+
+- 🎉 Stabilize automatic garbage collection for global caches.
+
+  When building, Cargo downloads and caches crates needed as dependencies.
+  Historically, these downloaded files would never be cleaned up, leading to an
+  unbounded amount of disk usage in Cargo's home directory. In this version,
+  Cargo introduces a garbage collection mechanism to automatically clean up old
+  files (e.g. .crate files). Cargo will remove files downloaded from the network
+  if not accessed in 3 months, and files obtained from the local system if not
+  accessed in 1 month. Note that this automatic garbage collection will not take
+  place if running offline (using `--offline` or `--frozen`).
+
+  Cargo 1.78 and newer track the access information needed for this garbage
+  collection. If you regularly use versions of Cargo older than 1.78, in
+  addition to running current versions of Cargo, and you expect to have some
+  crates accessed exclusively by the older versions of Cargo and don't want to
+  re-download those crates every ~3 months, you may wish to set
+  `cache.auto-clean-frequency = "never"` in the Cargo configuration.
+  ([docs](https://doc.rust-lang.org/nightly/cargo/reference/config.html#cache))
+  [#14287](https://github.com/rust-lang/cargo/pull/14287)
+- Allow boolean literals as cfg predicates in Cargo.toml and configurations.
+  For example, `[target.'cfg(not(false))'.dependencies]` is a valid cfg predicate.
+  ([RFC 3695](https://github.com/rust-lang/rfcs/pull/3695))
+  [#14649](https://github.com/rust-lang/cargo/pull/14649)
 
 ### Changed
 
 - Don't canonicalize executable path for the `CARGO` environment variable.
   [#15355](https://github.com/rust-lang/cargo/pull/15355)
+- Print target and package names formatted as file hyperlinks.
+  [#15405](https://github.com/rust-lang/cargo/pull/15405)
+- Make sure library search paths inside `OUT_DIR` precede external paths.
+  [#15221](https://github.com/rust-lang/cargo/pull/15221)
+- Suggest similar looking feature names when feature is missing.
+  [#15454](https://github.com/rust-lang/cargo/pull/15454)
+- Use `zlib-rs` for gzip (de)compression for `.crate` tarballs.
+  [#15417](https://github.com/rust-lang/cargo/pull/15417)
 
 ### Fixed
 
+- build-rs: Correct name of `CARGO_CFG_FEATURE`
+  [#15420](https://github.com/rust-lang/cargo/pull/15420)
 - cargo-tree: Make output more deterministic
   [#15369](https://github.com/rust-lang/cargo/pull/15369)
+- cargo-package: dont fail the entire command when the dirtiness check failed,
+  as git status check is mostly informational.
+  [#15416](https://github.com/rust-lang/cargo/pull/15416)
+  [#15419](https://github.com/rust-lang/cargo/pull/15419)
 
 ### Nightly only
 
@@ -22,13 +60,53 @@
   ([docs](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#rustdoc-depinfo))
   [#15359](https://github.com/rust-lang/cargo/pull/15359)
   [#15371](https://github.com/rust-lang/cargo/pull/15371)
+- `build-dir`: Added validation for unmatched brackets in build-dir template 
+  [#15414](https://github.com/rust-lang/cargo/pull/15414)
+- `build-dir`: Improved error message when build-dir template var is invalid 
+  [#15418](https://github.com/rust-lang/cargo/pull/15418)
+- `build-dir`: Added `build_directory` field to cargo metadata output 
+  [#15377](https://github.com/rust-lang/cargo/pull/15377)
+- `build-dir`: Added symlink resolution for `workspace-path-hash` 
+  [#15400](https://github.com/rust-lang/cargo/pull/15400)
+- `build-dir`: Added build_directory to cargo metadata documentation 
+  [#15410](https://github.com/rust-lang/cargo/pull/15410)
+- `unit-graph`: switch to Package ID Spec.
+  [#15447](https://github.com/rust-lang/cargo/pull/15447)
 - `-Zgc`: Rename the `gc` config table to `[cache]`.
   Low-level settings is now under `[cache.global-clean]`.
   [#15367](https://github.com/rust-lang/cargo/pull/15367)
+- `-Zdoctest-xcompile`: Update doctest xcompile flags.
+  [#15455](https://github.com/rust-lang/cargo/pull/15455)
 
 ### Documentation
 
+- Mention the convention of kebab-case for Cargo targets naming.
+  [#14439](https://github.com/rust-lang/cargo/pull/14439)
+- Use better example value in `CARGO_CFG_TARGET_ABI` 
+  [#15404](https://github.com/rust-lang/cargo/pull/15404)
+
 ### Internal
+
+- Fix formatting of CliUnstable parsing
+  [#15434](https://github.com/rust-lang/cargo/pull/15434)
+- ci: restore semver-checks for cargo-util
+  [#15389](https://github.com/rust-lang/cargo/pull/15389)
+- ci: add aarch64 linux runner
+  [#15077](https://github.com/rust-lang/cargo/pull/15077)
+- rustfix: Use `snapbox` for snapshot testing
+  [#15429](https://github.com/rust-lang/cargo/pull/15429)
+- test:Prevent undeclared public network access 
+  [#15368](https://github.com/rust-lang/cargo/pull/15368)
+- Update dependencies.
+  [#15373](https://github.com/rust-lang/cargo/pull/15373)
+  [#15381](https://github.com/rust-lang/cargo/pull/15381)
+  [#15391](https://github.com/rust-lang/cargo/pull/15391)
+  [#15394](https://github.com/rust-lang/cargo/pull/15394)
+  [#15403](https://github.com/rust-lang/cargo/pull/15403)
+  [#15415](https://github.com/rust-lang/cargo/pull/15415)
+  [#15421](https://github.com/rust-lang/cargo/pull/15421)
+  [#15446](https://github.com/rust-lang/cargo/pull/15446)
+
 
 ## Cargo 1.87 (2025-05-15)
 [ce948f46...rust-1.87.0](https://github.com/rust-lang/cargo/compare/ce948f46...rust-1.87.0)


### PR DESCRIPTION
[rendered](https://github.com/weihanglo/cargo/blob/version-bump/src/doc/src/CHANGELOG.md)

or preview through `mdbook serve src/doc`

---

Note that the long note of `-Zgc` stabilization is from Josh's comment here: <https://github.com/rust-lang/cargo/pull/14287#issuecomment-2802552543>