### PR TITLE
fix(package): Allow packaging of self-cycles with -Zpackage-workspace

### DIFF
--- a/src/cargo/ops/cargo_package/mod.rs
+++ b/src/cargo/ops/cargo_package/mod.rs
@@ -417,6 +417,11 @@ fn local_deps<T>(packages: impl Iterator<Item = (Package, T)>) -> LocalDependenc
                 continue;
             };
 
+            // We don't care about cycles
+            if dep.source_id() == pkg.package_id().source_id() {
+                continue;
+            }
+
             if let Some(dep_pkg) = source_to_pkg.get(&dep.source_id()) {
                 graph.link(pkg.package_id(), *dep_pkg);
             }

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -7585,10 +7585,9 @@ fn unpublished_cyclic_dev_dependencies_nightly() {
 
     p.cargo("package --no-verify --exclude-lockfile -Zpackage-workspace")
         .masquerade_as_nightly_cargo(&["package-workspace"])
-        .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] crates-io is replaced with remote registry dummy-registry;
-include `--registry dummy-registry` or `--registry crates-io`
+[PACKAGING] foo v0.0.1 ([ROOT]/foo)
+[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 
 "#]])
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

Found this as I was preparing for stabilization.

As we create a graph of packages to ensure publish order, a self-cycle shouldn't matter, so we can skip tracking it.

### How to test and review this PR?

