### PR TITLE
More helpful error for invalid cargo-features = []

### DIFF
--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -173,7 +173,9 @@ fn unknown_feature() {
 [ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
 
 Caused by:
-  unknown cargo feature `foo`
+  unknown Cargo.toml feature `foo`
+
+  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html for more information.
 
 "#]])
         .run();
@@ -202,7 +204,10 @@ fn wrong_kind_of_feature() {
 [ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
 
 Caused by:
-  unknown cargo feature `build-dir`
+  unknown Cargo.toml feature `build-dir`
+
+  This feature can be enabled via -Zbuild-dir or the `[unstable]` section in config.toml.
+  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html for more information.
 
 "#]])
         .run();
@@ -231,7 +236,9 @@ fn feature_syntax() {
 [ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
 
 Caused by:
-  unknown cargo feature `bad_feature`
+  unknown Cargo.toml feature `bad_feature`
+
+  Feature names must use '-' instead of '_'.
 
 "#]])
         .run();

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -180,6 +180,64 @@ Caused by:
 }
 
 #[cargo_test]
+fn wrong_kind_of_feature() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                cargo-features = ["build-dir"]
+
+                [package]
+                name = "a"
+                version = "0.0.1"
+                edition = "2015"
+                authors = []
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+    p.cargo("check")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
+
+Caused by:
+  unknown cargo feature `build-dir`
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn feature_syntax() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                cargo-features = ["bad_feature"]
+
+                [package]
+                name = "a"
+                version = "0.0.1"
+                edition = "2015"
+                authors = []
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+    p.cargo("check")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
+
+Caused by:
+  unknown cargo feature `bad_feature`
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn stable_feature_warns() {
     let p = project()
         .file(


### PR DESCRIPTION
The error message for unknown values of `cargo-features` was unhelpful:

```text
Caused by:
  unknown cargo feature `build-dir`
```

I've made it more explanatory, and matching the style of the other errors:

```text
Caused by:
  feature `build-dir` is not a valid unstable feature for Cargo.toml

  This feature can be enabled via -Zbuild-dir or the `[unstable]` section in config.toml.
  See https://doc.rust-lang.org/cargo/reference/unstable.html for more information.
```
