### PR TITLE
Adds a dry-run packaging mode that fiddles with checksums

### DIFF
--- a/src/bin/cargo/commands/package.rs
+++ b/src/bin/cargo/commands/package.rs
@@ -108,6 +108,7 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
             keep_going: args.keep_going(),
             cli_features: args.cli_features()?,
             reg_or_index,
+            dry_run: false,
         },
     )?;
 

--- a/src/cargo/core/resolver/resolve.rs
+++ b/src/cargo/core/resolver/resolve.rs
@@ -390,6 +390,10 @@ unable to verify that `{0}` is the same as when the lockfile was generated
         &self.checksums
     }
 
+    pub fn set_checksum(&mut self, pkg_id: PackageId, checksum: String) {
+        self.checksums.insert(pkg_id, Some(checksum));
+    }
+
     pub fn metadata(&self) -> &Metadata {
         &self.metadata
     }

--- a/src/cargo/ops/registry/publish.rs
+++ b/src/cargo/ops/registry/publish.rs
@@ -202,6 +202,7 @@ pub fn publish(ws: &Workspace<'_>, opts: &PublishOpts<'_>) -> CargoResult<()> {
             keep_going: opts.keep_going,
             cli_features: opts.cli_features.clone(),
             reg_or_index: reg_or_index.clone(),
+            dry_run: opts.dry_run,
         },
         pkgs,
     )?;

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -8082,3 +8082,80 @@ fn unpublished_dependency() {
         (),
     );
 }
+
+// This is a companion to `publish::checksum_changed`, but because this one
+// is packaging without dry-run, it should fail.
+#[cargo_test]
+fn checksum_changed() {
+    let registry = registry::RegistryBuilder::new()
+        .http_api()
+        .http_index()
+        .build();
+
+    Package::new("dep", "1.0.0").publish();
+    Package::new("transitive", "1.0.0")
+        .dep("dep", "1.0.0")
+        .publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [workspace]
+                members = ["dep"]
+
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                edition = "2015"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                documentation = "foo"
+
+                [dependencies]
+                dep = { path = "./dep", version = "1.0.0" }
+                transitive = "1.0.0"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file(
+            "dep/Cargo.toml",
+            r#"
+                [package]
+                name = "dep"
+                version = "1.0.0"
+                edition = "2015"
+            "#,
+        )
+        .file("dep/src/lib.rs", "")
+        .build();
+
+    p.cargo("check").run();
+
+    p.cargo("package --workspace -Zpackage-workspace")
+        .masquerade_as_nightly_cargo(&["package-workspace"])
+        .replace_crates_io(registry.index_url())
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[WARNING] manifest has no description, license, license-file, documentation, homepage or repository.
+See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
+[PACKAGING] dep v1.0.0 ([ROOT]/foo/dep)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGING] foo v0.0.1 ([ROOT]/foo)
+[ERROR] failed to prepare local package for uploading
+
+Caused by:
+  checksum for `dep v1.0.0` changed between lock files
+
+  this could be indicative of a few possible errors:
+
+      * the lock file is corrupt
+      * a replacement source in use (e.g., a mirror) returned a different checksum
+      * the source itself may be corrupt in one way or another
+
+  unable to verify that `dep v1.0.0` is the same as when the lockfile was generated
+
+"#]])
+        .run();
+}

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -4427,7 +4427,6 @@ fn checksum_changed() {
     p.cargo("publish --dry-run --workspace -Zpackage-workspace")
         .masquerade_as_nightly_cargo(&["package-workspace"])
         .replace_crates_io(registry.index_url())
-        .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] crates.io index
 [WARNING] crate dep@1.0.0 already exists on crates.io index
@@ -4436,18 +4435,21 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [PACKAGING] dep v1.0.0 ([ROOT]/foo/dep)
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [PACKAGING] foo v0.0.1 ([ROOT]/foo)
-[ERROR] failed to prepare local package for uploading
-
-Caused by:
-  checksum for `dep v1.0.0` changed between lock files
-
-  this could be indicative of a few possible errors:
-
-      * the lock file is corrupt
-      * a replacement source in use (e.g., a mirror) returned a different checksum
-      * the source itself may be corrupt in one way or another
-
-  unable to verify that `dep v1.0.0` is the same as when the lockfile was generated
+[UPDATING] crates.io index
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[VERIFYING] dep v1.0.0 ([ROOT]/foo/dep)
+[COMPILING] dep v1.0.0 ([ROOT]/foo/target/package/dep-1.0.0)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[VERIFYING] foo v0.0.1 ([ROOT]/foo)
+[UNPACKING] dep v1.0.0 (registry `[ROOT]/foo/target/package/tmp-registry`)
+[COMPILING] dep v1.0.0
+[COMPILING] transitive v1.0.0
+[COMPILING] foo v0.0.1 ([ROOT]/foo/target/package/foo-0.0.1)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[UPLOADING] dep v1.0.0 ([ROOT]/foo/dep)
+[WARNING] aborting upload due to dry run
+[UPLOADING] foo v0.0.1 ([ROOT]/foo)
+[WARNING] aborting upload due to dry run
 
 "#]])
         .run();

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -4378,3 +4378,77 @@ fn all_unpublishable_packages() {
 "#]])
         .run();
 }
+
+#[cargo_test]
+fn checksum_changed() {
+    let registry = RegistryBuilder::new().http_api().http_index().build();
+
+    Package::new("dep", "1.0.0").publish();
+    Package::new("transitive", "1.0.0")
+        .dep("dep", "1.0.0")
+        .publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [workspace]
+                members = ["dep"]
+
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                edition = "2015"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                documentation = "foo"
+
+                [dependencies]
+                dep = { path = "./dep", version = "1.0.0" }
+                transitive = "1.0.0"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file(
+            "dep/Cargo.toml",
+            r#"
+                [package]
+                name = "dep"
+                version = "1.0.0"
+                edition = "2015"
+            "#,
+        )
+        .file("dep/src/lib.rs", "")
+        .build();
+
+    p.cargo("check").run();
+
+    p.cargo("publish --dry-run --workspace -Zpackage-workspace")
+        .masquerade_as_nightly_cargo(&["package-workspace"])
+        .replace_crates_io(registry.index_url())
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[UPDATING] crates.io index
+[WARNING] crate dep@1.0.0 already exists on crates.io index
+[WARNING] manifest has no description, license, license-file, documentation, homepage or repository.
+See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
+[PACKAGING] dep v1.0.0 ([ROOT]/foo/dep)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGING] foo v0.0.1 ([ROOT]/foo)
+[ERROR] failed to prepare local package for uploading
+
+Caused by:
+  checksum for `dep v1.0.0` changed between lock files
+
+  this could be indicative of a few possible errors:
+
+      * the lock file is corrupt
+      * a replacement source in use (e.g., a mirror) returned a different checksum
+      * the source itself may be corrupt in one way or another
+
+  unable to verify that `dep v1.0.0` is the same as when the lockfile was generated
+
+"#]])
+        .run();
+}


### PR DESCRIPTION
Fixes #15647.

When dry-run publishing workspace without bumping versions first, the package-verification step would fail because it would see checksum mismatches between the old lock file (that saw index deps) and the new lock file where those index deps got replaced by local packages with the same version.

In this PR, the packaging step modifies the old lock file's checksums before re-resolving, but only in dry-run mode.
