### PR TITLE
chore: remove x86_64-apple-darwin from CI and tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,10 +143,6 @@ jobs:
           os: macos-14
           rust: stable
           other: x86_64-apple-darwin
-        - name: macOS x86_64 nightly
-          os: macos-13
-          rust: nightly
-          other: x86_64-apple-ios
         - name: macOS aarch64 nightly
           os: macos-14
           rust: nightly

--- a/crates/cargo-test-support/src/cross_compile.rs
+++ b/crates/cargo-test-support/src/cross_compile.rs
@@ -38,10 +38,8 @@ pub fn alternate() -> &'static str {
 
 /// A possible alternate target-triple to build with.
 pub(crate) fn try_alternate() -> Option<&'static str> {
-    if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+    if cfg!(target_os = "macos") {
         Some("x86_64-apple-darwin")
-    } else if cfg!(target_os = "macos") {
-        Some("x86_64-apple-ios")
     } else if cfg!(target_os = "linux") {
         Some("i686-unknown-linux-gnu")
     } else if cfg!(all(target_os = "windows", target_env = "msvc")) {

--- a/src/doc/contrib/src/tests/writing.md
+++ b/src/doc/contrib/src/tests/writing.md
@@ -132,16 +132,6 @@ The name of the target can be fetched with the [`cross_compile::alternate()`]
 function. The name of the host target can be fetched with
 [`cargo_test_support::rustc_host()`].
 
-The cross-tests need to distinguish between targets which can *build* versus
-those which can actually *run* the resulting executable. Unfortunately, macOS is
-currently unable to run an alternate target (Apple removed 32-bit support a
-long time ago). For building, `x86_64-apple-darwin` will target
-`x86_64-apple-ios` as its alternate. However, the iOS target can only execute
-binaries if the iOS simulator is installed and configured. The simulator is
-not available in CI, so all tests that need to run cross-compiled binaries are
-disabled on CI. If you are running on macOS locally, and have the simulator
-installed, then it should be able to run them.
-
 If the test needs to run the cross-compiled binary, then it should have
 something like this to exit the test before doing so:
 

--- a/tests/testsuite/utils/cross_compile.rs
+++ b/tests/testsuite/utils/cross_compile.rs
@@ -124,28 +124,12 @@ pub fn disabled() -> bool {
     install the necessary libraries.
     ",
         );
-    } else if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+    } else if cfg!(target_os = "macos") {
         message.push_str(
             "
     macOS on aarch64 cross tests to target x86_64-apple-darwin.
     This should be natively supported via Xcode, nothing additional besides the
     rustup target should be needed.
-    ",
-        );
-    } else if cfg!(target_os = "macos") {
-        message.push_str(
-            "
-    macOS on x86_64 cross tests to target x86_64-apple-ios, which requires the iOS
-    SDK to be installed. This should be included with Xcode automatically. If you
-    are using the Xcode command line tools, you'll need to install the full Xcode
-    app (from the Apple App Store), and switch to it with this command:
-
-        sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
-
-    Some cross-tests want to *run* the executables on the host. These tests will
-    be ignored if this is not possible. On macOS, this means you need an iOS
-    simulator installed to run these tests. To install a simulator, open Xcode, go
-    to preferences > Components, and download the latest iOS simulator.
     ",
         );
     } else if cfg!(target_os = "windows") {
@@ -202,19 +186,6 @@ pub fn can_run_on_host() -> bool {
     if disabled() {
         return false;
     }
-    // macos is currently configured to cross compile to x86_64-apple-ios
-    // which requires a simulator to run. Azure's CI image appears to have the
-    // SDK installed, but are not configured to launch iOS images with a
-    // simulator.
-    if cfg!(target_os = "macos") {
-        if CAN_RUN_ON_HOST.load(Ordering::SeqCst) {
-            return true;
-        } else {
-            println!("Note: Cannot run on host, skipping.");
-            return false;
-        }
-    } else {
-        assert!(CAN_RUN_ON_HOST.load(Ordering::SeqCst));
-        return true;
-    }
+    assert!(CAN_RUN_ON_HOST.load(Ordering::SeqCst));
+    return true;
 }


### PR DESCRIPTION
### What does this PR try to resolve?

RFC 3841 has merged, and x86_64-apple-darwin will be demoted to tier-2 in 1.90.0. In Cargo we usually run test against tier-1 platforms, so x86_64-apple-darwin should be removed.
Also, that target platform is often the slowest one in CI, we are happy to remove it to save us a couple of minutes.

https://rust-lang.github.io/rfcs/3841-demote-x86_64-apple-darwin.html

### How to test and review this PR?

Run `cargo test` locally with cross-compile tests enabled, and no regression.