### PR TITLE
Helpful error for invalid `cargo add`

### DIFF
--- a/src/cargo/ops/cargo_add/crate_spec.rs
+++ b/src/cargo/ops/cargo_add/crate_spec.rs
@@ -1,11 +1,16 @@
 //! Crate name parsing.
 
 use anyhow::Context as _;
+use thiserror::Error;
 
 use super::Dependency;
 use crate::util::toml_mut::dependency::RegistrySource;
 use crate::CargoResult;
 use cargo_util_schemas::manifest::PackageName;
+
+#[derive(Error, Debug)]
+#[error(transparent)]
+pub(crate) struct CrateSpecResolutionError(pub crate::Error);
 
 /// User-specified crate
 ///
@@ -22,7 +27,12 @@ pub struct CrateSpec {
 
 impl CrateSpec {
     /// Convert a string to a `Crate`
-    pub fn resolve(pkg_id: &str) -> CargoResult<Self> {
+    pub fn resolve(pkg_id: &str) -> Result<Self, CrateSpecResolutionError> {
+        // enables targeted add_spec_fix_suggestion
+        Self::resolve_inner(pkg_id).map_err(CrateSpecResolutionError)
+    }
+
+    fn resolve_inner(pkg_id: &str) -> CargoResult<Self> {
         let (name, version) = pkg_id
             .split_once('@')
             .map(|(n, v)| (n, Some(v)))


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/cargo/pull/15688)*

When users try to use paths and URLs directly in `cargo add`, like `cargo add ../path` or `cargo add ssh://git/dep.git`, cargo treats it as a package name syntax error and complains that "characters must be Unicode XID characters", which isn't addressing users' misconception.

I've added "note: ..." with recovery suggestions to these errors.

I've also noticed that `cargo add --path dir/Cargo.toml` errs with "failed to read dir/Cargo.toml/Cargo.toml". Explaining that failure case felt silly, so I've made `--path` automatically strip `Cargo.toml` from the path instead.
