### PR TITLE
fix(publish): Don't generate final artifacts

### DIFF
--- a/src/cargo/ops/cargo_package/mod.rs
+++ b/src/cargo/ops/cargo_package/mod.rs
@@ -217,10 +217,12 @@ pub fn package(ws: &Workspace<'_>, opts: &PackageOpts<'_>) -> CargoResult<Vec<Fi
     // So we need filter
     pkgs.retain(|(pkg, _feats)| specs.iter().any(|spec| spec.matches(pkg.package_id())));
 
-    Ok(do_package(ws, opts, pkgs)?
-        .into_iter()
-        .map(|x| x.2)
-        .collect())
+    let packaged = do_package(ws, opts, pkgs)?;
+
+    let mut result = Vec::new();
+    result.extend(packaged.into_iter().map(|(_, _, src)| src));
+
+    Ok(result)
 }
 
 /// Packages an entire workspace.

--- a/src/cargo/ops/cargo_package/mod.rs
+++ b/src/cargo/ops/cargo_package/mod.rs
@@ -160,7 +160,7 @@ fn create_package(
     }
 
     let filename = pkg.package_id().tarball_name();
-    let dir = ws.target_dir().join("package");
+    let dir = ws.build_dir().join("package");
     let mut dst = {
         let tmp = format!(".{}", filename);
         dir.open_rw_exclusive_create(&tmp, gctx, "package scratch space")?
@@ -220,7 +220,22 @@ pub fn package(ws: &Workspace<'_>, opts: &PackageOpts<'_>) -> CargoResult<Vec<Fi
     let packaged = do_package(ws, opts, pkgs)?;
 
     let mut result = Vec::new();
-    result.extend(packaged.into_iter().map(|(_, _, src)| src));
+    let target_dir = ws.target_dir();
+    let build_dir = ws.build_dir();
+    if target_dir == build_dir {
+        result.extend(packaged.into_iter().map(|(_, _, src)| src));
+    } else {
+        // Uplifting artifacts
+        let artifact_dir = target_dir.join("package");
+        for (pkg, _, src) in packaged {
+            let filename = pkg.package_id().tarball_name();
+            let dst =
+                artifact_dir.open_rw_exclusive_create(filename, ws.gctx(), "uplifted package")?;
+            src.file().seek(SeekFrom::Start(0))?;
+            std::io::copy(&mut src.file(), &mut dst.file())?;
+            result.push(dst);
+        }
+    }
 
     Ok(result)
 }

--- a/src/doc/src/reference/build-cache.md
+++ b/src/doc/src/reference/build-cache.md
@@ -62,7 +62,7 @@ the `target` directory:
 Directory | Description
 ----------|------------
 <code style="white-space: nowrap">target/doc/</code> | Contains rustdoc documentation ([`cargo doc`]).
-<code style="white-space: nowrap">target/package/</code> | Contains the output of the [`cargo package`] and [`cargo publish`] commands.
+<code style="white-space: nowrap">target/package/</code> | Contains the output of the [`cargo package`].
 
 Cargo also creates several other directories and files in the build-dir needed for the build
 process. The build-dir layout is considered internal to Cargo, and is subject to

--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -12,6 +12,7 @@
 use std::path::PathBuf;
 
 use crate::prelude::*;
+use cargo_test_support::registry::RegistryBuilder;
 use cargo_test_support::{Project, prelude::*};
 use cargo_test_support::{paths, project, str};
 use std::env::consts::{DLL_PREFIX, DLL_SUFFIX, EXE_SUFFIX};
@@ -345,6 +346,40 @@ fn cargo_package_should_build_in_build_dir_and_output_to_target_dir() {
         .build();
 
     p.cargo("package").enable_mac_dsym().run();
+
+    assert_build_dir_layout(p.root().join("build-dir"), "debug");
+
+    let package_artifact_dir = p.root().join("target-dir/package");
+    assert_exists(&package_artifact_dir);
+    assert_exists(&package_artifact_dir.join("foo-0.0.1.crate"));
+    assert!(package_artifact_dir.join("foo-0.0.1.crate").is_file());
+
+    let package_build_dir = p.root().join("build-dir/package");
+    assert_exists(&package_build_dir);
+    assert_exists(&package_build_dir.join("foo-0.0.1"));
+    assert!(package_build_dir.join("foo-0.0.1").is_dir());
+}
+
+#[cargo_test]
+fn cargo_publish_should_only_touch_build_dir() {
+    let registry = RegistryBuilder::new().http_api().http_index().build();
+
+    let p = project()
+        .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [build]
+            target-dir = "target-dir"
+            build-dir = "build-dir"
+            "#,
+        )
+        .build();
+
+    p.cargo("publish")
+        .replace_crates_io(registry.index_url())
+        .enable_mac_dsym()
+        .run();
 
     assert_build_dir_layout(p.root().join("build-dir"), "debug");
 

--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -384,9 +384,7 @@ fn cargo_publish_should_only_touch_build_dir() {
     assert_build_dir_layout(p.root().join("build-dir"), "debug");
 
     let package_artifact_dir = p.root().join("target-dir/package");
-    assert_exists(&package_artifact_dir);
-    assert_exists(&package_artifact_dir.join("foo-0.0.1.crate"));
-    assert!(package_artifact_dir.join("foo-0.0.1.crate").is_file());
+    assert!(!package_artifact_dir.exists());
 
     let package_build_dir = p.root().join("build-dir/package");
     assert_exists(&package_build_dir);


### PR DESCRIPTION
### What does this PR try to resolve?

When splitting `build-dir` out of `target-dir` (see #14125), we kept `.crate` files as final artifacts of `cargo package`.  However, that also made them final artifacts of `cargo publish` when the side effect of that should be the publish operation.

This changes things so that we instead package within `build-dir` and `cargo package` then uplifts these to `target-dir`.

Behavior change: when running `cargo publish` without `build-dir` set, `target/package/*.crate` will be moved to `target/package/tmp-crate/*.crate`.  This should be fine as its an intermediate artifact but there is a risk that this can break someone who did not realize that.  Part of the reason for making the `build-dir` / `target-dir` split is to make our intermediate/final artifact intent clearer.  We did intend to be a transition period before changing things, like with #15010.  I'm assuming its fine that we don't have a transition period here.

### How to test and review this PR?

### Notes

This was discussed at [#t-cargo > &#96;-Zbuild-dir&#96; and &#96;cargo publish&#96; / &#96;cargo package&#96; @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/.60-Zbuild-dir.60.20and.20.60cargo.20publish.60.20.2F.20.60cargo.20package.60/near/537336819)