### PR TITLE
feat: skip `publish=false` pkg when publishing entire workspace

### DIFF
--- a/src/cargo/ops/registry/publish.rs
+++ b/src/cargo/ops/registry/publish.rs
@@ -117,6 +117,22 @@ pub fn publish(ws: &Workspace<'_>, opts: &PublishOpts<'_>) -> CargoResult<()> {
         );
     }
 
+    if pkgs.is_empty() {
+        if allow_unpublishable {
+            let n = unpublishable.len();
+            let plural = if n == 1 { "" } else { "s" };
+            ws.gctx().shell().warn(format_args!(
+                "nothing to publish, but found {n} unpublishable package{plural}"
+            ))?;
+            ws.gctx().shell().note(format_args!(
+                "to publish packages, set `package.publish` to `true` or a non-empty list"
+            ))?;
+            return Ok(());
+        } else {
+            unreachable!("must have at least one publishable package");
+        }
+    }
+
     let just_pkgs: Vec<_> = pkgs.iter().map(|p| p.0).collect();
     let reg_or_index = match opts.reg_or_index.clone() {
         Some(r) => {

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -4353,7 +4353,8 @@ fn all_unpublishable_packages() {
         .masquerade_as_nightly_cargo(&["package-workspace"])
         .replace_crates_io(registry.index_url())
         .with_stderr_data(str![[r#"
-[UPDATING] crates.io index
+[WARNING] nothing to publish, but found 2 unpublishable packages
+[NOTE] to publish packages, set `package.publish` to `true` or a non-empty list
 
 "#]])
         .run();

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -4037,10 +4037,18 @@ fn one_unpublishable_package() {
     p.cargo("publish -Zpackage-workspace")
         .masquerade_as_nightly_cargo(&["package-workspace"])
         .replace_crates_io(registry.index_url())
-        .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] `main` cannot be published.
-`package.publish` must be set to `true` or a non-empty list in Cargo.toml to publish.
+[UPDATING] crates.io index
+[PACKAGING] dep v0.1.0 ([ROOT]/foo/dep)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[VERIFYING] dep v0.1.0 ([ROOT]/foo/dep)
+[COMPILING] dep v0.1.0 ([ROOT]/foo/target/package/dep-0.1.0)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[UPLOADING] dep v0.1.0 ([ROOT]/foo/dep)
+[UPLOADED] dep v0.1.0 to registry `crates-io`
+[NOTE] waiting for `dep v0.1.0` to be available at registry `crates-io`.
+You may press ctrl-c to skip waiting; the crate should be available shortly.
+[PUBLISHED] dep v0.1.0 at registry `crates-io`
 
 "#]])
         .run();
@@ -4109,10 +4117,18 @@ fn virtual_ws_with_multiple_unpublishable_package() {
     p.cargo("publish -Zpackage-workspace")
         .masquerade_as_nightly_cargo(&["package-workspace"])
         .replace_crates_io(registry.index_url())
-        .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] `dep`, `main` cannot be published.
-`package.publish` must be set to `true` or a non-empty list in Cargo.toml to publish.
+[UPDATING] crates.io index
+[PACKAGING] publishable v0.1.0 ([ROOT]/foo/publishable)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[VERIFYING] publishable v0.1.0 ([ROOT]/foo/publishable)
+[COMPILING] publishable v0.1.0 ([ROOT]/foo/target/package/publishable-0.1.0)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[UPLOADING] publishable v0.1.0 ([ROOT]/foo/publishable)
+[UPLOADED] publishable v0.1.0 to registry `crates-io`
+[NOTE] waiting for `publishable v0.1.0` to be available at registry `crates-io`.
+You may press ctrl-c to skip waiting; the crate should be available shortly.
+[PUBLISHED] publishable v0.1.0 at registry `crates-io`
 
 "#]])
         .run();
@@ -4173,10 +4189,18 @@ fn workspace_flag_with_unpublishable_packages() {
     p.cargo("publish --workspace -Zpackage-workspace")
         .masquerade_as_nightly_cargo(&["package-workspace"])
         .replace_crates_io(registry.index_url())
-        .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] `non-publishable`, `cwd` cannot be published.
-`package.publish` must be set to `true` or a non-empty list in Cargo.toml to publish.
+[UPDATING] crates.io index
+[PACKAGING] publishable v0.0.0 ([ROOT]/foo/publishable)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[VERIFYING] publishable v0.0.0 ([ROOT]/foo/publishable)
+[COMPILING] publishable v0.0.0 ([ROOT]/foo/target/package/publishable-0.0.0)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[UPLOADING] publishable v0.0.0 ([ROOT]/foo/publishable)
+[UPLOADED] publishable v0.0.0 to registry `crates-io`
+[NOTE] waiting for `publishable v0.0.0` to be available at registry `crates-io`.
+You may press ctrl-c to skip waiting; the crate should be available shortly.
+[PUBLISHED] publishable v0.0.0 at registry `crates-io`
 
 "#]])
         .run();
@@ -4233,8 +4257,15 @@ fn unpublishable_package_as_versioned_dev_dep() {
         .replace_crates_io(registry.index_url())
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] `dep` cannot be published.
-`package.publish` must be set to `true` or a non-empty list in Cargo.toml to publish.
+[UPDATING] crates.io index
+[PACKAGING] main v0.0.1 ([ROOT]/foo/main)
+[UPDATING] crates.io index
+[ERROR] failed to prepare local package for uploading
+
+Caused by:
+  no matching package named `dep` found
+  location searched: crates.io index
+  required by package `main v0.0.1 ([ROOT]/foo/main)`
 
 "#]])
         .run();
@@ -4244,8 +4275,15 @@ fn unpublishable_package_as_versioned_dev_dep() {
         .replace_crates_io(registry.index_url())
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] `dep` cannot be published.
-`package.publish` must be set to `true` or a non-empty list in Cargo.toml to publish.
+[UPDATING] crates.io index
+[PACKAGING] main v0.0.1 ([ROOT]/foo/main)
+[UPDATING] crates.io index
+[ERROR] failed to prepare local package for uploading
+
+Caused by:
+  no matching package named `dep` found
+  location searched: crates.io index
+  required by package `main v0.0.1 ([ROOT]/foo/main)`
 
 "#]])
         .run();
@@ -4255,8 +4293,15 @@ fn unpublishable_package_as_versioned_dev_dep() {
         .replace_crates_io(registry.index_url())
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] `dep` cannot be published.
-`package.publish` must be set to `true` or a non-empty list in Cargo.toml to publish.
+[UPDATING] crates.io index
+[PACKAGING] main v0.0.1 ([ROOT]/foo/main)
+[UPDATING] crates.io index
+[ERROR] failed to prepare local package for uploading
+
+Caused by:
+  no matching package named `dep` found
+  location searched: crates.io index
+  required by package `main v0.0.1 ([ROOT]/foo/main)`
 
 "#]])
         .run();
@@ -4307,10 +4352,8 @@ fn all_unpublishable_packages() {
     p.cargo("publish --workspace -Zpackage-workspace")
         .masquerade_as_nightly_cargo(&["package-workspace"])
         .replace_crates_io(registry.index_url())
-        .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] `non-publishable1`, `non-publishable2` cannot be published.
-`package.publish` must be set to `true` or a non-empty list in Cargo.toml to publish.
+[UPDATING] crates.io index
 
 "#]])
         .run();

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -3990,73 +3990,7 @@ You may press ctrl-c to skip waiting; the crate should be available shortly.
 
 #[cargo_test]
 fn one_unpublishable_package() {
-    let _alt_reg = registry::RegistryBuilder::new()
-        .http_api()
-        .http_index()
-        .alternative()
-        .build();
-
-    let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [workspace]
-            members = ["dep", "main"]
-            "#,
-        )
-        .file(
-            "main/Cargo.toml",
-            r#"
-            [package]
-            name = "main"
-            version = "0.0.1"
-            edition = "2015"
-            authors = []
-            license = "MIT"
-            description = "main"
-            repository = "bar"
-            publish = false
-
-            [dependencies]
-            dep = { path = "../dep", version = "0.1.0", registry = "alternative" }
-        "#,
-        )
-        .file("main/src/main.rs", "fn main() {}")
-        .file(
-            "dep/Cargo.toml",
-            r#"
-            [package]
-            name = "dep"
-            version = "0.1.0"
-            edition = "2015"
-            authors = []
-            license = "MIT"
-            description = "dep"
-            repository = "bar"
-            publish = ["alternative"]
-        "#,
-        )
-        .file("dep/src/lib.rs", "")
-        .build();
-
-    p.cargo("publish -Zpackage-workspace")
-        .masquerade_as_nightly_cargo(&["package-workspace"])
-        .with_status(101)
-        .with_stderr_data(str![[r#"
-[ERROR] `main` cannot be published.
-`package.publish` must be set to `true` or a non-empty list in Cargo.toml to publish.
-
-"#]])
-        .run();
-}
-
-#[cargo_test]
-fn multiple_unpublishable_package() {
-    let _alt_reg = registry::RegistryBuilder::new()
-        .http_api()
-        .http_index()
-        .alternative()
-        .build();
+    let registry = RegistryBuilder::new().http_api().http_index().build();
 
     let p = project()
         .file(
@@ -4095,7 +4029,6 @@ fn multiple_unpublishable_package() {
             license = "MIT"
             description = "dep"
             repository = "bar"
-            publish = false
         "#,
         )
         .file("dep/src/lib.rs", "")
@@ -4103,9 +4036,280 @@ fn multiple_unpublishable_package() {
 
     p.cargo("publish -Zpackage-workspace")
         .masquerade_as_nightly_cargo(&["package-workspace"])
+        .replace_crates_io(registry.index_url())
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] `main` cannot be published.
+`package.publish` must be set to `true` or a non-empty list in Cargo.toml to publish.
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn virtual_ws_with_multiple_unpublishable_package() {
+    let registry = RegistryBuilder::new().http_api().http_index().build();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["dep", "main", "publishable"]
+            "#,
+        )
+        .file(
+            "main/Cargo.toml",
+            r#"
+            [package]
+            name = "main"
+            version = "0.0.1"
+            edition = "2015"
+            authors = []
+            license = "MIT"
+            description = "main"
+            repository = "bar"
+            publish = false
+
+            [dependencies]
+            dep = { path = "../dep", version = "0.1.0" }
+        "#,
+        )
+        .file("main/src/main.rs", "fn main() {}")
+        .file(
+            "dep/Cargo.toml",
+            r#"
+            [package]
+            name = "dep"
+            version = "0.1.0"
+            edition = "2015"
+            authors = []
+            license = "MIT"
+            description = "dep"
+            repository = "bar"
+            publish = false
+        "#,
+        )
+        .file("dep/src/lib.rs", "")
+        .file(
+            "publishable/Cargo.toml",
+            r#"
+            [package]
+            name = "publishable"
+            version = "0.1.0"
+            edition = "2015"
+            license = "MIT"
+            description = "foo"
+            repository = "foo"
+        "#,
+        )
+        .file("publishable/src/lib.rs", "")
+        .build();
+
+    p.cargo("publish -Zpackage-workspace")
+        .masquerade_as_nightly_cargo(&["package-workspace"])
+        .replace_crates_io(registry.index_url())
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] `dep`, `main` cannot be published.
+`package.publish` must be set to `true` or a non-empty list in Cargo.toml to publish.
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn workspace_flag_with_unpublishable_packages() {
+    let registry = RegistryBuilder::new().http_api().http_index().build();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["publishable", "non-publishable"]
+
+            [package]
+            name = "cwd"
+            version = "0.0.0"
+            edition = "2015"
+            license = "MIT"
+            description = "foo"
+            repository = "foo"
+            publish = false
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file(
+            "publishable/Cargo.toml",
+            r#"
+            [package]
+            name = "publishable"
+            version = "0.0.0"
+            edition = "2015"
+            license = "MIT"
+            description = "foo"
+            repository = "foo"
+            publish = true
+        "#,
+        )
+        .file("publishable/src/lib.rs", "")
+        .file(
+            "non-publishable/Cargo.toml",
+            r#"
+            [package]
+            name = "non-publishable"
+            version = "0.0.0"
+            edition = "2015"
+            license = "MIT"
+            description = "foo"
+            repository = "foo"
+            publish = false
+        "#,
+        )
+        .file("non-publishable/src/lib.rs", "")
+        .build();
+
+    p.cargo("publish --workspace -Zpackage-workspace")
+        .masquerade_as_nightly_cargo(&["package-workspace"])
+        .replace_crates_io(registry.index_url())
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] `non-publishable`, `cwd` cannot be published.
+`package.publish` must be set to `true` or a non-empty list in Cargo.toml to publish.
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn unpublishable_package_as_versioned_dev_dep() {
+    let registry = RegistryBuilder::new().http_api().http_index().build();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["dep", "main"]
+            "#,
+        )
+        .file(
+            "main/Cargo.toml",
+            r#"
+            [package]
+            name = "main"
+            version = "0.0.1"
+            edition = "2015"
+            license = "MIT"
+            description = "main"
+            repository = "bar"
+
+            [dev-dependencies]
+            dep = { path = "../dep", version = "0.1.0" }
+        "#,
+        )
+        .file("main/src/main.rs", "fn main() {}")
+        .file(
+            "dep/Cargo.toml",
+            r#"
+            [package]
+            name = "dep"
+            version = "0.1.0"
+            edition = "2015"
+            license = "MIT"
+            description = "dep"
+            repository = "bar"
+            publish = false
+        "#,
+        )
+        .file("dep/src/lib.rs", "")
+        .build();
+
+    // It is expected to find the versioned dev dep not being published,
+    // regardless with `--dry-run` or `--no-verify`.
+    p.cargo("publish -Zpackage-workspace")
+        .masquerade_as_nightly_cargo(&["package-workspace"])
+        .replace_crates_io(registry.index_url())
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] `dep` cannot be published.
+`package.publish` must be set to `true` or a non-empty list in Cargo.toml to publish.
+
+"#]])
+        .run();
+
+    p.cargo("publish -Zpackage-workspace --dry-run")
+        .masquerade_as_nightly_cargo(&["package-workspace"])
+        .replace_crates_io(registry.index_url())
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] `dep` cannot be published.
+`package.publish` must be set to `true` or a non-empty list in Cargo.toml to publish.
+
+"#]])
+        .run();
+
+    p.cargo("publish -Zpackage-workspace --no-verify")
+        .masquerade_as_nightly_cargo(&["package-workspace"])
+        .replace_crates_io(registry.index_url())
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] `dep` cannot be published.
+`package.publish` must be set to `true` or a non-empty list in Cargo.toml to publish.
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn all_unpublishable_packages() {
+    let registry = RegistryBuilder::new().http_api().http_index().build();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["non-publishable1", "non-publishable2"]
+            "#,
+        )
+        .file(
+            "non-publishable1/Cargo.toml",
+            r#"
+            [package]
+            name = "non-publishable1"
+            version = "0.0.0"
+            edition = "2015"
+            license = "MIT"
+            description = "foo"
+            repository = "foo"
+            publish = false
+        "#,
+        )
+        .file("non-publishable1/src/lib.rs", "")
+        .file(
+            "non-publishable2/Cargo.toml",
+            r#"
+            [package]
+            name = "non-publishable2"
+            version = "0.0.0"
+            edition = "2015"
+            license = "MIT"
+            description = "foo"
+            repository = "foo"
+            publish = false
+        "#,
+        )
+        .file("non-publishable2/src/lib.rs", "")
+        .build();
+
+    p.cargo("publish --workspace -Zpackage-workspace")
+        .masquerade_as_nightly_cargo(&["package-workspace"])
+        .replace_crates_io(registry.index_url())
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] `non-publishable1`, `non-publishable2` cannot be published.
 `package.publish` must be set to `true` or a non-empty list in Cargo.toml to publish.
 
 "#]])


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes #15006

This changes how cargo-publish works with the unstable
`-Zpackage-workspace` feature.

Before this, when publishing the entire workspace,
like `cargo publish --workspace`,
if there is a package with `package.pulibsh=false,
it'll fail the entire publish process.

After this, when `--workspace` is passed,
or when publishing the virtual workspace,
the intent is more like “publish all publishable in this workspace”,
so skip `publish=false` packages and proceed to publish others.

The new overall behavior looks like this:

* `cargo publish` (inside a `package.publish = false` package): error
* `cargo publish -p publishable -p unpublishable`: error
* `cargo publish --workspace`: skips `package.publish = false

See https://github.com/rust-lang/cargo/issues/15006#issuecomment-2847660911

### How should we test and review this PR?

* `workspace_flag_with_unpublishable_packages` was added to ensure `--workspace` work with non-virtual workspace.
* `unpublishable_package_as_versioned_dev_dep` was added to ensure versioned dev-dependencies won't be skipped and still fail cargo-publish, as they are required to be published.

There is a new scenario that nothing is going to publish.
I went with a warning instead of hard error because missing publish for the entire worspace should be a fairly visible. However, this is open for future to configure via Cargo lint system.