### PR TITLE
docs: add lock file section to the resolver docs

### DIFF
--- a/src/doc/src/reference/resolver.md
+++ b/src/doc/src/reference/resolver.md
@@ -12,6 +12,25 @@ resolver.
 [dependency specification]: specifying-dependencies.md
 [`cargo tree`]: ../commands/cargo-tree.md
 
+## `Cargo.lock` lock-files
+
+The `Cargo.lock` file provides deterministic builds at different times and on
+different systems, by ensuring that the exact same dependencies, versions, and
+sources are used as when the `Cargo.lock` file was last generated.
+Dependancy resolution is not run when cargo reads from `Cargo.lock`.
+
+Not all cargo commands use `Cargo.lock` by default. Examples include
+`cargo install` and `cargo update`.In these cases, `--locked` can usually be
+passed to force cargo to use the dependency graph from an existing `Cargo.lock`
+(if one exists).
+
+### Libraries with `Cargo.lock`
+
+Cargo treats `Cargo.lock` files differently when a crate is used as a library
+dependency where an upper level `Cargo.lock` would exist. In these cases cargo will
+not inspect the dependency's `Cargo.lock` even if it exists, using only the
+top-level `Cargo.lock`.
+
 ## Constraints and Heuristics
 
 In many cases there is no single "best" dependency resolution.


### PR DESCRIPTION
Adds some documentation about how lockfiles work to the resolver section, particularly regarding when lock files exist in library dependencies.

Effectively re-adds an updated section of docs that was lost here: https://github.com/rust-lang/cargo/pull/12382/files#diff-197a732275c32bdbdb079bdd92ac8a4ba585ee556ea978e9e661804eb76ce9eeL117-L121

Related to this Zulip thread https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/cargo.20lock.20in.20dependency/with/519679182

<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
