### PR TITLE
Add autocomplete for nested examples

### DIFF
--- a/src/etc/cargo.bashcomp.sh
+++ b/src/etc/cargo.bashcomp.sh
@@ -246,7 +246,7 @@ _get_examples(){
 	local manifest=$(_locate_manifest)
 	[ -z "$manifest" ] && return 0
 
-	local files=("${manifest%/*}"/examples/*.rs)
+	local files=("${manifest%/*}"/examples/**/*.rs)
 	local names=("${files[@]##*/}")
 	local names=("${names[@]%.*}")
 	# "*" means no examples found


### PR DESCRIPTION
### What does this PR try to resolve?

Not all examples show up in auto-completion.
If the `examples` directory has nested examples, only the top level ones will be shown with  `cargo build --example<TAB>`.
[Bevy examples](https://github.com/bevyengine/bevy/tree/latest/examples) only show `hello_world` instead of all available examples.

![image](https://github.com/user-attachments/assets/cf776f5a-1780-4b76-9b81-e9af33280ab8)

Old:
![image](https://github.com/user-attachments/assets/9251556f-ab92-4e3a-b58f-ae152f7cd126)

New:
![image](https://github.com/user-attachments/assets/7df4762a-b365-43f3-93f2-5c47d76e1efb)


### How should we test and review this PR?
Go into a Rust project with nested example directories (Bevy for example) and press `cargo build --example<TAB>`.
Observe all examples being listed now.