### PR TITLE
fix(docs): align code block styles for shell snippets

### DIFF
--- a/src/doc/contrib/src/implementation/debugging.md
+++ b/src/doc/contrib/src/implementation/debugging.md
@@ -8,7 +8,7 @@ It also supports filtering for specific modules with comma-separated [directives
 Feel free to use [shorthand macros] to help with diagnosing problems.
 We're looking forward to making Cargo logging mechanism more structural!
 
-```sh
+```bash
 # Outputs all logs with levels debug and higher
 CARGO_LOG=debug cargo generate-lockfile
 

--- a/src/doc/contrib/src/tests/profiling.md
+++ b/src/doc/contrib/src/tests/profiling.md
@@ -13,9 +13,9 @@ At process exit, your trace will be in a file like `trace-1668480819035032.json`
 Open that file with [ui.perfetto.dev](https://ui.perfetto.dev) (or chrome://tracing) to browse your trace.
 
 Example:
-```console
-$ # Output first three levels of profiling info
-$ CARGO_LOG_PROFILE=true cargo generate-lockfile
+```bash
+# Output first three levels of profiling info
+CARGO_LOG_PROFILE=true cargo generate-lockfile
 ```
 
 **Note:** This is intended for the development of cargo and there are no compatibility guarantees on this functionality.

--- a/src/doc/contrib/src/tests/writing.md
+++ b/src/doc/contrib/src/tests/writing.md
@@ -221,8 +221,8 @@ Then populate
 
 The project, stdout, and stderr snapshots can be updated by running with the
 `SNAPSHOTS=overwrite` environment variable, like:
-```console
-$ SNAPSHOTS=overwrite cargo test
+```bash
+SNAPSHOTS=overwrite cargo test
 ```
 
 Be sure to check the snapshots to make sure they make sense.
@@ -265,18 +265,22 @@ expect, or you just generally want to experiment within the sandbox
 environment. The general process is:
 
 1. Build the sandbox for the test you want to investigate. For example:
-
-   `cargo test --test testsuite -- features2::inactivate_targets`.
+  ```bash
+  cargo test --test testsuite -- features2::inactivate_targets
+  ```
 2. In another terminal, head into the sandbox directory to inspect the files and run `cargo` directly.
     1. The sandbox directories start with `t0` for the first test.
-
-       `cd target/tmp/cit/t0`
+      ```bash
+      cd target/tmp/cit/t0
+      ```
     2. Set up the environment so that the sandbox configuration takes effect:
-
-       `export CARGO_HOME=$(pwd)/home/.cargo`
+      ```bash
+      export CARGO_HOME=$(pwd)/home/.cargo
+      ```
     3. Most tests create a `foo` project, so head into that:
-
-       `cd foo`
+      ```bash
+      cd foo
+      ```
 3. Run whatever cargo command you want. See [Running Cargo] for more details
    on running the correct `cargo` process. Some examples:
 


### PR DESCRIPTION
### What does this PR try to resolve?

Current contributor document has inconsistent styles for shell-command snippets, like with or without leading `$`. This PR removes all leading `$` and specify bash for syntax highlighting, for the ease of copy-pasting commands.
