### PR TITLE
Update "time out" to "timeout"

### DIFF
--- a/src/cargo/ops/registry/publish.rs
+++ b/src/cargo/ops/registry/publish.rs
@@ -329,7 +329,7 @@ pub fn publish(ws: &Workspace<'_>, opts: &PublishOpts<'_>) -> CargoResult<()> {
                 break;
             } else {
                 let failed_list = package_list(plan.iter(), "and");
-                bail!("unable to publish {failed_list} due to time out while waiting for published dependencies to be available.");
+                bail!("unable to publish {failed_list} due to a timeout while waiting for published dependencies to be available.");
             }
         }
         for id in &confirmed {

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -3391,7 +3391,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 2 remaining crates to be published
 [WARNING] timed out waiting for dep v0.0.1 to be available in registry `crates-io`
 [NOTE] the registry may have a backlog that is delaying making the crate available. The crate should be available soon.
-[ERROR] unable to publish main v0.0.1 and other v0.0.1 due to time out while waiting for published dependencies to be available.
+[ERROR] unable to publish main v0.0.1 and other v0.0.1 due to a timeout while waiting for published dependencies to be available.
 
 "#]])
         .run();


### PR DESCRIPTION
This read a little awkwardly to me. "time out" is a verb, but normally a noun follows "due to".
