### PR TITLE
Reorder `lto` options in profiles.md

### DIFF
--- a/src/doc/src/reference/profiles.md
+++ b/src/doc/src/reference/profiles.md
@@ -166,7 +166,7 @@ The `lto` setting controls `rustc`'s [`-C lto`], [`-C linker-plugin-lto`], and
 LTO can produce better optimized code, using whole-program analysis, at the cost
 of longer linking time.
 
-The valid options are:
+The valid options from most to least optimizing are:
 
 * `true` or `"fat"`: Performs "fat" LTO which attempts to perform
   optimizations across all crates within the dependency graph.


### PR DESCRIPTION
Aside from `false`, the `lto` options seem to be ordered from "most optimizing" to "least optimizing".

If this interpretation is correct, then I think `false` should go between `thin` and `off`.

cc: @ehuss (who I think wrote that text)