### PR TITLE
fix(workspace): reload current manifest path member only

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -306,7 +306,7 @@ impl<'gctx> Workspace<'gctx> {
     /// This is useful if the workspace has been updated, such as with `cargo
     /// fix` modifying the `Cargo.toml` file.
     pub fn reload(&self, gctx: &'gctx GlobalContext) -> CargoResult<Workspace<'gctx>> {
-        let mut ws = Workspace::new(self.root_manifest(), gctx)?;
+        let mut ws = Workspace::new(&self.current_manifest, gctx)?;
         ws.set_resolve_honors_rust_version(Some(self.resolve_honors_rust_version));
         ws.set_resolve_feature_unification(self.resolve_feature_unification);
         ws.set_requested_lockfile_path(self.requested_lockfile_path.clone());

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -2719,7 +2719,7 @@ fn nonexistence_package_together_with_workspace() {
 
 // A failing case from <https://github.com/rust-lang/cargo/issues/15625>
 #[cargo_test]
-fn clippy_fix_all_members_in_a_workspace() {
+fn fix_only_check_manifest_path_member() {
     let p = project()
         .file(
             "Cargo.toml",
@@ -2751,8 +2751,11 @@ fn clippy_fix_all_members_in_a_workspace() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("clippy --manifest-path foo/Cargo.toml --fix --allow-no-vcs")
-        .with_stderr_contains("[CHECKING] foo v0.1.0 ([ROOT]/foo/foo)")
-        .with_stderr_contains("[CHECKING] bar v0.1.0 ([ROOT]/foo/bar)")
+    p.cargo("fix --manifest-path foo/Cargo.toml --allow-no-vcs")
+        .with_stderr_data(str![[r#"
+[CHECKING] foo v0.1.0 ([ROOT]/foo/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?

As of #15625, the manifest path argument in `cargo clippy --manifest-path foo/Cargo.toml --fix` will be ignored. All the workspace members will be built. The cause is due to the `reload` usage in `cargo::ops::fix`. We reload the `root_manifest` in the function, which contains all workspace members.

Will close #15625.

### How to test and review this PR?

The first commit in the PR demonstrates the current problem, and the second commit corrects it. Use `cargo test --test testsuite workspaces::fix_only_check_manifest_path_member` to see the test results.