### PR TITLE
Add Arm64 Windows CI jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -159,6 +159,14 @@ jobs:
           os: windows-latest
           rust: nightly-msvc
           other: i686-pc-windows-msvc
+        - name: Windows aarch64 MSVC stable
+          os: windows-11-arm
+          rust: stable-msvc
+          other: i686-pc-windows-msvc
+        - name: Windows aarch64 MSVC nightly
+          os: windows-11-arm
+          rust: nightly-msvc
+          other: i686-pc-windows-msvc
         - name: Windows x86_64 gnu nightly # runs out of space while trying to link the test suite
           os: windows-latest
           rust: nightly-gnu
@@ -187,6 +195,10 @@ jobs:
       shell: pwsh
       run: Add-Content $env:GITHUB_PATH "C:\Program Files (x86)\Windows Kits\10\Debuggers\x64"
       if: matrix.os == 'windows-latest'
+    - name: Add Windows debuggers bin to PATH
+      shell: pwsh
+      run: Add-Content $env:GITHUB_PATH "C:\Program Files (x86)\Windows Kits\10\Debuggers\arm64"
+      if: matrix.os == 'windows-11-arm'
     - name: Configure extra test environment
       run: echo CARGO_CONTAINER_TESTS=1 >> $GITHUB_ENV
       if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
The `aarch64-pc-windows-msvc` target is on the path to being promoted to Tier 1: <https://github.com/rust-lang/rfcs/pull/3817>

Adding Arm64 Windows runners will catch any potential issues in Cargo before changes are merged in, instead of waiting for the Cargo submodule to be updated.