### PR TITLE
Accessing each build script's `OUT_DIR` and in the correct order

### DIFF
--- a/tests/testsuite/build_scripts_multiple.rs
+++ b/tests/testsuite/build_scripts_multiple.rs
@@ -609,6 +609,85 @@ Hello, from Build Script 2!
 }
 
 #[cargo_test]
+fn build_script_with_conflicts_reverse_sorted() {
+    // In this, multiple scripts create file with same name in their respective OUT_DIR.
+    // It is different from above because `package.build` is not sorted in this.
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                cargo-features = ["multiple-build-scripts"]
+
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2024"
+
+                build = ["build2.rs", "build1.rs"]
+            "#,
+        )
+        // OUT_DIR is set to the lexicographically largest build script's OUT_DIR by default
+        .file(
+            "src/main.rs",
+            r#"
+                include!(concat!(env!("OUT_DIR"), "/foo.rs"));
+                fn main() {
+                    println!("{}", message());
+                }
+            "#,
+        )
+        .file(
+            "build1.rs",
+            r#"
+            use std::env;
+            use std::fs;
+            use std::path::Path;
+
+            fn main() {
+                let out_dir = env::var_os("OUT_DIR").unwrap();
+                let dest_path = Path::new(&out_dir).join("foo.rs");
+                fs::write(
+                    &dest_path,
+                    "pub fn message() -> &'static str {
+                        \"Hello, from Build Script 1!\"
+                    }
+                    "
+                ).unwrap();
+             }"#,
+        )
+        .file(
+            "build2.rs",
+            r#"
+            use std::env;
+            use std::fs;
+            use std::path::Path;
+
+            fn main() {
+                let out_dir = env::var_os("OUT_DIR").unwrap();
+                let dest_path = Path::new(&out_dir).join("foo.rs");
+                fs::write(
+                    &dest_path,
+                    "pub fn message() -> &'static str {
+                        \"Hello, from Build Script 2!\"
+                    }
+                    "
+                ).unwrap();
+             }"#,
+        )
+        .build();
+
+    p.cargo("run -v")
+        .masquerade_as_nightly_cargo(&["multiple-build-scripts"])
+        .with_status(0)
+        .with_stdout_data(str![[r#"
+Hello, from Build Script 2!
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn rerun_untracks_other_files() {
     let p = project()
         .file(

--- a/tests/testsuite/build_scripts_multiple.rs
+++ b/tests/testsuite/build_scripts_multiple.rs
@@ -681,7 +681,7 @@ fn build_script_with_conflicts_reverse_sorted() {
         .masquerade_as_nightly_cargo(&["multiple-build-scripts"])
         .with_status(0)
         .with_stdout_data(str![[r#"
-Hello, from Build Script 2!
+Hello, from Build Script 1!
 
 "#]])
         .run();


### PR DESCRIPTION
Hi Everyone!

This PR is aimed to have some improvements over #15704

### What does this PR try to resolve?

Now, multiple build scripts are built correctly. But there are some underlying issues, that this PR is targeting.

- Preserving the order of the build scripts: Earlier the build scripts were sorted by default, but now, the order will be preserved.

### How to test and review this PR?

There is a feature gate `multiple-build-scripts` that can be passed via `cargo-features` in `Cargo.toml`. So, you have to add 
```toml
cargo-features = ["multiple-build-scripts"]
```
Preferably on the top of the `Cargo.toml` and use nightly toolchain to use the feature