### PR TITLE
Fixes error while running the cargo clippy --all-targets -- -D warning

### DIFF
--- a/tests/testsuite/cargo_add/git_branch/mod.rs
+++ b/tests/testsuite/cargo_add/git_branch/mod.rs
@@ -21,7 +21,7 @@ fn case() {
             .file("src/lib.rs", "")
     });
     let branch = "dev";
-    let find_head = || (git_repo.head().unwrap().peel_to_commit().unwrap());
+    let find_head = || git_repo.head().unwrap().peel_to_commit().unwrap();
     git_repo.branch(branch, &find_head(), false).unwrap();
     let git_url = git_dep.url().to_string();
 

--- a/tests/testsuite/cargo_add/git_rev/mod.rs
+++ b/tests/testsuite/cargo_add/git_rev/mod.rs
@@ -20,7 +20,7 @@ fn case() {
             )
             .file("src/lib.rs", "")
     });
-    let find_head = || (git_repo.head().unwrap().peel_to_commit().unwrap());
+    let find_head = || git_repo.head().unwrap().peel_to_commit().unwrap();
     let head = find_head().id().to_string();
     let git_url = git_dep.url().to_string();
 


### PR DESCRIPTION
This PR fixes this #15842

Before -:

<img width="895" height="701" alt="Screenshot From 2025-08-16 01-15-35" src="https://github.com/user-attachments/assets/5e8daca4-5fad-4fc7-bb12-f67288061704" />


After the fix-:

<img width="831" height="107" alt="Screenshot From 2025-08-16 01-28-50" src="https://github.com/user-attachments/assets/eb03c852-69a0-44a3-9562-f8a99dae4033" />
