### PR TITLE
Document automatic override of `strip`

### DIFF
--- a/src/doc/src/reference/profiles.md
+++ b/src/doc/src/reference/profiles.md
@@ -119,7 +119,9 @@ strip = "debuginfo"
 ```
 
 Possible string values of `strip` are `"none"`, `"debuginfo"`, and `"symbols"`.
-The default is `"none"`.
+The default is `"none"`. However, if [`debug`](#debug) is not enabled for any
+package in the dependency graph and `strip` is not explicitly set, it is
+overridden to `"debuginfo"`.
 
 You can also configure this option with the boolean values `true` or `false`.
 `strip = true` is equivalent to `strip = "symbols"`. `strip = false` is
@@ -304,6 +306,9 @@ incremental = false
 codegen-units = 16
 rpath = false
 ```
+
+Note that `strip` may automatically be overridden as described in
+[its section](#strip).
 
 ### test
 


### PR DESCRIPTION
Related: #13638, #13677

### What does this PR try to resolve?

Since #13257, Cargo may automatically set `strip = "debuginfo"`, but the documentation still states that the default is `"none"`. Although this is technically true (as pointed out in comments on the related PRs), it can be misleading. This PR retains the statements that `"none"` is the default, but adds details about the cases where it is overridden to `"debuginfo"`.