### PR TITLE
docs(contrib): change clap URL to docs.rs/clap

### DIFF
--- a/src/doc/contrib/src/implementation/subcommands.md
+++ b/src/doc/contrib/src/implementation/subcommands.md
@@ -17,7 +17,7 @@ automatically search for a subcommand named `cargo-{NAME}` in the users `PATH`
 to execute the subcommand.
 
 
-[`clap`]: https://clap.rs/
+[`clap`]: https://docs.rs/clap
 [`src/bin/cargo/commands/build.rs`]: https://github.com/rust-lang/cargo/tree/master/src/bin/cargo/commands/build.rs
 [`src/cargo/ops`]: https://github.com/rust-lang/cargo/tree/master/src/cargo/ops
 [`src/bin/cargo/commands`]: https://github.com/rust-lang/cargo/tree/master/src/bin/cargo/commands


### PR DESCRIPTION
### What does this PR try to resolve?

The current [subcommands page](https://doc.crates.io/contrib/implementation/subcommands.html) in Cargo contrib guide links clap to https://clap.rs, which doesn't exist. This PR updates that link to https://docs.rs/clap, which is the URL mentioned in [clap's repository](https://github.com/clap-rs/clap)

### How to test and review this PR?