### PR TITLE
Recommend `package.rust-version` in the Rust version section of `reference/semver.md`.

### DIFF
--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -2028,6 +2028,8 @@ Mitigation strategies:
   [`#[cfg(accessible(..))]`][cfg-accessible] features which provide an opt-in
   mechanism for new features. These are currently unstable and only available
   in the nightly channel.
+* Use [`package.rust-version`] to declare your package’s compatibility.
+  This allows `cargo update` to avoid introducing an incompatible update.
 
 ### Possibly-breaking: changing the platform and environment requirements {#env-change-requirements}
 
@@ -2296,6 +2298,7 @@ document what your commitments are.
 
 [`cfg` attribute]: ../../reference/conditional-compilation.md#the-cfg-attribute
 [`no_std`]: ../../reference/names/preludes.html#the-no_std-attribute
+[`package.rust-version`]: https://doc.rust-lang.org/cargo/reference/rust-version.html
 [`pub use`]: ../../reference/items/use-declarations.html
 [Cargo feature]: features.md
 [Cargo features]: features.md


### PR DESCRIPTION
Adds a recommendation that, to mitigate “possibly breaking” Rust version requirement increases, they should be declared using `package.rust-version`.

My main goal in this change is to make it *possible to find* the Rust version section in this page by searching it, but the most appropriate way to fit it into this section seemed to me to be making this recommendation. Declaring (and maintaining) `package.rust-version` is additional work, but it is a much lesser burden on maintainers than other items in the same list such as "Provide a large window of support".