### PR TITLE
fix(search): follow http redirects

### DIFF
--- a/src/cargo/ops/registry/mod.rs
+++ b/src/cargo/ops/registry/mod.rs
@@ -169,7 +169,8 @@ fn registry<'gctx>(
     } else {
         None
     };
-    let handle = http_handle(gctx)?;
+    let mut handle = http_handle(gctx)?;
+    handle.follow_location(true)?;
     Ok((
         Registry::new_handle(api_host, token, handle, cfg.auth_required),
         src,


### PR DESCRIPTION
Adds follow_location(true) to search commands, the same as other commands.

Fixes #15592 
