### PR TITLE
Non actionable error message

### DIFF
--- a/src/cargo/ops/registry/publish.rs
+++ b/src/cargo/ops/registry/publish.rs
@@ -643,7 +643,7 @@ fn transmit(
 
     let warnings = registry
         .publish(&new_crate, tarball)
-        .with_context(|| format!("failed to publish to registry at {}", registry.host()))?;
+        .with_context(|| format!("failed to publish to registry at {}\nPackage: {}", registry.host(), pkg.name()))?;
 
     if !warnings.invalid_categories.is_empty() {
         let msg = format!(

--- a/src/cargo/ops/registry/publish.rs
+++ b/src/cargo/ops/registry/publish.rs
@@ -658,15 +658,17 @@ fn transmit(
         return Ok(());
     }
 
-    let warnings = registry
-        .publish(&new_crate, tarball)
-        .with_context(|| {
-            let mut error_msg = format!("failed to publish to registry at {}\nPackage: {}", registry.host(), pkg.name());
-            if let Some(remaining) = &remaining_packages {
-                error_msg.push_str(&format!("\n\nRemaining packages to publish: {}", remaining));
-            }
-            error_msg
-        })?;
+    let warnings = registry.publish(&new_crate, tarball).with_context(|| {
+        let mut error_msg = format!(
+            "failed to publish to registry at {}\nPackage: {}",
+            registry.host(),
+            pkg.name()
+        );
+        if let Some(remaining) = &remaining_packages {
+            error_msg.push_str(&format!("\n\nRemaining packages to publish: {}", remaining));
+        }
+        error_msg
+    })?;
 
     if !warnings.invalid_categories.is_empty() {
         let msg = format!(

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -4497,8 +4497,8 @@ fn workspace_publish_error_reporting() {
         .file("c/src/lib.rs", "")
         .build();
 
-    // This test demonstrates improved error reporting during workspace publishing.
-    // Now when a publish fails, users can see which packages are still pending.
+    // This test verifies improved error reporting during workspace publishing.
+    // When a timeout occurs, users can see which packages are still pending publication.
     p.cargo("publish --registry alternative")
         .with_status(101)
         .with_stderr_data(str![[r#"

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -4420,7 +4420,7 @@ fn workspace_publish_error_reporting() {
             // Parse the request to get the crate name
             let body = req.body.as_ref().map(|b| String::from_utf8_lossy(b)).unwrap_or_default();
             let is_second_package = body.contains(r#""name":"b""#);
-            
+
             if is_second_package {
                 // Simulate rate limit error on the second package
                 Response {
@@ -4594,9 +4594,13 @@ fn workspace_transmit_error_includes_remaining_packages() {
         .http_api()
         .add_responder("/api/v1/crates/new", |req, _| {
             // Parse the request to get the crate name
-            let body = req.body.as_ref().map(|b| String::from_utf8_lossy(b)).unwrap_or_default();
+            let body = req
+                .body
+                .as_ref()
+                .map(|b| String::from_utf8_lossy(b))
+                .unwrap_or_default();
             let is_first_package = body.contains(r#""name":"a""#);
-            
+
             if is_first_package {
                 // Simulate server error on the first package
                 Response {
@@ -4607,7 +4611,9 @@ fn workspace_transmit_error_includes_remaining_packages() {
             } else {
                 // Other packages would succeed
                 Response {
-                    body: br#"{"warnings":{"invalid_categories":[],"invalid_badges":[],"other":[]}}"#.to_vec(),
+                    body:
+                        br#"{"warnings":{"invalid_categories":[],"invalid_badges":[],"other":[]}}"#
+                            .to_vec(),
                     code: 200,
                     headers: vec![],
                 }


### PR DESCRIPTION
### What does this PR try to resolve?

This PR improves the error reporting experience when running `cargo publish` on a workspace. Previously, if publishing failed partway through (for example, due to rate limiting or a server error), Cargo would emit a non-actionable error message that did not indicate which package failed or which packages were still pending publication. This made it difficult for users to recover from errors or know what steps to take next.

This PR addresses [issue #15754](https://github.com/rust-lang/cargo/issues/15754) by:

- Clearly indicating **which specific package failed to publish**.
- Listing **which packages in the workspace have not yet been published**.
- Providing **actionable, user-friendly error messages** to help users understand what went wrong and what remains to be done.

### How to test and review this PR?

**Testing:**

- New and updated tests are included in `tests/testsuite/publish.rs`:
  - The tests simulate workspace publishing scenarios where errors occur (such as rate limiting or server errors).
  - The tests verify that error messages now include:
    - The name of the package that failed to publish.
    - A list of remaining packages that still need to be published.
    - Clear guidance on what happened.
- To run the tests:
  ```sh
  cargo test workspace_publish_error_reporting
  cargo test workspace_transmit_error_includes_remaining_packages
  cargo test transmit_error_includes_package_name
  ```
- All existing tests continue to pass, ensuring no regressions.

**Review Guidance:**

- Review the changes in `src/cargo/ops/registry/publish.rs` for error context enhancements and message formatting.
- Review the new and updated tests in `tests/testsuite/publish.rs` to see how error scenarios are simulated and validated.
- Try running `cargo publish` on a workspace with multiple packages and simulate a failure (e.g., by using a test registry or causing a network error) to see the improved error output in action.

**Example improved error message:**
```
error: failed to publish to registry at https://crates.io
Package: my-package

Caused by:
  the remote server responded with an error (status 429 Too Many Requests): You have published too many new crates in a short period of time. Please try again after Fri, 18 Jul 2025 20:00:34 GMT or email help@crates.io to have your limit increased.

Remaining packages to publish: other-package-1, other-package-2, other-package-3
```

---

**Summary:**  
This PR makes workspace publishing failures much more actionable and user-friendly, helping users quickly identify what went wrong and what steps to take next. All changes are covered by tests and follow Cargo’s contribution guidelines.