### PR TITLE
chore: downgrade to libc@0.2.174

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2779,9 +2779,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libgit2-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ itertools = "0.14.0"
 jiff = { version = "0.2.15", default-features = false, features = [ "std" ] }
 jobserver = "0.1.33"
 lazycell = "1.3.0"
-libc = "0.2.175"
+libc = "0.2.174" # Please ensure in lockfile it stays as 0.2.174 until bytecodealliance/rustix#1496 resolved
 libgit2-sys = "0.18.2"
 libloading = "0.8.8"
 memchr = "2.7.5"


### PR DESCRIPTION
### What does this PR try to resolve?

There is incompatibility between rustix@1.0.8 and libc@0.2.175 that leads to compilation errors.

See

* https://github.com/bytecodealliance/rustix/issues/1496
* https://github.com/rust-lang/rust/pull/145478#issuecomment-3193494156

### How to test and review this PR?

In rust-lang/rust, update the `src/tools/cargo` submodule accordingly, and run

```
cargo run --manifest-path src/ci/citool/Cargo.toml run-local dist-loongarch64-musl
```

With this downgrade it should compile.