### PR TITLE
new/init: default git branch to 'main'; update tests and Dockerfiles

### DIFF
--- a/crates/cargo-test-support/containers/apache/Dockerfile
+++ b/crates/cargo-test-support/containers/apache/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /repos/bar
 RUN git config --global user.email "testuser@example.com" &&\
     git config --global user.name "Test User" &&\
     git config --system --add safe.directory '*' &&\
-    git init -b master . &&\
+    git init -b main . &&\
     git add Cargo.toml src &&\
     git commit -m "Initial commit" &&\
     cd .. &&\

--- a/crates/cargo-test-support/containers/sshd/Dockerfile
+++ b/crates/cargo-test-support/containers/sshd/Dockerfile
@@ -14,7 +14,7 @@ USER testuser
 WORKDIR /repos/bar
 RUN git config --global user.email "testuser@example.com" &&\
     git config --global user.name "Test User" &&\
-    git init -b master . &&\
+    git init -b main . &&\
     git add Cargo.toml src &&\
     git commit -m "Initial commit" &&\
     cd .. &&\

--- a/src/cargo/util/vcs.rs
+++ b/src/cargo/util/vcs.rs
@@ -32,7 +32,11 @@ pub struct FossilRepo;
 
 impl GitRepo {
     pub fn init(path: &Path, _: &Path) -> CargoResult<GitRepo> {
-        git2::Repository::init(path)?;
+        // Initialize Git repository with "main" as the default branch,
+        // regardless of the user's global git configuration.
+        let mut opts = git2::RepositoryInitOptions::new();
+        opts.initial_head("main");
+        git2::Repository::init_opts(path, &opts)?;
         Ok(GitRepo)
     }
     pub fn discover(path: &Path, _: &Path) -> Result<git2::Repository, git2::Error> {

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -15,13 +15,13 @@ fn create_default_gitconfig() {
     File::create(gitconfig).unwrap();
 
     // If we're running this under a user account that has a different default branch set up
-    // then tests that assume the default branch is master will fail. We set the default branch
-    // to master explicitly so that tests that rely on this behavior still pass.
+    // then tests that assume the default branch is main will fail. We set the default branch
+    // to main explicitly so that tests that rely on this behavior still pass.
     fs::write(
         paths::home().join(".gitconfig"),
         r#"
         [init]
-            defaultBranch = master
+            defaultBranch = main
         "#,
     )
     .unwrap();
@@ -536,7 +536,7 @@ fn git_default_branch() {
     cargo_process("new foo").run();
     let repo = git2::Repository::open(paths::root().join("foo")).unwrap();
     let head = repo.find_reference("HEAD").unwrap();
-    assert_eq!(head.symbolic_target().unwrap(), "refs/heads/master");
+    assert_eq!(head.symbolic_target().unwrap(), "refs/heads/main");
 
     fs::write(
         paths::home().join(".gitconfig"),
@@ -549,7 +549,7 @@ fn git_default_branch() {
     cargo_process("new bar").run();
     let repo = git2::Repository::open(paths::root().join("bar")).unwrap();
     let head = repo.find_reference("HEAD").unwrap();
-    assert_eq!(head.symbolic_target().unwrap(), "refs/heads/hello");
+    assert_eq!(head.symbolic_target().unwrap(), "refs/heads/main");
 }
 
 #[cargo_test]


### PR DESCRIPTION
### Summary
- **Change**: `cargo new`/`cargo init` initializes Git repos with `main` as the default branch.
- **Update**: Tests and test Dockerfiles adjusted to match the new default.

### Motivation
- **Consistency**: Stable behavior regardless of user `init.defaultBranch`.
- **Convention**: Align with current industry standard and inclusive naming.

### Behavior change
- **Before**: Default branch could be `master` or follow user Git config.
- **After**: Always `main` for repos initialized by Cargo. Existing repos unaffected.

### Implementation details
- **Core**: Set libgit2 `RepositoryInitOptions::initial_head("main")` in `GitRepo::init`.
- **Files**:
  - `src/cargo/util/vcs.rs`
  - `tests/testsuite/new.rs`
  - `crates/cargo-test-support/containers/apache/Dockerfile`
  - `crates/cargo-test-support/containers/sshd/Dockerfile`

### Tests
- **Adjusted**: `tests/testsuite/new.rs` expects `refs/heads/main`.
- **Infra**: Test Dockerfiles use `git init -b main`.

### Backwards compatibility
- **Scope**: Only affects newly created repos via `cargo new`/`cargo init`.
- **Note**: Scripts assuming `master` on fresh repos should be updated.

### How to verify
```bash
cargo new foo
git -C foo symbolic-ref HEAD  # expects: refs/heads/main
```

### Alternatives considered
- **Respect `init.defaultBranch`**: Rejected to ensure deterministic behavior across environments and CI.
- **Config override**: Could be added later if configurability is desired.

### Release notes
- Changed: `cargo new`/`cargo init` now create Git repositories with `main` as the default branch.

### Checklist
- [x] Code updated
- [x] Tests updated
- [x] Test Dockerfiles updated
- [ ] Documentation (can update if there’s a canonical place describing default branch behavior)