### PR TITLE
[Beta-1.89] Fix potential deadlock in `CacheState::lock`

### DIFF
--- a/src/cargo/util/cache_lock.rs
+++ b/src/cargo/util/cache_lock.rs
@@ -408,7 +408,10 @@ impl CacheState {
                     .lock_exclusive(gctx, DOWNLOAD_EXCLUSIVE_DESCR, blocking)
                 {
                     Ok(LockAcquired) => {}
-                    Ok(WouldBlock) => return Ok(WouldBlock),
+                    Ok(WouldBlock) => {
+                        self.mutate_lock.decrement();
+                        return Ok(WouldBlock);
+                    }
                     Err(e) => {
                         self.mutate_lock.decrement();
                         return Err(e);


### PR DESCRIPTION
Beta backports
- 0b362e320e518f180582138d3c538b6ee549cef1 (#15698)

In order to make CI pass, the following PRs are also cherry-picked:

---

Problem has been around since 1.75 but significant enough for us to aim for 6 weeks of testing instead of 12.