### PR TITLE
Configure snippets renderer to match rustc/Cargo style

### DIFF
--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -415,7 +415,11 @@ impl Shell {
         writeln!(
             self.err(),
             "{}",
-            Renderer::styled().term_width(term_width).render(message)
+            Renderer::styled()
+                .note(NOTE)
+                .help(HELP)
+                .term_width(term_width)
+                .render(message)
         )
     }
 }

--- a/src/cargo/util/style.rs
+++ b/src/cargo/util/style.rs
@@ -8,6 +8,7 @@ pub const PLACEHOLDER: Style = AnsiColor::Cyan.on_default();
 pub const ERROR: Style = AnsiColor::Red.on_default().effects(Effects::BOLD);
 pub const WARN: Style = AnsiColor::Yellow.on_default().effects(Effects::BOLD);
 pub const NOTE: Style = AnsiColor::Cyan.on_default().effects(Effects::BOLD);
+pub const HELP: Style = AnsiColor::Cyan.on_default().effects(Effects::BOLD);
 pub const GOOD: Style = AnsiColor::Green.on_default().effects(Effects::BOLD);
 pub const VALID: Style = AnsiColor::Cyan.on_default().effects(Effects::BOLD);
 pub const INVALID: Style = AnsiColor::Yellow.on_default().effects(Effects::BOLD);

--- a/tests/testsuite/lints/error/stderr.term.svg
+++ b/tests/testsuite/lints/error/stderr.term.svg
@@ -3,8 +3,8 @@
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
     .fg-bright-blue { fill: #5555FF }
-    .fg-bright-green { fill: #55FF55 }
     .fg-bright-red { fill: #FF5555 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -32,7 +32,7 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-blue bold">= </tspan><tspan class="fg-bright-green bold">note</tspan><tspan>: `cargo::im_a_teapot` is set to `deny` in `[lints]`</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-blue bold">= </tspan><tspan class="fg-cyan bold">note</tspan><tspan>: `cargo::im_a_teapot` is set to `deny` in `[lints]`</tspan>
 </tspan>
     <tspan x="10px" y="154px">
 </tspan>

--- a/tests/testsuite/lints/inherited/stderr.term.svg
+++ b/tests/testsuite/lints/inherited/stderr.term.svg
@@ -3,9 +3,8 @@
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
     .fg-bright-blue { fill: #5555FF }
-    .fg-bright-cyan { fill: #55FFFF }
-    .fg-bright-green { fill: #55FF55 }
     .fg-bright-red { fill: #FF5555 }
+    .fg-cyan { fill: #00AAAA }
     .fg-red { fill: #AA0000 }
     .container {
       padding: 0 10px;
@@ -34,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-bright-green bold">note</tspan><tspan>: </tspan><tspan class="bold">`cargo::im_a_teapot` was inherited</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-cyan bold">note</tspan><tspan>: </tspan><tspan class="bold">`cargo::im_a_teapot` was inherited</tspan>
 </tspan>
     <tspan x="10px" y="154px"><tspan> </tspan><tspan class="fg-bright-blue bold">--&gt;</tspan><tspan> foo/Cargo.toml:9:1</tspan>
 </tspan>
@@ -42,11 +41,11 @@
 </tspan>
     <tspan x="10px" y="190px"><tspan class="fg-bright-blue bold">9 |</tspan><tspan> workspace = true</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> </tspan><tspan class="fg-bright-green bold">----------------</tspan>
+    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> </tspan><tspan class="fg-cyan bold">----------------</tspan>
 </tspan>
     <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-bright-blue bold">= </tspan><tspan class="fg-bright-cyan bold">help</tspan><tspan>: consider adding `cargo-features = ["test-dummy-unstable"]` to the top of the manifest</tspan>
+    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-bright-blue bold">= </tspan><tspan class="fg-cyan bold">help</tspan><tspan>: consider adding `cargo-features = ["test-dummy-unstable"]` to the top of the manifest</tspan>
 </tspan>
     <tspan x="10px" y="262px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> encountered 1 errors(s) while verifying lints</tspan>
 </tspan>

--- a/tests/testsuite/lints/warning/stderr.term.svg
+++ b/tests/testsuite/lints/warning/stderr.term.svg
@@ -3,7 +3,7 @@
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
     .fg-bright-blue { fill: #5555FF }
-    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .fg-green { fill: #00AA00 }
     .fg-yellow { fill: #AA5500 }
     .container {
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-blue bold">= </tspan><tspan class="fg-bright-green bold">note</tspan><tspan>: `cargo::im_a_teapot` is set to `warn` in `[lints]`</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-blue bold">= </tspan><tspan class="fg-cyan bold">note</tspan><tspan>: `cargo::im_a_teapot` is set to `warn` in `[lints]`</tspan>
 </tspan>
     <tspan x="10px" y="154px"><tspan class="fg-green bold">    Checking</tspan><tspan> foo v0.0.1 ([ROOT]/foo)</tspan>
 </tspan>


### PR DESCRIPTION
`Renderer::styled()` defaults to green labels for `note` and `help`, but Cargo and `rustc` use cyan. 