### PR TITLE
feat: Add JSONPath query support via `cargo metadata --query <query>`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,6 +339,7 @@ dependencies = [
  "itertools 0.14.0",
  "jiff",
  "jobserver",
+ "jsonpath-rust",
  "lazycell",
  "libc",
  "libgit2-sys",
@@ -2470,6 +2471,19 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonpath-rust"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b37465feaf9d41f74df7da98c6c1c31ca8ea06d11b5bf7869c8f1ccc51a793f"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde_json",
+ "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,6 +184,7 @@ indexmap.workspace = true
 itertools.workspace = true
 jiff.workspace = true
 jobserver.workspace = true
+jsonpath-rust = "1"
 lazycell.workspace = true
 libgit2-sys.workspace = true
 memchr.workspace = true


### PR DESCRIPTION
### What does this PR try to resolve?

The `metadata` subcommand of `cargo` is *very* useful, for many different reasons. However, it outputs too much uncompressed information, which is hard to understand at a glance without a parser. In almost all cases, `cargo metadata` is used to extract some information about specific things. These specific things require parsing the full JSON and traversing it to find it externally.
To ease the use of `cargo metadata` and to make it much more useful, this PR adds a `query` argument which expects a `JSONPath` string. This string is used to print out only the information requested out of everything available, filtering all the noise and the results which are of no interest to the user.

### How to test and review this PR?

If in the root of this repository,
```sh
> $ cargo build
> $ cargo run -- metadata --query $.target_directory
>
> "/mnt/workspace/cargo/target"
```
