### PR TITLE
Add `[hints]` table in `Cargo.toml`, and a `hints.mostly-unused` hint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,7 +315,7 @@ dependencies = [
  "cargo-platform 0.3.1",
  "cargo-test-support",
  "cargo-util",
- "cargo-util-schemas 0.9.1",
+ "cargo-util-schemas 0.10.0",
  "clap",
  "clap_complete",
  "color-print",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util-schemas"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "schemars",
  "semver",
@@ -3373,7 +3373,7 @@ dependencies = [
  "cargo",
  "cargo-platform 0.3.1",
  "cargo-util",
- "cargo-util-schemas 0.9.1",
+ "cargo-util-schemas 0.10.0",
  "proptest",
  "varisat",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ cargo-platform = { path = "crates/cargo-platform", version = "0.3.0" }
 cargo-test-macro = { version = "0.4.4", path = "crates/cargo-test-macro" }
 cargo-test-support = { version = "0.8.0", path = "crates/cargo-test-support" }
 cargo-util = { version = "0.2.22", path = "crates/cargo-util" }
-cargo-util-schemas = { version = "0.9.0", path = "crates/cargo-util-schemas" }
+cargo-util-schemas = { version = "0.10.0", path = "crates/cargo-util-schemas" }
 cargo_metadata = "0.20.0"
 clap = "4.5.40"
 clap_complete = { version = "4.5.54", features = ["unstable-dynamic"] }

--- a/crates/cargo-util-schemas/Cargo.toml
+++ b/crates/cargo-util-schemas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-util-schemas"
-version = "0.9.1"
+version = "0.10.0"
 rust-version = "1.88"  # MSRV:1
 edition.workspace = true
 license.workspace = true

--- a/crates/cargo-util-schemas/manifest.schema.json
+++ b/crates/cargo-util-schemas/manifest.schema.json
@@ -1031,9 +1031,13 @@
       "type": "object",
       "properties": {
         "mostly-unused": {
-          "type": [
-            "boolean",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TomlValue"
+            },
+            {
+              "type": "null"
+            }
           ]
         }
       }

--- a/crates/cargo-util-schemas/manifest.schema.json
+++ b/crates/cargo-util-schemas/manifest.schema.json
@@ -167,6 +167,16 @@
         }
       ]
     },
+    "hints": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Hints"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "workspace": {
       "anyOf": [
         {
@@ -1015,6 +1025,17 @@
       ],
       "additionalProperties": {
         "$ref": "#/$defs/TomlValue"
+      }
+    },
+    "Hints": {
+      "type": "object",
+      "properties": {
+        "mostly-unused": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
       }
     },
     "TomlWorkspace": {

--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -1650,7 +1650,11 @@ pub enum TomlLintLevel {
 #[serde(rename_all = "kebab-case")]
 #[cfg_attr(feature = "unstable-schema", derive(schemars::JsonSchema))]
 pub struct Hints {
-    pub mostly_unused: Option<bool>,
+    #[cfg_attr(
+        feature = "unstable-schema",
+        schemars(with = "Option<TomlValueWrapper>")
+    )]
+    pub mostly_unused: Option<toml::Value>,
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -56,6 +56,7 @@ pub struct TomlManifest {
     pub build_dependencies2: Option<BTreeMap<PackageName, InheritableDependency>>,
     pub target: Option<BTreeMap<String, TomlPlatform>>,
     pub lints: Option<InheritableLints>,
+    pub hints: Option<Hints>,
 
     pub workspace: Option<TomlWorkspace>,
     pub profile: Option<TomlProfiles>,
@@ -85,6 +86,7 @@ impl TomlManifest {
                 .map(|_| "build-dependencies"),
             self.target.as_ref().map(|_| "target"),
             self.lints.as_ref().map(|_| "lints"),
+            self.hints.as_ref().map(|_| "hints"),
         ]
         .into_iter()
         .flatten()
@@ -1642,6 +1644,13 @@ pub enum TomlLintLevel {
     Deny,
     Warn,
     Allow,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[serde(rename_all = "kebab-case")]
+#[cfg_attr(feature = "unstable-schema", derive(schemars::JsonSchema))]
+pub struct Hints {
+    pub mostly_unused: Option<bool>,
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1148,6 +1148,13 @@ fn build_base_args(
             unit.pkg.package_id().version()
         ))
     };
+    let unit_capped_warn = |msg: &str| {
+        if unit.show_warnings(bcx.gctx) {
+            warn(msg)
+        } else {
+            Ok(())
+        }
+    };
 
     cmd.arg("--crate-name").arg(&unit.target.crate_name());
 
@@ -1339,7 +1346,7 @@ fn build_base_args(
         None => None,
         Some(toml::Value::Boolean(b)) => Some(b),
         Some(v) => {
-            warn(&format!(
+            unit_capped_warn(&format!(
                 "ignoring unsupported value type ({}) for 'hints.mostly-unused', which expects a boolean",
                 v.type_str()
             ))?;
@@ -1354,11 +1361,12 @@ fn build_base_args(
             cmd.arg("-Zhint-mostly-unused");
         } else {
             if profile_hint_mostly_unused.is_some() {
+                // Profiles come from the top-level unit, so we don't use `unit_capped_warn` here.
                 warn(
                     "ignoring 'hint-mostly-unused' profile option, pass `-Zprofile-hint-mostly-unused` to enable it",
                 )?;
             } else if pkg_hint_mostly_unused.is_some() {
-                warn(
+                unit_capped_warn(
                     "ignoring 'hints.mostly-unused', pass `-Zprofile-hint-mostly-unused` to enable it",
                 )?;
             }

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1141,6 +1141,14 @@ fn build_base_args(
     let hints = unit.pkg.hints().cloned().unwrap_or_default();
     let test = unit.mode.is_any_test();
 
+    let warn = |msg: &str| {
+        bcx.gctx.shell().warn(format!(
+            "{}@{}: {msg}",
+            unit.pkg.package_id().name(),
+            unit.pkg.package_id().version()
+        ))
+    };
+
     cmd.arg("--crate-name").arg(&unit.target.crate_name());
 
     let edition = unit.target.edition();
@@ -1331,7 +1339,7 @@ fn build_base_args(
         None => None,
         Some(toml::Value::Boolean(b)) => Some(b),
         Some(v) => {
-            bcx.gctx.shell().warn(format!(
+            warn(&format!(
                 "ignoring unsupported value type ({}) for 'hints.mostly-unused', which expects a boolean",
                 v.type_str()
             ))?;
@@ -1346,13 +1354,13 @@ fn build_base_args(
             cmd.arg("-Zhint-mostly-unused");
         } else {
             if profile_hint_mostly_unused.is_some() {
-                bcx.gctx
-                    .shell()
-                    .warn("ignoring 'hint-mostly-unused' profile option, pass `-Zprofile-hint-mostly-unused` to enable it")?;
+                warn(
+                    "ignoring 'hint-mostly-unused' profile option, pass `-Zprofile-hint-mostly-unused` to enable it",
+                )?;
             } else if pkg_hint_mostly_unused.is_some() {
-                bcx.gctx
-                    .shell()
-                    .warn("ignoring 'hints.mostly-unused', pass `-Zprofile-hint-mostly-unused` to enable it")?;
+                warn(
+                    "ignoring 'hints.mostly-unused', pass `-Zprofile-hint-mostly-unused` to enable it",
+                )?;
             }
         }
     }

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1138,6 +1138,7 @@ fn build_base_args(
         hint_mostly_unused,
         ..
     } = unit.profile.clone();
+    let hints = unit.pkg.hints().cloned().unwrap_or_default();
     let test = unit.mode.is_any_test();
 
     cmd.arg("--crate-name").arg(&unit.target.crate_name());
@@ -1326,13 +1327,19 @@ fn build_base_args(
         opt(cmd, "-C", "incremental=", Some(dir));
     }
 
-    if hint_mostly_unused {
+    if hint_mostly_unused.or(hints.mostly_unused).unwrap_or(false) {
         if bcx.gctx.cli_unstable().profile_hint_mostly_unused {
             cmd.arg("-Zhint-mostly-unused");
         } else {
-            bcx.gctx
-                .shell()
-                .warn("ignoring 'hint-mostly-unused' profile option, pass `-Zprofile-hint-mostly-unused` to enable it")?;
+            if hint_mostly_unused.is_some() {
+                bcx.gctx
+                    .shell()
+                    .warn("ignoring 'hint-mostly-unused' profile option, pass `-Zprofile-hint-mostly-unused` to enable it")?;
+            } else if hints.mostly_unused.is_some() {
+                bcx.gctx
+                    .shell()
+                    .warn("ignoring 'hints.mostly-unused', pass `-Zprofile-hint-mostly-unused` to enable it")?;
+            }
         }
     }
 

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use anyhow::Context as _;
 use cargo_util_schemas::manifest::RustVersion;
-use cargo_util_schemas::manifest::{TomlManifest, TomlProfiles};
+use cargo_util_schemas::manifest::{Hints, TomlManifest, TomlProfiles};
 use semver::Version;
 use serde::Serialize;
 use serde::ser;
@@ -90,6 +90,7 @@ pub struct Manifest {
     metabuild: Option<Vec<String>>,
     resolve_behavior: Option<ResolveBehavior>,
     lint_rustflags: Vec<String>,
+    hints: Option<Hints>,
     embedded: bool,
 }
 
@@ -521,6 +522,7 @@ impl Manifest {
         metabuild: Option<Vec<String>>,
         resolve_behavior: Option<ResolveBehavior>,
         lint_rustflags: Vec<String>,
+        hints: Option<Hints>,
         embedded: bool,
     ) -> Manifest {
         Manifest {
@@ -551,6 +553,7 @@ impl Manifest {
             metabuild,
             resolve_behavior,
             lint_rustflags,
+            hints,
             embedded,
         }
     }
@@ -666,6 +669,10 @@ impl Manifest {
     /// `RUSTFLAGS` from the `[lints]` table
     pub fn lint_rustflags(&self) -> &[String] {
         self.lint_rustflags.as_slice()
+    }
+
+    pub fn hints(&self) -> Option<&Hints> {
+        self.hints.as_ref()
     }
 
     pub fn map_source(self, to_replace: SourceId, replace_with: SourceId) -> Manifest {

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -9,7 +9,7 @@ use std::rc::Rc;
 use std::time::{Duration, Instant};
 
 use anyhow::Context as _;
-use cargo_util_schemas::manifest::RustVersion;
+use cargo_util_schemas::manifest::{Hints, RustVersion};
 use curl::easy::Easy;
 use curl::multi::{EasyHandle, Multi};
 use lazycell::LazyCell;
@@ -95,6 +95,8 @@ pub struct SerializedPackage {
     metabuild: Option<Vec<String>>,
     default_run: Option<String>,
     rust_version: Option<RustVersion>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hints: Option<Hints>,
 }
 
 impl Package {
@@ -172,6 +174,11 @@ impl Package {
         self.manifest().rust_version()
     }
 
+    /// Gets the package's hints.
+    pub fn hints(&self) -> Option<&Hints> {
+        self.manifest().hints()
+    }
+
     /// Returns `true` if the package uses a custom build script for any target.
     pub fn has_custom_build(&self) -> bool {
         self.targets().iter().any(|t| t.is_custom_build())
@@ -241,6 +248,7 @@ impl Package {
             publish: self.publish().as_ref().cloned(),
             default_run: self.manifest().default_run().map(|s| s.to_owned()),
             rust_version: self.rust_version().cloned(),
+            hints: self.hints().cloned(),
         }
     }
 }

--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -578,7 +578,7 @@ fn merge_profile(profile: &mut Profile, toml: &TomlProfile) {
         profile.trim_paths = Some(trim_paths.clone());
     }
     if let Some(hint_mostly_unused) = toml.hint_mostly_unused {
-        profile.hint_mostly_unused = hint_mostly_unused;
+        profile.hint_mostly_unused = Some(hint_mostly_unused);
     }
     profile.strip = match toml.strip {
         Some(StringOrBool::Bool(true)) => Strip::Resolved(StripInner::Named("symbols".into())),
@@ -629,8 +629,8 @@ pub struct Profile {
     // remove when `-Ztrim-paths` is stablized
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trim_paths: Option<TomlTrimPaths>,
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
-    pub hint_mostly_unused: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hint_mostly_unused: Option<bool>,
 }
 
 impl Default for Profile {
@@ -652,7 +652,7 @@ impl Default for Profile {
             strip: Strip::Deferred(StripInner::None),
             rustflags: vec![],
             trim_paths: None,
-            hint_mostly_unused: false,
+            hint_mostly_unused: None,
         }
     }
 }

--- a/src/cargo/sources/registry/index/cache.rs
+++ b/src/cargo/sources/registry/index/cache.rs
@@ -204,7 +204,7 @@ impl<'a> SummariesCache<'a> {
         let size = self
             .versions
             .iter()
-            .map(|(_version, data)| (10 + data.len()))
+            .map(|(_version, data)| 10 + data.len())
             .sum();
         let mut contents = Vec::with_capacity(size);
         contents.push(CURRENT_CACHE_VERSION);

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -327,6 +327,7 @@ fn normalize_toml(
         build_dependencies2: None,
         target: None,
         lints: None,
+        hints: None,
         workspace: original_toml.workspace.clone().or_else(|| {
             // Prevent looking for a workspace by `read_manifest_from_str`
             is_embedded.then(manifest::TomlWorkspace::default)
@@ -570,6 +571,8 @@ fn normalize_toml(
             workspace: false,
             lints,
         });
+
+        normalized_toml.hints = original_toml.hints.clone();
 
         normalized_toml.badges = original_toml.badges.clone();
     } else {
@@ -1628,6 +1631,8 @@ pub fn to_real_manifest(
             .unwrap_or(&default),
     )?;
 
+    let hints = normalized_toml.hints.clone();
+
     let metadata = ManifestMetadata {
         description: normalized_package
             .normalized_description()
@@ -1819,6 +1824,7 @@ pub fn to_real_manifest(
         metabuild,
         resolve_behavior,
         rustflags,
+        hints,
         is_embedded,
     );
     if manifest
@@ -3080,6 +3086,7 @@ fn prepare_toml_for_publish(
             None => None,
         },
         lints: me.lints.clone(),
+        hints: me.hints.clone(),
         workspace: None,
         profile: me.profile.clone(),
         patch: None,

--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -50,6 +50,7 @@ Every manifest file consists of the following sections:
 * [`[badges]`](#the-badges-section) --- Badges to display on a registry.
 * [`[features]`](features.md) --- Conditional compilation features.
 * [`[lints]`](#the-lints-section) --- Configure linters for this package.
+* [`[hints]`](#the-hints-section) --- Provide hints for compiling this package.
 * [`[patch]`](overriding-dependencies.md#the-patch-section) --- Override dependencies.
 * [`[replace]`](overriding-dependencies.md#the-replace-section) --- Override dependencies (deprecated).
 * [`[profile]`](profiles.md) --- Compiler settings and optimizations.
@@ -564,6 +565,26 @@ As for dependents, Cargo suppresses lints from non-path dependencies with featur
 [`--cap-lints`](../../rustc/lints/levels.html#capping-lints).
 
 > **MSRV:** Respected as of 1.74
+
+## The `[hints]` section
+
+The `[hints]` section allows specifying hints for compiling this package. Cargo
+will respect these hints by default when compiling this package, though the
+top-level package being built can override these values through the `[profile]`
+mechanism. Hints are, by design, always safe for Cargo to ignore; if Cargo
+encounters a hint it doesn't understand, or a hint it understands but with a
+value it doesn't understand, it will warn, but not error. As a result,
+specifying hints in a crate does not impact the MSRV of the crate.
+
+Individual hints may have an associated unstable feature gate that you need to
+pass in order to apply the configuration they specify, but if you don't specify
+that unstable feature gate, you will again get only a warning, not an error.
+
+There are no stable hints at this time. See the [hint-mostly-unused
+documentation](unstable.md#profile-hint-mostly-unused-option) for information
+on an unstable hint.
+
+> **MSRV:** Respected as of 1.90.
 
 ## The `[badges]` section
 

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -963,6 +963,18 @@ introduction of this feature will give an "unused manifest key" warning, but
 will otherwise function without erroring. This allows using the hint in a
 crate's `Cargo.toml` without mandating the use of a newer Cargo to build it.
 
+A crate can also provide this hint automatically for crates that depend on it,
+using the `[hints]` table (which will likewise be ignored by older Cargo):
+
+```toml
+[hints]
+mostly-unused = true
+```
+
+This will cause the crate to default to hint-mostly-unused, unless overridden
+via `profile`, which takes precedence, and which can only be specified in the
+top-level crate being built.
+
 ## rustdoc-map
 * Tracking Issue: [#8296](https://github.com/rust-lang/cargo/issues/8296)
 

--- a/tests/testsuite/hints.rs
+++ b/tests/testsuite/hints.rs
@@ -124,7 +124,6 @@ fn hint_unknown_type_warn() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [WARNING] foo@0.0.1: ignoring unsupported value type (string) for 'hints.mostly-unused', which expects a boolean
-[WARNING] bar@1.0.0: ignoring unsupported value type (integer) for 'hints.mostly-unused', which expects a boolean
 [CHECKING] bar v1.0.0
 [RUNNING] `rustc --crate-name bar [..]`
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -178,7 +177,6 @@ fn hints_mostly_unused_warn_without_gate() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [WARNING] foo@0.0.1: ignoring 'hints.mostly-unused', pass `-Zprofile-hint-mostly-unused` to enable it
-[WARNING] bar@1.0.0: ignoring 'hints.mostly-unused', pass `-Zprofile-hint-mostly-unused` to enable it
 [CHECKING] bar v1.0.0
 [RUNNING] `rustc --crate-name bar [..]`
 [CHECKING] foo v0.0.1 ([ROOT]/foo)

--- a/tests/testsuite/hints.rs
+++ b/tests/testsuite/hints.rs
@@ -1,0 +1,59 @@
+//! Tests for hints.
+
+use crate::prelude::*;
+use cargo_test_support::{project, str};
+
+#[cargo_test]
+fn empty_hints_warn() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            edition = "2015"
+
+            [hints]
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+    p.cargo("check -v")
+        .with_stderr_data(str![[r#"
+[WARNING] unused manifest key: hints
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn unknown_hints_warn() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            edition = "2015"
+
+            [hints]
+            this-is-an-unknown-hint = true
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+    p.cargo("check -v")
+        .with_stderr_data(str![[r#"
+[WARNING] unused manifest key: hints
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}

--- a/tests/testsuite/hints.rs
+++ b/tests/testsuite/hints.rs
@@ -91,19 +91,17 @@ fn hint_unknown_type_warn() {
         .file("src/main.rs", "fn main() {}")
         .build();
     p.cargo("check -v")
-        .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
-[ERROR] invalid type: integer `1`, expected a boolean
- --> ../home/.cargo/registry/src/-[HASH]/bar-1.0.0/Cargo.toml:8:29
-  |
-8 |             mostly-unused = 1
-  |                             ^
-  |
-[ERROR] failed to download replaced source registry `crates-io`
+[WARNING] ignoring unsupported value type (integer) for 'hints.mostly-unused', which expects a boolean
+[CHECKING] bar v1.0.0
+[RUNNING] `rustc --crate-name bar [..]`
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
         .with_stderr_does_not_contain("-Zhint-mostly-unused")

--- a/tests/testsuite/hints.rs
+++ b/tests/testsuite/hints.rs
@@ -1,6 +1,7 @@
 //! Tests for hints.
 
 use crate::prelude::*;
+use cargo_test_support::registry::Package;
 use cargo_test_support::{project, str};
 
 #[cargo_test]
@@ -55,5 +56,240 @@ fn unknown_hints_warn() {
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
+        .run();
+}
+
+#[cargo_test]
+fn hint_unknown_type_warn() {
+    Package::new("bar", "1.0.0")
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "bar"
+            version = "1.0.0"
+            edition = "2015"
+
+            [hints]
+            mostly-unused = 1
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            edition = "2015"
+
+            [dependencies]
+            bar = "1.0"
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+    p.cargo("check -v")
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
+[LOCKING] 1 package to latest compatible version
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
+[CHECKING] bar v1.0.0
+[RUNNING] `rustc --crate-name bar [..]`
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .with_stderr_does_not_contain("-Zhint-mostly-unused")
+        .run();
+}
+
+#[cargo_test]
+fn hints_mostly_unused_warn_without_gate() {
+    Package::new("bar", "1.0.0")
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "bar"
+            version = "1.0.0"
+            edition = "2015"
+
+            [hints]
+            mostly-unused = true
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            edition = "2015"
+
+            [dependencies]
+            bar = "1.0"
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+    p.cargo("check -v")
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
+[LOCKING] 1 package to latest compatible version
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
+[CHECKING] bar v1.0.0
+[RUNNING] `rustc --crate-name bar [..]`
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .with_stderr_does_not_contain("-Zhint-mostly-unused")
+        .run();
+}
+
+#[cargo_test(nightly, reason = "-Zhint-mostly-unused is unstable")]
+fn hints_mostly_unused_nightly() {
+    Package::new("bar", "1.0.0")
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "bar"
+            version = "1.0.0"
+            edition = "2015"
+
+            [hints]
+            mostly-unused = true
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            edition = "2015"
+
+            [dependencies]
+            bar = "1.0"
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+    p.cargo("check -Zprofile-hint-mostly-unused -v")
+        .masquerade_as_nightly_cargo(&["profile-hint-mostly-unused"])
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
+[LOCKING] 1 package to latest compatible version
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
+[CHECKING] bar v1.0.0
+[RUNNING] `rustc --crate-name bar [..]`
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .with_stderr_does_not_contain(
+            "[RUNNING] `rustc --crate-name foo [..] -Zhint-mostly-unused [..]",
+        )
+        .run();
+}
+
+#[cargo_test(nightly, reason = "-Zhint-mostly-unused is unstable")]
+fn mostly_unused_profile_overrides_hints_nightly() {
+    Package::new("bar", "1.0.0")
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "bar"
+            version = "1.0.0"
+            edition = "2015"
+
+            [hints]
+            mostly-unused = true
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            edition = "2015"
+
+            [dependencies]
+            bar = "1.0"
+
+            [profile.dev.package.bar]
+            hint-mostly-unused = false
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+    p.cargo("check -Zprofile-hint-mostly-unused -v")
+        .masquerade_as_nightly_cargo(&["profile-hint-mostly-unused"])
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
+[LOCKING] 1 package to latest compatible version
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
+[CHECKING] bar v1.0.0
+[RUNNING] `rustc --crate-name bar [..]`
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .with_stderr_does_not_contain("-Zhint-mostly-unused")
+        .run();
+}
+
+#[cargo_test(nightly, reason = "-Zhint-mostly-unused is unstable")]
+fn mostly_unused_profile_overrides_hints_on_self_nightly() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            edition = "2015"
+
+            [hints]
+            mostly-unused = true
+
+            [profile.dev]
+            hint-mostly-unused = false
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+    p.cargo("check -v")
+        .with_stderr_data(str![[r#"
+[WARNING] unused manifest key: hints
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .with_stderr_does_not_contain("-Zhint-mostly-unused")
         .run();
 }

--- a/tests/testsuite/hints.rs
+++ b/tests/testsuite/hints.rs
@@ -96,7 +96,7 @@ fn hint_unknown_type_warn() {
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
-[WARNING] ignoring unsupported value type (integer) for 'hints.mostly-unused', which expects a boolean
+[WARNING] bar@1.0.0: ignoring unsupported value type (integer) for 'hints.mostly-unused', which expects a boolean
 [CHECKING] bar v1.0.0
 [RUNNING] `rustc --crate-name bar [..]`
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -146,7 +146,7 @@ fn hints_mostly_unused_warn_without_gate() {
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
-[WARNING] ignoring 'hints.mostly-unused', pass `-Zprofile-hint-mostly-unused` to enable it
+[WARNING] bar@1.0.0: ignoring 'hints.mostly-unused', pass `-Zprofile-hint-mostly-unused` to enable it
 [CHECKING] bar v1.0.0
 [RUNNING] `rustc --crate-name bar [..]`
 [CHECKING] foo v0.0.1 ([ROOT]/foo)

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -106,6 +106,7 @@ mod git_shallow;
 mod glob_targets;
 mod global_cache_tracker;
 mod help;
+mod hints;
 mod https;
 mod inheritable_workspace_fields;
 mod install;

--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -904,7 +904,7 @@ fn profile_hint_mostly_unused_warn_without_gate() {
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
-[WARNING] ignoring 'hint-mostly-unused' profile option, pass `-Zprofile-hint-mostly-unused` to enable it
+[WARNING] bar@1.0.0: ignoring 'hint-mostly-unused' profile option, pass `-Zprofile-hint-mostly-unused` to enable it
 [CHECKING] bar v1.0.0
 [RUNNING] `rustc --crate-name bar [..]`
 [CHECKING] foo v0.0.1 ([ROOT]/foo)


### PR DESCRIPTION
The `[hints]` table in a `Cargo.toml` manifest provides optional
information that Cargo can use for building the package, and will use
even when using the package as a dependency. All hints can be safely
ignored, and Cargo only warns about unknown hints, but does not error.
This allows packages to use hints without depending on new Cargo.

Add a `mostly-unused` hint, which allows a package to hint that most
users of the package will not use most of its items. This is useful for
improving the build performance of crates with large dependencies.

Crates can override this hint using `hint-mostly-unused = false` in
their profile for a dependency.

---

In the future, this same mechanism could be used for other hints, such as
`min-opt-level`.

### How to test and review this PR?

This PR is built atop https://github.com/rust-lang/cargo/pull/15643 . I'd
suggest reviewing that PR separately, then just reviewing the new commits in
this PR.

The new "hints" testsuite module demonstrates the expected behavior of hints.

Like https://github.com/rust-lang/cargo/pull/15643 , the nightly-only tests
will only pass once https://github.com/rust-lang/rust/pull/135656 has been
merged into Rust.
