### PR TITLE
docs(README): fix the link to the changelog in the Cargo book

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ High level release notes are available as part of [Rust's release notes][rel].
 Detailed release notes are available in the [changelog].
 
 [rel]: https://github.com/rust-lang/rust/blob/master/RELEASES.md
-[changelog]: https://doc.rust-lang.org/nightly/cargo/CHANGELOG.md
+[changelog]: https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html
 
 ## Reporting issues
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
### What does this PR try to resolve?

When Cargo's changelog was moved into the book in  #15123, it seems the extension was left as `.md`, whereas the link should point to the rendered version, which ends with `.html`.

### How should we test and review this PR?

Following the new link in the README's rendered view and observing that it does indeed point to the changelog should be enough.