### PR TITLE
make `UnitGenerator` public in cargo-as-a-library

### DIFF
--- a/src/cargo/ops/cargo_compile/mod.rs
+++ b/src/cargo/ops/cargo_compile/mod.rs
@@ -60,7 +60,7 @@ use crate::util::{CargoResult, StableHasher};
 mod compile_filter;
 pub use compile_filter::{CompileFilter, FilterRule, LibRule};
 
-mod unit_generator;
+pub(super) mod unit_generator;
 use unit_generator::UnitGenerator;
 
 mod packages;

--- a/src/cargo/ops/cargo_compile/unit_generator.rs
+++ b/src/cargo/ops/cargo_compile/unit_generator.rs
@@ -46,7 +46,7 @@ struct Proposal<'a> {
 /// [`generate_root_units`]: UnitGenerator::generate_root_units
 /// [`build_unit_dependencies`]: crate::core::compiler::unit_dependencies::build_unit_dependencies
 /// [`UnitGraph`]: crate::core::compiler::unit_graph::UnitGraph
-pub(super) struct UnitGenerator<'a, 'gctx> {
+pub struct UnitGenerator<'a, 'gctx> {
     pub ws: &'a Workspace<'gctx>,
     pub packages: &'a [&'a Package],
     pub spec: &'a Packages,

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -1,6 +1,7 @@
 use crate::sources::CRATES_IO_DOMAIN;
 
 pub use self::cargo_clean::{CleanContext, CleanOptions, clean};
+pub use self::cargo_compile::unit_generator::UnitGenerator;
 pub use self::cargo_compile::{CompileFilter, FilterRule, LibRule, Packages};
 pub use self::cargo_compile::{
     CompileOptions, compile, compile_with_exec, compile_ws, create_bcx, print, resolve_all_features,


### PR DESCRIPTION
### What does this PR try to resolve?

This PR makes `UnitGenerator` public for experimenting with unit graph generation in cargo plumbing commands.

See https://github.com/crate-ci/cargo-plumbing/issues/39

### How to test and review this PR?

Verify that `UnitGenerator` is available when using cargo-as-a-library