### PR TITLE
Stabilize `build.build-dir`

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -844,7 +844,6 @@ unstable_cli_options!(
     avoid_dev_deps: bool = ("Avoid installing dev-dependencies if possible"),
     binary_dep_depinfo: bool = ("Track changes to dependency artifacts"),
     bindeps: bool = ("Allow Cargo packages to depend on bin, cdylib, and staticlib crates, and use the artifacts built by those crates"),
-    build_dir: bool = ("Enable the `build.build-dir` option in .cargo/config.toml file"),
     #[serde(deserialize_with = "deserialize_comma_separated_list")]
     build_std: Option<Vec<String>>  = ("Enable Cargo to compile the standard library itself as part of a crate graph compilation"),
     #[serde(deserialize_with = "deserialize_comma_separated_list")]
@@ -969,6 +968,8 @@ const STABILIZED_DOCTEST_XCOMPILE: &str = "Doctest cross-compiling is now always
 
 const STABILIZED_PACKAGE_WORKSPACE: &str =
     "Workspace packaging and publishing (a.k.a. `-Zpackage-workspace`) is now always enabled.";
+
+const STABILIZED_BUILD_DIR: &str = "build.build-dir is now always enabled.";
 
 fn deserialize_comma_separated_list<'de, D>(
     deserializer: D,
@@ -1352,6 +1353,7 @@ impl CliUnstable {
             "registry-auth" => stabilized_warn(k, "1.74", STABILIZED_REGISTRY_AUTH),
             "check-cfg" => stabilized_warn(k, "1.80", STABILIZED_CHECK_CFG),
             "package-workspace" => stabilized_warn(k, "1.89", STABILIZED_PACKAGE_WORKSPACE),
+            "build-dir" => stabilized_warn(k, "1.91", STABILIZED_BUILD_DIR),
 
             // Unstable features
             // Sorted alphabetically:
@@ -1360,7 +1362,6 @@ impl CliUnstable {
             "avoid-dev-deps" => self.avoid_dev_deps = parse_empty(k, v)?,
             "binary-dep-depinfo" => self.binary_dep_depinfo = parse_empty(k, v)?,
             "bindeps" => self.bindeps = parse_empty(k, v)?,
-            "build-dir" => self.build_dir = parse_empty(k, v)?,
             "build-std" => self.build_std = Some(parse_list(v)),
             "build-std-features" => self.build_std_features = Some(parse_list(v)),
             "cargo-lints" => self.cargo_lints = parse_empty(k, v)?,

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -443,9 +443,6 @@ impl<'gctx> Workspace<'gctx> {
     }
 
     pub fn build_dir(&self) -> Filesystem {
-        if !self.gctx().cli_unstable().build_dir {
-            return self.target_dir();
-        }
         self.build_dir.clone().unwrap_or_else(|| self.target_dir())
     }
 

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -78,7 +78,7 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
         // Note that we don't bother grabbing a lock here as we're just going to
         // blow it all away anyway.
         if opts.spec.is_empty() {
-            let paths: &[PathBuf] = if gctx.cli_unstable().build_dir && build_dir != target_dir {
+            let paths: &[PathBuf] = if build_dir != target_dir {
                 &[
                     target_dir.into_path_unlocked(),
                     build_dir.into_path_unlocked(),

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -52,11 +52,7 @@ pub fn output_metadata(ws: &Workspace<'_>, opt: &OutputMetadataOptions) -> Cargo
             .collect(),
         resolve,
         target_directory: ws.target_dir().into_path_unlocked(),
-        build_directory: ws
-            .gctx()
-            .cli_unstable()
-            .build_dir
-            .then(|| ws.build_dir().into_path_unlocked()),
+        build_directory: ws.build_dir().into_path_unlocked(),
         version: VERSION,
         workspace_root: ws.root().to_path_buf(),
         metadata: ws.custom_metadata().cloned(),
@@ -73,8 +69,7 @@ pub struct ExportInfo {
     workspace_default_members: Vec<PackageIdSpec>,
     resolve: Option<MetadataResolve>,
     target_directory: PathBuf,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    build_directory: Option<PathBuf>,
+    build_directory: PathBuf,
     version: u32,
     workspace_root: PathBuf,
     metadata: Option<toml::Value>,

--- a/src/cargo/ops/cargo_package/verify.rs
+++ b/src/cargo/ops/cargo_package/verify.rs
@@ -69,13 +69,7 @@ pub fn run_verify(
     // When packaging we use an ephemeral workspace but reuse the build cache to reduce
     // verification time if the user has already compiled the dependencies and the fingerprint
     // is unchanged.
-    let target_dir = if gctx.cli_unstable().build_dir {
-        Some(ws.build_dir())
-    } else {
-        Some(ws.target_dir())
-    };
-
-    let mut ws = Workspace::ephemeral(new_pkg, gctx, target_dir, true)?;
+    let mut ws = Workspace::ephemeral(new_pkg, gctx, Some(ws.build_dir()), true)?;
     if let Some(local_reg) = local_reg {
         ws.add_local_overlay(
             local_reg.upstream,

--- a/src/cargo/util/context/mod.rs
+++ b/src/cargo/util/context/mod.rs
@@ -650,9 +650,6 @@ impl GlobalContext {
     ///
     /// Callers should prefer [`Workspace::build_dir`] instead.
     pub fn build_dir(&self, workspace_manifest_path: &PathBuf) -> CargoResult<Option<Filesystem>> {
-        if !self.cli_unstable().build_dir {
-            return self.target_dir();
-        }
         if let Some(val) = &self.build_config()?.build_dir {
             let replacements = vec![
                 (

--- a/src/doc/src/reference/build-cache.md
+++ b/src/doc/src/reference/build-cache.md
@@ -1,10 +1,21 @@
 # Build cache
 
-Cargo stores the output of a build into the "target" directory. By default,
-this is the directory named `target` in the root of your
-[*workspace*][def-workspace]. To change the location, you can set the
+Cargo stores the output of a build into the "target" and "build" directories. By default,
+both directories point to a directory named `target` in the root of your
+[*workspace*][def-workspace]. To change the location of the target-dir, you can set the
 `CARGO_TARGET_DIR` [environment variable], the [`build.target-dir`] config
-value, or the `--target-dir` command-line flag.
+value, or the `--target-dir` command-line flag. To change the location of the build-dir, you can set the
+`CARGO_BUILD_BUILD_DIR` [environment variable] or the [`build.build-dir`] config value.
+
+Artifacts are split in two catagories:
+* Final build artifacts
+  * Final build artifacts are output meant for end users of Cargo
+  * e.g. binaries for bin crates, output of `cargo doc`, Cargo `--timings` reports
+  * Stored in the target-dir
+* Intermediate build artifacts
+  * Intermediate build artifacts are internal to Cargo and the Rust compiler
+  * End users will generally not need to interact with intermediate build artifacts
+  * Stored in the Cargo build-dir
 
 The directory layout depends on whether or not you are using the `--target`
 flag to build for a specific platform. If `--target` is not specified, Cargo
@@ -53,15 +64,15 @@ Directory | Description
 <code style="white-space: nowrap">target/doc/</code> | Contains rustdoc documentation ([`cargo doc`]).
 <code style="white-space: nowrap">target/package/</code> | Contains the output of the [`cargo package`] and [`cargo publish`] commands.
 
-Cargo also creates several other directories and files needed for the build
-process. Their layout is considered internal to Cargo, and is subject to
+Cargo also creates several other directories and files in the build-dir needed for the build
+process. The build-dir layout is considered internal to Cargo, and is subject to
 change. Some of these directories are:
 
 Directory | Description
 ----------|------------
-<code style="white-space: nowrap">target/debug/deps/</code> | Dependencies and other artifacts.
-<code style="white-space: nowrap">target/debug/incremental/</code> | `rustc` [incremental output], a cache used to speed up subsequent builds.
-<code style="white-space: nowrap">target/debug/build/</code> | Output from [build scripts].
+<code style="white-space: nowrap">build-dir/debug/deps/</code> | Dependencies and other artifacts.
+<code style="white-space: nowrap">build-dir/debug/incremental/</code> | `rustc` [incremental output], a cache used to speed up subsequent builds.
+<code style="white-space: nowrap">build-dir/debug/build/</code> | Output from [build scripts].
 
 ## Dep-info files
 
@@ -92,6 +103,7 @@ configuration][config]. Refer to sccache documentation for more details.
 [`build.dep-info-basedir`]: ../reference/config.md#builddep-info-basedir
 [`build.rustc-wrapper`]: ../reference/config.md#buildrustc-wrapper
 [`build.target-dir`]: ../reference/config.md#buildtarget-dir
+[`build.build-dir`]: ../reference/config.md#buildbuild-dir
 [`cargo doc`]: ../commands/cargo-doc.md
 [`cargo package`]: ../commands/cargo-package.md
 [`cargo publish`]: ../commands/cargo-publish.md

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -70,7 +70,8 @@ rustc-wrapper = "…"           # run this wrapper instead of `rustc`
 rustc-workspace-wrapper = "…" # run this wrapper instead of `rustc` for workspace members
 rustdoc = "rustdoc"           # the doc generator tool
 target = "triple"             # build for the target triple (ignored by `cargo install`)
-target-dir = "target"         # path of where to place all generated artifacts
+target-dir = "target"         # path of where to place generated artifacts
+build-dir = "target"          # path of where to place intermediate build artifacts
 rustflags = ["…", "…"]        # custom flags to pass to all compiler invocations
 rustdocflags = ["…", "…"]     # custom flags to pass to rustdoc
 incremental = true            # whether or not to enable incremental compilation
@@ -481,6 +482,26 @@ The path to where all compiler output is placed. The default if not specified
 is a directory named `target` located at the root of the workspace.
 
 Can be overridden with the `--target-dir` CLI option.
+
+For more information see the [build cache documentation](../reference/build-cache.md).
+
+#### `build.build-dir`
+
+* Type: string (path)
+* Default: Defaults to the value of `build.target-dir`
+* Environment: `CARGO_BUILD_BUILD_DIR`
+
+The directory where intermediate build artifacts will be stored.
+Intermediate artifacts are produced by Rustc/Cargo during the build process.
+
+This option supports path templating.
+
+Available template variables:
+* `{workspace-root}` resolves to root of the current workspace.
+* `{cargo-cache-home}` resolves to `CARGO_HOME`
+* `{workspace-path-hash}` resolves to a hash of the manifest path
+
+For more information see the [build cache documentation](../reference/build-cache.md).
 
 #### `build.rustflags`
 * Type: string or array of strings

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -95,6 +95,7 @@ In summary, the supported environment variables are:
 * `CARGO_BUILD_RUSTDOC` --- The `rustdoc` executable, see [`build.rustdoc`].
 * `CARGO_BUILD_TARGET` --- The default target platform, see [`build.target`].
 * `CARGO_BUILD_TARGET_DIR` --- The default output directory, see [`build.target-dir`].
+* `CARGO_BUILD_BUILD_DIR` --- The default build directory, see [`build.build-dir`].
 * `CARGO_BUILD_RUSTFLAGS` --- Extra `rustc` flags, see [`build.rustflags`].
 * `CARGO_BUILD_RUSTDOCFLAGS` --- Extra `rustdoc` flags, see [`build.rustdocflags`].
 * `CARGO_BUILD_INCREMENTAL` --- Incremental compilation, see [`build.incremental`].
@@ -160,6 +161,7 @@ In summary, the supported environment variables are:
 [`build.rustdoc`]: config.md#buildrustdoc
 [`build.target`]: config.md#buildtarget
 [`build.target-dir`]: config.md#buildtarget-dir
+[`build.build-dir`]: config.md#buildbuild-dir
 [`build.rustflags`]: config.md#buildrustflags
 [`build.rustdocflags`]: config.md#buildrustdocflags
 [`build.incremental`]: config.md#buildincremental

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -80,7 +80,6 @@ Each new feature described below should explain how to use it.
     * [feature-unification](#feature-unification) --- Enable new feature unification modes in workspaces
 * Output behavior
     * [artifact-dir](#artifact-dir) --- Adds a directory where artifacts are copied to.
-    * [build-dir](#build-dir) --- Adds a directory where intermediate build artifacts are stored.
     * [Different binary name](#different-binary-name) --- Assign a name to the built binary that is separate from the crate name.
     * [root-dir](#root-dir) --- Controls the root directory relative to which paths are printed
 * Compile behavior
@@ -246,34 +245,6 @@ This can also be specified in `.cargo/config.toml` files.
 [build]
 artifact-dir = "out"
 ```
-
-## build-dir
-* Original Issue: [#14125](https://github.com/rust-lang/cargo/issues/14125)
-* Tracking Issue: [#14125](https://github.com/rust-lang/cargo/issues/14125)
-
-The directory where intermediate build artifacts will be stored.
-Intermediate artifacts are produced by Rustc/Cargo during the build process.
-
-```toml
-[build]
-build-dir = "out"
-```
-
-### `build.build-dir`
-
-* Type: string (path)
-* Default: Defaults to the value of `build.target-dir`
-* Environment: `CARGO_BUILD_BUILD_DIR`
-
-The path to where internal files used as part of the build are placed.
-
-This option supports path templating.
-
-Available template variables:
-* `{workspace-root}` resolves to root of the current workspace.
-* `{cargo-cache-home}` resolves to `CARGO_HOME`
-* `{workspace-path-hash}` resolves to a hash of the manifest path
-
 
 ## root-dir
 * Original Issue: [#9887](https://github.com/rust-lang/cargo/issues/9887)
@@ -2230,3 +2201,9 @@ Example:
 cargo +nightly build --compile-time-deps -Z unstable-options
 cargo +nightly check --compile-time-deps --all-targets -Z unstable-options
 ```
+
+## build-dir
+
+Support for `build.build-dir` was stabilized in the 1.91 release.
+See the [config documentation](config.md#buildbuild-dir) for information about changing the build-dir
+

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -983,6 +983,7 @@ fn alt_reg_metadata() {
   ],
   "resolve": null,
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo#0.0.1"
@@ -1347,6 +1348,7 @@ fn alt_reg_metadata() {
     "root": "path+[ROOTURL]/foo#0.0.1"
   },
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo#0.0.1"
@@ -1609,6 +1611,7 @@ fn unknown_registry() {
     "root": "path+[ROOTURL]/foo#0.0.1"
   },
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo#0.0.1"

--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -17,30 +17,6 @@ use cargo_test_support::{paths, project, str};
 use std::env::consts::{DLL_PREFIX, DLL_SUFFIX, EXE_SUFFIX};
 
 #[cargo_test]
-fn verify_build_dir_is_disabled_by_feature_flag() {
-    let p = project()
-        .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
-        .file(
-            ".cargo/config.toml",
-            r#"
-            [build]
-            build-dir = "build-dir"
-            "#,
-        )
-        .build();
-
-    p.cargo("build")
-        .masquerade_as_nightly_cargo(&["build-dir"])
-        .enable_mac_dsym()
-        .run();
-
-    assert_build_dir_layout(p.root().join("target"), "debug");
-    assert_exists(&p.root().join(format!("target/debug/foo{EXE_SUFFIX}")));
-    assert_exists(&p.root().join("target/debug/foo.d"));
-    assert_not_exists(&p.root().join("build-dir"));
-}
-
-#[cargo_test]
 fn binary_with_debug() {
     let p = project()
         .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
@@ -54,10 +30,7 @@ fn binary_with_debug() {
         )
         .build();
 
-    p.cargo("build -Z build-dir")
-        .masquerade_as_nightly_cargo(&["build-dir"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("build").enable_mac_dsym().run();
 
     assert_build_dir_layout(p.root().join("build-dir"), "debug");
     assert_artifact_dir_layout(p.root().join("target-dir"), "debug");
@@ -89,10 +62,7 @@ fn binary_with_release() {
         )
         .build();
 
-    p.cargo("build --release -Z build-dir")
-        .masquerade_as_nightly_cargo(&["build-dir"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("build --release").enable_mac_dsym().run();
 
     assert_build_dir_layout(p.root().join("build-dir"), "release");
     assert_exists(&p.root().join(format!("target-dir/release/foo{EXE_SUFFIX}")));
@@ -173,10 +143,7 @@ fn libs() {
             )
             .build();
 
-        p.cargo("build -Z build-dir")
-            .masquerade_as_nightly_cargo(&["build-dir"])
-            .enable_mac_dsym()
-            .run();
+        p.cargo("build").enable_mac_dsym().run();
 
         assert_build_dir_layout(p.root().join("build-dir"), "debug");
 
@@ -191,10 +158,7 @@ fn should_default_to_target() {
         .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
         .build();
 
-    p.cargo("build -Z build-dir")
-        .masquerade_as_nightly_cargo(&["build-dir"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("build").enable_mac_dsym().run();
 
     assert_build_dir_layout(p.root().join("target"), "debug");
     assert_exists(&p.root().join(format!("target/debug/foo{EXE_SUFFIX}")));
@@ -206,8 +170,7 @@ fn should_respect_env_var() {
         .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
         .build();
 
-    p.cargo("build -Z build-dir")
-        .masquerade_as_nightly_cargo(&["build-dir"])
+    p.cargo("build")
         .env("CARGO_BUILD_BUILD_DIR", "build-dir")
         .enable_mac_dsym()
         .run();
@@ -242,10 +205,7 @@ fn build_script_should_output_to_build_dir() {
         )
         .build();
 
-    p.cargo("build -Z build-dir")
-        .masquerade_as_nightly_cargo(&["build-dir"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("build").enable_mac_dsym().run();
 
     assert_build_dir_layout(p.root().join("build-dir"), "debug");
     assert_exists_patterns_with_base_dir(
@@ -284,10 +244,7 @@ fn cargo_tmpdir_should_output_to_build_dir() {
         )
         .build();
 
-    p.cargo("test -Z build-dir")
-        .masquerade_as_nightly_cargo(&["build-dir"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("test").enable_mac_dsym().run();
 
     assert_build_dir_layout(p.root().join("build-dir"), "debug");
     assert_exists(&p.root().join(format!("build-dir/tmp/foo.txt")));
@@ -308,10 +265,7 @@ fn examples_should_output_to_build_dir_and_uplift_to_target_dir() {
         )
         .build();
 
-    p.cargo("build --examples -Z build-dir")
-        .masquerade_as_nightly_cargo(&["build-dir"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("build --examples").enable_mac_dsym().run();
 
     assert_build_dir_layout(p.root().join("build-dir"), "debug");
     assert_exists_patterns_with_base_dir(
@@ -342,10 +296,7 @@ fn benches_should_output_to_build_dir() {
         )
         .build();
 
-    p.cargo("build --bench=foo -Z build-dir")
-        .masquerade_as_nightly_cargo(&["build-dir"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("build --bench=foo").enable_mac_dsym().run();
 
     assert_build_dir_layout(p.root().join("build-dir"), "debug");
     assert_exists_patterns_with_base_dir(
@@ -371,10 +322,7 @@ fn cargo_doc_should_output_to_target_dir() {
         )
         .build();
 
-    p.cargo("doc -Z build-dir")
-        .masquerade_as_nightly_cargo(&["build-dir"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("doc").enable_mac_dsym().run();
 
     let docs_dir = p.root().join("target-dir/doc");
 
@@ -396,10 +344,7 @@ fn cargo_package_should_build_in_build_dir_and_output_to_target_dir() {
         )
         .build();
 
-    p.cargo("package -Z build-dir")
-        .masquerade_as_nightly_cargo(&["build-dir"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("package").enable_mac_dsym().run();
 
     assert_build_dir_layout(p.root().join("build-dir"), "debug");
 
@@ -428,17 +373,11 @@ fn cargo_clean_should_clean_the_target_dir_and_build_dir() {
         )
         .build();
 
-    p.cargo("build -Z build-dir")
-        .masquerade_as_nightly_cargo(&["build-dir"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("build").enable_mac_dsym().run();
 
     assert_build_dir_layout(p.root().join("build-dir"), "debug");
 
-    p.cargo("clean -Z build-dir")
-        .masquerade_as_nightly_cargo(&["build-dir"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("clean").enable_mac_dsym().run();
 
     assert_not_exists(&p.root().join("build-dir"));
     assert_not_exists(&p.root().join("target-dir"));
@@ -458,10 +397,7 @@ fn timings_report_should_output_to_target_dir() {
         )
         .build();
 
-    p.cargo("build --timings -Z build-dir")
-        .masquerade_as_nightly_cargo(&["build-dir"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("build --timings").enable_mac_dsym().run();
 
     assert_exists(&p.root().join("target-dir/cargo-timings/cargo-timing.html"));
 }
@@ -483,8 +419,7 @@ fn future_incompat_should_output_to_build_dir() {
         )
         .build();
 
-    p.cargo("build -Z build-dir")
-        .masquerade_as_nightly_cargo(&["build-dir"])
+    p.cargo("build")
         .arg("--future-incompat-report")
         .env("RUSTFLAGS", "-Zfuture-incompat-test")
         .run();
@@ -506,8 +441,7 @@ fn template_should_error_for_invalid_variables() {
         )
         .build();
 
-    p.cargo("build -Z build-dir")
-        .masquerade_as_nightly_cargo(&["build-dir"])
+    p.cargo("build")
         .enable_mac_dsym()
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -532,8 +466,7 @@ fn template_should_suggest_nearest_variable() {
         )
         .build();
 
-    p.cargo("build -Z build-dir")
-        .masquerade_as_nightly_cargo(&["build-dir"])
+    p.cargo("build")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] unexpected variable `workspace-ro` in build.build-dir path `{workspace-ro}/build-dir`
@@ -558,10 +491,7 @@ fn template_workspace_root() {
         )
         .build();
 
-    p.cargo("build -Z build-dir")
-        .masquerade_as_nightly_cargo(&["build-dir"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("build").enable_mac_dsym().run();
 
     assert_build_dir_layout(p.root().join("build-dir"), "debug");
     assert_artifact_dir_layout(p.root().join("target-dir"), "debug");
@@ -584,10 +514,7 @@ fn template_cargo_cache_home() {
         )
         .build();
 
-    p.cargo("build -Z build-dir")
-        .masquerade_as_nightly_cargo(&["build-dir"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("build").enable_mac_dsym().run();
 
     assert_build_dir_layout(paths::home().join(".cargo/build-dir"), "debug");
     assert_artifact_dir_layout(p.root().join("target-dir"), "debug");
@@ -620,10 +547,7 @@ fn template_workspace_path_hash() {
         )
         .build();
 
-    p.cargo("build -Z build-dir")
-        .masquerade_as_nightly_cargo(&["build-dir"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("build").enable_mac_dsym().run();
 
     let foo_dir = p.root().join("foo");
     assert_exists(&foo_dir);
@@ -670,10 +594,7 @@ fn template_workspace_path_hash_should_handle_symlink() {
         .build();
 
     // Build from the non-symlinked directory
-    p.cargo("check -Z build-dir")
-        .masquerade_as_nightly_cargo(&["build-dir"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("check").enable_mac_dsym().run();
 
     // Parse and verify the hash dir created from the non-symlinked dir
     let foo_dir = p.root().join("foo");
@@ -691,11 +612,7 @@ fn template_workspace_path_hash_should_handle_symlink() {
     foo_dir.rm_rf();
 
     // Run cargo from the symlinked dir
-    p.cargo("check -Z build-dir")
-        .cwd(&symlinked_dir)
-        .masquerade_as_nightly_cargo(&["build-dir"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("check").cwd(&symlinked_dir).enable_mac_dsym().run();
 
     // Parse and verify the hash created from the symlinked dir
     assert_exists(&foo_dir);
@@ -725,8 +642,7 @@ fn template_should_handle_reject_unmatched_brackets() {
         )
         .build();
 
-    p.cargo("build -Z build-dir")
-        .masquerade_as_nightly_cargo(&["build-dir"])
+    p.cargo("build")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] unexpected opening bracket `{` in build.build-dir path `foo/{bar`
@@ -745,8 +661,7 @@ fn template_should_handle_reject_unmatched_brackets() {
         )
         .build();
 
-    p.cargo("build -Z build-dir")
-        .masquerade_as_nightly_cargo(&["build-dir"])
+    p.cargo("build")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] unexpected closing bracket `}` in build.build-dir path `foo/}bar`

--- a/tests/testsuite/build_scripts_multiple.rs
+++ b/tests/testsuite/build_scripts_multiple.rs
@@ -170,6 +170,7 @@ fn multiple_build_scripts_metadata() {
     "root": "path+[ROOTURL]/foo#0.1.0"
   },
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo#0.1.0"

--- a/tests/testsuite/cargo/z_help/stdout.term.svg
+++ b/tests/testsuite/cargo/z_help/stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="1255px" height="884px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1255px" height="866px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -30,87 +30,85 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>    -Z bindeps                     Allow Cargo packages to depend on bin, cdylib, and staticlib crates, and use the artifacts built by those crates</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>    -Z build-dir                   Enable the `build.build-dir` option in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="154px"><tspan>    -Z build-std                   Enable Cargo to compile the standard library itself as part of a crate graph compilation</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>    -Z build-std                   Enable Cargo to compile the standard library itself as part of a crate graph compilation</tspan>
+    <tspan x="10px" y="172px"><tspan>    -Z build-std-features          Configure features enabled for the standard library itself when building the standard library</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>    -Z build-std-features          Configure features enabled for the standard library itself when building the standard library</tspan>
+    <tspan x="10px" y="190px"><tspan>    -Z cargo-lints                 Enable the `[lints.cargo]` table</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>    -Z cargo-lints                 Enable the `[lints.cargo]` table</tspan>
+    <tspan x="10px" y="208px"><tspan>    -Z checksum-freshness          Use a checksum to determine if output is fresh rather than filesystem mtime</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>    -Z checksum-freshness          Use a checksum to determine if output is fresh rather than filesystem mtime</tspan>
+    <tspan x="10px" y="226px"><tspan>    -Z codegen-backend             Enable the `codegen-backend` option in profiles in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>    -Z codegen-backend             Enable the `codegen-backend` option in profiles in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="244px"><tspan>    -Z config-include              Enable the `include` key in config files</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>    -Z config-include              Enable the `include` key in config files</tspan>
+    <tspan x="10px" y="262px"><tspan>    -Z direct-minimal-versions     Resolve minimal dependency versions instead of maximum (direct dependencies only)</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>    -Z direct-minimal-versions     Resolve minimal dependency versions instead of maximum (direct dependencies only)</tspan>
+    <tspan x="10px" y="280px"><tspan>    -Z dual-proc-macros            Build proc-macros for both the host and the target</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>    -Z dual-proc-macros            Build proc-macros for both the host and the target</tspan>
+    <tspan x="10px" y="298px"><tspan>    -Z feature-unification         Enable new feature unification modes in workspaces</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>    -Z feature-unification         Enable new feature unification modes in workspaces</tspan>
+    <tspan x="10px" y="316px"><tspan>    -Z fix-edition                 Permanently unstable edition migration helper</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>    -Z fix-edition                 Permanently unstable edition migration helper</tspan>
+    <tspan x="10px" y="334px"><tspan>    -Z gc                          Track cache usage and "garbage collect" unused files</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>    -Z gc                          Track cache usage and "garbage collect" unused files</tspan>
+    <tspan x="10px" y="352px"><tspan>    -Z git                         Enable support for shallow git fetch operations</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>    -Z git                         Enable support for shallow git fetch operations</tspan>
+    <tspan x="10px" y="370px"><tspan>    -Z gitoxide                    Use gitoxide for the given git interactions, or all of them if no argument is given</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>    -Z gitoxide                    Use gitoxide for the given git interactions, or all of them if no argument is given</tspan>
+    <tspan x="10px" y="388px"><tspan>    -Z host-config                 Enable the `[host]` section in the .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>    -Z host-config                 Enable the `[host]` section in the .cargo/config.toml file</tspan>
+    <tspan x="10px" y="406px"><tspan>    -Z minimal-versions            Resolve minimal dependency versions instead of maximum</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>    -Z minimal-versions            Resolve minimal dependency versions instead of maximum</tspan>
+    <tspan x="10px" y="424px"><tspan>    -Z msrv-policy                 Enable rust-version aware policy within cargo</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>    -Z msrv-policy                 Enable rust-version aware policy within cargo</tspan>
+    <tspan x="10px" y="442px"><tspan>    -Z mtime-on-use                Configure Cargo to update the mtime of used files</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>    -Z mtime-on-use                Configure Cargo to update the mtime of used files</tspan>
+    <tspan x="10px" y="460px"><tspan>    -Z no-embed-metadata           Avoid embedding metadata in library artifacts</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>    -Z no-embed-metadata           Avoid embedding metadata in library artifacts</tspan>
+    <tspan x="10px" y="478px"><tspan>    -Z no-index-update             Do not update the registry index even if the cache is outdated</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>    -Z no-index-update             Do not update the registry index even if the cache is outdated</tspan>
+    <tspan x="10px" y="496px"><tspan>    -Z panic-abort-tests           Enable support to run tests with -Cpanic=abort</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>    -Z panic-abort-tests           Enable support to run tests with -Cpanic=abort</tspan>
+    <tspan x="10px" y="514px"><tspan>    -Z profile-hint-mostly-unused  Enable the `hint-mostly-unused` setting in profiles to mark a crate as mostly unused.</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>    -Z profile-hint-mostly-unused  Enable the `hint-mostly-unused` setting in profiles to mark a crate as mostly unused.</tspan>
+    <tspan x="10px" y="532px"><tspan>    -Z profile-rustflags           Enable the `rustflags` option in profiles in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>    -Z profile-rustflags           Enable the `rustflags` option in profiles in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="550px"><tspan>    -Z public-dependency           Respect a dependency's `public` field in Cargo.toml to control public/private dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>    -Z public-dependency           Respect a dependency's `public` field in Cargo.toml to control public/private dependencies</tspan>
+    <tspan x="10px" y="568px"><tspan>    -Z publish-timeout             Enable the `publish.timeout` key in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>    -Z publish-timeout             Enable the `publish.timeout` key in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="586px"><tspan>    -Z root-dir                    Set the root directory relative to which paths are printed (defaults to workspace root)</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>    -Z root-dir                    Set the root directory relative to which paths are printed (defaults to workspace root)</tspan>
+    <tspan x="10px" y="604px"><tspan>    -Z rustdoc-depinfo             Use dep-info files in rustdoc rebuild detection</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>    -Z rustdoc-depinfo             Use dep-info files in rustdoc rebuild detection</tspan>
+    <tspan x="10px" y="622px"><tspan>    -Z rustdoc-map                 Allow passing external documentation mappings to rustdoc</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>    -Z rustdoc-map                 Allow passing external documentation mappings to rustdoc</tspan>
+    <tspan x="10px" y="640px"><tspan>    -Z rustdoc-scrape-examples     Allows Rustdoc to scrape code examples from reverse-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>    -Z rustdoc-scrape-examples     Allows Rustdoc to scrape code examples from reverse-dependencies</tspan>
+    <tspan x="10px" y="658px"><tspan>    -Z sbom                        Enable the `sbom` option in build config in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan>    -Z sbom                        Enable the `sbom` option in build config in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="676px"><tspan>    -Z script                      Enable support for single-file, `.rs` packages</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan>    -Z script                      Enable support for single-file, `.rs` packages</tspan>
+    <tspan x="10px" y="694px"><tspan>    -Z section-timings             Enable support for extended compilation sections in --timings output</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>    -Z section-timings             Enable support for extended compilation sections in --timings output</tspan>
+    <tspan x="10px" y="712px"><tspan>    -Z target-applies-to-host      Enable the `target-applies-to-host` key in the .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>    -Z target-applies-to-host      Enable the `target-applies-to-host` key in the .cargo/config.toml file</tspan>
+    <tspan x="10px" y="730px"><tspan>    -Z trim-paths                  Enable the `trim-paths` option in profiles</tspan>
 </tspan>
-    <tspan x="10px" y="748px"><tspan>    -Z trim-paths                  Enable the `trim-paths` option in profiles</tspan>
+    <tspan x="10px" y="748px"><tspan>    -Z unstable-options            Allow the usage of unstable options</tspan>
 </tspan>
-    <tspan x="10px" y="766px"><tspan>    -Z unstable-options            Allow the usage of unstable options</tspan>
+    <tspan x="10px" y="766px"><tspan>    -Z warnings                    Allow use of the build.warnings config key</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan>    -Z warnings                    Allow use of the build.warnings config key</tspan>
+    <tspan x="10px" y="784px">
 </tspan>
-    <tspan x="10px" y="802px">
+    <tspan x="10px" y="802px"><tspan>Run with `cargo -Z [FLAG] [COMMAND]`</tspan>
 </tspan>
-    <tspan x="10px" y="820px"><tspan>Run with `cargo -Z [FLAG] [COMMAND]`</tspan>
+    <tspan x="10px" y="820px">
 </tspan>
-    <tspan x="10px" y="838px">
+    <tspan x="10px" y="838px"><tspan>See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html for more information about these flags.</tspan>
 </tspan>
-    <tspan x="10px" y="856px"><tspan>See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html for more information about these flags.</tspan>
-</tspan>
-    <tspan x="10px" y="874px">
+    <tspan x="10px" y="856px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -206,7 +206,6 @@ fn wrong_kind_of_feature() {
 Caused by:
   unknown Cargo.toml feature `build-dir`
 
-  This feature can be enabled via -Zbuild-dir or the `[unstable]` section in config.toml.
   See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html for more information.
 
 "#]])

--- a/tests/testsuite/features_namespaced.rs
+++ b/tests/testsuite/features_namespaced.rs
@@ -635,6 +635,7 @@ fn json_exposed() {
   ],
   "resolve": null,
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo#0.1.0"

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -3647,6 +3647,7 @@ fn metadata_master_consistency() {
                 "root": "[..]foo#0.1.0"
               },
               "target_directory": "[..]",
+              "build_directory": "[..]",
               "version": 1,
               "workspace_root": "[..]",
               "metadata": null

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -77,6 +77,7 @@ fn cargo_metadata_simple() {
     "root": "path+[ROOTURL]/foo#0.5.0"
   },
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo#0.5.0"
@@ -190,6 +191,7 @@ crate-type = ["lib", "staticlib"]
     "root": "path+[ROOTURL]/foo#0.5.0"
   },
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo#0.5.0"
@@ -293,6 +295,7 @@ optional_feat = []
     "root": "path+[ROOTURL]/foo#0.5.0"
   },
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo#0.5.0"
@@ -612,6 +615,7 @@ fn cargo_metadata_with_deps_and_version() {
     "root": "path+[ROOTURL]/foo#0.5.0"
   },
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo#0.5.0"
@@ -919,6 +923,7 @@ name = "ex"
     "root": "path+[ROOTURL]/foo#0.1.0"
   },
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo#0.1.0"
@@ -1028,6 +1033,7 @@ crate-type = ["rlib", "dylib"]
     "root": "path+[ROOTURL]/foo#0.1.0"
   },
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo#0.1.0"
@@ -1188,6 +1194,7 @@ fn workspace_metadata() {
     "root": null
   },
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo/bar#0.5.0",
@@ -1410,6 +1417,7 @@ fn workspace_metadata_with_dependencies_no_deps() {
   ],
   "resolve": null,
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo/bar#0.5.0",
@@ -2044,6 +2052,7 @@ fn workspace_metadata_with_dependencies_and_resolve() {
     "root": null
   },
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo/bar#0.5.0",
@@ -2284,6 +2293,7 @@ fn cargo_metadata_no_deps_path_to_cargo_toml_relative() {
   ],
   "resolve": null,
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo#0.5.0"
@@ -2360,6 +2370,7 @@ fn cargo_metadata_no_deps_path_to_cargo_toml_absolute() {
   ],
   "resolve": null,
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo#0.5.0"
@@ -2469,6 +2480,7 @@ fn cargo_metadata_no_deps_cwd() {
   ],
   "resolve": null,
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo#0.5.0"
@@ -2609,6 +2621,7 @@ fn package_metadata() {
   ],
   "resolve": null,
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo#0.1.0"
@@ -2703,6 +2716,7 @@ fn package_publish() {
   ],
   "resolve": null,
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo#0.1.0"
@@ -2800,6 +2814,7 @@ fn cargo_metadata_path_to_cargo_toml_project() {
     "root": "path+[ROOTURL]/foo/target/package/bar-0.5.0#bar@0.5.0"
   },
   "target_directory": "[ROOT]/foo/target/package/bar-0.5.0/target",
+  "build_directory": "[ROOT]/foo/target/package/bar-0.5.0/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo/target/package/bar-0.5.0#bar@0.5.0"
@@ -2892,6 +2907,7 @@ fn package_edition_2018() {
     "root": "path+[ROOTURL]/foo#0.1.0"
   },
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo#0.1.0"
@@ -3044,6 +3060,7 @@ fn target_edition_2018() {
     "root": "path+[ROOTURL]/foo#0.1.0"
   },
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo#0.1.0"
@@ -3284,6 +3301,7 @@ fn rename_dependency() {
     "root": "path+[ROOTURL]/foo#0.0.1"
   },
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo#0.0.1"
@@ -3389,6 +3407,7 @@ fn metadata_links() {
     "root": "path+[ROOTURL]/foo#0.5.0"
   },
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo#0.5.0"
@@ -3496,6 +3515,7 @@ fn deps_with_bin_only() {
     "root": "path+[ROOTURL]/foo#0.1.0"
   },
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo#0.1.0"
@@ -4160,6 +4180,7 @@ fn dep_kinds() {
     "root": "path+[ROOTURL]/foo#0.1.0"
   },
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo#0.1.0"
@@ -4277,6 +4298,7 @@ fn dep_kinds_workspace() {
     "root": "path+[ROOTURL]/foo#0.1.0"
   },
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo#0.1.0"
@@ -4307,16 +4329,15 @@ fn build_dir() {
         )
         .build();
 
-    p.cargo("metadata -Z build-dir")
-        .masquerade_as_nightly_cargo(&["build-dir"])
+    p.cargo("metadata")
         .with_stdout_data(
             str![[r#"
 {
-  "build_directory": "[ROOT]/foo/build-dir",
   "metadata": null,
   "packages": "{...}",
   "resolve": "{...}",
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/build-dir",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo#0.0.1"
@@ -4581,6 +4602,7 @@ fn workspace_metadata_with_dependencies_no_deps_artifact() {
   ],
   "resolve": null,
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo/bar#0.5.0",
@@ -4866,6 +4888,7 @@ fn versionless_packages() {
     "root": null
   },
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo/bar#0.0.0",
@@ -4978,6 +5001,7 @@ local-time = 1979-05-27
     "root": "path+[ROOTURL]/foo#0.0.0"
   },
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo#0.0.0"

--- a/tests/testsuite/pkgid.rs
+++ b/tests/testsuite/pkgid.rs
@@ -389,6 +389,7 @@ fn pkgid_json_message_metadata_consistency() {
     "root": "path+[ROOTURL]/foo#0.5.0"
   },
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo#0.5.0"

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -1534,6 +1534,7 @@ fn cmd_metadata_with_embedded() {
     "root": "path+[ROOTURL]/foo/script.rs#script@0.0.0"
   },
   "target_directory": "[ROOT]/home/.cargo/target/[HASH]",
+  "build_directory": "[ROOT]/home/.cargo/target/[HASH]",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo/script.rs#script@0.0.0"

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -827,6 +827,7 @@ fn update_precise_first_run() {
     "root": "path+[ROOTURL]/foo#bar@0.0.1"
   },
   "target_directory": "[ROOT]/foo/target",
+  "build_directory": "[ROOT]/foo/target",
   "version": 1,
   "workspace_default_members": [
     "path+[ROOTURL]/foo#bar@0.0.1"


### PR DESCRIPTION
This PR stabilizes `build.build-dir` which moves intermediate build artifacts out of `target-dir`.


* Tracking issue: #14125
  * Call for testing: https://github.com/rust-lang/cargo/issues/14125#issuecomment-3029073591
  * FCP: https://github.com/rust-lang/cargo/issues/14125#issuecomment-3029073904
* Implementation: https://github.com/rust-lang/cargo/pull/15104



Closes #14125