### PR TITLE
Fix Non-actionable error messages

### DIFF
--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -2261,10 +2261,7 @@ fn api_error_json() {
 [PACKAGING] foo v0.0.1 ([ROOT]/foo)
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
-[ERROR] failed to publish `foo` v0.0.1
-
-Caused by:
-  failed to publish to registry at http://127.0.0.1:[..]/
+[ERROR] failed to publish `foo` v0.0.1 to registry at http://127.0.0.1:[..]/
 
 Caused by:
   the remote server responded with an error (status 403 Forbidden): you must be logged in
@@ -2312,10 +2309,7 @@ fn api_error_200() {
 [PACKAGING] foo v0.0.1 ([ROOT]/foo)
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
-[ERROR] failed to publish `foo` v0.0.1
-
-Caused by:
-  failed to publish to registry at http://127.0.0.1:[..]/
+[ERROR] failed to publish `foo` v0.0.1 to registry at http://127.0.0.1:[..]/
 
 Caused by:
   the remote server responded with an [ERROR] max upload size is 123
@@ -2363,10 +2357,7 @@ fn api_error_code() {
 [PACKAGING] foo v0.0.1 ([ROOT]/foo)
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
-[ERROR] failed to publish `foo` v0.0.1
-
-Caused by:
-  failed to publish to registry at http://127.0.0.1:[..]/
+[ERROR] failed to publish `foo` v0.0.1 to registry at http://127.0.0.1:[..]/
 
 Caused by:
   failed to get a 200 OK response, got 400
@@ -2423,10 +2414,7 @@ fn api_curl_error() {
 [PACKAGING] foo v0.0.1 ([ROOT]/foo)
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
-[ERROR] failed to publish `foo` v0.0.1
-
-Caused by:
-  failed to publish to registry at http://127.0.0.1:[..]/
+[ERROR] failed to publish `foo` v0.0.1 to registry at http://127.0.0.1:[..]/
 
 Caused by:
   [52] Server returned nothing (no headers, no data) (Empty reply from server)
@@ -2474,10 +2462,7 @@ fn api_other_error() {
 [PACKAGING] foo v0.0.1 ([ROOT]/foo)
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
-[ERROR] failed to publish `foo` v0.0.1
-
-Caused by:
-  failed to publish to registry at http://127.0.0.1:[..]/
+[ERROR] failed to publish `foo` v0.0.1 to registry at http://127.0.0.1:[..]/
 
 Caused by:
   invalid response body from server
@@ -3624,10 +3609,7 @@ fn invalid_token() {
 [PACKAGING] foo v0.0.1 ([ROOT]/foo)
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
-[ERROR] failed to publish `foo` v0.0.1
-
-Caused by:
-  failed to publish to registry at http://127.0.0.1:[..]/
+[ERROR] failed to publish `foo` v0.0.1 to registry at http://127.0.0.1:[..]/
 
 Caused by:
   token contains invalid characters.
@@ -4464,10 +4446,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [COMPILING] c v0.1.0 ([ROOT]/foo/target/package/c-0.1.0)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] a v0.1.0 ([ROOT]/foo/a)
-[ERROR] failed to publish `a` v0.1.0; the following crates have not been published yet: b v0.1.0, c v0.1.0
-
-Caused by:
-  failed to publish to registry at http://127.0.0.1:[..]/
+[ERROR] failed to publish `a` v0.1.0 to registry at http://127.0.0.1:[..]/; the following crates have not been published yet: b v0.1.0, c v0.1.0
 
 Caused by:
   the remote server responded with an error (status 400 Bad Request): crate a@0.1.0 already exists on crates.io index


### PR DESCRIPTION
### What does this PR try to resolve?

This PR fixes [issue #15754](https://github.com/rust-lang/cargo/issues/15754) by improving error reporting for workspace publish failures.  
Previously, when publishing a workspace, if one package failed (e.g., due to an existing version), Cargo did not clearly list which packages failed and which remained unpublished.  
This change ensures that the error message now includes both the failed package and any remaining unpublished packages, making it easier for users to understand what went wrong and what still needs to be published.

---

### How to test and review this PR?

- A new test (`workspace_publish_failure_reports_remaining_packages`) was added to publish.rs to demonstrate the previous behavior and verify the fix.
- The test first fails with the old behavior, then passes after the fix is applied.
- All commits are split for clarity: the test is added first, then the implementation is updated.
- To review:
  1. Check that the new test covers the relevant error scenario.
  2. Review the implementation changes in publish.rs for error context propagation.
  3. Confirm that all tests pass (`SNAPSHOTS=overwrite cargo test`).
  4. Review commit-by-commit for a clear history.

---

**How to test locally:**
```bash
SNAPSHOTS=overwrite cargo test --test testsuite publish::workspace_publish_failure_reports_remaining_packages
```
or simply
```bash
SNAPSHOTS=overwrite cargo test
```
or 
```bash
cargo test
```
to run the full suite.

---

