### PR TITLE
Support profile overrides for `-Z build-std`

### DIFF
--- a/src/cargo/ops/cargo_compile/mod.rs
+++ b/src/cargo/ops/cargo_compile/mod.rs
@@ -344,11 +344,14 @@ pub fn create_bcx<'a, 'gctx>(
     }
 
     let profiles = Profiles::new(ws, build_config.requested_profile)?;
-    profiles.validate_packages(
-        ws.profiles(),
-        &mut gctx.shell(),
-        workspace_resolve.as_ref().unwrap_or(&resolve),
-    )?;
+    let pkg_resolve = workspace_resolve.as_ref().unwrap_or(&resolve);
+    if let Some((std_resolve, _)) = &std_resolve_features {
+        profiles.validate_packages(ws.profiles(), &mut gctx.shell(), || {
+            pkg_resolve.iter().chain(std_resolve.iter())
+        })?
+    } else {
+        profiles.validate_packages(ws.profiles(), &mut gctx.shell(), || pkg_resolve.iter())?
+    };
 
     // If `--target` has not been specified, then the unit graph is built
     // assuming `--target $HOST` was specified. See


### PR DESCRIPTION
Pass both the main package graph and the build-std package graph to the verifier so that e.g. `[profile.dev.package.core]` is not rejected and ignored if `core` is being built.

### What does this PR try to resolve?

Currently, `[profile.dev.package.my_std_crate_here]` will not be respected when `-Z build-std=my_std_crate_here` is passed, because profile overrides are verified on a package graph that does not include the build-std package graph.

This is important to support because many users of `-Z build-std` are targeting embedded environments where image space may be at a premium. This means that while they may be able to support a more relaxed dev build for their own code, they'd like to build standard libraries with optimizations and fewer assertions to shrink things down.

The default behavior without `-Z build-std` is to use prebuilt stdlibs, so you will get an optimized stdlib and a dev-profile version of your project. This configurability allows developers to opt back in to a similar configuration with `-Z build-std` by setting profile flags for `core`/`compiler_builtins`/`alloc`/`std` as appropriate.

### How to test and review this PR?

`cargo test` should test it - I've added a new test which ensures both that:
* No warning is emitted when a stdlib is specified in a profile clause and `-Z build-std` is used
* The adjustment to the profile affects the requested crate
* The adjustment to the profile does not affect another crate in the graph