### PR TITLE
fix(vendor)!: vendor files with .rej/.orig suffix

### DIFF
--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -618,10 +618,6 @@ fn vendor_this(relative: &Path) -> bool {
         // Temporary Cargo files
         Some(".cargo-ok") => false,
 
-        // Skip patch-style orig/rej files. Published crates on crates.io
-        // have `Cargo.toml.orig` which we don't want to use here and
-        // otherwise these are rarely used as part of the build process.
-        Some(p) if p.ends_with(".orig") || p.ends_with(".rej") => false,
         _ => true,
     }
 }

--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -1087,13 +1087,14 @@ fn ignore_files() {
     Package::new("url", "1.4.1")
         // These will be vendored
         .file(".cargo_vcs_info.json", "")
+        .file("Cargo.toml.orig", "")
+        .file("foo.orig", "")
+        .file("foo.rej", "")
         .file("src/lib.rs", "")
         // These will not be vendored
         .file(".cargo-ok", "")
         .file(".gitattributes", "")
         .file(".gitignore", "")
-        .file("foo.orig", "")
-        .file("foo.rej", "")
         .publish();
 
     p.cargo("vendor --respect-source-config").run();
@@ -1105,6 +1106,9 @@ fn ignore_files() {
   "files": {
     ".cargo_vcs_info.json": "[..]",
     "Cargo.toml": "[..]",
+    "Cargo.toml.orig": "[..]",
+    "foo.orig": "[..]",
+    "foo.rej": "[..]",
     "src/lib.rs": "[..]"
   },
   "package": "[..]"

--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -1094,11 +1094,19 @@ fn ignore_files() {
 
     p.cargo("vendor --respect-source-config").run();
     let csum = p.read_file("vendor/url/.cargo-checksum.json");
-    assert!(!csum.contains("foo.orig"));
-    assert!(!csum.contains(".gitignore"));
-    assert!(!csum.contains(".gitattributes"));
-    assert!(!csum.contains(".cargo-ok"));
-    assert!(!csum.contains("foo.rej"));
+    assert_e2e().eq(
+        csum,
+        str![[r#"
+{
+  "files": {
+    "Cargo.toml": "[..]",
+    "src/lib.rs": "[..]"
+  },
+  "package": "[..]"
+}
+"#]]
+        .is_json(),
+    );
 }
 
 #[cargo_test]

--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -1085,10 +1085,14 @@ fn ignore_files() {
         .build();
 
     Package::new("url", "1.4.1")
+        // These will be vendored
+        .file(".cargo_vcs_info.json", "")
         .file("src/lib.rs", "")
-        .file("foo.orig", "")
-        .file(".gitignore", "")
+        // These will not be vendored
+        .file(".cargo-ok", "")
         .file(".gitattributes", "")
+        .file(".gitignore", "")
+        .file("foo.orig", "")
         .file("foo.rej", "")
         .publish();
 
@@ -1099,6 +1103,7 @@ fn ignore_files() {
         str![[r#"
 {
   "files": {
+    ".cargo_vcs_info.json": "[..]",
     "Cargo.toml": "[..]",
     "src/lib.rs": "[..]"
   },


### PR DESCRIPTION
### What does this PR try to resolve?

This is meant to fixes #13191

As git sources and registry sources are considered immutable.
I don't think there is any reason excluding those files.
There might be a little chance local Git repositories might have those,
though that is a rare use case.

Alternatively,
we could reject all `.rej`/`.orig` files but `Cargo.toml.orig`.

### How should we test and review this PR?

Test updates should be sufficient.

### Additional information

This is a follow-up of #15514
