### PR TITLE
Remove unnecessary target-c-int-width from target specs

### DIFF
--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -271,7 +271,6 @@ fn cross_custom() {
                 "arch": "x86_64",
                 "target-endian": "little",
                 "target-pointer-width": "64",
-                "target-c-int-width": "32",
                 "os": "none",
                 "linker-flavor": "ld.lld"
             }
@@ -312,7 +311,6 @@ fn custom_test_framework() {
                 "arch": "x86_64",
                 "target-endian": "little",
                 "target-pointer-width": "64",
-                "target-c-int-width": "32",
                 "os": "none",
                 "linker-flavor": "ld.lld",
                 "linker": "rust-lld",

--- a/tests/testsuite/custom_target.rs
+++ b/tests/testsuite/custom_target.rs
@@ -38,7 +38,6 @@ const SIMPLE_SPEC: &str = r#"
     "arch": "x86_64",
     "target-endian": "little",
     "target-pointer-width": "64",
-    "target-c-int-width": "32",
     "os": "none",
     "linker-flavor": "ld.lld",
     "linker": "rust-lld",


### PR DESCRIPTION
### What does this PR try to resolve?

This is not necessary, as 32 is the default, and actually of the wrong type now since it's a number now.
When planning to make these type mismatches error in https://github.com/rust-lang/rust/pull/144218, cargo would fail here, so I just removed it.

This custom target test very much shows how Cargo should be a subtree, in this case it was fine because there's a compatible fix that I can push now, otherwise it would have been very annoying.

### How to test and review this PR?

If the test suite passes, it works