### PR TITLE
Expose artifact dependency getters in cargo-as-a-library

### DIFF
--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -443,7 +443,7 @@ impl Dependency {
         Arc::make_mut(&mut self.inner).artifact = Some(artifact);
     }
 
-    pub(crate) fn artifact(&self) -> Option<&Artifact> {
+    pub fn artifact(&self) -> Option<&Artifact> {
         self.inner.artifact.as_ref()
     }
 
@@ -508,15 +508,15 @@ impl Artifact {
         })
     }
 
-    pub(crate) fn kinds(&self) -> &[ArtifactKind] {
+    pub fn kinds(&self) -> &[ArtifactKind] {
         &self.inner
     }
 
-    pub(crate) fn is_lib(&self) -> bool {
+    pub fn is_lib(&self) -> bool {
         self.is_lib
     }
 
-    pub(crate) fn target(&self) -> Option<ArtifactTarget> {
+    pub fn target(&self) -> Option<ArtifactTarget> {
         self.target
     }
 }


### PR DESCRIPTION
### What does this PR try to resolve?

Information about artifact dependencies is already available through `cargo metadata`, and therefore also through serializing and re-parsing `dependency.serialized()` using `serde_json::to_value` + `serde_json::from_value`. This PR makes the same information available directly through the library API of `cargo::core::Dependency`.

I ran into these private methods while working on https://github.com/rust-lang/cargo/issues/15751.

### How to test and review this PR?

`cargo check`