### PR TITLE
feat: Implementation and tests for `multiple-build-scripts`

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -45,7 +45,7 @@ pub struct Doctest {
     /// The script metadata, if this unit's package has a build script.
     ///
     /// This is used for indexing [`Compilation::extra_env`].
-    pub script_meta: Option<UnitHash>,
+    pub script_metas: Option<Vec<UnitHash>>,
 
     /// Environment variables to set in the rustdoc process.
     pub env: HashMap<String, OsString>,
@@ -61,7 +61,7 @@ pub struct UnitOutput {
     /// The script metadata, if this unit's package has a build script.
     ///
     /// This is used for indexing [`Compilation::extra_env`].
-    pub script_meta: Option<UnitHash>,
+    pub script_metas: Option<Vec<UnitHash>>,
 }
 
 /// A structure returning the result of a compilation.
@@ -197,14 +197,14 @@ impl<'gctx> Compilation<'gctx> {
     pub fn rustdoc_process(
         &self,
         unit: &Unit,
-        script_meta: Option<UnitHash>,
+        script_metas: Option<&Vec<UnitHash>>,
     ) -> CargoResult<ProcessBuilder> {
         let mut rustdoc = ProcessBuilder::new(&*self.gctx.rustdoc()?);
         if self.gctx.extra_verbose() {
             rustdoc.display_env_vars();
         }
         let cmd = fill_rustc_tool_env(rustdoc, unit);
-        let mut cmd = self.fill_env(cmd, &unit.pkg, script_meta, unit.kind, ToolKind::Rustdoc)?;
+        let mut cmd = self.fill_env(cmd, &unit.pkg, script_metas, unit.kind, ToolKind::Rustdoc)?;
         cmd.retry_with_argfile(true);
         unit.target.edition().cmd_edition_arg(&mut cmd);
 
@@ -248,7 +248,7 @@ impl<'gctx> Compilation<'gctx> {
     /// target platform. This is typically used for `cargo run` and `cargo
     /// test`.
     ///
-    /// `script_meta` is the metadata for the `RunCustomBuild` unit that this
+    /// `script_metas` is the metadata for the `RunCustomBuild` unit that this
     /// unit used for its build script. Use `None` if the package did not have
     /// a build script.
     pub fn target_process<T: AsRef<OsStr>>(
@@ -256,7 +256,7 @@ impl<'gctx> Compilation<'gctx> {
         cmd: T,
         kind: CompileKind,
         pkg: &Package,
-        script_meta: Option<UnitHash>,
+        script_metas: Option<&Vec<UnitHash>>,
     ) -> CargoResult<ProcessBuilder> {
         let builder = if let Some((runner, args)) = self.target_runner(kind) {
             let mut builder = ProcessBuilder::new(runner);
@@ -267,7 +267,7 @@ impl<'gctx> Compilation<'gctx> {
             ProcessBuilder::new(cmd)
         };
         let tool_kind = ToolKind::TargetProcess;
-        let mut builder = self.fill_env(builder, pkg, script_meta, kind, tool_kind)?;
+        let mut builder = self.fill_env(builder, pkg, script_metas, kind, tool_kind)?;
 
         if let Some(client) = self.gctx.jobserver_from_env() {
             builder.inherit_jobserver(client);
@@ -285,7 +285,7 @@ impl<'gctx> Compilation<'gctx> {
         &self,
         mut cmd: ProcessBuilder,
         pkg: &Package,
-        script_meta: Option<UnitHash>,
+        script_metas: Option<&Vec<UnitHash>>,
         kind: CompileKind,
         tool_kind: ToolKind,
     ) -> CargoResult<ProcessBuilder> {
@@ -343,10 +343,12 @@ impl<'gctx> Compilation<'gctx> {
         let search_path = paths::join_paths(&search_path, paths::dylib_path_envvar())?;
 
         cmd.env(paths::dylib_path_envvar(), &search_path);
-        if let Some(meta) = script_meta {
-            if let Some(env) = self.extra_env.get(&meta) {
-                for (k, v) in env {
-                    cmd.env(k, v);
+        if let Some(meta_vec) = script_metas {
+            for meta in meta_vec {
+                if let Some(env) = self.extra_env.get(meta) {
+                    for (k, v) in env {
+                        cmd.env(k, v);
+                    }
                 }
             }
         }

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -1286,10 +1286,12 @@ pub fn build_map(build_runner: &mut BuildRunner<'_, '_>) -> CargoResult<()> {
 
         // If a package has a build script, add itself as something to inspect for linking.
         if !unit.target.is_custom_build() && unit.pkg.has_custom_build() {
-            let script_meta = build_runner
-                .find_build_script_metadata(unit)
+            let script_metas = build_runner
+                .find_build_script_metadatas(unit)
                 .expect("has_custom_build should have RunCustomBuild");
-            add_to_link(&mut ret, unit.pkg.package_id(), script_meta);
+            for script_meta in script_metas {
+                add_to_link(&mut ret, unit.pkg.package_id(), script_meta);
+            }
         }
 
         if unit.mode.is_run_custom_build() {

--- a/src/cargo/core/compiler/output_depinfo.rs
+++ b/src/cargo/core/compiler/output_depinfo.rs
@@ -75,18 +75,20 @@ fn add_deps_for_unit(
     }
 
     // Add rerun-if-changed dependencies
-    if let Some(metadata) = build_runner.find_build_script_metadata(unit) {
-        if let Some(output) = build_runner
-            .build_script_outputs
-            .lock()
-            .unwrap()
-            .get(metadata)
-        {
-            for path in &output.rerun_if_changed {
-                // The paths we have saved from the unit are of arbitrary relativeness and may be
-                // relative to the crate root of the dependency.
-                let path = unit.pkg.root().join(path);
-                deps.insert(path);
+    if let Some(metadata_vec) = build_runner.find_build_script_metadatas(unit) {
+        for metadata in metadata_vec {
+            if let Some(output) = build_runner
+                .build_script_outputs
+                .lock()
+                .unwrap()
+                .get(metadata)
+            {
+                for path in &output.rerun_if_changed {
+                    // The paths we have saved from the unit are of arbitrary relativeness and may be
+                    // relative to the crate root of the dependency.
+                    let path = unit.pkg.root().join(path);
+                    deps.insert(path);
+                }
             }
         }
     }

--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -95,7 +95,7 @@ pub fn run(
     let UnitOutput {
         unit,
         path,
-        script_meta,
+        script_metas,
     } = &compile.binaries[0];
     let exe = match path.strip_prefix(gctx.cwd()) {
         Ok(path) if path.file_name() == Some(path.as_os_str()) => Path::new(".").join(path),
@@ -103,7 +103,7 @@ pub fn run(
         Err(_) => path.to_path_buf(),
     };
     let pkg = bins[0].0;
-    let mut process = compile.target_process(exe, unit.kind, pkg, *script_meta)?;
+    let mut process = compile.target_process(exe, unit.kind, pkg, script_metas.as_ref())?;
 
     // Sets the working directory of the child process to the current working
     // directory of the parent process.

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -125,7 +125,7 @@ fn run_unit_tests(
     for UnitOutput {
         unit,
         path,
-        script_meta,
+        script_metas,
     } in compilation.tests.iter()
     {
         let (exe_display, mut cmd) = cmd_builds(
@@ -133,7 +133,7 @@ fn run_unit_tests(
             cwd,
             unit,
             path,
-            script_meta,
+            script_metas.as_ref(),
             test_args,
             compilation,
             "unittests",
@@ -184,12 +184,12 @@ fn run_doc_tests(
             unstable_opts,
             unit,
             linker,
-            script_meta,
+            script_metas,
             env,
         } = doctest_info;
 
         gctx.shell().status("Doc-tests", unit.target.name())?;
-        let mut p = compilation.rustdoc_process(unit, *script_meta)?;
+        let mut p = compilation.rustdoc_process(unit, script_metas.as_ref())?;
 
         for (var, value) in env {
             p.env(var, value);
@@ -295,7 +295,7 @@ fn display_no_run_information(
     for UnitOutput {
         unit,
         path,
-        script_meta,
+        script_metas,
     } in compilation.tests.iter()
     {
         let (exe_display, cmd) = cmd_builds(
@@ -303,7 +303,7 @@ fn display_no_run_information(
             cwd,
             unit,
             path,
-            script_meta,
+            script_metas.as_ref(),
             test_args,
             compilation,
             exec_type,
@@ -327,7 +327,7 @@ fn cmd_builds(
     cwd: &Path,
     unit: &Unit,
     path: &PathBuf,
-    script_meta: &Option<UnitHash>,
+    script_metas: Option<&Vec<UnitHash>>,
     test_args: &[&str],
     compilation: &Compilation<'_>,
     exec_type: &str,
@@ -352,7 +352,7 @@ fn cmd_builds(
         ),
     };
 
-    let mut cmd = compilation.target_process(path, unit.kind, &unit.pkg, *script_meta)?;
+    let mut cmd = compilation.target_process(path, unit.kind, &unit.pkg, script_metas)?;
     cmd.args(test_args);
     if unit.target.harness() && gctx.shell().verbosity() == Verbosity::Quiet {
         cmd.arg("--quiet");

--- a/tests/testsuite/build_scripts_multiple.rs
+++ b/tests/testsuite/build_scripts_multiple.rs
@@ -639,12 +639,12 @@ fn bar() {
         .file("assets/foo.txt", "foo")
         .file("assets/bar.txt", "bar")
         .build();
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     // Editing foo.txt won't recompile, leading to unnoticed changes
 
     p.change_file("assets/foo.txt", "foo updated");
-    p.cargo("build -v")
+    p.cargo("check -v")
         .with_stderr_data(str![[r#"
 [FRESH] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -655,7 +655,7 @@ fn bar() {
     // Editing bar.txt will recompile
 
     p.change_file("assets/bar.txt", "bar updated");
-    p.cargo("build -v")
+    p.cargo("check -v")
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.1.0 ([ROOT]/foo): the file `assets/bar.txt` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [COMPILING] foo v0.1.0 ([ROOT]/foo)

--- a/tests/testsuite/build_scripts_multiple.rs
+++ b/tests/testsuite/build_scripts_multiple.rs
@@ -436,13 +436,12 @@ fn custom_build_script_first_index_script_failed() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name build_script_build1 --edition=2024 build1.rs [..]--crate-type bin [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build1`
+...
 [ERROR] failed to run custom build command for `foo v0.1.0 ([ROOT]/foo)`
 
 Caused by:
   process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build1` ([EXIT_STATUS]: 101)
-
+...
 "#]])
         .run();
 }
@@ -472,14 +471,15 @@ fn custom_build_script_second_index_script_failed() {
 
     p.cargo("check -v")
         .masquerade_as_nightly_cargo(&["multiple-build-scripts"])
-        .with_status(0)
+        .with_status(101)
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name build_script_build1 --edition=2024 build1.rs [..]--crate-type bin [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build1`
-[RUNNING] `rustc --crate-name foo --edition=2024 src/main.rs [..] --crate-type bin [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+...
+[ERROR] failed to run custom build command for `foo v0.1.0 ([ROOT]/foo)`
 
+Caused by:
+  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build2` ([EXIT_STATUS]: 101)
+...
 "#]])
         .run();
 }
@@ -602,7 +602,7 @@ fn build_script_with_conflicting_out_dirs() {
         .masquerade_as_nightly_cargo(&["multiple-build-scripts"])
         .with_status(0)
         .with_stdout_data(str![[r#"
-Hello, from Build Script 1!
+Hello, from Build Script 2!
 
 "#]])
         .run();
@@ -614,23 +614,34 @@ fn rerun_untracks_other_files() {
         .file(
             "Cargo.toml",
             r#"
+                cargo-features = ["multiple-build-scripts"]
+
                 [package]
                 name = "foo"
                 version = "0.1.0"
                 edition = "2024"
+                build = ["build1.rs", "build2.rs"]
             "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
-            "build.rs",
+            "build1.rs",
             r#"
 fn main() {
     foo();
-    bar();
 }
 fn foo() {
     let _path = "assets/foo.txt";
 }
+"#,
+        )
+        .file(
+            "build2.rs",
+            r#"
+fn main() {
+    bar();
+}
+
 fn bar() {
     let path = "assets/bar.txt";
     println!("cargo::rerun-if-changed={path}");
@@ -639,27 +650,34 @@ fn bar() {
         .file("assets/foo.txt", "foo")
         .file("assets/bar.txt", "bar")
         .build();
-    p.cargo("check").run();
+    p.cargo("check")
+        .masquerade_as_nightly_cargo(&["multiple-build-scripts"])
+        .run();
 
-    // Editing foo.txt won't recompile, leading to unnoticed changes
-
+    // Editing foo.txt will also recompile now since they are separate build scripts
     p.change_file("assets/foo.txt", "foo updated");
     p.cargo("check -v")
+        .masquerade_as_nightly_cargo(&["multiple-build-scripts"])
         .with_stderr_data(str![[r#"
-[FRESH] foo v0.1.0 ([ROOT]/foo)
+[DIRTY] foo v0.1.0 ([ROOT]/foo): the [..]
+[COMPILING] foo v0.1.0 ([ROOT]/foo)
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build1`
+[RUNNING] `rustc --crate-name foo --edition=2024 src/main.rs [..] --crate-type bin [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
         .run();
 
-    // Editing bar.txt will recompile
+    // Editing bar.txt will also recompile now since they are separate build scripts
 
     p.change_file("assets/bar.txt", "bar updated");
     p.cargo("check -v")
+        .masquerade_as_nightly_cargo(&["multiple-build-scripts"])
         .with_stderr_data(str![[r#"
-[DIRTY] foo v0.1.0 ([ROOT]/foo): the file `assets/bar.txt` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
+[DIRTY] foo v0.1.0 ([ROOT]/foo): the [..]
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build[..]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build[..]`
 [RUNNING] `rustc --crate-name foo --edition=2024 src/main.rs [..] --crate-type bin [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/build_scripts_multiple.rs
+++ b/tests/testsuite/build_scripts_multiple.rs
@@ -524,7 +524,7 @@ fn build_script_with_conflicting_environment_variables() {
         .masquerade_as_nightly_cargo(&["multiple-build-scripts"])
         .with_status(0)
         .with_stdout_data(str![[r#"
-bar1
+bar2
 
 "#]])
         .run();


### PR DESCRIPTION
Hi Everyone!

This is PR for the implementation of the first milestone of [GSoC Project : Build Script Delegation](https://summerofcode.withgoogle.com/programs/2025/projects/nUt4PdAA)

This will provide actual implementation for #15630

### What does this PR try to resolve?

Now, multiple build scripts are parsed, this PR aims to implement the functioning the feature. This PR will allow users to use multiple build scripts, and is backward compatible with single script as well as boolean values. 

**Motivation :** This will help users to maintain separate smaller and cleaner build scripts instead of one large build script. This is also necessary for build script delegation.

Deferred
- Accessing each build script's `OUT_DIR`:  This will be handled in a follow up PR.  For now, each build script writes to its own `OUT_DIR` and `OUT_DIR` for the regular build targets is set to the build script with the **lexicographically largest** name..
- User control over which build script wins in a conflict.  This will be handled in a follow up PR.  If two build scripts write to the same env variable, which gets applied to the binary?  Currently, its the build script with the **lexicographically largest** name.  This makes it deterministic.  With some futzing, users can control this for now.  However, with build script delegation, users won't be able to control this.  We likely want it based off of the order the user assigns into the build script array.
- Something about linking a C library is actually preferring **lexicographically smallest** name.  We should handle conflicts consistently.  We need to dig into what parts are doing it based on smallest and make sure that whatever priority scheme we use for env variables applies here as well.

### How to test and review this PR?

There is a feature gate `multiple-build-scripts` that can be passed via `cargo-features` in `Cargo.toml`. So, you have to add 
```toml
cargo-features = ["multiple-build-scripts"]
```
Preferably on the top of the `Cargo.toml` and use nightly toolchain to use the feature