### PR TITLE
cargo-credential-libsecret: give FFI correctly-sized object

### DIFF
--- a/credential/cargo-credential-libsecret/src/lib.rs
+++ b/credential/cargo-credential-libsecret/src/lib.rs
@@ -168,7 +168,7 @@ mod linux {
 
             let index_url_c = CString::new(registry.index_url).unwrap();
             let mut error: *mut GError = null_mut();
-            let attr_url = CString::new("url").unwrap();
+            let attr_url = b"url\0".as_ptr() as *const gchar;
             let schema = schema();
             match action {
                 cargo_credential::Action::Get(_) => {
@@ -177,7 +177,7 @@ mod linux {
                             &schema,
                             null_mut(),
                             &mut error,
-                            attr_url.as_ptr(),
+                            attr_url,
                             index_url_c.as_ptr(),
                             null() as *const gchar,
                         );
@@ -217,7 +217,7 @@ mod linux {
                             token.as_ptr(),
                             null_mut(),
                             &mut error,
-                            attr_url.as_ptr(),
+                            attr_url,
                             index_url_c.as_ptr(),
                             null() as *const gchar,
                         );
@@ -239,7 +239,7 @@ mod linux {
                             &schema,
                             null_mut(),
                             &mut error,
-                            attr_url.as_ptr(),
+                            attr_url,
                             index_url_c.as_ptr(),
                             null() as *const gchar,
                         );

--- a/credential/cargo-credential-libsecret/src/lib.rs
+++ b/credential/cargo-credential-libsecret/src/lib.rs
@@ -145,11 +145,11 @@ mod linux {
             }
 
             let index_url_c = CString::new(registry.index_url).unwrap();
+            let mut error: *mut GError = null_mut();
+            let attr_url = CString::new("url").unwrap();
+            let schema = schema();
             match action {
                 cargo_credential::Action::Get(_) => {
-                    let mut error: *mut GError = null_mut();
-                    let attr_url = CString::new("url").unwrap();
-                    let schema = schema();
                     unsafe {
                         let token_c = secret_password_lookup_sync(
                             &schema,
@@ -187,9 +187,6 @@ mod linux {
                 cargo_credential::Action::Login(options) => {
                     let label = label(registry.name.unwrap_or(registry.index_url));
                     let token = CString::new(read_token(options, registry)?.expose()).unwrap();
-                    let mut error: *mut GError = null_mut();
-                    let attr_url = CString::new("url").unwrap();
-                    let schema = schema();
                     unsafe {
                         secret_password_store_sync(
                             &schema,
@@ -215,9 +212,6 @@ mod linux {
                     Ok(CredentialResponse::Login)
                 }
                 cargo_credential::Action::Logout => {
-                    let schema = schema();
-                    let mut error: *mut GError = null_mut();
-                    let attr_url = CString::new("url").unwrap();
                     unsafe {
                         secret_password_clear_sync(
                             &schema,

--- a/credential/cargo-credential-libsecret/src/lib.rs
+++ b/credential/cargo-credential-libsecret/src/lib.rs
@@ -111,11 +111,11 @@ mod linux {
             attr_type: SecretSchemaAttributeType::String,
         }; 32];
         attributes[0] = SecretSchemaAttribute {
-            name: b"url\0".as_ptr() as *const gchar,
+            name: c"url".as_ptr() as *const gchar,
             attr_type: SecretSchemaAttributeType::String,
         };
         SecretSchema {
-            name: b"org.rust-lang.cargo.registry\0".as_ptr() as *const gchar,
+            name: c"org.rust-lang.cargo.registry".as_ptr() as *const gchar,
             flags: SecretSchemaFlags::None,
             attributes,
             reserved: 0,
@@ -168,7 +168,7 @@ mod linux {
 
             let index_url_c = CString::new(registry.index_url).unwrap();
             let mut error: *mut GError = null_mut();
-            let attr_url = b"url\0".as_ptr() as *const gchar;
+            let attr_url = c"url".as_ptr() as *const gchar;
             let schema = schema();
             match action {
                 cargo_credential::Action::Get(_) => unsafe {
@@ -210,7 +210,7 @@ mod linux {
                     unsafe {
                         secret_password_store_sync(
                             &schema,
-                            b"default\0".as_ptr() as *const gchar,
+                            c"default".as_ptr() as *const gchar,
                             label.as_ptr(),
                             token.as_ptr(),
                             null_mut(),

--- a/credential/cargo-credential-libsecret/src/lib.rs
+++ b/credential/cargo-credential-libsecret/src/lib.rs
@@ -22,6 +22,12 @@ mod linux {
     #[allow(non_camel_case_types)]
     type gboolean = c_int;
 
+    #[allow(non_camel_case_types)]
+    type gint = c_int;
+
+    #[allow(non_camel_case_types)]
+    type gpointer = *mut ();
+
     type GQuark = u32;
 
     #[repr(C)]
@@ -41,6 +47,14 @@ mod linux {
         name: *const gchar,
         flags: SecretSchemaFlags,
         attributes: [SecretSchemaAttribute; 32],
+        reserved: gint,
+        reserved1: gpointer,
+        reserved2: gpointer,
+        reserved3: gpointer,
+        reserved4: gpointer,
+        reserved5: gpointer,
+        reserved6: gpointer,
+        reserved7: gpointer,
     }
 
     #[repr(C)]
@@ -104,6 +118,14 @@ mod linux {
             name: b"org.rust-lang.cargo.registry\0".as_ptr() as *const gchar,
             flags: SecretSchemaFlags::None,
             attributes,
+            reserved: 0,
+            reserved1: null_mut(),
+            reserved2: null_mut(),
+            reserved3: null_mut(),
+            reserved4: null_mut(),
+            reserved5: null_mut(),
+            reserved6: null_mut(),
+            reserved7: null_mut(),
         }
     }
 


### PR DESCRIPTION
### What does this PR try to resolve?

The type is
```c
typedef struct {
	const gchar *name;
	SecretSchemaFlags flags;
	SecretSchemaAttribute attributes[32];

	/* <private> */
	gint reserved;
	gpointer reserved1;
	gpointer reserved2;
	gpointer reserved3;
	gpointer reserved4;
	gpointer reserved5;
	gpointer reserved6;
	gpointer reserved7;
} SecretSchema;
```
so the current object we give it is 8 pointers too short

It's incredibly lucky that libsecret, at this time, only uses `reserved`, and not in any of the functions we call

Also, some obvious cleanups while I was there and comparing with [my implementation](https://github.com/nabijaczleweli/cargo-update/blob/v17.0.0/src/ops/mod.rs#L1443) from [cargo-update 17.0.0](https://github.com/nabijaczleweli/cargo-update/releases/v17.0.0).

### How to test and review this PR?

Observe https://sources.debian.org/src/libsecret/0.20.5-3/libsecret/secret-schema.h/#L43 I suppose?