### PR TITLE
Use a different lint for the `fix_only_once_for_duplicates` test

### DIFF
--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -2410,7 +2410,8 @@ fn fix_only_once_for_duplicates() {
             r#"
 macro_rules! foo {
     () => {
-        &1;
+        let x = Box::new(1);
+        std::mem::forget(&x);
     };
 }
 
@@ -2438,7 +2439,8 @@ fn main() {
 
 macro_rules! foo {
     () => {
-        let _ = &1;
+        let x = Box::new(1);
+        let _ = &x;
     };
 }
 


### PR DESCRIPTION
### What does this PR try to resolve?

This PR changes the triggering `rustc` lint in the `fix_only_once_for_duplicates` test from `unused_must_use` to `forgetting_references`, because we are changing in https://github.com/rust-lang/rust/pull/143030 the interaction between that lint and macros.

This is required as it blocking the rust PR, https://github.com/rust-lang/rust/pull/143030#issuecomment-3009124056.

### How to test and review this PR?

Look at the test changes.
