### PR TITLE
perf(package): Always reuse the workspace's target-dir

### DIFF
--- a/src/cargo/ops/cargo_package/verify.rs
+++ b/src/cargo/ops/cargo_package/verify.rs
@@ -66,10 +66,13 @@ pub fn run_verify(
     let new_pkg = src.root_package()?;
     let pkg_fingerprint = hash_all(&dst)?;
 
+    // When packaging we use an ephemeral workspace but reuse the build cache to reduce
+    // verification time if the user has already compiled the dependencies and the fingerprint
+    // is unchanged.
     let target_dir = if gctx.cli_unstable().build_dir {
         Some(ws.build_dir())
     } else {
-        None
+        Some(ws.target_dir())
     };
 
     let mut ws = Workspace::ephemeral(new_pkg, gctx, target_dir, true)?;

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1828,7 +1828,7 @@ fn package_two_kinds_of_deps() {
 }
 
 #[cargo_test]
-fn package_should_not_use_build_cache() {
+fn package_should_use_build_cache() {
     Package::new("other", "1.0.0").publish();
     let p = project()
         .file(
@@ -1850,7 +1850,7 @@ fn package_should_not_use_build_cache() {
     // Build once so that the build cache is populated
     p.cargo("build").run();
 
-    // Run package and verify we rebuild everything
+    // Run package and verify we do not rebuild the `other` crate
     p.cargo("package")
         .with_stderr_data(str![[r#"
 [WARNING] manifest has no description, license, license-file, documentation, homepage or repository.
@@ -1859,7 +1859,6 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [UPDATING] `dummy-registry` index
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [VERIFYING] foo v0.0.1 ([ROOT]/foo)
-[COMPILING] other v1.0.0
 [COMPILING] foo v0.0.1 ([ROOT]/foo/target/package/foo-0.0.1)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -5745,7 +5744,6 @@ fn workspace_with_local_deps() {
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [VERIFYING] level1 v0.0.1 ([ROOT]/foo/level1)
 [UNPACKING] level2 v0.0.1 (registry `[ROOT]/foo/target/package/tmp-registry`)
-[COMPILING] level3 v0.0.1
 [COMPILING] level2 v0.0.1
 [COMPILING] level1 v0.0.1 ([ROOT]/foo/target/package/level1-0.0.1)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -6654,7 +6652,6 @@ fn workspace_with_renamed_member() {
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [VERIFYING] obeli-sk-utils v0.16.2 ([ROOT]/foo/crates/utils)
 [UNPACKING] obeli-sk-concepts v0.16.2 (registry `[ROOT]/foo/target/package/tmp-registry`)
-[COMPILING] obeli-sk-val-json v0.16.2
 [COMPILING] obeli-sk-concepts v0.16.2
 [COMPILING] obeli-sk-utils v0.16.2 ([ROOT]/foo/target/package/obeli-sk-utils-0.16.2)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -7037,7 +7034,6 @@ fn registry_inference_ignores_unpublishable() {
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [VERIFYING] main v0.0.1 ([ROOT]/foo/main)
 [UPDATING] `alternative` index
-[COMPILING] dep v0.1.0 (registry `alternative`)
 [COMPILING] main v0.0.1 ([ROOT]/foo/target/package/main-0.0.1)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -1341,7 +1341,6 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [UPDATING] crates.io index
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [VERIFYING] foo v0.0.1 ([ROOT]/foo)
-[COMPILING] bar v1.0.0
 [COMPILING] foo v0.0.1 ([ROOT]/foo/target/package/foo-0.0.1)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
@@ -3746,7 +3745,6 @@ fn workspace_with_local_deps() {
 [VERIFYING] level1 v0.0.1 ([ROOT]/foo/level1)
 [UPDATING] crates.io index
 [UNPACKING] level2 v0.0.1 (registry `[ROOT]/foo/target/package/tmp-registry`)
-[COMPILING] level3 v0.0.1
 [COMPILING] level2 v0.0.1
 [COMPILING] level1 v0.0.1 ([ROOT]/foo/target/package/level1-0.0.1)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/publish_lockfile.rs
+++ b/tests/testsuite/publish_lockfile.rs
@@ -563,7 +563,6 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [COMPILING] bar v0.0.1 ([ROOT]/foo/target/package/bar-0.0.1)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [VERIFYING] foo v0.0.1 ([ROOT]/foo)
-[COMPILING] serde v0.2.0
 [COMPILING] foo v0.0.1 ([ROOT]/foo/target/package/foo-0.0.1)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 


### PR DESCRIPTION
### What does this PR try to resolve?

While preparing to stabilize `build-dir`, [it was discovered](https://github.com/rust-lang/cargo/issues/14125#issuecomment-3127467689) that `cargo package` will sometimes use the build cache for dependency crates if `CARGO_TARGET_DIR` is explicitly set.

If target-dir is not set, the build will be preformed in an "inner target dir" at `target/package/{name}-{version}/target` and rebuild everything.

This PR changes the default behavior to always use the build cache,
matching the behavior of having `target-dir` set.


### How to test and review this PR?

Added a dedicated test to verify the previous behavior (cargo recompiled non-workspace crates) in the first commit.
Then updated it to verify the new behavior.

### Related links/notes

* I did some Git archaeology and I _think_ this behavior was introduced in #2912
  * While searching through the commit/pr history was never able to find any explicit reason why the behavior is the way it is.
  * Even if it was intentional, it has been 9 years since and Cargo's fingerprinting/rebuild detection is much more mature now so I believe its worth revisiting if this is still the desired behavior.
* Would help mitigate https://github.com/rust-lang/cargo/issues/14941