### PR TITLE
refactor: replace InternedString with Cow in IndexPackage

### DIFF
--- a/benches/benchsuite/src/bin/capture-last-use.rs
+++ b/benches/benchsuite/src/bin/capture-last-use.rs
@@ -14,7 +14,6 @@
 
 use cargo::core::global_cache_tracker::{self, DeferredGlobalLastUse, GlobalCacheTracker};
 use cargo::util::cache_lock::CacheLockMode;
-use cargo::util::interning::InternedString;
 use cargo::GlobalContext;
 use rand::prelude::*;
 use std::collections::HashMap;
@@ -57,7 +56,7 @@ fn main() {
     let cache_dir = real_home.join("registry/cache");
     for dir_ent in fs::read_dir(cache_dir).unwrap() {
         let registry = dir_ent.unwrap();
-        let encoded_registry_name = InternedString::new(&registry.file_name().to_string_lossy());
+        let encoded_registry_name = registry.file_name().to_string_lossy().into();
         for krate in fs::read_dir(registry.path()).unwrap() {
             let krate = krate.unwrap();
             let meta = krate.metadata().unwrap();
@@ -77,7 +76,7 @@ fn main() {
     let cache_dir = real_home.join("registry/src");
     for dir_ent in fs::read_dir(cache_dir).unwrap() {
         let registry = dir_ent.unwrap();
-        let encoded_registry_name = InternedString::new(&registry.file_name().to_string_lossy());
+        let encoded_registry_name = registry.file_name().to_string_lossy().into();
         for krate in fs::read_dir(registry.path()).unwrap() {
             let krate = krate.unwrap();
             let meta = krate.metadata().unwrap();
@@ -95,7 +94,7 @@ fn main() {
     let git_co_dir = real_home.join("git/checkouts");
     for dir_ent in fs::read_dir(git_co_dir).unwrap() {
         let git_source = dir_ent.unwrap();
-        let encoded_git_name = InternedString::new(&git_source.file_name().to_string_lossy());
+        let encoded_git_name = git_source.file_name().to_string_lossy().into();
         for co in fs::read_dir(git_source.path()).unwrap() {
             let co = co.unwrap();
             let meta = co.metadata().unwrap();

--- a/src/bin/cargo/commands/add.rs
+++ b/src/bin/cargo/commands/add.rs
@@ -10,7 +10,6 @@ use cargo::ops::cargo_add::AddOptions;
 use cargo::ops::cargo_add::DepOp;
 use cargo::ops::resolve_ws;
 use cargo::util::command_prelude::*;
-use cargo::util::interning::InternedString;
 use cargo::util::toml_mut::manifest::DepTable;
 use cargo::CargoResult;
 
@@ -287,7 +286,7 @@ fn parse_dependencies(gctx: &GlobalContext, matches: &ArgMatches) -> CargoResult
         .map(String::as_str)
         .flat_map(parse_feature)
     {
-        let parsed_value = FeatureValue::new(InternedString::new(feature));
+        let parsed_value = FeatureValue::new(feature.into());
         match parsed_value {
             FeatureValue::Feature(_) => {
                 if 1 < crates.len() {

--- a/src/bin/cargo/commands/rustc.rs
+++ b/src/bin/cargo/commands/rustc.rs
@@ -1,6 +1,5 @@
 use crate::command_prelude::*;
 use cargo::ops;
-use cargo::util::interning::InternedString;
 
 const PRINT_ARG_NAME: &str = "print";
 const CRATE_TYPE_ARG_NAME: &str = "crate-type";
@@ -77,7 +76,7 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
         ProfileChecking::LegacyRustc,
     )?;
     if compile_opts.build_config.requested_profile == "check" {
-        compile_opts.build_config.requested_profile = InternedString::new("dev");
+        compile_opts.build_config.requested_profile = "dev".into();
     }
     let target_args = values(args, "args");
     compile_opts.target_rustc_args = if target_args.is_empty() {

--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -116,7 +116,7 @@ impl BuildConfig {
             requested_kinds,
             jobs,
             keep_going,
-            requested_profile: InternedString::new("dev"),
+            requested_profile: "dev".into(),
             intent,
             message_format: MessageFormat::Human,
             force_rebuild: false,

--- a/src/cargo/core/compiler/fingerprint/mod.rs
+++ b/src/cargo/core/compiler/fingerprint/mod.rs
@@ -694,7 +694,7 @@ impl<'de> Deserialize<'de> for DepFingerprint {
         let (pkg_id, name, public, hash) = <(u64, String, bool, u64)>::deserialize(d)?;
         Ok(DepFingerprint {
             pkg_id,
-            name: InternedString::new(&name),
+            name: name.into(),
             public,
             fingerprint: Arc::new(Fingerprint {
                 memoized_hash: Mutex::new(Some(hash)),

--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -632,7 +632,7 @@ impl ArtifactKind {
             _ => {
                 return kind
                     .strip_prefix("bin:")
-                    .map(|bin_name| ArtifactKind::SelectedBinary(InternedString::new(bin_name)))
+                    .map(|bin_name| ArtifactKind::SelectedBinary(bin_name.into()))
                     .ok_or_else(|| anyhow::anyhow!("'{}' is not a valid artifact specifier", kind))
             }
         })

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -208,14 +208,7 @@ impl Package {
         let crate_features = summary
             .features()
             .iter()
-            .map(|(k, v)| {
-                (
-                    *k,
-                    v.iter()
-                        .map(|fv| InternedString::new(&fv.to_string()))
-                        .collect(),
-                )
-            })
+            .map(|(k, v)| (*k, v.iter().map(|fv| fv.to_string().into()).collect()))
             .collect();
 
         SerializedPackage {
@@ -443,7 +436,7 @@ impl<'gctx> PackageSet<'gctx> {
             ))),
             downloads_finished: 0,
             downloaded_bytes: 0,
-            largest: (0, InternedString::new("")),
+            largest: (0, "".into()),
             success: false,
             updated_at: Cell::new(Instant::now()),
             timeout,

--- a/src/cargo/core/package_id.rs
+++ b/src/cargo/core/package_id.rs
@@ -78,7 +78,7 @@ impl<'de> de::Deserialize<'de> for PackageId {
         let (field, rest) = string
             .split_once(' ')
             .ok_or_else(|| de::Error::custom("invalid serialized PackageId"))?;
-        let name = InternedString::new(field);
+        let name = field.into();
 
         let (field, rest) = rest
             .split_once(' ')

--- a/src/cargo/core/resolver/features.rs
+++ b/src/cargo/core/resolver/features.rs
@@ -306,7 +306,7 @@ impl CliFeatures {
             .flat_map(|s| s.split_whitespace())
             .flat_map(|s| s.split(','))
             .filter(|s| !s.is_empty())
-            .map(InternedString::new)
+            .map(|s| s.into())
             .map(FeatureValue::new)
             .collect()
     }

--- a/src/cargo/core/summary.rs
+++ b/src/cargo/core/summary.rs
@@ -377,15 +377,15 @@ impl FeatureValue {
             Some((dep, dep_feat)) => {
                 let dep_name = dep.strip_suffix('?');
                 FeatureValue::DepFeature {
-                    dep_name: InternedString::new(dep_name.unwrap_or(dep)),
-                    dep_feature: InternedString::new(dep_feat),
+                    dep_name: dep_name.unwrap_or(dep).into(),
+                    dep_feature: dep_feat.into(),
                     weak: dep_name.is_some(),
                 }
             }
             None => {
                 if let Some(dep_name) = feature.strip_prefix("dep:") {
                     FeatureValue::Dep {
-                        dep_name: InternedString::new(dep_name),
+                        dep_name: dep_name.into(),
                     }
                 } else {
                     FeatureValue::Feature(feature)

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1549,7 +1549,7 @@ impl<'gctx> Workspace<'gctx> {
             .flatten()
             .unique()
             .filter(|element| {
-                let feature = FeatureValue::new(InternedString::new(element));
+                let feature = FeatureValue::new(element.into());
                 !cli_features.features.contains(&feature) && !found_features.contains(&feature)
             })
             .sorted()

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -302,7 +302,7 @@ fn build_resolve_graph_r(
                         // Given that Cargo doesn't know which target it should resolve to,
                         // when an artifact dep is specified with { target = "target" },
                         // keep it with a special "<target>" string,
-                        .or_else(|| Some(InternedString::new("<target>"))),
+                        .or_else(|| Some("<target>".into())),
                     None => None,
                 };
 
@@ -334,7 +334,7 @@ fn build_resolve_graph_r(
                 },
                 // No lib target exists but contains artifact deps.
                 (None, 1..) => Dep {
-                    name: InternedString::new(""),
+                    name: "".into(),
                     pkg: pkg_id.to_spec(),
                     pkg_id,
                     dep_kinds,

--- a/src/cargo/ops/registry/info/view.rs
+++ b/src/cargo/ops/registry/info/view.rs
@@ -135,7 +135,7 @@ pub(super) fn pretty_view(
         )?;
     }
 
-    let activated = &[InternedString::new("default")];
+    let activated = &["default".into()];
     let resolved_features = resolve_features(activated, summary.features());
     pretty_features(
         resolved_features.clone(),

--- a/src/cargo/sources/registry/index/mod.rs
+++ b/src/cargo/sources/registry/index/mod.rs
@@ -683,7 +683,7 @@ impl Summaries {
     /// represents information previously cached by Cargo.
     pub fn parse_cache(contents: Vec<u8>) -> CargoResult<(Summaries, InternedString)> {
         let cache = SummariesCache::parse(&contents)?;
-        let index_version = InternedString::new(cache.index_version);
+        let index_version = cache.index_version.into();
         let mut ret = Summaries::default();
         for (version, summary) in cache.versions {
             let (start, end) = subslice_bounds(&contents, summary);

--- a/src/cargo/sources/registry/index/mod.rs
+++ b/src/cargo/sources/registry/index/mod.rs
@@ -198,7 +198,8 @@ impl IndexSummary {
 #[derive(Deserialize, Serialize)]
 pub struct IndexPackage<'a> {
     /// Name of the package.
-    pub name: InternedString,
+    #[serde(borrow)]
+    pub name: Cow<'a, str>,
     /// The version of this dependency.
     pub vers: Version,
     /// All kinds of direct dependencies of the package, including dev and
@@ -207,14 +208,14 @@ pub struct IndexPackage<'a> {
     pub deps: Vec<RegistryDependency<'a>>,
     /// Set of features defined for the package, i.e., `[features]` table.
     #[serde(default)]
-    pub features: BTreeMap<InternedString, Vec<InternedString>>,
+    pub features: BTreeMap<Cow<'a, str>, Vec<Cow<'a, str>>>,
     /// This field contains features with new, extended syntax. Specifically,
     /// namespaced features (`dep:`) and weak dependencies (`pkg?/feat`).
     ///
     /// This is separated from `features` because versions older than 1.19
     /// will fail to load due to not being able to parse the new syntax, even
     /// with a `Cargo.lock` file.
-    pub features2: Option<BTreeMap<InternedString, Vec<InternedString>>>,
+    pub features2: Option<BTreeMap<Cow<'a, str>, Vec<Cow<'a, str>>>>,
     /// Checksum for verifying the integrity of the corresponding downloaded package.
     pub cksum: String,
     /// If `true`, Cargo will skip this version when resolving.
@@ -226,7 +227,7 @@ pub struct IndexPackage<'a> {
     ///
     /// Added early 2018 (see <https://github.com/rust-lang/cargo/pull/4978>),
     /// can be `None` if published before then.
-    pub links: Option<InternedString>,
+    pub links: Option<Cow<'a, str>>,
     /// Required version of rust
     ///
     /// Corresponds to `package.rust-version`.
@@ -263,7 +264,11 @@ impl IndexPackage<'_> {
     fn to_summary(&self, source_id: SourceId) -> CargoResult<Summary> {
         // ****CAUTION**** Please be extremely careful with returning errors, see
         // `IndexSummary::parse` for details
-        let pkgid = PackageId::new(self.name.into(), self.vers.clone(), source_id);
+        let pkgid = PackageId::new(
+            InternedString::new(&self.name),
+            self.vers.clone(),
+            source_id,
+        );
         let deps = self
             .deps
             .iter()
@@ -272,24 +277,31 @@ impl IndexPackage<'_> {
         let mut features = self.features.clone();
         if let Some(features2) = &self.features2 {
             for (name, values) in features2 {
-                features.entry(*name).or_default().extend(values);
+                features
+                    .entry(name.clone())
+                    .or_default()
+                    .extend(values.iter().cloned());
             }
         }
-        let mut summary = Summary::new(
-            pkgid,
-            deps,
-            &features,
-            self.links,
-            self.rust_version.clone(),
-        )?;
+        let features = features
+            .into_iter()
+            .map(|(name, values)| {
+                (
+                    InternedString::new(&name),
+                    values.iter().map(|v| InternedString::new(&v)).collect(),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        let links = self.links.as_ref().map(|l| InternedString::new(&l));
+        let mut summary = Summary::new(pkgid, deps, &features, links, self.rust_version.clone())?;
         summary.set_checksum(self.cksum.clone());
         Ok(summary)
     }
 }
 
 #[derive(Deserialize, Serialize)]
-struct IndexPackageMinimum {
-    name: InternedString,
+struct IndexPackageMinimum<'a> {
+    name: Cow<'a, str>,
     vers: Version,
 }
 
@@ -308,13 +320,14 @@ struct IndexPackageV {
 pub struct RegistryDependency<'a> {
     /// Name of the dependency. If the dependency is renamed, the original
     /// would be stored in [`RegistryDependency::package`].
-    pub name: InternedString,
+    #[serde(borrow)]
+    pub name: Cow<'a, str>,
     /// The SemVer requirement for this dependency.
     #[serde(borrow)]
     pub req: Cow<'a, str>,
     /// Set of features enabled for this dependency.
     #[serde(default)]
-    pub features: Vec<InternedString>,
+    pub features: Vec<Cow<'a, str>>,
     /// Whether or not this is an optional dependency.
     #[serde(default)]
     pub optional: bool,
@@ -329,7 +342,7 @@ pub struct RegistryDependency<'a> {
     // `None` if it is from the same index.
     pub registry: Option<Cow<'a, str>>,
     /// The original name if the dependency is renamed.
-    pub package: Option<InternedString>,
+    pub package: Option<Cow<'a, str>>,
     /// Whether or not this is a public dependency. Unstable. See [RFC 1977].
     ///
     /// [RFC 1977]: https://rust-lang.github.io/rfcs/1977-public-private-dependencies.html
@@ -759,7 +772,7 @@ impl IndexSummary {
             Ok((index, summary)) => (index, summary, true),
             Err(err) => {
                 let Ok(IndexPackageMinimum { name, vers }) =
-                    serde_json::from_slice::<IndexPackageMinimum>(line)
+                    serde_json::from_slice::<IndexPackageMinimum<'_>>(line)
                 else {
                     // If we can't recover, prefer the original error
                     return Err(err);
@@ -833,9 +846,10 @@ impl<'a> RegistryDependency<'a> {
             default
         };
 
-        let mut dep = Dependency::parse(package.unwrap_or(name), Some(&req), id)?;
+        let interned_name = InternedString::new(package.as_ref().unwrap_or(&name));
+        let mut dep = Dependency::parse(interned_name, Some(&req), id)?;
         if package.is_some() {
-            dep.set_explicit_name_in_toml(name);
+            dep.set_explicit_name_in_toml(InternedString::new(&name));
         }
         let kind = match kind.as_deref().unwrap_or("") {
             "dev" => DepKind::Development,
@@ -869,6 +883,7 @@ impl<'a> RegistryDependency<'a> {
             dep.set_artifact(artifact);
         }
 
+        let features = features.iter().map(|f| InternedString::new(&f));
         dep.set_optional(optional)
             .set_default_features(default_features)
             .set_features(features)

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -844,7 +844,7 @@ impl<'gctx> Source for RegistrySource<'gctx> {
                     dep.package_name().replace('-', "_"),
                     dep.package_name().replace('_', "-"),
                 ] {
-                    let name_permutation = InternedString::new(&name_permutation);
+                    let name_permutation = name_permutation.into();
                     if name_permutation == dep.package_name() {
                         continue;
                     }

--- a/src/cargo/sources/registry/remote.rs
+++ b/src/cargo/sources/registry/remote.rs
@@ -198,7 +198,7 @@ impl<'gctx> RemoteRegistry<'gctx> {
         if let Some(sha) = self.current_sha.get() {
             return Some(sha);
         }
-        let sha = InternedString::new(&self.head().ok()?.to_string());
+        let sha = self.head().ok()?.to_string().into();
         self.current_sha.set(Some(sha));
         Some(sha)
     }

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -681,7 +681,7 @@ Run `{cmd}` to see possible targets."
             (Some(name @ ("dev" | "test" | "bench" | "check")), ProfileChecking::LegacyRustc)
             // `cargo fix` and `cargo check` has legacy handling of this profile name
             | (Some(name @ "test"), ProfileChecking::LegacyTestOnly) => {
-                return Ok(InternedString::new(name));
+                return Ok(name.into());
             }
             _ => {}
         }
@@ -708,7 +708,7 @@ Run `{cmd}` to see possible targets."
             }
         };
 
-        Ok(InternedString::new(name))
+        Ok(name.into())
     }
 
     fn packages_from_flags(&self) -> CargoResult<Packages> {
@@ -1133,7 +1133,7 @@ fn get_profile_candidates() -> Vec<clap_complete::CompletionCandidate> {
 fn get_workspace_profile_candidates() -> CargoResult<Vec<clap_complete::CompletionCandidate>> {
     let gctx = new_gctx_for_completions()?;
     let ws = Workspace::new(&find_root_manifest_for_wd(gctx.cwd())?, &gctx)?;
-    let profiles = Profiles::new(&ws, InternedString::new("dev"))?;
+    let profiles = Profiles::new(&ws, "dev".into())?;
 
     let mut candidates = Vec::new();
     for name in profiles.profile_names() {

--- a/src/cargo/util/interning.rs
+++ b/src/cargo/util/interning.rs
@@ -47,7 +47,7 @@ impl<'a> From<&'a String> for InternedString {
 
 impl From<String> for InternedString {
     fn from(item: String) -> Self {
-        InternedString::from_cow(item.into())
+        InternedString::from(Cow::Owned(item))
     }
 }
 
@@ -69,14 +69,8 @@ impl<'a> PartialEq<&'a str> for InternedString {
     }
 }
 
-impl Eq for InternedString {}
-
-impl InternedString {
-    pub fn new(s: &str) -> InternedString {
-        InternedString::from_cow(s.into())
-    }
-
-    fn from_cow<'a>(cs: Cow<'a, str>) -> InternedString {
+impl<'a> From<Cow<'a, str>> for InternedString {
+    fn from(cs: Cow<'a, str>) -> Self {
         let mut cache = interned_storage();
         let s = cache.get(cs.as_ref()).copied().unwrap_or_else(|| {
             let s = cs.into_owned().leak();
@@ -86,7 +80,14 @@ impl InternedString {
 
         InternedString { inner: s }
     }
+}
 
+impl Eq for InternedString {}
+
+impl InternedString {
+    pub fn new(s: &str) -> InternedString {
+        InternedString::from(Cow::Borrowed(s))
+    }
     pub fn as_str(&self) -> &'static str {
         self.inner
     }

--- a/src/cargo/util/interning.rs
+++ b/src/cargo/util/interning.rs
@@ -176,7 +176,7 @@ impl<'de> serde::Deserialize<'de> for InternedString {
     {
         UntaggedEnumVisitor::new()
             .expecting("an String like thing")
-            .string(|value| Ok(InternedString::new(value)))
+            .string(|value| Ok(value.into()))
             .deserialize(deserializer)
     }
 }

--- a/src/cargo/util/rustc.rs
+++ b/src/cargo/util/rustc.rs
@@ -79,7 +79,7 @@ impl Rustc {
                 })
         };
 
-        let host = InternedString::new(extract("host: ")?);
+        let host = extract("host: ")?.into();
         let version = semver::Version::parse(extract("release: ")?).with_context(|| {
             format!(
                 "rustc version does not appear to be a valid semver version, from:\n{}",

--- a/src/cargo/util/sqlite.rs
+++ b/src/cargo/util/sqlite.rs
@@ -7,7 +7,7 @@ use rusqlite::{Connection, TransactionBehavior};
 
 impl FromSql for InternedString {
     fn column_result(value: rusqlite::types::ValueRef<'_>) -> Result<Self, FromSqlError> {
-        value.as_str().map(InternedString::new)
+        value.as_str().map(InternedString::from)
     }
 }
 

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1697,7 +1697,7 @@ pub fn to_real_manifest(
                 .iter()
                 .map(|(k, v)| {
                     (
-                        InternedString::new(k),
+                        k.to_string().into(),
                         v.iter().map(InternedString::from).collect(),
                     )
                 })
@@ -3090,7 +3090,7 @@ fn prepare_toml_for_publish(
 
         features.values_mut().for_each(|feature_deps| {
             feature_deps.retain(|feature_dep| {
-                let feature_value = FeatureValue::new(InternedString::new(feature_dep));
+                let feature_value = FeatureValue::new(feature_dep.into());
                 match feature_value {
                     FeatureValue::Dep { dep_name } | FeatureValue::DepFeature { dep_name, .. } => {
                         let k = &manifest::PackageName::new(dep_name.to_string()).unwrap();

--- a/src/cargo/util/toml_mut/manifest.rs
+++ b/src/cargo/util/toml_mut/manifest.rs
@@ -10,7 +10,6 @@ use super::dependency::Dependency;
 use crate::core::dependency::DepKind;
 use crate::core::{FeatureValue, Features, Workspace};
 use crate::util::closest;
-use crate::util::interning::InternedString;
 use crate::util::toml::{is_embedded, ScriptSource};
 use crate::{CargoResult, GlobalContext};
 
@@ -533,7 +532,7 @@ impl LocalManifest {
                 .filter_map(|v| v.as_array())
             {
                 for value in values.iter().filter_map(|v| v.as_str()) {
-                    let value = FeatureValue::new(InternedString::new(value));
+                    let value = FeatureValue::new(value.into());
                     if let FeatureValue::Dep { dep_name } = &value {
                         if dep_name.as_str() == dep_key {
                             return true;
@@ -637,7 +636,7 @@ fn fix_feature_activations(
         .enumerate()
         .filter_map(|(idx, value)| value.as_str().map(|s| (idx, s)))
         .filter_map(|(idx, value)| {
-            let parsed_value = FeatureValue::new(InternedString::new(value));
+            let parsed_value = FeatureValue::new(value.into());
             match status {
                 DependencyStatus::None => match (parsed_value, explicit_dep_activation) {
                     (FeatureValue::Feature(dep_name), false)
@@ -666,7 +665,7 @@ fn fix_feature_activations(
     if status == DependencyStatus::Required {
         for value in feature_values.iter_mut() {
             let parsed_value = if let Some(value) = value.as_str() {
-                FeatureValue::new(InternedString::new(value))
+                FeatureValue::new(value.into())
             } else {
                 continue;
             };

--- a/tests/testsuite/global_cache_tracker.rs
+++ b/tests/testsuite/global_cache_tracker.rs
@@ -16,7 +16,6 @@ use std::time::{Duration, SystemTime};
 
 use cargo::core::global_cache_tracker::{self, DeferredGlobalLastUse, GlobalCacheTracker};
 use cargo::util::cache_lock::CacheLockMode;
-use cargo::util::interning::InternedString;
 use cargo::GlobalContext;
 use cargo_test_support::compare::assert_e2e;
 use cargo_test_support::paths;
@@ -137,7 +136,7 @@ fn populate_cache(
         .join(".cargo/registry/index/example.com-a6c4a5adcb232b9a")
         .mkdir_p();
     let mut create = |name: &str, age, crate_size: u64, src_size: u64| {
-        let crate_filename = InternedString::new(&format!("{name}.crate"));
+        let crate_filename = format!("{name}.crate").into();
         deferred.mark_registry_crate_used_stamp(
             global_cache_tracker::RegistryCrate {
                 encoded_registry_name: "example.com-a6c4a5adcb232b9a".into(),

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -375,7 +375,6 @@ fn named_config_profile() {
     use cargo::core::compiler::CompileKind;
     use cargo::core::profiles::{Profiles, UnitFor};
     use cargo::core::{PackageId, Workspace};
-    use cargo::util::interning::InternedString;
     use std::fs;
     paths::root().join(".cargo").mkdir_p();
     fs::write(
@@ -421,7 +420,7 @@ fn named_config_profile() {
     )
     .unwrap();
     let gctx = GlobalContextBuilder::new().build();
-    let profile_name = InternedString::new("foo");
+    let profile_name = "foo".into();
     let ws = Workspace::new(&paths::root().join("Cargo.toml"), &gctx).unwrap();
     let profiles = Profiles::new(&ws, profile_name).unwrap();
 


### PR DESCRIPTION
### What does this PR try to resolve?

ref https://github.com/rust-lang/cargo/issues/14834

As described in the issue, we want to move IndexPackage into cargo-util-schemas. However, it contains InternedString fields, which we don't want to expose as part of the public API.
This PR replaces InternedString with Cow.

And also, as @weihanglo's suggested, I implemented the From/Into trait to simplify code.

From Cow tarit implementation: [`42f593f` (#15559)](https://github.com/rust-lang/cargo/pull/15559/commits/42f593fa72c6eb5e4d1b660be1cca0d1858ab126)

Replace InternedString with `into()` across the whole codebase: [`5f90098` (#15559)](https://github.com/rust-lang/cargo/pull/15559/commits/5f900981de60ce4df51f3161d5505fedbf179d1d)
I am unsure if it worsens the readability. Feel free to comment.


### How should we test and review this PR?

It shouldn't change or break any tests.

Benchmark 1: https://github.com/rust-lang/cargo/pull/15559#issuecomment-2913155520
Benchmark 2: https://github.com/rust-lang/cargo/pull/15559#issuecomment-2927304675

### Additional information

None