### PR TITLE
fix(doc): pass `toolchain-shared-resources` to get doc styled

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -810,8 +810,10 @@ fn prepare_rustdoc(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> CargoResu
     add_allow_features(build_runner, &mut rustdoc);
 
     if build_runner.bcx.gctx.cli_unstable().rustdoc_depinfo {
+        // toolchain-shared-resources is required for keeping the shared styling resources
         // invocation-specific is required for keeping the original rustdoc emission
-        let mut arg = OsString::from("--emit=invocation-specific,dep-info=");
+        let mut arg =
+            OsString::from("--emit=toolchain-shared-resources,invocation-specific,dep-info=");
         arg.push(rustdoc_dep_info_loc(build_runner, unit));
         rustdoc.arg(arg);
 


### PR DESCRIPTION

### What does this PR try to resolve?

Fixes #15604

rustdoc assumes to add static files only when the
toolchain-shared-resources emit-type is specified, or when no emit-type is specified.

See https://github.com/rust-lang/rust/blob/80c34983c63968c204096e79b9126c0039790741/src/librustdoc/html/render/write_shared.rs#L206-L213

### How should we test and review this PR?

Not going to write a test because I don't think we want to inspect into how rustdoc arranges static files.

### Additional information

