### PR TITLE
docs(profile): revert wrong statement of lto options' optimization

### DIFF
--- a/src/doc/src/reference/profiles.md
+++ b/src/doc/src/reference/profiles.md
@@ -166,7 +166,7 @@ The `lto` setting controls `rustc`'s [`-C lto`], [`-C linker-plugin-lto`], and
 LTO can produce better optimized code, using whole-program analysis, at the cost
 of longer linking time.
 
-The valid options from most to least optimizing are:
+The valid options are:
 
 * `true` or `"fat"`: Performs "fat" LTO which attempts to perform
   optimizations across all crates within the dependency graph.


### PR DESCRIPTION
There is no clear winner between fat LTO and ThinLTO, so don't say "from most to least optimizing" here.

See https://github.com/rust-lang/cargo/pull/15841#discussion_r2281037386