### PR TITLE
Make timings graphs scalable to user's window

### DIFF
--- a/src/cargo/core/compiler/timings.rs
+++ b/src/cargo/core/compiler/timings.rs
@@ -776,11 +776,18 @@ static HTML_CANVAS: &str = r#"
 <table class="input-table">
   <tr>
     <td><label for="min-unit-time">Min unit time:</label></td>
-    <td><label for="scale">Scale:</label></td>
+    <td title="Scale corresponds to a number of pixels per second. It is automatically initialized based on your viewport width.">
+      <label for="scale">Scale:</label>
+    </td>
   </tr>
   <tr>
     <td><input type="range" min="0" max="30" step="0.1" value="0" id="min-unit-time"></td>
-    <td><input type="range" min="1" max="50" value="20" id="scale"></td>
+    <!--
+        The scale corresponds to some number of "pixels per second".
+        Its min, max, and initial values are automatically set by JavaScript on page load,
+        based on the client viewport.
+    -->
+    <td><input type="range" min="1" max="100" value="50" id="scale"></td>
   </tr>
   <tr>
     <td><output for="min-unit-time" id="min-unit-time-output"></output></td>


### PR DESCRIPTION
### What does this PR try to resolve?

This PR changes the way the charts produced by `cargo build --timings` scale. It changes the scale slider so that its min/max values adapt to the duration of the build, to allow zooming in/out even for very short build durations. It also automatically initializes the scale value based on the client's window width.

The number of pixels per second per scale value has been changed from 1 to 8, to avoid having too many scale values for the given duration of supported chart widths, which I have determined in this PR to be `[200, 4096]` pixels.

https://github.com/user-attachments/assets/3e6e9f14-eabe-425a-a568-9fcb5c835145

### How to test and review this PR?

Run `cargo build --timings` e.g. on https://github.com/BurntSushi/ripgrep. Then open the resulting page in a browser, and try to enlarge/ensmall the window (possibly using mobile emulation), and see how the charts react to window size.

Fixes: https://github.com/rust-lang/cargo/issues/15666