### PR TITLE
Add initial integration for `--json=timings`

### DIFF
--- a/src/cargo/core/compiler/job_queue/job_state.rs
+++ b/src/cargo/core/compiler/job_queue/job_state.rs
@@ -7,6 +7,7 @@ use cargo_util::ProcessBuilder;
 use crate::CargoResult;
 use crate::core::compiler::build_runner::OutputFile;
 use crate::core::compiler::future_incompat::FutureBreakageItem;
+use crate::core::compiler::timings::SectionTiming;
 use crate::util::Queue;
 
 use super::{Artifact, DiagDedupe, Job, JobId, Message};
@@ -141,6 +142,10 @@ impl<'a, 'gctx> JobState<'a, 'gctx> {
         self.rmeta_required.set(false);
         self.messages
             .push(Message::Finish(self.id, Artifact::Metadata, Ok(())));
+    }
+
+    pub fn on_section_timing_emitted(&self, section: SectionTiming) {
+        self.messages.push(Message::SectionTiming(self.id, section));
     }
 
     /// Drives a [`Job`] to finish. This ensures that a [`Message::Finish`] is

--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -133,7 +133,7 @@ pub use self::job::{Job, Work};
 pub use self::job_state::JobState;
 use super::build_runner::OutputFile;
 use super::custom_build::Severity;
-use super::timings::Timings;
+use super::timings::{SectionTiming, Timings};
 use super::{BuildContext, BuildPlan, BuildRunner, CompileMode, Unit};
 use crate::core::compiler::descriptive_pkg_name;
 use crate::core::compiler::future_incompat::{
@@ -374,6 +374,7 @@ enum Message {
     Token(io::Result<Acquired>),
     Finish(JobId, Artifact, CargoResult<()>),
     FutureIncompatReport(JobId, Vec<FutureBreakageItem>),
+    SectionTiming(JobId, SectionTiming),
 }
 
 impl<'gctx> JobQueue<'gctx> {
@@ -713,6 +714,9 @@ impl<'gctx> DrainState<'gctx> {
             Message::Token(acquired_token) => {
                 let token = acquired_token.context("failed to acquire jobserver token")?;
                 self.tokens.push(token);
+            }
+            Message::SectionTiming(id, section) => {
+                self.timings.unit_section_timing(id, &section);
             }
         }
 

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -90,6 +90,7 @@ use self::output_depinfo::output_depinfo;
 use self::output_sbom::build_sbom;
 use self::unit_graph::UnitDep;
 use crate::core::compiler::future_incompat::FutureIncompatReport;
+use crate::core::compiler::timings::SectionTiming;
 pub use crate::core::compiler::unit::{Unit, UnitInterner};
 use crate::core::manifest::TargetSourcePath;
 use crate::core::profiles::{PanicStrategy, Profile, StripInner};
@@ -1095,6 +1096,12 @@ fn add_allow_features(build_runner: &BuildRunner<'_, '_>, cmd: &mut ProcessBuild
 ///
 /// [`--error-format`]: https://doc.rust-lang.org/nightly/rustc/command-line-arguments.html#--error-format-control-how-errors-are-produced
 fn add_error_format_and_color(build_runner: &BuildRunner<'_, '_>, cmd: &mut ProcessBuilder) {
+    let enable_timings = build_runner.bcx.gctx.nightly_features_allowed
+        && !build_runner.bcx.build_config.timing_outputs.is_empty();
+    if enable_timings {
+        cmd.arg("-Zunstable-options");
+    }
+
     cmd.arg("--error-format=json");
     let mut json = String::from("--json=diagnostic-rendered-ansi,artifacts,future-incompat");
 
@@ -1104,6 +1111,11 @@ fn add_error_format_and_color(build_runner: &BuildRunner<'_, '_>, cmd: &mut Proc
         }
         _ => {}
     }
+
+    if enable_timings {
+        json.push_str(",timings");
+    }
+
     cmd.arg(json);
 
     let gctx = build_runner.bcx.gctx;
@@ -1955,6 +1967,12 @@ fn on_stderr_line_inner(
         }
         state.future_incompat_report(report.future_incompat_report);
         return Ok(true);
+    }
+
+    let res = serde_json::from_str::<SectionTiming>(compiler_message.get());
+    if let Ok(timing_record) = res {
+        state.on_section_timing_emitted(timing_record);
+        return Ok(false);
     }
 
     // Depending on what we're emitting from Cargo itself, we figure out what to

--- a/src/cargo/core/compiler/timings.rs
+++ b/src/cargo/core/compiler/timings.rs
@@ -92,6 +92,50 @@ struct UnitTime {
     sections: HashMap<String, TimingSection>,
 }
 
+impl UnitTime {
+    fn aggregate_sections(&self) -> AggregatedSections {
+        let end = self.duration;
+
+        let codegen_section = self.sections.get("codegen");
+        let link_section = self.sections.get("link");
+
+        // Best case: we know all three sections
+        if let (Some(codegen_section), Some(link_section)) = (codegen_section, link_section) {
+            let link_start = link_section.start;
+            let codegen_end = codegen_section.end.unwrap_or(link_start);
+
+            AggregatedSections::Sections {
+                frontend: SectionData {
+                    start: 0.0,
+                    end: codegen_section.start,
+                },
+                codegen: SectionData {
+                    start: codegen_section.start,
+                    end: codegen_end,
+                },
+                linking: SectionData {
+                    start: link_start,
+                    end: link_section.end.unwrap_or(end),
+                },
+            }
+        } else if let Some(rmeta_time) = self.rmeta_time {
+            // We know at least the .rmeta time
+            AggregatedSections::OnlyCodegenDuration {
+                frontend: SectionData {
+                    start: 0.0,
+                    end: rmeta_time,
+                },
+                codegen: SectionData {
+                    start: rmeta_time,
+                    end,
+                },
+            }
+        } else {
+            AggregatedSections::OnlyTotalDuration
+        }
+    }
+}
+
 /// Periodic concurrency tracking information.
 #[derive(serde::Serialize)]
 struct Concurrency {
@@ -104,6 +148,39 @@ struct Concurrency {
     /// Number of units that are not yet ready, because they are waiting for
     /// dependencies to finish.
     inactive: usize,
+}
+
+/// Postprocessed section data that has both start and an end.
+#[derive(serde::Serialize)]
+struct SectionData {
+    /// Start (relative to the start of the unit)
+    start: f64,
+    /// End (relative to the start of the unit)
+    end: f64,
+}
+
+impl SectionData {
+    fn duration(&self) -> f64 {
+        (self.end - self.start).max(0.0)
+    }
+}
+
+/// Contains post-processed data of individual compilation sections.
+#[derive(serde::Serialize)]
+enum AggregatedSections {
+    /// We know only the total duration
+    OnlyTotalDuration,
+    /// We only know when .rmeta was generated, so we can distill frontend and codegen time.
+    OnlyCodegenDuration {
+        frontend: SectionData,
+        codegen: SectionData,
+    },
+    /// We know the durations of the three individual sections.
+    Sections {
+        frontend: SectionData,
+        codegen: SectionData,
+        linking: SectionData,
+    },
 }
 
 impl<'gctx> Timings<'gctx> {
@@ -476,6 +553,7 @@ impl<'gctx> Timings<'gctx> {
             .enumerate()
             .map(|(i, ut)| (ut.unit.clone(), i))
             .collect();
+
         #[derive(serde::Serialize)]
         struct UnitData {
             i: usize,
@@ -549,6 +627,18 @@ impl<'gctx> Timings<'gctx> {
 
     /// Render the table of all units.
     fn write_unit_table(&self, f: &mut impl Write) -> CargoResult<()> {
+        let mut units: Vec<&UnitTime> = self.unit_times.iter().collect();
+        units.sort_unstable_by(|a, b| b.duration.partial_cmp(&a.duration).unwrap());
+
+        let has_linking_time = units
+            .iter()
+            .any(|u| matches!(u.aggregate_sections(), AggregatedSections::Sections { .. }));
+        // Skip the linker column if we have no data for it
+        let linking_header = if has_linking_time {
+            "<th>Linking</th>"
+        } else {
+            ""
+        };
         write!(
             f,
             r#"
@@ -558,20 +648,38 @@ impl<'gctx> Timings<'gctx> {
       <th></th>
       <th>Unit</th>
       <th>Total</th>
+      <th>Frontend</th>
       <th>Codegen</th>
+      {linking_header}
       <th>Features</th>
     </tr>
   </thead>
   <tbody>
 "#
         )?;
-        let mut units: Vec<&UnitTime> = self.unit_times.iter().collect();
-        units.sort_unstable_by(|a, b| b.duration.partial_cmp(&a.duration).unwrap());
+
         for (i, unit) in units.iter().enumerate() {
-            let codegen = match unit.codegen_time() {
+            let format_duration = |section: Option<SectionData>| match section {
+                Some(section) => {
+                    let duration = section.duration();
+                    let pct = (duration / unit.duration) * 100.0;
+                    format!("{duration:.1}s ({:.0}%)", pct)
+                }
                 None => "".to_string(),
-                Some((_rt, ctime, cent)) => format!("{:.1}s ({:.0}%)", ctime, cent),
             };
+            let sections = unit.aggregate_sections();
+            let (frontend, codegen, linking) = match sections {
+                AggregatedSections::OnlyTotalDuration => (None, None, None),
+                AggregatedSections::OnlyCodegenDuration { frontend, codegen } => {
+                    (Some(frontend), Some(codegen), None)
+                }
+                AggregatedSections::Sections {
+                    frontend,
+                    codegen,
+                    linking,
+                } => (Some(frontend), Some(codegen), Some(linking)),
+            };
+
             let features = unit.unit.features.join(", ");
             write!(
                 f,
@@ -582,13 +690,21 @@ impl<'gctx> Timings<'gctx> {
   <td>{:.1}s</td>
   <td>{}</td>
   <td>{}</td>
+  {}
+  <td>{}</td>
 </tr>
 "#,
                 i + 1,
                 unit.name_ver(),
                 unit.target,
                 unit.duration,
-                codegen,
+                format_duration(frontend),
+                format_duration(codegen),
+                if has_linking_time {
+                    format!("<td>{}</td>", format_duration(linking))
+                } else {
+                    "".to_string()
+                },
                 features,
             )?;
         }
@@ -598,15 +714,6 @@ impl<'gctx> Timings<'gctx> {
 }
 
 impl UnitTime {
-    /// Returns the codegen time as (`rmeta_time`, `codegen_time`, percent of total)
-    fn codegen_time(&self) -> Option<(f64, f64, f64)> {
-        self.rmeta_time.map(|rmeta_time| {
-            let ctime = self.duration - rmeta_time;
-            let cent = (ctime / self.duration) * 100.0;
-            (rmeta_time, ctime, cent)
-        })
-    }
-
     fn name_ver(&self) -> String {
         format!("{} v{}", self.unit.pkg.name(), self.unit.pkg.version())
     }


### PR DESCRIPTION
### What does this PR try to resolve?

This PR adds initial support into Cargo for JSON timing sections, implemented in rustc in https://github.com/rust-lang/rust/pull/142123. This allows Cargo to read frontend/codegen/linking time from rustc, and thus reporting slightly more detailed data in the `cargo build --timings` output.

Currently this PR modifies Cargo to tell rustc to emit the section messages (`--json=...,timings`), and also renders the sections in the unit table of the unit timings table in the HTML output. As a follow-up, I also want to integrate the individual sections in the actual unit graph.

Note that the JSON timings are currently only supported on the nightly compiler (they are not stabilized). That means two things:
- Cargo has to somehow figure out if it should pass `--json=timings` to `rustc` or not. I don't think that it's worth it to add a new unstable Cargo flag just for this (ofc if you disagree, I'd be happy to implement that), instead I think that Cargo could just detect if the used rustc is nightly, and if yes, pass the flag always. I'm not sure how best to detect that though. So far I just used `gctx.nightly_features_allowed`, but I don't know if it's correct.
- The timings HTML page has to be prepared for the data to be both present and missing. I tried to do that with the `AggregatedSections` enum, and by modifying the table to skip the linking column when no data for it are present. A slight change from before is that both the Frontend and Codegen columns are now always present, while before the Frontend column value had to be "inferred" by the user (by computing `Total` - `Codegen`). I think that's an all-around improvement.

### How to test and review this PR?

You can run e.g. this to generate the timing report with a nightly compiler:
```bash
export RUSTC=`rustup +nightly which rustc`
target/debug/cargo build --timings
```
on some crate, e.g. [ripgrep](https://github.com/BurntSushi/ripgrep).

I have also included example output with and without the section timings: [timings.zip](https://github.com/user-attachments/files/21472709/timings.zip).