### PR TITLE
docs(package): expand the manifest nromalization

### DIFF
--- a/src/doc/man/cargo-package.md
+++ b/src/doc/man/cargo-package.md
@@ -27,6 +27,8 @@ stored in the `target/package` directory. This performs the following steps:
     - Fields not recognized by the current Cargo version are dropped.
     - Certain paths, such as `package.readme` and `package.license-file`,
       are rewritten if they point outside the package root.
+    - **Note**: the normalized `Cargo.toml` is intended to be stable,
+      but its exact form may change between Cargo versions.
 
 2. Create the compressed `.crate` file.
     - The normalized `Cargo.toml` is included, and the original manifest is

--- a/src/doc/man/generated_txt/cargo-package.txt
+++ b/src/doc/man/generated_txt/cargo-package.txt
@@ -31,6 +31,9 @@ DESCRIPTION
           o  Certain paths, such as package.readme and package.license-file,
              are rewritten if they point outside the package root.
 
+          o  Note: the normalized Cargo.toml is intended to be stable, but its
+             exact form may change between Cargo versions.
+
        2. Create the compressed .crate file.
 
           o  The normalized Cargo.toml is included, and the original manifest

--- a/src/doc/src/commands/cargo-package.md
+++ b/src/doc/src/commands/cargo-package.md
@@ -22,6 +22,8 @@ stored in the `target/package` directory. This performs the following steps:
     - Fields not recognized by the current Cargo version are dropped.
     - Certain paths, such as `package.readme` and `package.license-file`,
       are rewritten if they point outside the package root.
+    - **Note**: the normalized `Cargo.toml` is intended to be stable,
+      but its exact form may change between Cargo versions.
 
 2. Create the compressed `.crate` file.
     - The normalized `Cargo.toml` is included, and the original manifest is

--- a/src/etc/man/cargo-package.1
+++ b/src/etc/man/cargo-package.1
@@ -43,6 +43,11 @@ stored in the \fBtarget/package\fR directory. This performs the following steps:
 \h'-04'\(bu\h'+03'Certain paths, such as \fBpackage.readme\fR and \fBpackage.license\-file\fR,
 are rewritten if they point outside the package root.
 .RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+03'\fBNote\fR: the normalized \fBCargo.toml\fR is intended to be stable,
+but its exact form may change between Cargo versions.
+.RE
 .RE
 .sp
 .RS 4


### PR DESCRIPTION
### What does this PR try to resolve?

Resolves #15836

This also temporarily removes the mention of restriction in `git` and
`path` dependencies without a `version` key, and `dev-dependencies`.
Those are mentioned in the "Specifying Dependencies" chapter already.

(To be honest, I am not sure whether they should mention here or there)

Also added a note about the form of the normalized manifest is not "stable".

### How to test and review this PR?

Check whether if we've exposed implementation details that users don't need to know, like `license-file`? Though that one Cargo already emitted a warning if happened.