### PR TITLE
docs: clarify that `cargo:rustc-link-arg-tests` only applies to integration tests

### DIFF
--- a/crates/build-rs/src/output.rs
+++ b/crates/build-rs/src/output.rs
@@ -118,7 +118,7 @@ pub fn rustc_link_arg_bins(flag: &str) {
 
 /// The `rustc-link-arg-tests` instruction tells Cargo to pass the
 /// [`-C link-arg=FLAG` option][link-arg] to the compiler, but only when building
-/// a tests target.
+/// an integration test target.
 ///
 /// [link-arg]: https://doc.rust-lang.org/rustc/codegen-options/index.html#link-arg
 #[track_caller]

--- a/src/doc/src/reference/build-scripts.md
+++ b/src/doc/src/reference/build-scripts.md
@@ -174,8 +174,8 @@ to set a linker script or other linker options.
 ### `cargo::rustc-link-arg-tests=FLAG` {#rustc-link-arg-tests}
 
 The `rustc-link-arg-tests` instruction tells Cargo to pass the [`-C
-link-arg=FLAG` option][link-arg] to the compiler, but only when building a
-tests target.
+link-arg=FLAG` option][link-arg] to the compiler, but only when building an integration
+test target.
 
 ### `cargo::rustc-link-arg-examples=FLAG` {#rustc-link-arg-examples}
 


### PR DESCRIPTION
### What does this PR try to resolve?

`cargo:rustc-link-arg-tests` only applies to integration test targets, not to all test targets as originally intended.

This PR updates the doc, to at least reflect what `cargo:rustc-link-arg-tests` currently does, until #10937 is resolved.
