### PR TITLE
fix(package): Skip registry check if its not needed

### DIFF
--- a/src/cargo/ops/cargo_package/mod.rs
+++ b/src/cargo/ops/cargo_package/mod.rs
@@ -240,10 +240,13 @@ fn do_package<'a>(
     let just_pkgs: Vec<_> = pkgs.iter().map(|p| p.0).collect();
 
     let mut local_reg = if ws.gctx().cli_unstable().package_workspace {
-        // The publish registry doesn't matter unless there are local dependencies,
+        // The publish registry doesn't matter unless there are local dependencies that will be
+        // resolved,
         // so only try to get one if we need it. If they explicitly passed a
         // registry on the CLI, we check it no matter what.
-        let sid = if deps.has_dependencies() || opts.reg_or_index.is_some() {
+        let sid = if (deps.has_dependencies() && (opts.include_lockfile || opts.verify))
+            || opts.reg_or_index.is_some()
+        {
             let sid = get_registry(ws.gctx(), &just_pkgs, opts.reg_or_index.clone())?;
             debug!("packaging for registry {}", sid);
             Some(sid)

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -7084,9 +7084,11 @@ fn registry_not_inferred_because_of_conflict_nightly() {
 
     p.cargo("package --exclude-lockfile --no-verify -Zpackage-workspace")
         .masquerade_as_nightly_cargo(&["package-workspace"])
-        .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] conflicts between `package.publish` fields in the selected packages
+[PACKAGING] dep v0.1.0 ([ROOT]/foo/dep)
+[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGING] main v0.0.1 ([ROOT]/foo/main)
+[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 
 "#]])
         .run();
@@ -7401,9 +7403,11 @@ fn registry_not_inferred_because_of_multiple_options_nightly() {
 
     p.cargo("package --exclude-lockfile --no-verify -Zpackage-workspace")
         .masquerade_as_nightly_cargo(&["package-workspace"])
-        .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] --registry is required to disambiguate between "alternative" or "alternative2" registries
+[PACKAGING] dep v0.1.0 ([ROOT]/foo/dep)
+[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGING] main v0.0.1 ([ROOT]/foo/main)
+[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 
 "#]])
         .run();
@@ -7631,9 +7635,11 @@ fn registry_not_inferred_because_of_mismatch_nightly() {
 
     p.cargo("package --exclude-lockfile --no-verify -Zpackage-workspace")
         .masquerade_as_nightly_cargo(&["package-workspace"])
-        .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] --registry is required because not all `package.publish` settings agree
+[PACKAGING] dep v0.1.0 ([ROOT]/foo/dep)
+[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGING] main v0.0.1 ([ROOT]/foo/main)
+[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 
 "#]])
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

As of #13947, `-Zpackage-workspace` made `cargo package` require extra arguments when it didn't need it before.  When a packaging operation will resolve dependencies, we need to know what registry packages would be published to in order to correctly generate the overlay to generate the right lockfile.

We skipped this if there were no dependencies, so no overlay was going to be used, to reduce the impact of this.

This change goes a step further and only runs the check if the resolver will run.  This should mean that `-Zpackage-workspace` should now only error when `cargo package` would have failed before.

### How to test and review this PR?

To verify this, the existing failure tests were forked, removing `-Zpackage-workspace`, and then `--exclude-lockfile`, `--no-verify`, and `--exclude-lockfile --no-verify` variants were added to characterize when the check is behavior-neutral vs not needed and that the behavior is now the same.