### PR TITLE
Clarify package ID specifications in SBOMs are fully qualified

### DIFF
--- a/src/doc/src/reference/pkgid-spec.md
+++ b/src/doc/src/reference/pkgid-spec.md
@@ -9,12 +9,18 @@ is a string which is used to uniquely refer to one package within a graph of
 packages.
 
 The specification may be fully qualified, such as
-`https://github.com/rust-lang/crates.io-index#regex@1.4.3` or it may be
+`registry+https://github.com/rust-lang/crates.io-index#regex@1.4.3` or it may be
 abbreviated, such as `regex`. The abbreviated form may be used as long as it
 uniquely identifies a single package in the dependency graph. If there is
 ambiguity, additional qualifiers can be added to make it unique. For example,
 if there are two versions of the `regex` package in the graph, then it can be
 qualified with a version to make it unique, such as `regex@1.4.3`.
+
+Fully qualified package ID specifications are output by Cargo in:
+* [cargo pkgid](../commands/cargo-pkgid.md)
+* [cargo metadata](../commands/cargo-metadata.md)
+* [compiler artifact json messages](./external-tools.md#json-messages)
+* [SBOM pre-cursor files](./unstable.md#sbom)
 
 ### Specification grammar
 

--- a/src/doc/src/reference/pkgid-spec.md
+++ b/src/doc/src/reference/pkgid-spec.md
@@ -16,11 +16,7 @@ ambiguity, additional qualifiers can be added to make it unique. For example,
 if there are two versions of the `regex` package in the graph, then it can be
 qualified with a version to make it unique, such as `regex@1.4.3`.
 
-Fully qualified package ID specifications are output by Cargo in:
-* [cargo pkgid](../commands/cargo-pkgid.md)
-* [cargo metadata](../commands/cargo-metadata.md)
-* [compiler artifact json messages](./external-tools.md#json-messages)
-* [SBOM pre-cursor files](./unstable.md#sbom)
+Package ID specifications output by cargo, for example in [cargo metadata](../commands/cargo-metadata.md) output, are fully qualified.
 
 ### Specification grammar
 

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -480,7 +480,7 @@ that are uplifted into the target or artifact directories.
   // crate is compiled differently (different opt-level, features, etc).
   "crates": [
     {
-      // Package ID specification
+      // Fully qualified package ID specification
       "id": "path+file:///sample-package#0.1.0",
       // List of target kinds: bin, lib, rlib, dylib, cdylib, staticlib, proc-macro, example, test, bench, custom-build
       "kind": ["bin"],


### PR DESCRIPTION
### What does this PR try to resolve?

cargo-auditable 0.7.0 will use the unstable Cargo SBOM precursor files if a user configures Cargo to generate the SBOM files. cargo-auditable assumes that the package ID specifiers in Cargo SBOM files are fully qualified.

We'd like to enforce this assumption in Cargo so we can keep our package ID spec parsing simpler by not considering non-fully qualified package ID specs. This PR updates the cargo docs to state where fully qualified package ID specs are used, and also adds SBOMs to the existing `cargo pkgid` test that is currently enforcing consistency between the various usages of fully qualified package id specs.

Previously raised at [#t-cargo > sbom missing name, version, source @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/sbom.20missing.20name.2C.20version.2C.20source/near/525443447)

### How to test and review this PR?

Change doesn't affect current behaviour.
