### PR TITLE
Use `Not::not` rather than a custom `is_false` function

### DIFF
--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -1496,7 +1496,7 @@ impl TomlPlatform {
 #[derive(Serialize, Debug, Clone)]
 #[cfg_attr(feature = "unstable-schema", derive(schemars::JsonSchema))]
 pub struct InheritableLints {
-    #[serde(skip_serializing_if = "is_false")]
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
     #[cfg_attr(feature = "unstable-schema", schemars(default))]
     pub workspace: bool,
     #[serde(flatten)]
@@ -1511,10 +1511,6 @@ impl InheritableLints {
             Ok(&self.lints)
         }
     }
-}
-
-fn is_false(b: &bool) -> bool {
-    !b
 }
 
 impl<'de> Deserialize<'de> for InheritableLints {

--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -82,12 +82,8 @@ pub struct NewCrateDependency {
     pub artifact: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bindep_target: Option<String>,
-    #[serde(default, skip_serializing_if = "is_false")]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub lib: bool,
-}
-
-fn is_false(x: &bool) -> bool {
-    *x == false
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
The `is_false` function already exists in the standard library, as `Not::not`; use that in `skip_serializing_if` rather than defining an `is_false` function.
