### PR TITLE
[Pre-RFC] Enable `.cargo/root`, `CARGO_ROOTS` + `--root` to limit config + manifest searches

### DIFF
--- a/benches/benchsuite/benches/global_cache_tracker.rs
+++ b/benches/benchsuite/benches/global_cache_tracker.rs
@@ -35,7 +35,7 @@ fn initialize_context() -> GlobalContext {
     let cwd = homedir.clone();
     let mut gctx = GlobalContext::new(shell, cwd, homedir);
     gctx.nightly_features_allowed = true;
-    gctx.set_search_stop_path(root());
+    gctx.set_config_search_root(root());
     gctx.configure(
         0,
         false,

--- a/crates/cargo-util/src/paths.rs
+++ b/crates/cargo-util/src/paths.rs
@@ -441,14 +441,14 @@ pub struct PathAncestors<'a> {
 
 impl<'a> PathAncestors<'a> {
     fn new(path: &'a Path, stop_root_at: Option<&Path>) -> PathAncestors<'a> {
-        let stop_at = env::var("__CARGO_TEST_ROOT")
-            .ok()
-            .map(PathBuf::from)
-            .or_else(|| stop_root_at.map(|p| p.to_path_buf()));
+        tracing::trace!(
+            "creating path ancestors iterator from `{}` to `{}`",
+            path.display(),
+            stop_root_at.map_or("<root>".to_string(), |p| p.display().to_string())
+        );
         PathAncestors {
             current: Some(path),
-            //HACK: avoid reading `~/.cargo/config` when testing Cargo itself.
-            stop_at,
+            stop_at: stop_root_at.map(|p| p.to_path_buf()),
         }
     }
 }
@@ -466,6 +466,7 @@ impl<'a> Iterator for PathAncestors<'a> {
                 }
             }
 
+            tracing::trace!("next path ancestor: `{}`", path.display());
             Some(path)
         } else {
             None

--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::ffi::OsString;
 use std::fmt::Write;
+use tracing::warn;
 
 use super::commands;
 use super::list_commands;
@@ -131,6 +132,10 @@ pub fn main(gctx: &mut GlobalContext) -> CliResult {
 
     // Reload now that we have established the cwd and root
     gctx.reload_cwd()?;
+
+    if gctx.find_nearest_root(gctx.cwd())?.is_none() {
+        gctx.shell().warn("Cargo is running outside of any root directory, limiting loading of ancestor configs and manifest")?;
+    }
 
     let (expanded_args, global_args) = expand_aliases(gctx, args, vec![])?;
 

--- a/src/bin/cargo/commands/locate_project.rs
+++ b/src/bin/cargo/commands/locate_project.rs
@@ -30,10 +30,12 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
     let workspace;
     let root = match WhatToFind::parse(args) {
         WhatToFind::CurrentManifest => {
+            tracing::trace!("locate-project::exec(): finding root manifest");
             root_manifest = args.root_manifest(gctx)?;
             &root_manifest
         }
         WhatToFind::Workspace => {
+            tracing::trace!("locate-project::exec(): finding workspace root manifest");
             workspace = args.workspace(gctx)?;
             workspace.root_manifest()
         }

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -2024,7 +2024,7 @@ fn find_workspace_root_with_loader(
     gctx: &GlobalContext,
     mut loader: impl FnMut(&Path) -> CargoResult<Option<PathBuf>>,
 ) -> CargoResult<Option<PathBuf>> {
-    let search_route = gctx.find_manifest_search_route(manifest_path);
+    let search_route = gctx.find_workspace_manifest_search_route(manifest_path);
 
     // Check if there are any workspace roots that have already been found that would work
     {

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -21,7 +21,7 @@ use crate::core::{
 use crate::core::{EitherManifest, Package, SourceId, VirtualManifest};
 use crate::ops;
 use crate::sources::{PathSource, SourceConfigMap, CRATES_IO_INDEX, CRATES_IO_REGISTRY};
-use crate::util::context::FeatureUnification;
+use crate::util::context::{FeatureUnification, SearchRoute};
 use crate::util::edit_distance;
 use crate::util::errors::{CargoResult, ManifestError};
 use crate::util::interning::InternedString;
@@ -746,6 +746,7 @@ impl<'gctx> Workspace<'gctx> {
     /// Returns an error if `manifest_path` isn't actually a valid manifest or
     /// if some other transient error happens.
     fn find_root(&mut self, manifest_path: &Path) -> CargoResult<Option<PathBuf>> {
+        debug!("find_root - {}", manifest_path.display());
         let current = self.packages.load(manifest_path)?;
         match current
             .workspace_config()
@@ -2023,12 +2024,14 @@ fn find_workspace_root_with_loader(
     gctx: &GlobalContext,
     mut loader: impl FnMut(&Path) -> CargoResult<Option<PathBuf>>,
 ) -> CargoResult<Option<PathBuf>> {
+    let search_route = gctx.find_manifest_search_route(manifest_path);
+
     // Check if there are any workspace roots that have already been found that would work
     {
         let roots = gctx.ws_roots.borrow();
         // Iterate through the manifests parent directories until we find a workspace
         // root. Note we skip the first item since that is just the path itself
-        for current in paths::ancestors(manifest_path, gctx.search_stop_path()).skip(1) {
+        for current in paths::ancestors(&search_route.start, search_route.root.as_deref()).skip(1) {
             if let Some(ws_config) = roots.get(current) {
                 if !ws_config.is_excluded(manifest_path) {
                     // Add `Cargo.toml` since ws_root is the root and not the file
@@ -2038,7 +2041,7 @@ fn find_workspace_root_with_loader(
         }
     }
 
-    for ances_manifest_path in find_root_iter(manifest_path, gctx) {
+    for ances_manifest_path in find_root_iter(&search_route, gctx) {
         debug!("find_root - trying {}", ances_manifest_path.display());
         if let Some(ws_root_path) = loader(&ances_manifest_path)? {
             return Ok(Some(ws_root_path));
@@ -2058,10 +2061,10 @@ fn read_root_pointer(member_manifest: &Path, root_link: &str) -> PathBuf {
 }
 
 fn find_root_iter<'a>(
-    manifest_path: &'a Path,
+    search_route: &'a SearchRoute,
     gctx: &'a GlobalContext,
 ) -> impl Iterator<Item = PathBuf> + 'a {
-    LookBehind::new(paths::ancestors(manifest_path, gctx.search_stop_path()).skip(2))
+    LookBehind::new(paths::ancestors(&search_route.start, search_route.root.as_deref()).skip(2))
         .take_while(|path| !path.curr.ends_with("target/package"))
         // Don't walk across `CARGO_HOME` when we're looking for the
         // workspace root. Sometimes a package will be organized with

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -2028,7 +2028,7 @@ fn find_workspace_root_with_loader(
         let roots = gctx.ws_roots.borrow();
         // Iterate through the manifests parent directories until we find a workspace
         // root. Note we skip the first item since that is just the path itself
-        for current in manifest_path.ancestors().skip(1) {
+        for current in paths::ancestors(manifest_path, gctx.search_stop_path()).skip(1) {
             if let Some(ws_config) = roots.get(current) {
                 if !ws_config.is_excluded(manifest_path) {
                     // Add `Cargo.toml` since ws_root is the root and not the file
@@ -2061,7 +2061,7 @@ fn find_root_iter<'a>(
     manifest_path: &'a Path,
     gctx: &'a GlobalContext,
 ) -> impl Iterator<Item = PathBuf> + 'a {
-    LookBehind::new(paths::ancestors(manifest_path, None).skip(2))
+    LookBehind::new(paths::ancestors(manifest_path, gctx.search_stop_path()).skip(2))
         .take_while(|path| !path.curr.ends_with("target/package"))
         // Don't walk across `CARGO_HOME` when we're looking for the
         // workspace root. Sometimes a package will be organized with

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -802,7 +802,7 @@ fn mk(gctx: &GlobalContext, opts: &MkOptions<'_>) -> CargoResult<()> {
     }
 
     let manifest_path = paths::normalize_path(&path.join("Cargo.toml"));
-    if let Ok(root_manifest_path) = find_root_manifest_for_wd(&manifest_path) {
+    if let Ok(root_manifest_path) = find_root_manifest_for_wd(gctx, &manifest_path) {
         let root_manifest = paths::read(&root_manifest_path)?;
         // Sometimes the root manifest is not a valid manifest, so we only try to parse it if it is.
         // This should not block the creation of the new project. It is only a best effort to

--- a/src/cargo/ops/registry/owner.rs
+++ b/src/cargo/ops/registry/owner.rs
@@ -28,7 +28,7 @@ pub fn modify_owners(gctx: &GlobalContext, opts: &OwnersOptions) -> CargoResult<
     let name = match opts.krate {
         Some(ref name) => name.clone(),
         None => {
-            let manifest_path = find_root_manifest_for_wd(gctx.cwd())?;
+            let manifest_path = find_root_manifest_for_wd(gctx, gctx.cwd())?;
             let ws = Workspace::new(&manifest_path, gctx)?;
             ws.current()?.package_id().name().to_string()
         }

--- a/src/cargo/ops/registry/yank.rs
+++ b/src/cargo/ops/registry/yank.rs
@@ -26,7 +26,7 @@ pub fn yank(
     let name = match krate {
         Some(name) => name,
         None => {
-            let manifest_path = find_root_manifest_for_wd(gctx.cwd())?;
+            let manifest_path = find_root_manifest_for_wd(gctx, gctx.cwd())?;
             let ws = Workspace::new(&manifest_path, gctx)?;
             ws.current()?.package_id().name().to_string()
         }

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -1077,7 +1077,7 @@ pub fn root_manifest(manifest_path: Option<&Path>, gctx: &GlobalContext) -> Carg
         }
         Ok(path)
     } else {
-        find_root_manifest_for_wd(gctx.cwd())
+        find_root_manifest_for_wd(gctx, gctx.cwd())
     }
 }
 
@@ -1132,7 +1132,7 @@ fn get_profile_candidates() -> Vec<clap_complete::CompletionCandidate> {
 
 fn get_workspace_profile_candidates() -> CargoResult<Vec<clap_complete::CompletionCandidate>> {
     let gctx = new_gctx_for_completions()?;
-    let ws = Workspace::new(&find_root_manifest_for_wd(gctx.cwd())?, &gctx)?;
+    let ws = Workspace::new(&find_root_manifest_for_wd(&gctx, gctx.cwd())?, &gctx)?;
     let profiles = Profiles::new(&ws, InternedString::new("dev"))?;
 
     let mut candidates = Vec::new();
@@ -1216,7 +1216,7 @@ fn get_bin_candidates() -> Vec<clap_complete::CompletionCandidate> {
 fn get_targets_from_metadata() -> CargoResult<Vec<Target>> {
     let cwd = std::env::current_dir()?;
     let gctx = GlobalContext::new(shell::Shell::new(), cwd.clone(), cargo_home_with_cwd(&cwd)?);
-    let ws = Workspace::new(&find_root_manifest_for_wd(&cwd)?, &gctx)?;
+    let ws = Workspace::new(&find_root_manifest_for_wd(&gctx, &cwd)?, &gctx)?;
 
     let packages = ws.members().collect::<Vec<_>>();
 
@@ -1271,7 +1271,10 @@ fn get_target_triples_from_rustup() -> CargoResult<Vec<clap_complete::Completion
 fn get_target_triples_from_rustc() -> CargoResult<Vec<clap_complete::CompletionCandidate>> {
     let cwd = std::env::current_dir()?;
     let gctx = GlobalContext::new(shell::Shell::new(), cwd.clone(), cargo_home_with_cwd(&cwd)?);
-    let ws = Workspace::new(&find_root_manifest_for_wd(&PathBuf::from(&cwd))?, &gctx);
+    let ws = Workspace::new(
+        &find_root_manifest_for_wd(&gctx, &PathBuf::from(&cwd))?,
+        &gctx,
+    );
 
     let rustc = gctx.load_global_rustc(ws.as_ref().ok())?;
 
@@ -1374,7 +1377,7 @@ pub fn get_pkg_id_spec_candidates() -> Vec<clap_complete::CompletionCandidate> {
 fn get_packages() -> CargoResult<Vec<Package>> {
     let gctx = new_gctx_for_completions()?;
 
-    let ws = Workspace::new(&find_root_manifest_for_wd(gctx.cwd())?, &gctx)?;
+    let ws = Workspace::new(&find_root_manifest_for_wd(&gctx, gctx.cwd())?, &gctx)?;
 
     let requested_kinds = CompileKind::from_requested_targets(ws.gctx(), &[])?;
     let mut target_data = RustcTargetData::new(&ws, &requested_kinds)?;

--- a/src/cargo/util/context/mod.rs
+++ b/src/cargo/util/context/mod.rs
@@ -639,7 +639,7 @@ impl GlobalContext {
         }
     }
 
-    fn find_nearest_root<P: AsRef<Path>>(
+    pub fn find_nearest_root<P: AsRef<Path>>(
         &self,
         start: P,
     ) -> CargoResult<Option<(PathBuf, PathBuf)>> {

--- a/src/cargo/util/context/mod.rs
+++ b/src/cargo/util/context/mod.rs
@@ -567,6 +567,11 @@ impl GlobalContext {
         }
     }
 
+    /// Gets the path where ancestor config file and workspace searching will stop.
+    pub fn search_stop_path(&self) -> Option<&Path> {
+        self.search_stop_path.as_deref()
+    }
+
     /// Sets the path where ancestor config file searching will stop. The
     /// given path is included, but its ancestors are not.
     pub fn set_search_stop_path<P: Into<PathBuf>>(&mut self, path: P) {

--- a/src/cargo/util/context/mod.rs
+++ b/src/cargo/util/context/mod.rs
@@ -159,6 +159,30 @@ pub struct CredentialCacheValue {
     pub operation_independent: bool,
 }
 
+/// A point-to-point route for searching config files or manifests, resolved
+/// based on a starting directory and a set of root directories.
+#[derive(Clone, Debug)]
+pub struct SearchRoute {
+    /// The first directory in the route to search (inclusive)
+    /// The path is canonicalized.
+    pub start: PathBuf,
+    /// The last directory in the route to search (inclusive)
+    /// If not set then the route ends at the root of the filesystem.
+    /// The path is canonicalized.
+    pub root: Option<PathBuf>,
+}
+
+impl SearchRoute {
+    pub fn sentinal(path: impl AsRef<Path>) -> Self {
+        let start = path
+            .as_ref()
+            .canonicalize()
+            .expect("failed to canonicalize path");
+        let root = Some(start.clone());
+        Self { start, root }
+    }
+}
+
 /// Configuration information for cargo. This is not specific to a build, it is information
 /// relating to cargo itself.
 #[derive(Debug)]
@@ -175,8 +199,13 @@ pub struct GlobalContext {
     cli_config: Option<Vec<String>>,
     /// The current working directory of cargo
     cwd: PathBuf,
-    /// Directory where config file searching should stop (inclusive).
-    search_stop_path: Option<PathBuf>,
+    /// The full set of root directories that limit config file searching.
+    /// Sorted by path length, longest first.
+    sorted_roots: Vec<PathBuf>,
+    /// Directories to search for config files (invalidated if roots or cwd changes).
+    config_search_route: RefCell<Option<SearchRoute>>,
+    /// Directories to search for manifest files (invalidated if roots or starting point changes).
+    manifest_search_route: RefCell<Option<SearchRoute>>,
     /// The location of the cargo executable (path to current process)
     cargo_exe: LazyCell<PathBuf>,
     /// The location of the rustdoc executable
@@ -281,11 +310,17 @@ impl GlobalContext {
             _ => true,
         };
 
+        // By default only allow searching the current directory, until roots
+        // are set.
+        //let config_search_route = SearchRoute::sentinal(&cwd);
+
         GlobalContext {
             home_path: Filesystem::new(homedir),
             shell: RefCell::new(shell),
             cwd,
-            search_stop_path: None,
+            sorted_roots: Vec::new(),
+            config_search_route: RefCell::new(None),
+            manifest_search_route: RefCell::new(None),
             values: LazyCell::new(),
             credential_values: LazyCell::new(),
             cli_config: None,
@@ -567,17 +602,132 @@ impl GlobalContext {
         }
     }
 
-    /// Gets the path where ancestor config file and workspace searching will stop.
-    pub fn search_stop_path(&self) -> Option<&Path> {
-        self.search_stop_path.as_deref()
+    pub fn add_root<P: AsRef<Path>>(&mut self, path: P) -> CargoResult<()> {
+        let path = path
+            .as_ref()
+            .canonicalize()
+            .context("couldn't canonicalize path")?;
+        if !self.sorted_roots.iter().any(|root| root == &path) {
+            self.sorted_roots.push(path);
+            self.sorted_roots
+                .sort_by_key(|p| std::cmp::Reverse(p.components().count()));
+            self.config_search_route = RefCell::new(None);
+            self.manifest_search_route = RefCell::new(None);
+        }
+        Ok(())
     }
 
-    /// Sets the path where ancestor config file searching will stop. The
-    /// given path is included, but its ancestors are not.
-    pub fn set_search_stop_path<P: Into<PathBuf>>(&mut self, path: P) {
-        let path = path.into();
-        debug_assert!(self.cwd.starts_with(&path));
-        self.search_stop_path = Some(path);
+    /// Find shortest route between `start` and one of the roots in [Self::sorted_roots].
+    ///
+    /// If no root is found then fallback to root == start so we only search one directory.
+    /// - This is a safety measure to reduce the risk of reading unsafe state from locations
+    ///   that are not owned by the user (for example building under `/tmp`).
+    fn find_search_route<P: AsRef<Path>>(&self, start: P) -> CargoResult<SearchRoute> {
+        let start = start
+            .as_ref()
+            .canonicalize()
+            .context("couldn't canonicalize path")?;
+
+        tracing::debug!("Searching sorted roots for start {:?}", self.sorted_roots);
+        let root = self
+            .sorted_roots
+            .iter()
+            .filter_map(|root| {
+                if start.starts_with(root) {
+                    tracing::debug!(
+                        "Found candidate search root {:?} for start {:?}",
+                        root,
+                        start
+                    );
+                    Some(root.clone())
+                } else {
+                    tracing::debug!(
+                        "Skipping candidate search root {:?} for start {:?}",
+                        root,
+                        start
+                    );
+                    None
+                }
+            })
+            .next();
+
+        // Cargo no longer allows searching up to the root of the filesystem unless the root is
+        // explicitly added to `sorted_roots`.
+        let root = root.unwrap_or_else(|| start.clone());
+        Ok(SearchRoute {
+            start,
+            root: Some(root),
+        })
+    }
+
+    /// Ignore any configured roots and define a config search route between
+    /// `cwd` and `path`. If `path` is `None`, then the search route will go to
+    /// the root of the filesystem which could be unsafe.
+    ///
+    /// Normally [`update_config_search_route`] should be used instead.
+    pub fn set_config_search_root<P: Into<PathBuf>>(&mut self, root: Option<P>) {
+        let Ok(start) = self.cwd().canonicalize() else {
+            *self.config_search_route.borrow_mut() = None;
+            return;
+        };
+        if let Some(path) = root {
+            let root = path.into();
+            debug_assert!(self.cwd.starts_with(&root));
+            let Ok(root) = root.canonicalize() else {
+                *self.config_search_route.borrow_mut() = None;
+                return;
+            };
+            *self.config_search_route.borrow_mut() = Some(SearchRoute {
+                start,
+                root: Some(root),
+            });
+        } else {
+            *self.config_search_route.borrow_mut() = Some(SearchRoute { start, root: None });
+        }
+    }
+
+    pub fn find_config_search_route<P: AsRef<Path>>(&self, start: P) -> SearchRoute {
+        tracing::trace!(
+            "Finding config search route starting at {:?}",
+            start.as_ref()
+        );
+
+        let start = start
+            .as_ref()
+            .canonicalize()
+            .expect("failed to canonicalize cwd");
+        // Return the existing route if the start == path.
+        if let Some(route) = &*self.config_search_route.borrow() {
+            if route.start == start {
+                tracing::trace!("Using cached config search route: {:?}", route);
+                return route.clone();
+            }
+        }
+
+        let config_search_route = self
+            .find_search_route(start)
+            .expect("failed to find config file search route");
+        *self.config_search_route.borrow_mut() = Some(config_search_route.clone());
+        config_search_route
+    }
+
+    pub fn find_manifest_search_route<P: AsRef<Path>>(&self, start: P) -> SearchRoute {
+        let start = start
+            .as_ref()
+            .canonicalize()
+            .expect("failed to canonicalize path");
+        // Return the existing route if the start == path.
+        if let Some(route) = &*self.manifest_search_route.borrow() {
+            if route.start == start {
+                return route.clone();
+            }
+        }
+
+        let manifest_search_route = self
+            .find_search_route(start)
+            .expect("failed to find manifest search route");
+        *self.manifest_search_route.borrow_mut() = Some(manifest_search_route.clone());
+        manifest_search_route.clone()
     }
 
     /// Switches the working directory to [`std::env::current_dir`]
@@ -594,6 +744,7 @@ impl GlobalContext {
         })?;
 
         self.cwd = cwd;
+        *self.config_search_route.borrow_mut() = None;
         self.home_path = Filesystem::new(homedir);
         self.reload_rooted_at(self.cwd.clone())?;
         Ok(())
@@ -1262,7 +1413,7 @@ impl GlobalContext {
         let mut result = Vec::new();
         let mut seen = HashSet::new();
         let home = self.home_path.clone().into_path_unlocked();
-        self.walk_tree(&self.cwd, &home, |path| {
+        self.walk_config_search_route(&self.cwd, &home, |path| {
             let mut cv = self._load_file(path, &mut seen, false, WhyLoad::FileDiscovery)?;
             if self.cli_unstable().config_include {
                 self.load_unmerged_include(&mut cv, &mut seen, &mut result)?;
@@ -1303,7 +1454,7 @@ impl GlobalContext {
         let mut cfg = CV::Table(HashMap::new(), Definition::Path(PathBuf::from(".")));
         let home = self.home_path.clone().into_path_unlocked();
 
-        self.walk_tree(path, &home, |path| {
+        self.walk_config_search_route(path, &home, |path| {
             let value = self.load_file(path)?;
             cfg.merge(value, false).with_context(|| {
                 format!("failed to merge configuration at `{}`", path.display())
@@ -1681,13 +1832,14 @@ impl GlobalContext {
         }
     }
 
-    fn walk_tree<F>(&self, pwd: &Path, home: &Path, mut walk: F) -> CargoResult<()>
+    fn walk_config_search_route<F>(&self, pwd: &Path, home: &Path, mut walk: F) -> CargoResult<()>
     where
         F: FnMut(&Path) -> CargoResult<()>,
     {
         let mut seen_dir = HashSet::new();
 
-        for current in paths::ancestors(pwd, self.search_stop_path.as_deref()) {
+        let search_route = self.find_config_search_route(pwd);
+        for current in paths::ancestors(&search_route.start, search_route.root.as_deref()) {
             let config_root = current.join(".cargo");
             if let Some(path) = self.get_file_path(&config_root, "config", true)? {
                 walk(&path)?;
@@ -3157,7 +3309,6 @@ mod tests {
     #[test]
     fn disables_multiplexing() {
         let mut gctx = GlobalContext::new(Shell::new(), "".into(), "".into());
-        gctx.set_search_stop_path(std::path::PathBuf::new());
         gctx.set_env(Default::default());
 
         let mut http = CargoHttpConfig::default();

--- a/src/cargo/util/important_paths.rs
+++ b/src/cargo/util/important_paths.rs
@@ -10,7 +10,7 @@ pub fn find_root_manifest_for_wd(gctx: &GlobalContext, cwd: &Path) -> CargoResul
     let invalid_cargo_toml_file_name = "cargo.toml";
     let mut invalid_cargo_toml_path_exists = false;
 
-    let search_route = gctx.find_manifest_search_route(cwd);
+    let search_route = gctx.find_package_manifest_search_route(cwd);
     for current in paths::ancestors(&search_route.start, search_route.root.as_deref()) {
         let manifest = current.join(valid_cargo_toml_file_name);
         if manifest.exists() {

--- a/src/cargo/util/important_paths.rs
+++ b/src/cargo/util/important_paths.rs
@@ -2,13 +2,16 @@ use crate::util::errors::CargoResult;
 use cargo_util::paths;
 use std::path::{Path, PathBuf};
 
+use super::GlobalContext;
+
 /// Finds the root `Cargo.toml`.
-pub fn find_root_manifest_for_wd(cwd: &Path) -> CargoResult<PathBuf> {
+pub fn find_root_manifest_for_wd(gctx: &GlobalContext, cwd: &Path) -> CargoResult<PathBuf> {
     let valid_cargo_toml_file_name = "Cargo.toml";
     let invalid_cargo_toml_file_name = "cargo.toml";
     let mut invalid_cargo_toml_path_exists = false;
 
-    for current in paths::ancestors(cwd, None) {
+    let search_route = gctx.find_manifest_search_route(cwd);
+    for current in paths::ancestors(&search_route.start, search_route.root.as_deref()) {
         let manifest = current.join(valid_cargo_toml_file_name);
         if manifest.exists() {
             return Ok(manifest);

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -44,6 +44,19 @@ those configuration files if it is invoked from the workspace root
 > and is the preferred form. If both files exist, Cargo will use the file
 > without the extension.
 
+The root of the search hierarchy can be constrained in three ways:
+
+1. By creating a `.cargo/root` file (empty)
+2. By setting the `CARGO_ROOT` environment variable
+3. Passing `--root`.
+
+If a root directory is given then Cargo will search parent directories up until
+it reaches the root directory, instead of searching all the way up to the root
+of the filesystem. Cargo will still check `$CARGO_HOME/config.toml` even if it
+is outside of the root directory. If multiple paths are specified then the
+effective root is the one that's most-specific (closest to the current working
+directory).
+
 ## Configuration format
 
 Configuration files are written in the [TOML format][toml] (like the

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -20,6 +20,10 @@ system:
   location of this directory. Once a crate is cached it is not removed by the
   clean command.
   For more details refer to the [guide](../guide/cargo-home.md).
+* `CARGO_ROOT` --- Instead of letting Cargo search every ancestor directory, up
+  to the root of the filesystem, looking for `.cargo` config directories or
+  workspace manifests, this limits how far Cargo can search. It doesn't stop
+  Cargo from reading `$CARGO_HOME/config.toml`, even if it's outside the root.
 * `CARGO_TARGET_DIR` --- Location of where to place all generated artifacts,
   relative to the current working directory. See [`build.target-dir`] to set
   via config.

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -110,7 +110,7 @@ impl GlobalContextBuilder {
         let mut gctx = GlobalContext::new(shell, cwd, homedir);
         gctx.nightly_features_allowed = self.enable_nightly_features || !self.unstable.is_empty();
         gctx.set_env(self.env.clone());
-        gctx.set_search_stop_path(&root);
+        gctx.set_config_search_root(&root);
         gctx.configure(
             0,
             false,


### PR DESCRIPTION
_This is a draft proposal that I think could address a number of issues in Cargo (e.g. #5418, #7871) and could be an alternative (or complementary) approach to addressing the safety issues discussed in https://github.com/rust-lang/rfcs/pull/3279_

_The intention here is to prototype a practical solution that can then hopefully inform any follow up discussions._

_My current [motivation](https://github.com/rust-lang/cargo/issues/5418#issuecomment-2886497944) for looking at this comes from using Cargo as part of a [rustdoc-markdown](https://github.com/Dooyo-Labs/rustdoc-markdown) toolchain that should be able to build third-party crates without worrying about side effects from unrelated configs or workspace manifests in parent directories._

--

This adds the notion of root directories to Cargo, which act as limits to how far Cargo  will search ancestors looking for `.cargo` config files or `Cargo.toml` manifests (instead of walking to the root of the filesystem).

This has some similarity to Git's `GIT_CEILING_DIRECTORIES` mechanism.

There are three notable searches that root directories affect:
1. How far should Cargo search when loading `.cargo/Config.toml` files
2. How far should Cargo search from when loading a `Cargo.toml` package manifest
3. How far should Cargo search from a package manifest directory looking for a `Cargo.toml` workspace manifest.

Roots can be specified in three ways:

1. By setting the `CARGO_ROOTS` environment variable to a colon (semicolon on Windows) separated list of directories
4. By passing `--root` on the command line (can be passed multiple times)
   i. Suited to tool configurations where appending to environment variables may be limited (e.g. limited environment variable interpolation in vscode settings)
5. The existence of a `.cargo/root` file (discovered by checking parents up towards the root of the filesystem)
    i. Suited to sandboxing directories when the absolute path might vary, such in within monorepos that could be cloned to different locations or directories that may get mounted in Docker containers.

By default, if `CARGO_ROOTS` has not been set then the user's home directory is implicitly added as a root directory.
- This is for safer default behaviour that stops Cargo from loading configs from shared directories like `/tmp/.cargo/`, or `C:/.cargo` or searching for workspace manifests.

The default home-directory root also mitigates issues with triggering automounters on some systems.

Whenever Cargo needs to search ancestors for files it will resolve the closest root directory that is an ancestor of the starting directory and that root is the last directory Cargo will search.

If the starting directory is not within any root then Cargo will only search the starting directory. Cargo will also print a warning to indicate that it's loading of configs + workspace manifests is limited.

_As a safety / ergonomics (+ backwards compatibility) trade-off, there is a special case that allows Cargo to search up to the root of the filesystem when searching for the first `Cargo.toml` package manifest, IFF the starting directory is outside of all roots. This enables a package to be unpacked under a shared directory like `/tmp/my-package` and start a build from `/tmp/my-package/sub/dir` which will load `/tmp/my-package/Cargo.toml` but will _not_ then allow Cargo to attempt loading a workspace at `/tmp/Cargo.toml`._

### What does this PR try to resolve?

Fixes: #5418
- For use cases where the workaround described in #6805 isn't appropriate (to add an empty workspace to nested packages)

Fixes: #7871
  - Addresses safety issues with building under shared directories like `/tmp`
  - Mitigates triggering home directory automounters

Addresses: https://github.com/rust-lang/rfcs/pull/3279

This gives more flexibility for tools that want to use cargo as an implementation detail. In particular this allows you to sandbox the build of nested third-party workspaces that may be (unknowingly) dynamically unpacked within an outer workspace, in situations where neither the workspace being built and the outer workspace are owned by the tool that is managing the build.

This does not attempt to support nesting workspaces with inheritence (as described in #5042).

For example a tool based on rustdoc-json should be able to fetch and build documentation for third-party crates under any user-specified build/target directory without having to worry about spooky action at a distance due to config files and workspaces in ancestor directories.

In my case, I have an runtime for coding with LLMs that is given a repo to work on and is expected to keep its artifacts contained to a `.ai/` directory. This runtime supports building markdown documentation for Rust crates, which involves using cargo to generate rustdoc-json data. That tool is expected to keep its artifacts contained within `.ai/docs/rust/build/` within the project being worked on. It's possible that the project itself is Rust based and could define a workspace or `.cargo/config.toml` but from the pov of this toolchain those have nothing to do with the crate whose documentation is being generated (which are packages downloaded from crates.io).

### How to test and review this PR?

_**TODO**: write tests_

Root directories can be smoke tested by attempting to build any package that doesn't define a workspace, nested within a repo that does, E.g.:

```bash
mkdir cargo-root-test
cd cargo-root-test

# Clone anything that defines an outer workspace...
git clone https://github.com/serde-rs/serde.git

# Then clone a nested repo that doesn't have a workspace
cd serde
git clone https://github.com/meta-rust/rust-hello-world

# Attempting to build will lead to an error like "error: current package believes it's in a workspace when it's not"
cargo build

# But if we know that the outer workspaces is unrelated we can specify a root directory and isolate the build...
cargo --root . build
# Or
env CARGO_ROOTS="$PWD" cargo build
# Or
mkdir .cargo
touch .cargo/root
cargo build
```

### Known Issues

The current implementation makes heavy use of `std::fs::canonicalize` while the original expectation had been that the UNC prefixes for Windows wouldn't matter when just internally checking paths for equivalence.

As things have evolved I think the use of `canonicalize` should be replaced with a normalization that just maps root directories to absolute paths and uses Cargo's `normalize_path` utility. This way we would avoid resolving symlinks and rely on lexical path comparisons.

Ideally the normalized paths can even be kept as a hidden implementation detail when resolving a `SearchRoute` that would allow the following use of `path::ancestors` to iterate in accordance with any non-normalized starting directory.