### PR TITLE
implement package feature unification

### DIFF
--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -96,7 +96,7 @@ pub fn resolve_std<'gctx>(
         &features, /*all_features*/ false, /*uses_default_features*/ false,
     )?;
     let dry_run = false;
-    let resolve = ops::resolve_ws_with_opts(
+    let mut resolve = ops::resolve_ws_with_opts(
         &std_ws,
         target_data,
         &build_config.requested_kinds,
@@ -106,10 +106,15 @@ pub fn resolve_std<'gctx>(
         crate::core::resolver::features::ForceAllTargets::No,
         dry_run,
     )?;
+    debug_assert_eq!(resolve.specs_and_features.len(), 1);
     Ok((
         resolve.pkg_set,
         resolve.targeted_resolve,
-        resolve.resolved_features,
+        resolve
+            .specs_and_features
+            .pop()
+            .expect("resolve should have a single spec with resolved features")
+            .resolved_features,
     ))
 }
 

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1287,7 +1287,7 @@ impl<'gctx> Workspace<'gctx> {
         self.target_dir = Some(target_dir);
     }
 
-    /// Returns a Vec of `(&Package, RequestedFeatures)` tuples that
+    /// Returns a Vec of `(&Package, CliFeatures)` tuples that
     /// represent the workspace members that were requested on the command-line.
     ///
     /// `specs` may be empty, which indicates it should return all workspace

--- a/src/cargo/ops/fix/mod.rs
+++ b/src/cargo/ops/fix/mod.rs
@@ -588,7 +588,15 @@ fn check_resolver_change<'gctx>(
             feature_opts,
         )?;
 
-        let diffs = v2_features.compare_legacy(&ws_resolve.resolved_features);
+        if ws_resolve.specs_and_features.len() != 1 {
+            bail!(r#"cannot fix edition when using `feature-unification = "package"`."#);
+        }
+        let resolved_features = &ws_resolve
+            .specs_and_features
+            .first()
+            .expect("We've already checked that there is exactly one.")
+            .resolved_features;
+        let diffs = v2_features.compare_legacy(resolved_features);
         Ok((ws_resolve, diffs))
     };
     let (_, without_dev_diffs) = resolve_differences(HasDevUnits::No)?;

--- a/src/cargo/util/context/mod.rs
+++ b/src/cargo/util/context/mod.rs
@@ -2864,6 +2864,7 @@ pub enum IncompatibleRustVersions {
 #[derive(Copy, Clone, Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum FeatureUnification {
+    Package,
     Selected,
     Workspace,
 }

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1899,7 +1899,7 @@ Specify which packages participate in [feature unification](../reference/feature
 * `selected`: Merge dependency features from all packages specified for the current build.
 * `workspace`: Merge dependency features across all workspace members,
   regardless of which packages are specified for the current build.
-* `package` _(unimplemented)_: Dependency features are considered on a package-by-package basis,
+* `package`: Dependency features are considered on a package-by-package basis,
   preferring duplicate builds of dependencies when different sets of features are activated by the packages.
 
 ## Package message format

--- a/tests/testsuite/feature_unification.rs
+++ b/tests/testsuite/feature_unification.rs
@@ -2,7 +2,13 @@
 
 use crate::prelude::*;
 use crate::utils::cargo_process;
-use cargo_test_support::{basic_manifest, project, str};
+use cargo_test_support::{
+    basic_manifest,
+    compare::assert_e2e,
+    project,
+    registry::{Dependency, Package},
+    str,
+};
 
 #[cargo_test]
 fn workspace_feature_unification() {
@@ -108,6 +114,792 @@ fn workspace_feature_unification() {
 }
 
 #[cargo_test]
+fn package_feature_unification() {
+    Package::new("outside", "0.1.0")
+        .feature("a", &[])
+        .feature("b", &[])
+        .file(
+            "src/lib.rs",
+            r#"
+                #[cfg(all(feature = "a", feature = "b"))]
+                compile_error!("features were unified");
+                #[cfg(feature = "a")]
+                pub fn a() {}
+                #[cfg(feature = "b")]
+                pub fn b() {}
+            "#,
+        )
+        .publish();
+
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            r#"
+                [resolver]
+                feature-unification = "selected"
+            "#,
+        )
+        .file(
+            "Cargo.toml",
+            r#"
+                [workspace]
+                resolver = "2"
+                members = ["common", "a", "b"]
+            "#,
+        )
+        .file(
+            "common/Cargo.toml",
+            r#"
+                [package]
+                name = "common"
+                version = "0.1.0"
+                edition = "2021"
+
+                [features]
+                a = []
+                b = []
+            "#,
+        )
+        .file(
+            "common/src/lib.rs",
+            r#"
+                #[cfg(all(feature = "a", feature = "b"))]
+                compile_error!("features were unified");
+                #[cfg(feature = "a")]
+                pub fn a() {}
+                #[cfg(feature = "b")]
+                pub fn b() {}
+            "#,
+        )
+        .file(
+            "a/Cargo.toml",
+            r#"
+                [package]
+                name = "a"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                common = { path = "../common", features = ["a"] }
+                outside = { version = "0.1.0", features = ["a"] }
+            "#,
+        )
+        .file("a/src/lib.rs", "pub use common::a;")
+        .file(
+            "b/Cargo.toml",
+            r#"
+                [package]
+                name = "b"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                common = { path = "../common", features = ["b"] }
+                outside = { version = "0.1.0", features = ["b"] }
+            "#,
+        )
+        .file("b/src/lib.rs", "pub use common::b;")
+        .build();
+
+    p.cargo("check -p common")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
+[LOCKING] 1 package to latest compatible version
+[CHECKING] common v0.1.0 ([ROOT]/foo/common)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+    p.cargo("check -p a")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .with_stderr_data(
+            str![[r#"
+[DOWNLOADING] crates ...
+[DOWNLOADED] outside v0.1.0 (registry `dummy-registry`)
+[CHECKING] outside v0.1.0
+[CHECKING] common v0.1.0 ([ROOT]/foo/common)
+[CHECKING] a v0.1.0 ([ROOT]/foo/a)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]]
+            .unordered(),
+        )
+        .run();
+    p.cargo("check -p b")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .with_stderr_data(
+            str![[r#"
+[CHECKING] outside v0.1.0
+[CHECKING] common v0.1.0 ([ROOT]/foo/common)
+[CHECKING] b v0.1.0 ([ROOT]/foo/b)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]]
+            .unordered(),
+        )
+        .run();
+    p.cargo("check -p a -p b")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .with_status(101)
+        .with_stderr_contains("[ERROR] features were unified")
+        .run();
+    p.cargo("check")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .with_status(101)
+        .with_stderr_contains("[ERROR] features were unified")
+        .run();
+    // Sanity check that compilation without package feature unification does not work
+    p.cargo("check -p a -p b")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "selected")
+        .with_status(101)
+        .with_stderr_contains("[ERROR] features were unified")
+        .run();
+}
+
+#[cargo_test]
+fn package_feature_unification_default_features() {
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            r#"
+                [resolver]
+                feature-unification = "selected"
+            "#,
+        )
+        .file(
+            "Cargo.toml",
+            r#"
+                [workspace]
+                resolver = "2"
+                members = ["common", "a", "b"]
+            "#,
+        )
+        .file(
+            "common/Cargo.toml",
+            r#"
+                [package]
+                name = "common"
+                version = "0.1.0"
+                edition = "2021"
+
+                [features]
+                default = ["a"]
+                a = []
+                b = []
+            "#,
+        )
+        .file(
+            "common/src/lib.rs",
+            r#"
+                #[cfg(all(feature = "a", feature = "b"))]
+                compile_error!("features were unified");
+                #[cfg(feature = "a")]
+                pub fn a() {}
+                #[cfg(feature = "b")]
+                pub fn b() {}
+            "#,
+        )
+        .file(
+            "a/Cargo.toml",
+            r#"
+                [package]
+                name = "a"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                common = { path = "../common" }
+            "#,
+        )
+        .file("a/src/lib.rs", "pub use common::a;")
+        .file(
+            "b/Cargo.toml",
+            r#"
+                [package]
+                name = "b"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                common = { path = "../common", features = ["b"], default-features = false }
+            "#,
+        )
+        .file("b/src/lib.rs", "pub use common::b;")
+        .build();
+
+    p.cargo("check -p common")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .with_stderr_data(str![[r#"
+[CHECKING] common v0.1.0 ([ROOT]/foo/common)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+    p.cargo("check -p a")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .with_stderr_data(str![[r#"
+[CHECKING] a v0.1.0 ([ROOT]/foo/a)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+    p.cargo("check -p b")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .with_stderr_data(str![[r#"
+[CHECKING] common v0.1.0 ([ROOT]/foo/common)
+[CHECKING] b v0.1.0 ([ROOT]/foo/b)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+    p.cargo("check")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .with_status(101)
+        .with_stderr_data(
+            str![[r#"
+[CHECKING] common v0.1.0 ([ROOT]/foo/common)
+[ERROR] features were unified
+ --> common/src/lib.rs:3:17
+  |
+3 |                 compile_error!("features were unified");
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+[ERROR] could not compile `common` (lib) due to 1 previous error
+
+"#]]
+            .unordered(),
+        )
+        .run();
+}
+
+#[cargo_test]
+fn package_feature_unification_cli_features() {
+    Package::new("outside", "0.1.0")
+        .feature("a", &[])
+        .feature("b", &[])
+        .file(
+            "src/lib.rs",
+            r#"
+                #[cfg(all(feature = "a", feature = "b"))]
+                compile_error!("features were unified");
+                #[cfg(feature = "a")]
+                pub fn a() {}
+                #[cfg(feature = "b")]
+                pub fn b() {}
+            "#,
+        )
+        .publish();
+
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            r#"
+                [resolver]
+                feature-unification = "selected"
+            "#,
+        )
+        .file(
+            "Cargo.toml",
+            r#"
+                [workspace]
+                resolver = "2"
+                members = ["common", "a", "b"]
+            "#,
+        )
+        .file(
+            "common/Cargo.toml",
+            r#"
+                [package]
+                name = "common"
+                version = "0.1.0"
+                edition = "2021"
+
+                [features]
+                a = []
+                b = []
+            "#,
+        )
+        .file(
+            "common/src/lib.rs",
+            r#"
+                #[cfg(all(feature = "a", feature = "b"))]
+                compile_error!("features were unified");
+                #[cfg(feature = "a")]
+                pub fn a() {}
+                #[cfg(feature = "b")]
+                pub fn b() {}
+            "#,
+        )
+        .file(
+            "a/Cargo.toml",
+            r#"
+                [package]
+                name = "a"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                common = { path = "../common" }
+                outside = "0.1.0"
+
+                [features]
+                a = ["common/a", "outside/a"]
+            "#,
+        )
+        .file("a/src/lib.rs", "pub use common::a;")
+        .file(
+            "b/Cargo.toml",
+            r#"
+                [package]
+                name = "b"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                common = { path = "../common", features = ["b"] }
+                outside = "0.1.0"
+
+                [features]
+                b = ["common/b", "outside/b"]
+            "#,
+        )
+        .file("b/src/lib.rs", "pub use common::b;")
+        .build();
+
+    p.cargo("check -p a -p b -F a,b")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .with_status(101)
+        .with_stderr_data(
+            str![[r#"
+[CHECKING] common v0.1.0 ([ROOT]/foo/common)
+[ERROR] features were unified
+ --> common/src/lib.rs:3:17
+  |
+3 |                 compile_error!("features were unified");
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+[ERROR] could not compile `common` (lib) due to 1 previous error
+[UPDATING] `dummy-registry` index
+[LOCKING] 1 package to latest compatible version
+[DOWNLOADING] crates ...
+[DOWNLOADED] outside v0.1.0 (registry `dummy-registry`)
+[CHECKING] outside v0.1.0
+[ERROR] features were unified
+ --> [ROOT]/home/.cargo/registry/src/-[HASH]/outside-0.1.0/src/lib.rs:3:17
+  |
+3 |                 compile_error!("features were unified");
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+[ERROR] could not compile `outside` (lib) due to 1 previous error
+[WARNING] build failed, waiting for other jobs to finish...
+
+"#]]
+            .unordered(),
+        )
+        .run();
+    p.cargo("check --workspace --exclude common -F a,b")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .with_status(101)
+        .with_stderr_data(
+            str![[r#"
+[CHECKING] outside v0.1.0
+[CHECKING] common v0.1.0 ([ROOT]/foo/common)
+[ERROR] features were unified
+ --> common/src/lib.rs:3:17
+  |
+3 |                 compile_error!("features were unified");
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+[ERROR] features were unified
+ --> [ROOT]/home/.cargo/registry/src/-[HASH]/outside-0.1.0/src/lib.rs:3:17
+  |
+3 |                 compile_error!("features were unified");
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+[ERROR] could not compile `outside` (lib) due to 1 previous error
+[WARNING] build failed, waiting for other jobs to finish...
+[ERROR] could not compile `common` (lib) due to 1 previous error
+
+"#]]
+            .unordered(),
+        )
+        .run();
+
+    p.cargo("check -p a -p b -F a/a,b/b")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .with_status(101)
+        .with_stderr_data(
+            str![[r#"
+[CHECKING] outside v0.1.0
+[CHECKING] common v0.1.0 ([ROOT]/foo/common)
+[ERROR] features were unified
+ --> common/src/lib.rs:3:17
+  |
+3 |                 compile_error!("features were unified");
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+[ERROR] features were unified
+ --> [ROOT]/home/.cargo/registry/src/-[HASH]/outside-0.1.0/src/lib.rs:3:17
+  |
+3 |                 compile_error!("features were unified");
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+[ERROR] could not compile `common` (lib) due to 1 previous error
+[WARNING] build failed, waiting for other jobs to finish...
+[ERROR] could not compile `outside` (lib) due to 1 previous error
+
+"#]]
+            .unordered(),
+        )
+        .run();
+    p.cargo("check -p a -p b -F a,b,c")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] none of the selected packages contains this feature: c
+selected packages: a, b
+
+"#]])
+        .run();
+    p.cargo("check -p a -F b")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] the package 'a' does not contain this feature: b
+[HELP] packages with the missing feature: common, b
+
+"#]])
+        .run();
+    p.cargo("check -p a -F a/a,common/b")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .with_status(101)
+        .with_stderr_contains("[ERROR] features were unified")
+        .run();
+
+    p.cargo("check -p a -F a/a,outside/b")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .with_status(101)
+        .with_stderr_contains("[ERROR] features were unified")
+        .run();
+
+    // Sanity check that compilation without package feature unification does not work
+    p.cargo("check -p a -p b -F a,b")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "selected")
+        .with_status(101)
+        .with_stderr_contains("[ERROR] features were unified")
+        .run();
+}
+
+#[cargo_test]
+fn package_feature_unification_weak_dependencies() {
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            r#"
+                [resolver]
+                feature-unification = "selected"
+            "#,
+        )
+        .file(
+            "Cargo.toml",
+            r#"
+                [workspace]
+                resolver = "2"
+                members = ["common", "a", "b"]
+            "#,
+        )
+        .file(
+            "common/Cargo.toml",
+            r#"
+                [package]
+                name = "common"
+                version = "0.1.0"
+                edition = "2021"
+
+                [features]
+                a = []
+                b = []
+            "#,
+        )
+        .file(
+            "common/src/lib.rs",
+            r#"
+                #[cfg(all(feature = "a", feature = "b"))]
+                compile_error!("features were unified");
+                #[cfg(feature = "a")]
+                pub fn a() {}
+                #[cfg(feature = "b")]
+                pub fn b() {}
+            "#,
+        )
+        .file(
+            "a/Cargo.toml",
+            r#"
+                [package]
+                name = "a"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                common = { path = "../common", optional = true }
+
+                [features]
+                default = ["dep:common", "common?/a"]
+            "#,
+        )
+        .file("a/src/lib.rs", "pub use common::a;")
+        .file(
+            "b/Cargo.toml",
+            r#"
+                [package]
+                name = "b"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                common = { path = "../common", optional = true }
+
+                [features]
+                default = ["dep:common", "common?/b"]
+            "#,
+        )
+        .file("b/src/lib.rs", "pub use common::b;")
+        .build();
+
+    p.cargo("check -p a -p b")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .with_status(101)
+        .with_stderr_data(
+            str![[r#"
+[CHECKING] common v0.1.0 ([ROOT]/foo/common)
+[ERROR] features were unified
+ --> common/src/lib.rs:3:17
+  |
+3 |                 compile_error!("features were unified");
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+[ERROR] could not compile `common` (lib) due to 1 previous error
+
+"#]]
+            .unordered(),
+        )
+        .run();
+    p.cargo("check")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[CHECKING] common v0.1.0 ([ROOT]/foo/common)
+[ERROR] features were unified
+ --> common/src/lib.rs:3:17
+  |
+3 |                 compile_error!("features were unified");
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+[ERROR] could not compile `common` (lib) due to 1 previous error
+
+"#]])
+        .run();
+
+    // Sanity check that compilation without package feature unification does not work
+    p.cargo("check -p a -p b")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "selected")
+        .with_status(101)
+        .with_stderr_contains("[ERROR] features were unified")
+        .run();
+}
+
+#[cargo_test]
+fn feature_unification_cargo_tree() {
+    Package::new("outside", "0.1.0")
+        .feature("a", &[])
+        .feature("b", &[])
+        .file(
+            "src/lib.rs",
+            r#"
+                #[cfg(all(feature = "a", feature = "b"))]
+                compile_error!("features were unified");
+                #[cfg(feature = "a")]
+                pub fn a() {}
+                #[cfg(feature = "b")]
+                pub fn b() {}
+            "#,
+        )
+        .publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [workspace]
+                resolver = "2"
+                members = ["common", "a", "b"]
+            "#,
+        )
+        .file(
+            "common/Cargo.toml",
+            r#"
+                [package]
+                name = "common"
+                version = "0.1.0"
+                edition = "2021"
+
+                [features]
+                a = []
+                b = []
+            "#,
+        )
+        .file(
+            "common/src/lib.rs",
+            r#"
+                #[cfg(all(feature = "a", feature = "b"))]
+                compile_error!("features were unified");
+                #[cfg(feature = "a")]
+                pub fn a() {}
+                #[cfg(feature = "b")]
+                pub fn b() {}
+            "#,
+        )
+        .file(
+            "a/Cargo.toml",
+            r#"
+                [package]
+                name = "a"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                common = { path = "../common", features = ["a"] }
+                outside = { version = "0.1.0", features = ["a"] }
+            "#,
+        )
+        .file("a/src/lib.rs", "pub use common::a;")
+        .file(
+            "b/Cargo.toml",
+            r#"
+                [package]
+                name = "b"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                common = { path = "../common", features = ["b"] }
+                outside = { version = "0.1.0", features = ["b"] }
+            "#,
+        )
+        .file("b/src/lib.rs", "pub use common::b;")
+        .build();
+
+    p.cargo("tree -e features")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "selected")
+        .with_stdout_data(str![[r#"
+a v0.1.0 ([ROOT]/foo/a)
+├── common feature "a"
+│   └── common v0.1.0 ([ROOT]/foo/common)
+├── common feature "default" (command-line)
+│   └── common v0.1.0 ([ROOT]/foo/common)
+├── outside feature "a"
+│   └── outside v0.1.0
+└── outside feature "default"
+    └── outside v0.1.0
+
+b v0.1.0 ([ROOT]/foo/b)
+├── common feature "b"
+│   └── common v0.1.0 ([ROOT]/foo/common)
+├── common feature "default" (command-line) (*)
+├── outside feature "b"
+│   └── outside v0.1.0
+└── outside feature "default" (*)
+
+common v0.1.0 ([ROOT]/foo/common)
+
+"#]])
+        .run();
+
+    p.cargo("tree -e features")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "workspace")
+        .with_stdout_data(str![[r#"
+a v0.1.0 ([ROOT]/foo/a)
+├── common feature "a"
+│   └── common v0.1.0 ([ROOT]/foo/common)
+├── common feature "default" (command-line)
+│   └── common v0.1.0 ([ROOT]/foo/common)
+├── outside feature "a"
+│   └── outside v0.1.0
+└── outside feature "default"
+    └── outside v0.1.0
+
+b v0.1.0 ([ROOT]/foo/b)
+├── common feature "b"
+│   └── common v0.1.0 ([ROOT]/foo/common)
+├── common feature "default" (command-line) (*)
+├── outside feature "b"
+│   └── outside v0.1.0
+└── outside feature "default" (*)
+
+common v0.1.0 ([ROOT]/foo/common)
+
+"#]])
+        .run();
+
+    p.cargo("tree -e features")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "selected") // To be changed to package later
+        .with_stdout_data(str![[r#"
+a v0.1.0 ([ROOT]/foo/a)
+├── common feature "a"
+│   └── common v0.1.0 ([ROOT]/foo/common)
+├── common feature "default" (command-line)
+│   └── common v0.1.0 ([ROOT]/foo/common)
+├── outside feature "a"
+│   └── outside v0.1.0
+└── outside feature "default"
+    └── outside v0.1.0
+
+b v0.1.0 ([ROOT]/foo/b)
+├── common feature "b"
+│   └── common v0.1.0 ([ROOT]/foo/common)
+├── common feature "default" (command-line) (*)
+├── outside feature "b"
+│   └── outside v0.1.0
+└── outside feature "default" (*)
+
+common v0.1.0 ([ROOT]/foo/common)
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn cargo_install_ignores_config() {
     let p = project()
         .file(
@@ -177,6 +969,20 @@ fn cargo_install_ignores_config() {
 
 "#]])
         .run();
+    cargo_process("install --path")
+        .arg(p.root())
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "selected")
+        .with_stderr_data(str![[r#"
+[INSTALLING] a v0.1.0 ([ROOT]/foo)
+[FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
+[REPLACING] [ROOT]/home/.cargo/bin/a[EXE]
+[REPLACED] package `a v0.1.0 ([ROOT]/foo)` with `a v0.1.0 ([ROOT]/foo)` (executable `a[EXE]`)
+[WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
+
+"#]])
+        .run();
 }
 
 #[cargo_test]
@@ -200,6 +1006,365 @@ fn unstable_config_on_stable() {
 [WARNING] ignoring `resolver.feature-unification` without `-Zfeature-unification`
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn cargo_fix_works() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+# Before project
+[ project ] # After project header
+# After project header line
+name = "foo"
+edition = "2021"
+# After project table
+"#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("fix --edition --allow-no-vcs")
+        .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "selected")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .with_stderr_data(str![[r#"
+[MIGRATING] Cargo.toml from 2021 edition to 2024
+[FIXED] Cargo.toml (1 fix)
+[CHECKING] foo v0.0.0 ([ROOT]/foo)
+[MIGRATING] src/lib.rs from 2021 edition to 2024
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+    assert_e2e().eq(
+        p.read_file("Cargo.toml"),
+        str![[r#"
+
+# Before project
+[ package ] # After project header
+# After project header line
+name = "foo"
+edition = "2021"
+# After project table
+
+"#]],
+    );
+}
+
+#[cargo_test]
+fn edition_v2_resolver_report() {
+    // Show a report if the V2 resolver shows differences.
+    Package::new("common", "1.0.0")
+        .feature("f1", &[])
+        .feature("dev-feat", &[])
+        .add_dep(Dependency::new("opt_dep", "1.0").optional(true))
+        .publish();
+    Package::new("opt_dep", "1.0.0").publish();
+
+    Package::new("bar", "1.0.0")
+        .add_dep(
+            Dependency::new("common", "1.0")
+                .target("cfg(whatever)")
+                .enable_features(&["f1"]),
+        )
+        .publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [workspace]
+                members = ["bar"]
+
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2018"
+
+                [dependencies]
+                common = "1.0"
+                bar = "1.0"
+
+                [build-dependencies]
+                common = { version = "1.0", features = ["opt_dep"] }
+
+                [dev-dependencies]
+                common = { version="1.0", features=["dev-feat"] }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file(
+            "bar/Cargo.toml",
+            r#"
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                edition = "2018"
+            "#,
+        )
+        .file("bar/src/lib.rs", "")
+        .build();
+
+    p.cargo("fix --edition --allow-no-vcs --workspace")
+        .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "selected")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .with_status(0)
+        .with_stderr_data(
+            str![[r#"
+[MIGRATING] Cargo.toml from 2018 edition to 2021
+[UPDATING] `dummy-registry` index
+[LOCKING] 3 packages to latest compatible versions
+[DOWNLOADING] crates ...
+[DOWNLOADED] common v1.0.0 (registry `dummy-registry`)
+[DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
+[DOWNLOADED] opt_dep v1.0.0 (registry `dummy-registry`)
+[MIGRATING] bar/Cargo.toml from 2018 edition to 2021
+[NOTE] Switching to Edition 2021 will enable the use of the version 2 feature resolver in Cargo.
+This may cause some dependencies to be built with fewer features enabled than previously.
+More information about the resolver changes may be found at https://doc.rust-lang.org/nightly/edition-guide/rust-2021/default-cargo-resolver.html
+When building the following dependencies, the given features will no longer be used:
+
+  common v1.0.0 removed features: dev-feat, f1, opt_dep
+  common v1.0.0 (as host dependency) removed features: dev-feat, f1
+
+The following differences only apply when building with dev-dependencies:
+
+  common v1.0.0 removed features: f1, opt_dep
+
+[CHECKING] opt_dep v1.0.0
+[CHECKING] bar v1.0.0
+[CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
+[MIGRATING] bar/src/lib.rs from 2018 edition to 2021
+[CHECKING] common v1.0.0
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[MIGRATING] src/lib.rs from 2018 edition to 2021
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]]
+            .unordered(),
+        )
+        .run();
+}
+
+#[cargo_test]
+fn feature_unification_of_cli_features_within_workspace() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [workspace]
+                resolver = "2"
+                members = ["parent", "child", "grandchild"]
+            "#,
+        )
+        .file(
+            "grandchild/Cargo.toml",
+            r#"
+                [package]
+                name = "grandchild"
+                version = "0.1.0"
+                edition = "2021"
+
+                [features]
+                a = []
+            "#,
+        )
+        .file(
+            "grandchild/src/lib.rs",
+            r#"
+                #[cfg(feature = "a")]
+                pub fn a() {}
+            "#,
+        )
+        .file(
+            "child/Cargo.toml",
+            r#"
+                [package]
+                name = "child"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                grandchild = { path = "../grandchild" }
+            "#,
+        )
+        .file("child/src/lib.rs", "pub use grandchild::*;")
+        .file(
+            "parent/Cargo.toml",
+            r#"
+                [package]
+                name = "parent"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                child = { path = "../child" }
+            "#,
+        )
+        .file("parent/src/lib.rs", "pub use child::a;")
+        .build();
+
+    p.cargo("check -p parent -F grandchild/a")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        // .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "package")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] the package 'parent' does not contain this feature: grandchild/a
+
+"#]])
+        .run();
+
+    p.cargo("check -p parent -F grandchild/a")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "workspace")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] the package 'parent' does not contain this feature: grandchild/a
+
+"#]])
+        .run();
+
+    p.cargo("check -p parent -F grandchild/a")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "selected")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] the package 'parent' does not contain this feature: grandchild/a
+
+"#]])
+        .run();
+
+    p.cargo("check -p child -F grandchild/a")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        // .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "package")
+        .with_stderr_data(str![[r#"
+[CHECKING] grandchild v0.1.0 ([ROOT]/foo/grandchild)
+[CHECKING] child v0.1.0 ([ROOT]/foo/child)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+
+    p.cargo("check -p child -F grandchild/a")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "workspace")
+        .with_stderr_data(str![[r#"
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+
+    p.cargo("check -p child -F grandchild/a")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "selected")
+        .with_stderr_data(str![[r#"
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+
+    p.cargo("check -F grandchild/a")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        // .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "package")
+        .with_stderr_data(str![[r#"
+[CHECKING] parent v0.1.0 ([ROOT]/foo/parent)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+
+    p.cargo("check -F grandchild/a")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "workspace")
+        .with_stderr_data(str![[r#"
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+
+    p.cargo("check -F grandchild/a")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "selected")
+        .with_stderr_data(str![[r#"
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+
+    p.cargo("check -F grandchild/a --workspace --exclude grandchild")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        // .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "package")
+        .with_stderr_data(str![[r#"
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+
+    p.cargo("check -F grandchild/a --workspace --exclude grandchild")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "workspace")
+        .with_stderr_data(str![[r#"
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+
+    p.cargo("check -F grandchild/a --workspace --exclude grandchild")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "selected")
+        .with_stderr_data(str![[r#"
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+
+    p.cargo("check -F grandchild/a --workspace --exclude grandchild --exclude child")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        // .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "package")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] the package 'parent' does not contain this feature: grandchild/a
+
+"#]])
+        .run();
+
+    p.cargo("check -F grandchild/a --workspace --exclude grandchild --exclude child")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "workspace")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] the package 'parent' does not contain this feature: grandchild/a
+
+"#]])
+        .run();
+
+    p.cargo("check -F grandchild/a --workspace --exclude grandchild --exclude child")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "selected")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] the package 'parent' does not contain this feature: grandchild/a
 
 "#]])
         .run();


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/cargo/pull/15684)*

### What does this PR try to resolve?

Implements another part of feature unification (#14774, [rfc](https://github.com/rust-lang/rfcs/blob/1c590ce05d676e72e2217845ee054758d3a6df34/text/3692-feature-unification.md)). The `workspace` option was implemented in #15157, this adds the `package` option.

### How to test and review this PR?

The important change is changing `WorkspaceResolve` so it can contain multiple `ResolvedFeature`s. Along with that, it also needs to know which specs those features are resolved for. This was used in several other places:
- `cargo fix --edition` (from 2018 to 2021) - I think it should be ok to disallow using `cargo fix --edition` when someone already uses this feature.
- building std - it should be safe to assume std is not using this feature so I just unwrap there. I'm not sure if some attempt to later feature unification would be better.
- `cargo tree` - I just use the first feature set. This is definitely not ideal, but I'm not entirely sure what's the correct solution here. Printing multiple trees? Disallowing this, forcing users to select only one package?

Based on comments in #15157 I've added tests first with `selected` feature unification and then changed that after implementation. I'm not sure if that's how you expect the tests to be added first, if not, I can change the history.

I've expanded the test checking that this is ignored for `cargo install` although it should work the same way even if it is not ignored (`selected` and `package` are the same thing when just one package is selected).