### PR TITLE
Bump cargo-util-schemas version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util-schemas"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "schemars",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ cargo-platform = { path = "crates/cargo-platform", version = "0.3.0" }
 cargo-test-macro = { version = "0.4.4", path = "crates/cargo-test-macro" }
 cargo-test-support = { version = "0.7.5", path = "crates/cargo-test-support" }
 cargo-util = { version = "0.2.22", path = "crates/cargo-util" }
-cargo-util-schemas = { version = "0.8.3", path = "crates/cargo-util-schemas" }
+cargo-util-schemas = { version = "0.9.0", path = "crates/cargo-util-schemas" }
 cargo_metadata = "0.19.1"
 clap = "4.5.28"
 clap_complete = { version = "4.5.44", features = ["unstable-dynamic"] }

--- a/crates/cargo-util-schemas/Cargo.toml
+++ b/crates/cargo-util-schemas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-util-schemas"
-version = "0.8.3"
+version = "0.9.0"
 rust-version = "1.87"  # MSRV:1
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
https://github.com/rust-lang/cargo/pull/15643 introduced a semver breaking change by adding a new pub field to `TomlProfile`.
