### PR TITLE
 test: avoid hardcoded target spec json

### DIFF
--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -20,7 +20,13 @@
 
 #![allow(clippy::disallowed_methods)]
 
-use cargo_test_support::{Execs, basic_manifest, paths, project, rustc_host, str};
+use cargo_test_support::Execs;
+use cargo_test_support::basic_manifest;
+use cargo_test_support::paths;
+use cargo_test_support::project;
+use cargo_test_support::rustc_host;
+use cargo_test_support::str;
+use cargo_test_support::target_spec_json;
 use cargo_test_support::{Project, prelude::*};
 use std::env;
 use std::path::{Path, PathBuf};
@@ -262,20 +268,7 @@ fn cross_custom() {
         )
         .file("dep/Cargo.toml", &basic_manifest("dep", "0.1.0"))
         .file("dep/src/lib.rs", "#![no_std] pub fn answer() -> u32 { 42 }")
-        .file(
-            "custom-target.json",
-            r#"
-            {
-                "llvm-target": "x86_64-unknown-none-gnu",
-                "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
-                "arch": "x86_64",
-                "target-endian": "little",
-                "target-pointer-width": "64",
-                "os": "none",
-                "linker-flavor": "ld.lld"
-            }
-            "#,
-        )
+        .file("custom-target.json", target_spec_json())
         .build();
 
     p.cargo("build --target custom-target.json -v")
@@ -302,23 +295,7 @@ fn custom_test_framework() {
             }
             "#,
         )
-        .file(
-            "target.json",
-            r#"
-            {
-                "llvm-target": "x86_64-unknown-none-gnu",
-                "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
-                "arch": "x86_64",
-                "target-endian": "little",
-                "target-pointer-width": "64",
-                "os": "none",
-                "linker-flavor": "ld.lld",
-                "linker": "rust-lld",
-                "executables": true,
-                "panic-strategy": "abort"
-            }
-            "#,
-        )
+        .file("target.json", target_spec_json())
         .build();
 
     // This is a bit of a hack to use the rust-lld that ships with most toolchains.

--- a/tests/testsuite/custom_target.rs
+++ b/tests/testsuite/custom_target.rs
@@ -3,7 +3,10 @@
 use std::fs;
 
 use crate::prelude::*;
-use cargo_test_support::{basic_manifest, project, str};
+use cargo_test_support::basic_manifest;
+use cargo_test_support::project;
+use cargo_test_support::str;
+use cargo_test_support::target_spec_json;
 
 const MINIMAL_LIB: &str = r#"
 #![allow(internal_features)]
@@ -31,20 +34,6 @@ pub trait Copy {
 }
 "#;
 
-const SIMPLE_SPEC: &str = r#"
-{
-    "llvm-target": "x86_64-unknown-none-gnu",
-    "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
-    "arch": "x86_64",
-    "target-endian": "little",
-    "target-pointer-width": "64",
-    "os": "none",
-    "linker-flavor": "ld.lld",
-    "linker": "rust-lld",
-    "executables": true
-}
-"#;
-
 #[cargo_test(nightly, reason = "requires features no_core, lang_items")]
 fn custom_target_minimal() {
     let p = project()
@@ -59,7 +48,7 @@ fn custom_target_minimal() {
             "
             .replace("__MINIMAL_LIB__", MINIMAL_LIB),
         )
-        .file("custom-target.json", SIMPLE_SPEC)
+        .file("custom-target.json", target_spec_json())
         .build();
 
     p.cargo("build --lib --target custom-target.json -v").run();
@@ -127,7 +116,7 @@ fn custom_target_dependency() {
             "
             .replace("__MINIMAL_LIB__", MINIMAL_LIB),
         )
-        .file("custom-target.json", SIMPLE_SPEC)
+        .file("custom-target.json", target_spec_json())
         .build();
 
     p.cargo("build --lib --target custom-target.json -v").run();
@@ -146,7 +135,7 @@ fn custom_bin_target() {
             "
             .replace("__MINIMAL_LIB__", MINIMAL_LIB),
         )
-        .file("custom-bin-target.json", SIMPLE_SPEC)
+        .file("custom-bin-target.json", target_spec_json())
         .build();
 
     p.cargo("build --target custom-bin-target.json -v").run();
@@ -167,7 +156,7 @@ fn changing_spec_rebuilds() {
             "
             .replace("__MINIMAL_LIB__", MINIMAL_LIB),
         )
-        .file("custom-target.json", SIMPLE_SPEC)
+        .file("custom-target.json", target_spec_json())
         .build();
 
     p.cargo("build --lib --target custom-target.json -v").run();
@@ -212,7 +201,7 @@ fn changing_spec_relearns_crate_types() {
             "#,
         )
         .file("src/lib.rs", MINIMAL_LIB)
-        .file("custom-target.json", SIMPLE_SPEC)
+        .file("custom-target.json", target_spec_json())
         .build();
 
     p.cargo("build --lib --target custom-target.json -v")
@@ -254,8 +243,8 @@ fn custom_target_ignores_filepath() {
             "
             .replace("__MINIMAL_LIB__", MINIMAL_LIB),
         )
-        .file("b/custom-target.json", SIMPLE_SPEC)
-        .file("a/custom-target.json", SIMPLE_SPEC)
+        .file("b/custom-target.json", target_spec_json())
+        .file("a/custom-target.json", target_spec_json())
         .build();
 
     // Should build the library the first time.

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -1,7 +1,12 @@
 //! Tests for the `cargo rustc` command.
 
 use crate::prelude::*;
-use cargo_test_support::{basic_bin_manifest, basic_lib_manifest, basic_manifest, project, str};
+use cargo_test_support::basic_bin_manifest;
+use cargo_test_support::basic_lib_manifest;
+use cargo_test_support::basic_manifest;
+use cargo_test_support::project;
+use cargo_test_support::str;
+use cargo_test_support::target_spec_json;
 
 #[cargo_test]
 fn build_lib_for_foo() {
@@ -820,15 +825,7 @@ windows
 fn rustc_with_print_cfg_config_toml_env() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file(
-            "targets/best-target.json",
-            r#"{
-  "llvm-target": "x86_64-unknown-none",
-  "target-pointer-width": "64",
-  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
-  "arch": "x86_64"
-}"#,
-        )
+        .file("targets/best-target.json", target_spec_json())
         .file(
             ".cargo/config.toml",
             r#"


### PR DESCRIPTION
Read a real target spec JSON so we no longer need to hardcode
a target spec JSON here.
Cargo itself should not care about the spec schema.

Let's stop bothering compiler contributors.

* https://github.com/rust-lang/rust/pull/144443
* https://github.com/rust-lang/rust/pull/145764#issuecomment-3216104449
* [#t-compiler > Is it possible to add a commit to a submodule? @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/Is.20it.20possible.20to.20add.20a.20commit.20to.20a.20submodule.3F/near/535865215)