### PR TITLE
test(trim-paths): enable more tests for windows-msvc

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -155,6 +155,10 @@ jobs:
           os: windows-latest
           rust: stable-msvc
           other: i686-pc-windows-msvc
+        - name: Windows x86_64 MSVC nightly
+          os: windows-latest
+          rust: nightly-msvc
+          other: i686-pc-windows-msvc
         - name: Windows x86_64 gnu nightly # runs out of space while trying to link the test suite
           os: windows-latest
           rust: nightly-gnu
@@ -179,6 +183,10 @@ jobs:
     - run: sudo apt update -y && sudo apt install lldb gcc-multilib libsecret-1-0 libsecret-1-dev -y
       if: matrix.os == 'ubuntu-latest'
     - run: rustup component add rustfmt || echo "rustfmt not available"
+    - name: Add Windows debuggers bin to PATH
+      shell: pwsh
+      run: Add-Content $env:GITHUB_PATH "C:\Program Files (x86)\Windows Kits\10\Debuggers\x64"
+      if: matrix.os == 'windows-latest'
     - name: Configure extra test environment
       run: echo CARGO_CONTAINER_TESTS=1 >> $GITHUB_ENV
       if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
### What does this PR try to resolve?

Before this some end-to-end tests didn't cover Windows platforms.

After this, we cover windows-msvc for 

* End-to-end debugger tests.
* Check path is trimmed with symbol viewers like `strings`.

windows-gnu isn't covered


### How to test and review this PR?

There are things needing attentions:

* This adds a new CI job for window-msvc "nightly" toolchain.
* In 2f923b3ff25f847d we don't check if an executable's availability by running `<cmd> --version`. Instead, we check the file execute bit.
* Enabled windows-msvc tests rely on the software provided by [GitHub windows runner image](https://github.com/actions/runner-images/blob/e330e24b7e154207c9d76ce3b5472bfc6ceef55f/images/windows/Windows2022-Readme.md)
  * Windows SDK which provides cdb and other debugger tools
  * `strings` is provided by MinGW.
