### PR TITLE
fix: Make UI tests handle hyperlinks consistently

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1505,6 +1505,7 @@ impl CargoCommandExt for snapbox::cmd::Command {
         Self::new(cargo_exe())
             .with_assert(compare::assert_ui())
             .env("CARGO_TERM_COLOR", "always")
+            .env("CARGO_TERM_HYPERLINKS", "true")
             .test_env()
     }
 }

--- a/tests/testsuite/lints/warning/stderr.term.svg
+++ b/tests/testsuite/lints/warning/stderr.term.svg
@@ -37,7 +37,7 @@
 </tspan>
     <tspan x="10px" y="154px"><tspan class="fg-green bold">    Checking</tspan><tspan> foo v0.0.1 ([ROOT]/foo)</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-green bold">    Finished</tspan><tspan> `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-green bold">    Finished</tspan><tspan> </tspan><tspan><a href="https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles">`dev` profile [unoptimized + debuginfo]</a></tspan><tspan> target(s) in [ELAPSED]s</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>


### PR DESCRIPTION
In #15639, @weihanglo noted that one of the lint tests passed in CI, but locally it would fail as it had a hyperlink added to its output. The root cause appears to be the recent update to `anstyle-svg@0.1.8`, which added support for hyperlinks, combined with our hyperlink support autodetection, disabling them in CI, but allowing them locally. To ensure we are consistently handling hyperlinks, I made them always enabled for UI tests. This seemed like the best option given that we already force colors for UI tests, and it allows us to test our hyperlink output.