### PR TITLE
Clarify that `cargo doc --no-deps` is cumulative and won’t delete prev

### DIFF
--- a/src/doc/man/cargo-doc.md
+++ b/src/doc/man/cargo-doc.md
@@ -16,6 +16,8 @@ cargo-doc --- Build a package's documentation
 Build the documentation for the local package and all dependencies. The output
 is placed in `target/doc` in rustdoc's usual format.
 
+**Note:** Documentation generation is cumulative: existing doc files in the target directory are preserved across different `cargo doc` invocations. To remove existing generated docs, pass `--doc` to {{man "cargo-clean" 1}}.
+
 ## OPTIONS
 
 ### Documentation Options

--- a/src/doc/man/generated_txt/cargo-doc.txt
+++ b/src/doc/man/generated_txt/cargo-doc.txt
@@ -10,6 +10,10 @@ DESCRIPTION
        Build the documentation for the local package and all dependencies. The
        output is placed in target/doc in rustdoc’s usual format.
 
+       Note: Documentation generation is cumulative: existing doc files in the
+       target directory are preserved across different cargo doc invocations.
+       To remove existing generated docs, pass --doc to cargo-clean(1).
+
 OPTIONS
    Documentation Options
        --open

--- a/src/doc/src/commands/cargo-doc.md
+++ b/src/doc/src/commands/cargo-doc.md
@@ -12,6 +12,8 @@ cargo-doc --- Build a package's documentation
 Build the documentation for the local package and all dependencies. The output
 is placed in `target/doc` in rustdoc's usual format.
 
+**Note:** Documentation generation is cumulative: existing doc files in the target directory are preserved across different `cargo doc` invocations. To remove existing generated docs, pass `--doc` to [cargo-clean(1)](cargo-clean.html).
+
 ## OPTIONS
 
 ### Documentation Options

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -10,6 +10,8 @@ cargo\-doc \[em] Build a package\[cq]s documentation
 .SH "DESCRIPTION"
 Build the documentation for the local package and all dependencies. The output
 is placed in \fBtarget/doc\fR in rustdoc\[cq]s usual format.
+.sp
+\fBNote:\fR Documentation generation is cumulative: existing doc files in the target directory are preserved across different \fBcargo doc\fR invocations. To remove existing generated docs, pass \fB\-\-doc\fR to \fBcargo\-clean\fR(1).
 .SH "OPTIONS"
 .SS "Documentation Options"
 .sp


### PR DESCRIPTION

### What does this PR try to resolve?
clarifies that cargo doc --no-deps will not delete previously-built dependency docs, and points users to cargo clean --doc or manual deletion if they want a truly “fresh” doc set. This pr fixed https://github.com/rust-lang/cargo/issues/15728

### How to test and review this PR?
No testing required.
