### PR TITLE
chore: remove HTML comments and inline guide

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,36 +1,12 @@
-<!--
-Thanks for submitting a pull request 🎉! Here are some tips for you:
-
-* If this is your first contribution, read "Cargo Contribution Guide" first:
-  https://doc.crates.io/contrib/
-* Run `cargo fmt --all` to format your code changes.
-* Small commits and pull requests are always preferable and easy to review.
-* If your idea is large and needs feedback from the community, read how:
-  https://doc.crates.io/contrib/process/#working-on-large-features
-* Cargo takes care of compatibility. Read our design principles:
-  https://doc.crates.io/contrib/design.html
-* When changing help text of cargo commands, follow the steps to generate docs:
-  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
-* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
-* It's ok to use the CI resources to test your PR, but please don't abuse them.
+_Thanks for the pull request 🎉!_
+_Please read the contribution guide: <https://doc.crates.io/contrib/>._
 
 ### What does this PR try to resolve?
 
-Explain the motivation behind this change.
-A clear overview along with an in-depth explanation are helpful.
+_Explain the motivation behind this change._
+_A clear overview along with an in-depth explanation are helpful._
 
-You can use `Fixes #<issue number>` to associate this PR to an existing issue.
+### How to test and review this PR?
 
-### How should we test and review this PR?
-
-Demonstrate how you test this change and guide reviewers through your PR.
-With a smooth review process, a pull request usually gets reviewed quicker.
-
-If you don't know how to write and run your tests, please read the guide:
-https://doc.crates.io/contrib/tests
-
-### Additional information
-
-Other information you want to mention in this PR, such as prior arts,
-future extensions, an unresolved problem, or a TODO list.
--->
+_Demonstrate how you test this change and guide reviewers through your PR._
+_With a smooth review process, a pull request usually gets reviewed quicker._


### PR DESCRIPTION
### What does this PR try to resolve?

The HTML comments in the PR template, after this repo migrated to GitHub merge queue, often show up in the merge commit message when people forgot to delete it.

This PR removes those, as they are only important for people never look at the contributor guide. We keep one link to the guide though at the top of the template.

It also moves the entire template out of HTML comments, so it is more obvious for maintainers to see what will be in the merge commit message.

The “Additional information” paragraph is removed, as I observed it is seldom used.

### How to test and review this PR?

Copy and paste the PR template into the PR description preview, and see if it satisfies your eyes.
