### PR TITLE
make resolve features public for cargo-as-a-library

### DIFF
--- a/src/cargo/core/resolver/features.rs
+++ b/src/cargo/core/resolver/features.rs
@@ -52,18 +52,18 @@ use std::rc::Rc;
 
 /// The key used in various places to store features for a particular dependency.
 /// The actual discrimination happens with the [`FeaturesFor`] type.
-type PackageFeaturesKey = (PackageId, FeaturesFor);
+pub type PackageFeaturesKey = (PackageId, FeaturesFor);
 /// Map of activated features.
-type ActivateMap = HashMap<PackageFeaturesKey, BTreeSet<InternedString>>;
+pub type ActivateMap = HashMap<PackageFeaturesKey, BTreeSet<InternedString>>;
 
 /// Set of all activated features for all packages in the resolve graph.
 pub struct ResolvedFeatures {
-    activated_features: ActivateMap,
+    pub activated_features: ActivateMap,
     /// Optional dependencies that should be built.
     ///
     /// The value is the `name_in_toml` of the dependencies.
-    activated_dependencies: ActivateMap,
-    opts: FeatureOpts,
+    pub activated_dependencies: ActivateMap,
+    pub opts: FeatureOpts,
 }
 
 /// Options for how the feature resolver works.


### PR DESCRIPTION
### What does this PR try to resolve?

While working on a [plumbing command](https://github.com/crate-ci/cargo-plumbing) for feature resolution, I hit a dead end where the fields and types are private. This PR changes the needed things into `pub`.

r? @epage 

### How to test and review this PR?

`cargo check`