### PR TITLE
fix(publish): Don't tell people to ctrl-c without knowing consequences 

### DIFF
--- a/src/cargo/ops/registry/publish.rs
+++ b/src/cargo/ops/registry/publish.rs
@@ -274,7 +274,8 @@ pub fn publish(ws: &Workspace<'_>, opts: &PublishOpts<'_>) -> CargoResult<()> {
                 let short_pkg_descriptions = package_list(to_confirm.iter().copied(), "or");
                 opts.gctx.shell().note(format!(
                     "waiting for {short_pkg_descriptions} to be available at {source_description}.\n\
-                    You may press ctrl-c to skip waiting; the crate should be available shortly."
+                    You may press ctrl-c to skip waiting; the {crate} should be available shortly.",
+                    crate = if to_confirm.len() == 1 { "crate" } else {"crates"}
                 ))?;
 
                 let timeout = Duration::from_secs(timeout);
@@ -299,10 +300,15 @@ pub fn publish(ws: &Workspace<'_>, opts: &PublishOpts<'_>) -> CargoResult<()> {
                     opts.gctx.shell().warn(format!(
                         "timed out waiting for {short_pkg_descriptions} to be available in {source_description}",
                     ))?;
-                    opts.gctx.shell().note(
+                    opts.gctx.shell().note(format!(
                         "the registry may have a backlog that is delaying making the \
-                        crate available. The crate should be available soon.",
-                    )?;
+                        {crate} available. The {crate} should be available soon.",
+                        crate = if to_confirm.len() == 1 {
+                            "crate"
+                        } else {
+                            "crates"
+                        }
+                    ))?;
                 }
                 confirmed
             } else {

--- a/src/cargo/ops/registry/publish.rs
+++ b/src/cargo/ops/registry/publish.rs
@@ -736,7 +736,7 @@ impl PublishPlan {
 fn package_list(pkgs: impl IntoIterator<Item = PackageId>, final_sep: &str) -> String {
     let mut names: Vec<_> = pkgs
         .into_iter()
-        .map(|pkg| format!("`{} v{}`", pkg.name(), pkg.version()))
+        .map(|pkg| format!("{} v{}", pkg.name(), pkg.version()))
         .collect();
     names.sort();
 

--- a/src/cargo/ops/registry/publish.rs
+++ b/src/cargo/ops/registry/publish.rs
@@ -286,11 +286,7 @@ pub fn publish(ws: &Workspace<'_>, opts: &PublishOpts<'_>) -> CargoResult<()> {
                     timeout,
                 )?;
                 if !confirmed.is_empty() {
-                    let short_pkg_description = confirmed
-                        .iter()
-                        .map(|pkg| format!("{} v{}", pkg.name(), pkg.version()))
-                        .sorted()
-                        .join(", ");
+                    let short_pkg_description = package_list(confirmed.iter().copied(), "and");
                     opts.gctx.shell().status(
                         "Published",
                         format!("{short_pkg_description} at {source_description}"),

--- a/src/cargo/ops/registry/publish.rs
+++ b/src/cargo/ops/registry/publish.rs
@@ -270,13 +270,41 @@ pub fn publish(ws: &Workspace<'_>, opts: &PublishOpts<'_>) -> CargoResult<()> {
                 DEFAULT_TIMEOUT
             };
             if 0 < timeout {
+                let source_description = source.source_id().to_string();
+                let short_pkg_descriptions = package_list(to_confirm.iter().copied(), "or");
+                opts.gctx.shell().note(format!(
+                    "waiting for {short_pkg_descriptions} to be available at {source_description}.\n\
+                    You may press ctrl-c to skip waiting; the crate should be available shortly."
+                ))?;
+
                 let timeout = Duration::from_secs(timeout);
-                wait_for_any_publish_confirmation(
+                let confirmed = wait_for_any_publish_confirmation(
                     opts.gctx,
                     source_ids.original,
                     &to_confirm,
                     timeout,
-                )?
+                )?;
+                if !confirmed.is_empty() {
+                    let short_pkg_description = confirmed
+                        .iter()
+                        .map(|pkg| format!("{} v{}", pkg.name(), pkg.version()))
+                        .sorted()
+                        .join(", ");
+                    opts.gctx.shell().status(
+                        "Published",
+                        format!("{short_pkg_description} at {source_description}"),
+                    )?;
+                } else {
+                    let short_pkg_descriptions = package_list(to_confirm.iter().copied(), "or");
+                    opts.gctx.shell().warn(format!(
+                        "timed out waiting for {short_pkg_descriptions} to be available in {source_description}",
+                    ))?;
+                    opts.gctx.shell().note(
+                        "the registry may have a backlog that is delaying making the \
+                        crate available. The crate should be available soon.",
+                    )?;
+                }
+                confirmed
             } else {
                 BTreeSet::new()
             }
@@ -317,17 +345,10 @@ fn wait_for_any_publish_confirmation(
     // of independent progress bars can be a little confusing. There is an
     // overall progress bar managed here.
     source.set_quiet(true);
-    let source_description = source.source_id().to_string();
 
     let now = std::time::Instant::now();
     let sleep_time = Duration::from_secs(1);
     let max = timeout.as_secs() as usize;
-    // Short does not include the registry name.
-    let short_pkg_descriptions = package_list(pkgs.iter().copied(), "or");
-    gctx.shell().note(format!(
-        "waiting for {short_pkg_descriptions} to be available at {source_description}.\n\
-        You may press ctrl-c to skip waiting; the crate should be available shortly."
-    ))?;
     let mut progress = Progress::with_style("Waiting", ProgressStyle::Ratio, gctx);
     progress.tick_now(0, max, "")?;
     let available = loop {
@@ -356,30 +377,12 @@ fn wait_for_any_publish_confirmation(
 
         let elapsed = now.elapsed();
         if timeout < elapsed {
-            gctx.shell().warn(format!(
-                "timed out waiting for {short_pkg_descriptions} to be available in {source_description}",
-            ))?;
-            gctx.shell().note(
-                "the registry may have a backlog that is delaying making the \
-                crate available. The crate should be available soon.",
-            )?;
             break BTreeSet::new();
         }
 
         progress.tick_now(elapsed.as_secs() as usize, max, "")?;
         std::thread::sleep(sleep_time);
     };
-    if !available.is_empty() {
-        let short_pkg_description = available
-            .iter()
-            .map(|pkg| format!("{} v{}", pkg.name(), pkg.version()))
-            .sorted()
-            .join(", ");
-        gctx.shell().status(
-            "Published",
-            format!("{short_pkg_description} at {source_description}"),
-        )?;
-    }
 
     Ok(available)
 }

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -356,7 +356,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
 [UPLOADED] foo v0.0.1 to registry `alternative`
-[NOTE] waiting for `foo v0.0.1` to be available at registry `alternative`.
+[NOTE] waiting for foo v0.0.1 to be available at registry `alternative`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.0.1 at registry `alternative`
 
@@ -519,7 +519,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
 [UPLOADED] foo v0.0.1 to registry `alternative`
-[NOTE] waiting for `foo v0.0.1` to be available at registry `alternative`.
+[NOTE] waiting for foo v0.0.1 to be available at registry `alternative`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.0.1 at registry `alternative`
 
@@ -601,7 +601,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
 [UPLOADED] foo v0.0.1 to registry `alternative`
-[NOTE] waiting for `foo v0.0.1` to be available at registry `alternative`.
+[NOTE] waiting for foo v0.0.1 to be available at registry `alternative`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.0.1 at registry `alternative`
 

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -2258,7 +2258,7 @@ fn publish_artifact_dep() {
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] foo v0.1.0 ([ROOT]/foo)
 [UPLOADED] foo v0.1.0 to registry `crates-io`
-[NOTE] waiting for `foo v0.1.0` to be available at registry `crates-io`.
+[NOTE] waiting for foo v0.1.0 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.1.0 at registry `crates-io`
 

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -643,7 +643,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] a v0.0.1 ([ROOT]/foo)
 [UPLOADED] a v0.0.1 to registry `crates-io`
-[NOTE] waiting for `a v0.0.1` to be available at registry `crates-io`.
+[NOTE] waiting for a v0.0.1 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] a v0.0.1 at registry `crates-io`
 

--- a/tests/testsuite/credential_process.rs
+++ b/tests/testsuite/credential_process.rs
@@ -79,7 +79,7 @@ fn publish() {
 [UPLOADING] foo v0.1.0 ([ROOT]/foo)
 {"v":1,"registry":{"index-url":"[..]","name":"alternative"},"kind":"get","operation":"publish","name":"foo","vers":"0.1.0","cksum":"[..]"}
 [UPLOADED] foo v0.1.0 to registry `alternative`
-[NOTE] waiting for `foo v0.1.0` to be available at registry `alternative`.
+[NOTE] waiting for foo v0.1.0 to be available at registry `alternative`.
 You may press ctrl-c [..]
 [PUBLISHED] foo v0.1.0 at registry `alternative`
 

--- a/tests/testsuite/cross_publish.rs
+++ b/tests/testsuite/cross_publish.rs
@@ -114,7 +114,7 @@ fn publish_with_target() {
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] foo v0.0.0 ([ROOT]/foo)
 [UPLOADED] foo v0.0.0 to registry `crates-io`
-[NOTE] waiting for `foo v0.0.0` to be available at registry `crates-io`.
+[NOTE] waiting for foo v0.0.0 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.0.0 at registry `crates-io`
 

--- a/tests/testsuite/features_namespaced.rs
+++ b/tests/testsuite/features_namespaced.rs
@@ -930,7 +930,7 @@ fn publish_no_implicit() {
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] foo v0.1.0 ([ROOT]/foo)
 [UPLOADED] foo v0.1.0 to registry `crates-io`
-[NOTE] waiting for `foo v0.1.0` to be available at registry `crates-io`.
+[NOTE] waiting for foo v0.1.0 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.1.0 at registry `crates-io`
 
@@ -1074,7 +1074,7 @@ fn publish() {
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] foo v0.1.0 ([ROOT]/foo)
 [UPLOADED] foo v0.1.0 to registry `crates-io`
-[NOTE] waiting for `foo v0.1.0` to be available at registry `crates-io`.
+[NOTE] waiting for foo v0.1.0 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.1.0 at registry `crates-io`
 

--- a/tests/testsuite/inheritable_workspace_fields.rs
+++ b/tests/testsuite/inheritable_workspace_fields.rs
@@ -167,7 +167,7 @@ fn inherit_own_workspace_fields() {
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] foo v1.2.3 ([ROOT]/foo)
 [UPLOADED] foo v1.2.3 to registry `crates-io`
-[NOTE] waiting for `foo v1.2.3` to be available at registry `crates-io`.
+[NOTE] waiting for foo v1.2.3 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v1.2.3 at registry `crates-io`
 
@@ -334,7 +334,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] bar v0.2.0 ([ROOT]/foo)
 [UPLOADED] bar v0.2.0 to registry `crates-io`
-[NOTE] waiting for `bar v0.2.0` to be available at registry `crates-io`.
+[NOTE] waiting for bar v0.2.0 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] bar v0.2.0 at registry `crates-io`
 
@@ -501,7 +501,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] bar v0.2.0 ([ROOT]/foo)
 [UPLOADED] bar v0.2.0 to registry `crates-io`
-[NOTE] waiting for `bar v0.2.0` to be available at registry `crates-io`.
+[NOTE] waiting for bar v0.2.0 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] bar v0.2.0 at registry `crates-io`
 
@@ -762,7 +762,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-lice
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] bar v1.2.3 ([ROOT]/foo/bar)
 [UPLOADED] bar v1.2.3 to registry `crates-io`
-[NOTE] waiting for `bar v1.2.3` to be available at registry `crates-io`.
+[NOTE] waiting for bar v1.2.3 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] bar v1.2.3 at registry `crates-io`
 
@@ -936,7 +936,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] bar v0.2.0 ([ROOT]/foo/bar)
 [UPLOADED] bar v0.2.0 to registry `crates-io`
-[NOTE] waiting for `bar v0.2.0` to be available at registry `crates-io`.
+[NOTE] waiting for bar v0.2.0 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] bar v0.2.0 at registry `crates-io`
 

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -3891,7 +3891,7 @@ fn workspace_parallel() {
 [UPLOADED] a v0.0.1 to registry `crates-io`
 [NOTE] waiting for a v0.0.1 or b v0.0.1 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crates should be available shortly.
-[PUBLISHED] a v0.0.1, b v0.0.1 at registry `crates-io`
+[PUBLISHED] a v0.0.1 and b v0.0.1 at registry `crates-io`
 [UPLOADING] c v0.0.1 ([ROOT]/foo/c)
 [UPLOADED] c v0.0.1 to registry `crates-io`
 [NOTE] waiting for c v0.0.1 to be available at registry `crates-io`.

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -3388,7 +3388,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [UPLOADING] dep v0.0.1 ([ROOT]/foo/dep)
 [UPLOADED] dep v0.0.1 to registry `crates-io`
 [NOTE] waiting for dep v0.0.1 to be available at registry `crates-io`.
-You may press ctrl-c to skip waiting; the crate should be available shortly.
+2 remaining crates to be published
 [WARNING] timed out waiting for dep v0.0.1 to be available in registry `crates-io`
 [NOTE] the registry may have a backlog that is delaying making the crate available. The crate should be available soon.
 [ERROR] unable to publish main v0.0.1 and other v0.0.1 due to time out while waiting for published dependencies to be available.
@@ -3785,12 +3785,12 @@ fn workspace_with_local_deps_nightly() {
 [UPLOADING] level3 v0.0.1 ([ROOT]/foo/level3)
 [UPLOADED] level3 v0.0.1 to registry `crates-io`
 [NOTE] waiting for level3 v0.0.1 to be available at registry `crates-io`.
-You may press ctrl-c to skip waiting; the crate should be available shortly.
+2 remaining crates to be published
 [PUBLISHED] level3 v0.0.1 at registry `crates-io`
 [UPLOADING] level2 v0.0.1 ([ROOT]/foo/level2)
 [UPLOADED] level2 v0.0.1 to registry `crates-io`
 [NOTE] waiting for level2 v0.0.1 to be available at registry `crates-io`.
-You may press ctrl-c to skip waiting; the crate should be available shortly.
+1 remaining crate to be published
 [PUBLISHED] level2 v0.0.1 at registry `crates-io`
 [UPLOADING] level1 v0.0.1 ([ROOT]/foo/level1)
 [UPLOADED] level1 v0.0.1 to registry `crates-io`
@@ -3890,7 +3890,7 @@ fn workspace_parallel() {
 [UPLOADED] b v0.0.1 to registry `crates-io`
 [UPLOADED] a v0.0.1 to registry `crates-io`
 [NOTE] waiting for a v0.0.1 or b v0.0.1 to be available at registry `crates-io`.
-You may press ctrl-c to skip waiting; the crates should be available shortly.
+1 remaining crate to be published
 [PUBLISHED] a v0.0.1 and b v0.0.1 at registry `crates-io`
 [UPLOADING] c v0.0.1 ([ROOT]/foo/c)
 [UPLOADED] c v0.0.1 to registry `crates-io`

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -3890,7 +3890,7 @@ fn workspace_parallel() {
 [UPLOADED] b v0.0.1 to registry `crates-io`
 [UPLOADED] a v0.0.1 to registry `crates-io`
 [NOTE] waiting for `a v0.0.1` or `b v0.0.1` to be available at registry `crates-io`.
-You may press ctrl-c to skip waiting; the crate should be available shortly.
+You may press ctrl-c to skip waiting; the crates should be available shortly.
 [PUBLISHED] a v0.0.1, b v0.0.1 at registry `crates-io`
 [UPLOADING] c v0.0.1 ([ROOT]/foo/c)
 [UPLOADED] c v0.0.1 to registry `crates-io`

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -120,7 +120,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
 [UPLOADED] foo v0.0.1 to registry `crates-io`
-[NOTE] waiting for `foo v0.0.1` to be available at registry `crates-io`.
+[NOTE] waiting for foo v0.0.1 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.0.1 at registry `crates-io`
 
@@ -214,7 +214,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
 [UPLOADED] foo v0.0.1 to registry `dummy-registry`
-[NOTE] waiting for `foo v0.0.1` to be available at registry `dummy-registry`.
+[NOTE] waiting for foo v0.0.1 to be available at registry `dummy-registry`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.0.1 at registry `dummy-registry`
 
@@ -257,7 +257,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
 [UPLOADED] foo v0.0.1 to registry `dummy-registry`
-[NOTE] waiting for `foo v0.0.1` to be available at registry `dummy-registry`.
+[NOTE] waiting for foo v0.0.1 to be available at registry `dummy-registry`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.0.1 at registry `dummy-registry`
 
@@ -313,7 +313,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
 [UPLOADED] foo v0.0.1 to registry `crates-io`
-[NOTE] waiting for `foo v0.0.1` to be available at registry `crates-io`.
+[NOTE] waiting for foo v0.0.1 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.0.1 at registry `crates-io`
 
@@ -358,7 +358,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
 [UPLOADED] foo v0.0.1 to registry `[ROOT]/registry`
-[NOTE] waiting for `foo v0.0.1` to be available at registry `[ROOT]/registry`.
+[NOTE] waiting for foo v0.0.1 to be available at registry `[ROOT]/registry`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.0.1 at registry `[ROOT]/registry`
 
@@ -558,7 +558,7 @@ fn publish_clean() {
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
 [UPLOADED] foo v0.0.1 to registry `crates-io`
-[NOTE] waiting for `foo v0.0.1` to be available at registry `crates-io`.
+[NOTE] waiting for foo v0.0.1 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.0.1 at registry `crates-io`
 
@@ -607,7 +607,7 @@ fn publish_in_sub_repo() {
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] foo v0.0.1 ([ROOT]/foo/bar)
 [UPLOADED] foo v0.0.1 to registry `crates-io`
-[NOTE] waiting for `foo v0.0.1` to be available at registry `crates-io`.
+[NOTE] waiting for foo v0.0.1 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.0.1 at registry `crates-io`
 
@@ -656,7 +656,7 @@ fn publish_when_ignored() {
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
 [UPLOADED] foo v0.0.1 to registry `crates-io`
-[NOTE] waiting for `foo v0.0.1` to be available at registry `crates-io`.
+[NOTE] waiting for foo v0.0.1 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.0.1 at registry `crates-io`
 
@@ -704,7 +704,7 @@ fn ignore_when_crate_ignored() {
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] foo v0.0.1 ([ROOT]/foo/bar)
 [UPLOADED] foo v0.0.1 to registry `crates-io`
-[NOTE] waiting for `foo v0.0.1` to be available at registry `crates-io`.
+[NOTE] waiting for foo v0.0.1 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.0.1 at registry `crates-io`
 
@@ -895,7 +895,7 @@ fn publish_allowed_registry() {
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
 [UPLOADED] foo v0.0.1 to registry `alternative`
-[NOTE] waiting for `foo v0.0.1` to be available at registry `alternative`.
+[NOTE] waiting for foo v0.0.1 to be available at registry `alternative`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.0.1 at registry `alternative`
 
@@ -956,7 +956,7 @@ fn publish_implicitly_to_only_allowed_registry() {
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
 [UPLOADED] foo v0.0.1 to registry `alternative`
-[NOTE] waiting for `foo v0.0.1` to be available at registry `alternative`.
+[NOTE] waiting for foo v0.0.1 to be available at registry `alternative`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.0.1 at registry `alternative`
 
@@ -1124,7 +1124,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
 [UPLOADED] foo v0.0.1 to registry `crates-io`
-[NOTE] waiting for `foo v0.0.1` to be available at registry `crates-io`.
+[NOTE] waiting for foo v0.0.1 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.0.1 at registry `crates-io`
 
@@ -1175,7 +1175,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
 [UPLOADED] foo v0.0.1 to registry `crates-io`
-[NOTE] waiting for `foo v0.0.1` to be available at registry `crates-io`.
+[NOTE] waiting for foo v0.0.1 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.0.1 at registry `crates-io`
 
@@ -1226,7 +1226,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
 [UPLOADED] foo v0.0.1 to registry `crates-io`
-[NOTE] waiting for `foo v0.0.1` to be available at registry `crates-io`.
+[NOTE] waiting for foo v0.0.1 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.0.1 at registry `crates-io`
 
@@ -1340,7 +1340,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
 [UPLOADED] foo v0.0.1 to registry `crates-io`
-[NOTE] waiting for `foo v0.0.1` to be available at registry `crates-io`.
+[NOTE] waiting for foo v0.0.1 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.0.1 at registry `crates-io`
 
@@ -1547,7 +1547,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] foo v0.1.0 ([ROOT]/foo)
 [UPLOADED] foo v0.1.0 to registry `crates-io`
-[NOTE] waiting for `foo v0.1.0` to be available at registry `crates-io`.
+[NOTE] waiting for foo v0.1.0 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.1.0 at registry `crates-io`
 
@@ -1803,7 +1803,7 @@ fn publish_dev_dep_stripping() {
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] foo v0.1.0 ([ROOT]/foo)
 [UPLOADED] foo v0.1.0 to registry `crates-io`
-[NOTE] waiting for `foo v0.1.0` to be available at registry `crates-io`.
+[NOTE] waiting for foo v0.1.0 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.1.0 at registry `crates-io`
 
@@ -2142,7 +2142,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
 [UPLOADED] foo v0.0.1 to registry `crates-io`
-[NOTE] waiting for `foo v0.0.1` to be available at registry `crates-io`.
+[NOTE] waiting for foo v0.0.1 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.0.1 at registry `crates-io`
 
@@ -2510,7 +2510,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] li v0.0.1 ([ROOT]/foo/li)
 [UPLOADED] li v0.0.1 to registry `crates-io`
-[NOTE] waiting for `li v0.0.1` to be available at registry `crates-io`.
+[NOTE] waiting for li v0.0.1 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] li v0.0.1 at registry `crates-io`
 
@@ -2617,7 +2617,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] li v0.0.1 ([ROOT]/foo/li)
 [UPLOADED] li v0.0.1 to registry `crates-io`
-[NOTE] waiting for `li v0.0.1` to be available at registry `crates-io`.
+[NOTE] waiting for li v0.0.1 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] li v0.0.1 at registry `crates-io`
 
@@ -2714,7 +2714,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] li v0.0.1 ([ROOT]/foo/li)
 [UPLOADED] li v0.0.1 to registry `crates-io`
-[NOTE] waiting for `li v0.0.1` to be available at registry `crates-io`.
+[NOTE] waiting for li v0.0.1 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] li v0.0.1 at registry `crates-io`
 
@@ -2899,7 +2899,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
 [UPLOADED] foo v0.0.1 to registry `crates-io`
-[NOTE] waiting for `foo v0.0.1` to be available at registry `crates-io`.
+[NOTE] waiting for foo v0.0.1 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.0.1 at registry `crates-io`
 
@@ -2977,7 +2977,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] delay v0.0.1 ([ROOT]/foo)
 [UPLOADED] delay v0.0.1 to registry `crates-io`
-[NOTE] waiting for `delay v0.0.1` to be available at registry `crates-io`.
+[NOTE] waiting for delay v0.0.1 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] delay v0.0.1 at registry `crates-io`
 
@@ -3070,7 +3070,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] delay_with_underscore v0.0.1 ([ROOT]/foo)
 [UPLOADED] delay_with_underscore v0.0.1 to registry `crates-io`
-[NOTE] waiting for `delay_with_underscore v0.0.1` to be available at registry `crates-io`.
+[NOTE] waiting for delay_with_underscore v0.0.1 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] delay_with_underscore v0.0.1 at registry `crates-io`
 
@@ -3170,7 +3170,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] delay v0.0.2 ([ROOT]/foo)
 [UPLOADED] delay v0.0.2 to registry `crates-io`
-[NOTE] waiting for `delay v0.0.2` to be available at registry `crates-io`.
+[NOTE] waiting for delay v0.0.2 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] delay v0.0.2 at registry `crates-io`
 
@@ -3288,9 +3288,9 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] delay v0.0.1 ([ROOT]/foo)
 [UPLOADED] delay v0.0.1 to registry `crates-io`
-[NOTE] waiting for `delay v0.0.1` to be available at registry `crates-io`.
+[NOTE] waiting for delay v0.0.1 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
-[WARNING] timed out waiting for `delay v0.0.1` to be available in registry `crates-io`
+[WARNING] timed out waiting for delay v0.0.1 to be available in registry `crates-io`
 [NOTE] the registry may have a backlog that is delaying making the crate available. The crate should be available soon.
 
 "#]])
@@ -3387,11 +3387,11 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] dep v0.0.1 ([ROOT]/foo/dep)
 [UPLOADED] dep v0.0.1 to registry `crates-io`
-[NOTE] waiting for `dep v0.0.1` to be available at registry `crates-io`.
+[NOTE] waiting for dep v0.0.1 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
-[WARNING] timed out waiting for `dep v0.0.1` to be available in registry `crates-io`
+[WARNING] timed out waiting for dep v0.0.1 to be available in registry `crates-io`
 [NOTE] the registry may have a backlog that is delaying making the crate available. The crate should be available soon.
-[ERROR] unable to publish `main v0.0.1` and `other v0.0.1` due to time out while waiting for published dependencies to be available.
+[ERROR] unable to publish main v0.0.1 and other v0.0.1 due to time out while waiting for published dependencies to be available.
 
 "#]])
         .run();
@@ -3569,7 +3569,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] delay v0.0.2 ([ROOT]/foo)
 [UPLOADED] delay v0.0.2 to registry `crates-io`
-[NOTE] waiting for `delay v0.0.2` to be available at registry `crates-io`.
+[NOTE] waiting for delay v0.0.2 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] delay v0.0.2 at registry `crates-io`
 
@@ -3784,17 +3784,17 @@ fn workspace_with_local_deps_nightly() {
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] level3 v0.0.1 ([ROOT]/foo/level3)
 [UPLOADED] level3 v0.0.1 to registry `crates-io`
-[NOTE] waiting for `level3 v0.0.1` to be available at registry `crates-io`.
+[NOTE] waiting for level3 v0.0.1 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] level3 v0.0.1 at registry `crates-io`
 [UPLOADING] level2 v0.0.1 ([ROOT]/foo/level2)
 [UPLOADED] level2 v0.0.1 to registry `crates-io`
-[NOTE] waiting for `level2 v0.0.1` to be available at registry `crates-io`.
+[NOTE] waiting for level2 v0.0.1 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] level2 v0.0.1 at registry `crates-io`
 [UPLOADING] level1 v0.0.1 ([ROOT]/foo/level1)
 [UPLOADED] level1 v0.0.1 to registry `crates-io`
-[NOTE] waiting for `level1 v0.0.1` to be available at registry `crates-io`.
+[NOTE] waiting for level1 v0.0.1 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] level1 v0.0.1 at registry `crates-io`
 
@@ -3889,12 +3889,12 @@ fn workspace_parallel() {
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADED] b v0.0.1 to registry `crates-io`
 [UPLOADED] a v0.0.1 to registry `crates-io`
-[NOTE] waiting for `a v0.0.1` or `b v0.0.1` to be available at registry `crates-io`.
+[NOTE] waiting for a v0.0.1 or b v0.0.1 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crates should be available shortly.
 [PUBLISHED] a v0.0.1, b v0.0.1 at registry `crates-io`
 [UPLOADING] c v0.0.1 ([ROOT]/foo/c)
 [UPLOADED] c v0.0.1 to registry `crates-io`
-[NOTE] waiting for `c v0.0.1` to be available at registry `crates-io`.
+[NOTE] waiting for c v0.0.1 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] c v0.0.1 at registry `crates-io`
 [UPLOADING] a v0.0.1 ([ROOT]/foo/a)
@@ -3981,7 +3981,7 @@ Caused by:
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] a v0.0.1 ([ROOT]/foo/a)
 [UPLOADED] a v0.0.1 to registry `crates-io`
-[NOTE] waiting for `a v0.0.1` to be available at registry `crates-io`.
+[NOTE] waiting for a v0.0.1 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] a v0.0.1 at registry `crates-io`
 
@@ -4059,7 +4059,7 @@ fn one_unpublishable_package() {
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] dep v0.1.0 ([ROOT]/foo/dep)
 [UPLOADED] dep v0.1.0 to registry `crates-io`
-[NOTE] waiting for `dep v0.1.0` to be available at registry `crates-io`.
+[NOTE] waiting for dep v0.1.0 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] dep v0.1.0 at registry `crates-io`
 
@@ -4139,7 +4139,7 @@ fn virtual_ws_with_multiple_unpublishable_package() {
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] publishable v0.1.0 ([ROOT]/foo/publishable)
 [UPLOADED] publishable v0.1.0 to registry `crates-io`
-[NOTE] waiting for `publishable v0.1.0` to be available at registry `crates-io`.
+[NOTE] waiting for publishable v0.1.0 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] publishable v0.1.0 at registry `crates-io`
 
@@ -4211,7 +4211,7 @@ fn workspace_flag_with_unpublishable_packages() {
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] publishable v0.0.0 ([ROOT]/foo/publishable)
 [UPLOADED] publishable v0.0.0 to registry `crates-io`
-[NOTE] waiting for `publishable v0.0.0` to be available at registry `crates-io`.
+[NOTE] waiting for publishable v0.0.0 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] publishable v0.0.0 at registry `crates-io`
 

--- a/tests/testsuite/source_replacement.rs
+++ b/tests/testsuite/source_replacement.rs
@@ -221,7 +221,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
 [UPLOADED] foo v0.0.1 to registry `crates-io`
-[NOTE] waiting for `foo v0.0.1` to be available at registry `crates-io`.
+[NOTE] waiting for foo v0.0.1 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.0.1 at registry `crates-io`
 

--- a/tests/testsuite/weak_dep_features.rs
+++ b/tests/testsuite/weak_dep_features.rs
@@ -576,7 +576,7 @@ fn publish() {
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] foo v0.1.0 ([ROOT]/foo)
 [UPLOADED] foo v0.1.0 to registry `crates-io`
-[NOTE] waiting for `foo v0.1.0` to be available at registry `crates-io`.
+[NOTE] waiting for foo v0.1.0 to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.1.0 at registry `crates-io`
 


### PR DESCRIPTION
### What does this PR try to resolve?

Telling people they are free to hit ctrl-c while waiting for packages could mean some packages may not be published and the user wouldn't know until they get a complaint about a missing package.

Instead, if there are remaining packages, we'll tell the user that.

Fixes #15005

### How to test and review this PR?

