### PR TITLE
add is_inherited methods to InheritableDependency and InheritableField

### DIFF
--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -351,6 +351,10 @@ impl<T> InheritableField<T> {
             InheritableField::Value(defined) => Some(defined),
         }
     }
+
+    pub fn is_inherited(&self) -> bool {
+        matches!(self, Self::Inherit(_))
+    }
 }
 
 //. This already has a `Deserialize` impl from version_trim_whitespace


### PR DESCRIPTION
I was looking into adding cargo_util_schemas as a parsing backend for crates-io and this was a little method I found myself missing a lot.
