### PR TITLE
test(build-std): relax the thread name assertion

### DIFF
--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -375,7 +375,7 @@ fn remap_path_scope() {
 [FINISHED] `release` profile [optimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `target/[HOST_TARGET]/release/foo`
 ...
-[..]thread '[..]' panicked at [..]src/main.rs:3:[..]:
+[..]thread [..] panicked at [..]src/main.rs:3:[..]:
 [..]remap to /rustc/<hash>[..]
 [..]at /rustc/[..]/library/std/src/[..]
 [..]at ./src/main.rs:3:[..]


### PR DESCRIPTION
rust-lang/rust#115746 changed to print thread ID,
so we update accordingly.

See <https://github.com/rust-lang/cargo/actions/runs/16839675728/job/47707652618?pr=15821>