### PR TITLE
chore(toml): disable `toml`'s default features, unless necessary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ tar = { version = "0.4.43", default-features = false }
 tempfile = "3.20.0"
 thiserror = "2.0.11"
 time = { version = "0.3.37", features = ["parsing", "formatting", "serde"] }
-toml = "0.8.20"
+toml = { version = "0.8.20", default-features = false }
 toml_edit = { version = "0.22.23", features = ["serde"] }
 tracing = { version = "0.1.41", default-features = false, features = ["std"] } # be compatible with rustc_log: https://github.com/rust-lang/rust/blob/e51e98dde6a/compiler/rustc_log/Cargo.toml#L9
 tracing-chrome = "0.7.2"
@@ -210,7 +210,7 @@ tar.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 time.workspace = true
-toml.workspace = true
+toml = { workspace = true, features = ["display", "parse"] }
 toml_edit.workspace = true
 tracing = { workspace = true, features = ["attributes"] }
 tracing-subscriber.workspace = true

--- a/benches/capture/Cargo.toml
+++ b/benches/capture/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 cargo_metadata.workspace = true
 flate2.workspace = true
 tar.workspace = true
-toml.workspace = true
+toml = { workspace = true, features = ["display", "parse"] }
 
 [lints]
 workspace = true

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -27,7 +27,7 @@ serde_json.workspace = true
 snapbox.workspace = true
 tar.workspace = true
 time.workspace = true
-toml.workspace = true
+toml = { workspace = true, features = ["display"] }
 url.workspace = true
 walkdir.workspace = true
 


### PR DESCRIPTION
### What does this PR try to resolve?

This reduces the build time of `cargo-util-schemas` by disabling the unused `display` and `parse` features of `toml` (which are enabled by default).

This is useful as `cargo-util-schemas` is intended to be reused outside of Cargo.

### How should we test and review this PR?

As I believe these features only *feature-gate* items on `toml` (they do not affect runtime behavior silently), the CI building successfully should be enough to make sure this does not break anything. ~If this does not build, I will try to tend to it today, otherwise feel free to push to this branch.~