### PR TITLE
feat(publish): Stabilize multi-package publishing

### DIFF
--- a/src/bin/cargo/commands/package.rs
+++ b/src/bin/cargo/commands/package.rs
@@ -7,8 +7,8 @@ use cargo::ops::PackageOpts;
 pub fn cli() -> Command {
     subcommand("package")
         .about("Assemble the local package into a distributable tarball")
-        .arg_index("Registry index URL to prepare the package for (unstable)")
-        .arg_registry("Registry to prepare the package for (unstable)")
+        .arg_index("Registry index URL to prepare the package for")
+        .arg_registry("Registry to prepare the package for")
         .arg(
             flag(
                 "list",
@@ -57,22 +57,6 @@ pub fn cli() -> Command {
 }
 
 pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
-    if args._value_of("registry").is_some() {
-        gctx.cli_unstable().fail_if_stable_opt_custom_z(
-            "--registry",
-            13947,
-            "package-workspace",
-            gctx.cli_unstable().package_workspace,
-        )?;
-    }
-    if args._value_of("index").is_some() {
-        gctx.cli_unstable().fail_if_stable_opt_custom_z(
-            "--index",
-            13947,
-            "package-workspace",
-            gctx.cli_unstable().package_workspace,
-        )?;
-    }
     let reg_or_index = args.registry_or_index(gctx)?;
     let ws = args.workspace(gctx)?;
     if ws.root_maybe().is_embedded() {

--- a/src/bin/cargo/commands/publish.rs
+++ b/src/bin/cargo/commands/publish.rs
@@ -20,8 +20,8 @@ pub fn cli() -> Command {
         .arg_silent_suggestion()
         .arg_package_spec_no_all(
             "Package(s) to publish",
-            "Publish all packages in the workspace (unstable)",
-            "Don't publish specified packages (unstable)",
+            "Publish all packages in the workspace",
+            "Don't publish specified packages",
         )
         .arg_features()
         .arg_parallel()
@@ -43,23 +43,6 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
             ws.root_manifest().display()
         )
         .into());
-    }
-
-    let unstable = gctx.cli_unstable();
-    let enabled = unstable.package_workspace;
-    if args.get_flag("workspace") {
-        unstable.fail_if_stable_opt_custom_z("--workspace", 10948, "package-workspace", enabled)?;
-    }
-    if args._value_of("exclude").is_some() {
-        unstable.fail_if_stable_opt_custom_z("--exclude", 10948, "package-workspace", enabled)?;
-    }
-    if args._values_of("package").len() > 1 {
-        unstable.fail_if_stable_opt_custom_z(
-            "--package (multiple occurrences)",
-            10948,
-            "package-workspace",
-            enabled,
-        )?;
     }
 
     ops::publish(

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -845,7 +845,6 @@ unstable_cli_options!(
     next_lockfile_bump: bool,
     no_embed_metadata: bool = ("Avoid embedding metadata in library artifacts"),
     no_index_update: bool = ("Do not update the registry index even if the cache is outdated"),
-    package_workspace: bool = ("Handle intra-workspace dependencies when packaging"),
     panic_abort_tests: bool = ("Enable support to run tests with -Cpanic=abort"),
     profile_hint_mostly_unused: bool = ("Enable the `hint-mostly-unused` setting in profiles to mark a crate as mostly unused."),
     profile_rustflags: bool = ("Enable the `rustflags` option in profiles in .cargo/config.toml file"),
@@ -941,6 +940,9 @@ const STABILIZED_CHECK_CFG: &str =
     "Compile-time checking of conditional (a.k.a. `-Zcheck-cfg`) is now always enabled.";
 
 const STABILIZED_DOCTEST_XCOMPILE: &str = "Doctest cross-compiling is now always enabled.";
+
+const STABILIZED_PACKAGE_WORKSPACE: &str =
+    "Workspace packaging and publishing (a.k.a. `-Zpackage-workspace`) is now always enabled.";
 
 fn deserialize_comma_separated_list<'de, D>(
     deserializer: D,
@@ -1323,6 +1325,7 @@ impl CliUnstable {
             "lints" => stabilized_warn(k, "1.74", STABILIZED_LINTS),
             "registry-auth" => stabilized_warn(k, "1.74", STABILIZED_REGISTRY_AUTH),
             "check-cfg" => stabilized_warn(k, "1.80", STABILIZED_CHECK_CFG),
+            "package-workspace" => stabilized_warn(k, "1.89", STABILIZED_PACKAGE_WORKSPACE),
 
             // Unstable features
             // Sorted alphabetically:
@@ -1366,7 +1369,6 @@ impl CliUnstable {
             "mtime-on-use" => self.mtime_on_use = parse_empty(k, v)?,
             "no-embed-metadata" => self.no_embed_metadata = parse_empty(k, v)?,
             "no-index-update" => self.no_index_update = parse_empty(k, v)?,
-            "package-workspace" => self.package_workspace = parse_empty(k, v)?,
             "panic-abort-tests" => self.panic_abort_tests = parse_empty(k, v)?,
             "public-dependency" => self.public_dependency = parse_empty(k, v)?,
             "profile-hint-mostly-unused" => self.profile_hint_mostly_unused = parse_empty(k, v)?,

--- a/src/cargo/ops/cargo_package/mod.rs
+++ b/src/cargo/ops/cargo_package/mod.rs
@@ -262,7 +262,7 @@ fn do_package<'a>(
     let deps = local_deps(pkgs.iter().map(|(p, f)| ((*p).clone(), f.clone())));
     let just_pkgs: Vec<_> = pkgs.iter().map(|p| p.0).collect();
 
-    let mut local_reg = if ws.gctx().cli_unstable().package_workspace {
+    let mut local_reg = {
         // The publish registry doesn't matter unless there are local dependencies that will be
         // resolved,
         // so only try to get one if we need it. If they explicitly passed a
@@ -279,8 +279,6 @@ fn do_package<'a>(
         let reg_dir = ws.build_dir().join("package").join("tmp-registry");
         sid.map(|sid| TmpRegistry::new(ws.gctx(), reg_dir, sid))
             .transpose()?
-    } else {
-        None
     };
 
     // Packages need to be created in dependency order, because dependencies must

--- a/src/doc/man/cargo-publish.md
+++ b/src/doc/man/cargo-publish.md
@@ -68,64 +68,7 @@ which defaults to `crates-io`.
 
 {{/options}}
 
-### Package Selection
-
-By default, when no package selection options are given, the packages selected
-depend on the selected manifest file (based on the current working directory if
-`--manifest-path` is not given). If the manifest is the root of a workspace then
-the workspaces default members are selected, otherwise only the package defined
-by the manifest will be selected.
-
-The default members of a workspace can be set explicitly with the
-`workspace.default-members` key in the root manifest. If this is not set, a
-virtual workspace will include all workspace members (equivalent to passing
-`--workspace`), and a non-virtual workspace will include only the root crate itself.
-
-Selecting more than one package is unstable and available only on the
-[nightly channel](https://doc.rust-lang.org/book/appendix-07-nightly-rust.html)
-and requires the `-Z package-workspace` flag to enable.
-See <https://github.com/rust-lang/cargo/issues/10948> for more information.
-
-
-{{#options}}
-
-{{#option "`-p` _spec_..." "`--package` _spec_..."}}
-{{actionverb}} only the specified packages. See {{man "cargo-pkgid" 1}} for the
-SPEC format. This flag may be specified multiple times and supports common Unix
-glob patterns like `*`, `?` and `[]`. However, to avoid your shell accidentally 
-expanding glob patterns before Cargo handles them, you must use single quotes or
-double quotes around each pattern.
-
-Selecting more than one package with this option is unstable and available only
-on the
-[nightly channel](https://doc.rust-lang.org/book/appendix-07-nightly-rust.html)
-and requires the `-Z package-workspace` flag to enable.
-See <https://github.com/rust-lang/cargo/issues/10948> for more information.
-{{/option}}
-
-{{#option "`--workspace`" }}
-{{actionverb}} all members in the workspace.
-
-This option is unstable and available only on the
-[nightly channel](https://doc.rust-lang.org/book/appendix-07-nightly-rust.html)
-and requires the `-Z package-workspace` flag to enable.
-See <https://github.com/rust-lang/cargo/issues/10948> for more information.
-{{/option}}
-
-{{#option "`--exclude` _SPEC_..." }}
-Exclude the specified packages. Must be used in conjunction with the
-`--workspace` flag. This flag may be specified multiple times and supports
-common Unix glob patterns like `*`, `?` and `[]`. However, to avoid your shell
-accidentally expanding glob patterns before Cargo handles them, you must use
-single quotes or double quotes around each pattern.
-
-This option is unstable and available only on the
-[nightly channel](https://doc.rust-lang.org/book/appendix-07-nightly-rust.html)
-and requires the `-Z package-workspace` flag to enable.
-See <https://github.com/rust-lang/cargo/issues/10948> for more information.
-{{/option}}
-
-{{/options}}
+{{> section-package-selection }}
 
 ### Compilation Options
 

--- a/src/doc/man/generated_txt/cargo-publish.txt
+++ b/src/doc/man/generated_txt/cargo-publish.txt
@@ -85,12 +85,6 @@ OPTIONS
        passing --workspace), and a non-virtual workspace will include only the
        root crate itself.
 
-       Selecting more than one package is unstable and available only on the
-       nightly channel
-       <https://doc.rust-lang.org/book/appendix-07-nightly-rust.html> and
-       requires the -Z package-workspace flag to enable. See
-       <https://github.com/rust-lang/cargo/issues/10948> for more information.
-
        -p spec…, --package spec…
            Publish only the specified packages. See cargo-pkgid(1) for the SPEC
            format. This flag may be specified multiple times and supports
@@ -99,21 +93,11 @@ OPTIONS
            them, you must use single quotes or double quotes around each
            pattern.
 
-           Selecting more than one package with this option is unstable and
-           available only on the nightly channel
-           <https://doc.rust-lang.org/book/appendix-07-nightly-rust.html> and
-           requires the -Z package-workspace flag to enable. See
-           <https://github.com/rust-lang/cargo/issues/10948> for more
-           information.
-
        --workspace
            Publish all members in the workspace.
 
-           This option is unstable and available only on the nightly channel
-           <https://doc.rust-lang.org/book/appendix-07-nightly-rust.html> and
-           requires the -Z package-workspace flag to enable. See
-           <https://github.com/rust-lang/cargo/issues/10948> for more
-           information.
+       --all
+           Deprecated alias for --workspace.
 
        --exclude SPEC…
            Exclude the specified packages. Must be used in conjunction with the
@@ -122,12 +106,6 @@ OPTIONS
            avoid your shell accidentally expanding glob patterns before Cargo
            handles them, you must use single quotes or double quotes around
            each pattern.
-
-           This option is unstable and available only on the nightly channel
-           <https://doc.rust-lang.org/book/appendix-07-nightly-rust.html> and
-           requires the -Z package-workspace flag to enable. See
-           <https://github.com/rust-lang/cargo/issues/10948> for more
-           information.
 
    Compilation Options
        --target triple

--- a/src/doc/src/commands/cargo-publish.md
+++ b/src/doc/src/commands/cargo-publish.md
@@ -88,12 +88,6 @@ The default members of a workspace can be set explicitly with the
 virtual workspace will include all workspace members (equivalent to passing
 `--workspace`), and a non-virtual workspace will include only the root crate itself.
 
-Selecting more than one package is unstable and available only on the
-[nightly channel](https://doc.rust-lang.org/book/appendix-07-nightly-rust.html)
-and requires the `-Z package-workspace` flag to enable.
-See <https://github.com/rust-lang/cargo/issues/10948> for more information.
-
-
 <dl>
 
 <dt class="option-term" id="option-cargo-publish--p"><a class="option-anchor" href="#option-cargo-publish--p"></a><code>-p</code> <em>spec</em>…</dt>
@@ -102,20 +96,15 @@ See <https://github.com/rust-lang/cargo/issues/10948> for more information.
 SPEC format. This flag may be specified multiple times and supports common Unix
 glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell accidentally
 expanding glob patterns before Cargo handles them, you must use single quotes or
-double quotes around each pattern.</p>
-<p>Selecting more than one package with this option is unstable and available only
-on the
-<a href="https://doc.rust-lang.org/book/appendix-07-nightly-rust.html">nightly channel</a>
-and requires the <code>-Z package-workspace</code> flag to enable.
-See <a href="https://github.com/rust-lang/cargo/issues/10948">https://github.com/rust-lang/cargo/issues/10948</a> for more information.</dd>
+double quotes around each pattern.</dd>
 
 
 <dt class="option-term" id="option-cargo-publish---workspace"><a class="option-anchor" href="#option-cargo-publish---workspace"></a><code>--workspace</code></dt>
-<dd class="option-desc">Publish all members in the workspace.</p>
-<p>This option is unstable and available only on the
-<a href="https://doc.rust-lang.org/book/appendix-07-nightly-rust.html">nightly channel</a>
-and requires the <code>-Z package-workspace</code> flag to enable.
-See <a href="https://github.com/rust-lang/cargo/issues/10948">https://github.com/rust-lang/cargo/issues/10948</a> for more information.</dd>
+<dd class="option-desc">Publish all members in the workspace.</dd>
+
+
+<dt class="option-term" id="option-cargo-publish---all"><a class="option-anchor" href="#option-cargo-publish---all"></a><code>--all</code></dt>
+<dd class="option-desc">Deprecated alias for <code>--workspace</code>.</dd>
 
 
 <dt class="option-term" id="option-cargo-publish---exclude"><a class="option-anchor" href="#option-cargo-publish---exclude"></a><code>--exclude</code> <em>SPEC</em>…</dt>
@@ -123,11 +112,7 @@ See <a href="https://github.com/rust-lang/cargo/issues/10948">https://github.com
 <code>--workspace</code> flag. This flag may be specified multiple times and supports
 common Unix glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell
 accidentally expanding glob patterns before Cargo handles them, you must use
-single quotes or double quotes around each pattern.</p>
-<p>This option is unstable and available only on the
-<a href="https://doc.rust-lang.org/book/appendix-07-nightly-rust.html">nightly channel</a>
-and requires the <code>-Z package-workspace</code> flag to enable.
-See <a href="https://github.com/rust-lang/cargo/issues/10948">https://github.com/rust-lang/cargo/issues/10948</a> for more information.</dd>
+single quotes or double quotes around each pattern.</dd>
 
 
 </dl>

--- a/src/etc/man/cargo-publish.1
+++ b/src/etc/man/cargo-publish.1
@@ -100,11 +100,6 @@ The default members of a workspace can be set explicitly with the
 virtual workspace will include all workspace members (equivalent to passing
 \fB\-\-workspace\fR), and a non\-virtual workspace will include only the root crate itself.
 .sp
-Selecting more than one package is unstable and available only on the
-\fInightly channel\fR <https://doc.rust\-lang.org/book/appendix\-07\-nightly\-rust.html>
-and requires the \fB\-Z package\-workspace\fR flag to enable.
-See <https://github.com/rust\-lang/cargo/issues/10948> for more information.
-.sp
 \fB\-p\fR \fIspec\fR\[u2026], 
 \fB\-\-package\fR \fIspec\fR\[u2026]
 .RS 4
@@ -113,22 +108,16 @@ SPEC format. This flag may be specified multiple times and supports common Unix
 glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell accidentally
 expanding glob patterns before Cargo handles them, you must use single quotes or
 double quotes around each pattern.
-.sp
-Selecting more than one package with this option is unstable and available only
-on the
-\fInightly channel\fR <https://doc.rust\-lang.org/book/appendix\-07\-nightly\-rust.html>
-and requires the \fB\-Z package\-workspace\fR flag to enable.
-See <https://github.com/rust\-lang/cargo/issues/10948> for more information.
 .RE
 .sp
 \fB\-\-workspace\fR
 .RS 4
 Publish all members in the workspace.
+.RE
 .sp
-This option is unstable and available only on the
-\fInightly channel\fR <https://doc.rust\-lang.org/book/appendix\-07\-nightly\-rust.html>
-and requires the \fB\-Z package\-workspace\fR flag to enable.
-See <https://github.com/rust\-lang/cargo/issues/10948> for more information.
+\fB\-\-all\fR
+.RS 4
+Deprecated alias for \fB\-\-workspace\fR\&.
 .RE
 .sp
 \fB\-\-exclude\fR \fISPEC\fR\[u2026]
@@ -138,11 +127,6 @@ Exclude the specified packages. Must be used in conjunction with the
 common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell
 accidentally expanding glob patterns before Cargo handles them, you must use
 single quotes or double quotes around each pattern.
-.sp
-This option is unstable and available only on the
-\fInightly channel\fR <https://doc.rust\-lang.org/book/appendix\-07\-nightly\-rust.html>
-and requires the \fB\-Z package\-workspace\fR flag to enable.
-See <https://github.com/rust\-lang/cargo/issues/10948> for more information.
 .RE
 .SS "Compilation Options"
 .sp

--- a/tests/testsuite/cargo/z_help/stdout.term.svg
+++ b/tests/testsuite/cargo/z_help/stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="1255px" height="884px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1255px" height="866px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -70,47 +70,45 @@
 </tspan>
     <tspan x="10px" y="496px"><tspan>    -Z no-index-update             Do not update the registry index even if the cache is outdated</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>    -Z package-workspace           Handle intra-workspace dependencies when packaging</tspan>
+    <tspan x="10px" y="514px"><tspan>    -Z panic-abort-tests           Enable support to run tests with -Cpanic=abort</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>    -Z panic-abort-tests           Enable support to run tests with -Cpanic=abort</tspan>
+    <tspan x="10px" y="532px"><tspan>    -Z profile-hint-mostly-unused  Enable the `hint-mostly-unused` setting in profiles to mark a crate as mostly unused.</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>    -Z profile-hint-mostly-unused  Enable the `hint-mostly-unused` setting in profiles to mark a crate as mostly unused.</tspan>
+    <tspan x="10px" y="550px"><tspan>    -Z profile-rustflags           Enable the `rustflags` option in profiles in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>    -Z profile-rustflags           Enable the `rustflags` option in profiles in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="568px"><tspan>    -Z public-dependency           Respect a dependency's `public` field in Cargo.toml to control public/private dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>    -Z public-dependency           Respect a dependency's `public` field in Cargo.toml to control public/private dependencies</tspan>
+    <tspan x="10px" y="586px"><tspan>    -Z publish-timeout             Enable the `publish.timeout` key in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>    -Z publish-timeout             Enable the `publish.timeout` key in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="604px"><tspan>    -Z root-dir                    Set the root directory relative to which paths are printed (defaults to workspace root)</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>    -Z root-dir                    Set the root directory relative to which paths are printed (defaults to workspace root)</tspan>
+    <tspan x="10px" y="622px"><tspan>    -Z rustdoc-depinfo             Use dep-info files in rustdoc rebuild detection</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>    -Z rustdoc-depinfo             Use dep-info files in rustdoc rebuild detection</tspan>
+    <tspan x="10px" y="640px"><tspan>    -Z rustdoc-map                 Allow passing external documentation mappings to rustdoc</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>    -Z rustdoc-map                 Allow passing external documentation mappings to rustdoc</tspan>
+    <tspan x="10px" y="658px"><tspan>    -Z rustdoc-scrape-examples     Allows Rustdoc to scrape code examples from reverse-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan>    -Z rustdoc-scrape-examples     Allows Rustdoc to scrape code examples from reverse-dependencies</tspan>
+    <tspan x="10px" y="676px"><tspan>    -Z sbom                        Enable the `sbom` option in build config in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan>    -Z sbom                        Enable the `sbom` option in build config in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="694px"><tspan>    -Z script                      Enable support for single-file, `.rs` packages</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>    -Z script                      Enable support for single-file, `.rs` packages</tspan>
+    <tspan x="10px" y="712px"><tspan>    -Z target-applies-to-host      Enable the `target-applies-to-host` key in the .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>    -Z target-applies-to-host      Enable the `target-applies-to-host` key in the .cargo/config.toml file</tspan>
+    <tspan x="10px" y="730px"><tspan>    -Z trim-paths                  Enable the `trim-paths` option in profiles</tspan>
 </tspan>
-    <tspan x="10px" y="748px"><tspan>    -Z trim-paths                  Enable the `trim-paths` option in profiles</tspan>
+    <tspan x="10px" y="748px"><tspan>    -Z unstable-options            Allow the usage of unstable options</tspan>
 </tspan>
-    <tspan x="10px" y="766px"><tspan>    -Z unstable-options            Allow the usage of unstable options</tspan>
+    <tspan x="10px" y="766px"><tspan>    -Z warnings                    Allow use of the build.warnings config key</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan>    -Z warnings                    Allow use of the build.warnings config key</tspan>
+    <tspan x="10px" y="784px">
 </tspan>
-    <tspan x="10px" y="802px">
+    <tspan x="10px" y="802px"><tspan>Run with `cargo -Z [FLAG] [COMMAND]`</tspan>
 </tspan>
-    <tspan x="10px" y="820px"><tspan>Run with `cargo -Z [FLAG] [COMMAND]`</tspan>
+    <tspan x="10px" y="820px">
 </tspan>
-    <tspan x="10px" y="838px">
+    <tspan x="10px" y="838px"><tspan>See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html for more information about these flags.</tspan>
 </tspan>
-    <tspan x="10px" y="856px"><tspan>See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html for more information about these flags.</tspan>
-</tspan>
-    <tspan x="10px" y="874px">
+    <tspan x="10px" y="856px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_package/help/stdout.term.svg
+++ b/tests/testsuite/cargo_package/help/stdout.term.svg
@@ -29,9 +29,9 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>      </tspan><tspan class="fg-cyan bold">--index</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;INDEX&gt;</tspan><tspan>            Registry index URL to prepare the package for (unstable)</tspan>
+    <tspan x="10px" y="118px"><tspan>      </tspan><tspan class="fg-cyan bold">--index</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;INDEX&gt;</tspan><tspan>            Registry index URL to prepare the package for</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>      </tspan><tspan class="fg-cyan bold">--registry</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;REGISTRY&gt;</tspan><tspan>      Registry to prepare the package for (unstable)</tspan>
+    <tspan x="10px" y="136px"><tspan>      </tspan><tspan class="fg-cyan bold">--registry</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;REGISTRY&gt;</tspan><tspan>      Registry to prepare the package for</tspan>
 </tspan>
     <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-cyan bold">-l</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--list</tspan><tspan>                     Print files included in a package without making one</tspan>
 </tspan>

--- a/tests/testsuite/cargo_publish/help/stdout.term.svg
+++ b/tests/testsuite/cargo_publish/help/stdout.term.svg
@@ -61,9 +61,9 @@
 </tspan>
     <tspan x="10px" y="388px"><tspan>  </tspan><tspan class="fg-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package(s) to publish</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--workspace</tspan><tspan>         Publish all packages in the workspace (unstable)</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--workspace</tspan><tspan>         Publish all packages in the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--exclude</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>    Don't publish specified packages (unstable)</tspan>
+    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--exclude</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>    Don't publish specified packages</tspan>
 </tspan>
     <tspan x="10px" y="442px">
 </tspan>

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -2682,22 +2682,20 @@ fn nonexistence_package_together_with_workspace() {
 "#]])
         .run();
 
-    p.cargo("publish --dry-run --package nonexistence -Zpackage-workspace --workspace")
+    p.cargo("publish --dry-run --package nonexistence --workspace")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] package(s) `nonexistence` not found in workspace `[ROOT]/foo`
 
 "#]])
-        .masquerade_as_nightly_cargo(&["package-workspace"])
         .run();
     // With pattern *
-    p.cargo("publish --dry-run --package nonpattern* -Zpackage-workspace --workspace")
+    p.cargo("publish --dry-run --package nonpattern* --workspace")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] package pattern(s) `nonpattern*` not found in workspace `[ROOT]/foo`
 
 "#]])
-        .masquerade_as_nightly_cargo(&["package-workspace"])
         .run();
 
     p.cargo("tree --package nonexistence  --workspace")


### PR DESCRIPTION
### What does this PR try to resolve?

A user will now be able to use flags like `--workspace` with `cargo publish`.
`cargo package` will now also work with those flags without having to pass `--no-verify --exclude-lockfile`.

Many release tools have come out that solve this problem. They will still need a lot of the logic that went into that for other parts of the release process.
However, a cargo-native solution allows for:
- Verification during dry-run
- Better strategies for waiting for the publish timeout

`cargo publish` is non-atomic at this time.
If there is a server side error, network error, or rate limit during the publish, the workspace will be left in a partially published state. Verification is done before any publishing so that won't affect things. There are multiple strategies we can employ for improving this over time, including
- atomic publish
- `--idempotent` (#13397)
- leave this to release tools to manage

This includes support for `--dry-run` verification. As release tools didn't have a way to do this before, users may be surprised at how slow this is because a `cargo build` is done instead of a `cargo check`.  This is being tracked in #14941.

This adds to `cargo package` the `--registry` and `--index` flags to help with resolving dependencies when depending on a package being packaged at that moment.
These flags are only needed when a `cargo package --workspace` operation would have failed before due to inability to find a locally created dependency.

Regarding the publish timeout, `cargo publish --workspace` publishes packages in batches and we only timeout if nothing in the batch has finished being published within the timeout, deferring the rest to the next wait-for-publish. So for example, if you have packages `a`, `b`, `c` then we'll wait up to 60 seconds and if only `a` and `b` were ready in that time, we'll then wait another 60 seconds for `c`.

During testing, users ran into issues with `.crate` checksums:
- ~~#15647~~ Fixed for `cargo publish --dry-run` in #15711 
  - But `cargo package` still has the problem
- #14396 (not been able to reproduce)
- #15622 (reproducible with consecutive `cargo publish` calls)

Fixes #1169
Fixes #10948

### How to test and review this PR?

By stabilizing this, Cargo's behavior becomes dependent on an overlay registry.
When generating a lockfile or verifying a package, we overlay the locally generated `.crate` files on top of the registry so the registry appears as it would and everything works.
If there is a conflict with a version, the local version wins which is important for the dry-run mode of release tools as they won't have bumped the version yet.
Our concern for the overlay registry is dependency confusion attacks. Considering this is not accessible for general user operations, this should be fine.