### PR TITLE
chore(release): Publish build-rs on release

### DIFF
--- a/publish.py
+++ b/publish.py
@@ -31,6 +31,7 @@ TO_PUBLISH = [
     'crates/cargo-util-schemas',
     'crates/cargo-test-macro',
     'crates/cargo-test-support',
+    'crates/build-rs',
     '.',
 ]
 


### PR DESCRIPTION
### What does this PR try to resolve?

I know that us not publishing `build-rs` recently came up and was surprised to see this wasn't fixed.  Unsure where that conversation is or what happened with it.

Looks like it was in #15567 and there was no follow up on my side...

### How to test and review this PR?

