### PR TITLE
fix(publish): Move `.crate` out of final artifact location

### DIFF
--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -524,8 +524,8 @@ fn cargo_package_should_build_in_build_dir_and_output_to_target_dir() {
 [ROOT]/foo/build-dir/package/foo-0.0.1/Cargo.toml
 [ROOT]/foo/build-dir/package/foo-0.0.1/Cargo.toml.orig
 [ROOT]/foo/build-dir/package/foo-0.0.1/src/main.rs
-[ROOT]/foo/build-dir/package/foo-0.0.1.crate
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/package/tmp-crate/foo-0.0.1.crate
 
 "#]]);
 

--- a/tests/testsuite/build_dir_legacy.rs
+++ b/tests/testsuite/build_dir_legacy.rs
@@ -493,8 +493,8 @@ fn cargo_package_should_build_in_build_dir_and_output_to_target_dir() {
 [ROOT]/foo/build-dir/package/foo-0.0.1/Cargo.toml
 [ROOT]/foo/build-dir/package/foo-0.0.1/Cargo.toml.orig
 [ROOT]/foo/build-dir/package/foo-0.0.1/src/main.rs
-[ROOT]/foo/build-dir/package/foo-0.0.1.crate
 [ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/package/tmp-crate/foo-0.0.1.crate
 
 "#]]);
 


### PR DESCRIPTION
When `target_dir == build_dir`, ensure `cargo publish` doesn't put intermediate artifacts in the final artifact location of `cargo package`.

### What does this PR try to resolve?

In #15910, users could identify that `.crate` files from `cargo publish` are not final artifacts by setting a custom `build-dir`.  This extends that to all users, ie when `build-dir = target-dir` (the default currently), making it clear that these files are internal.

This also cleans things up by consolidating all of the uplifting logic and avoids dealing with overlapping `target_dir` and `build_dir`.

### How to test and review this PR?


### Notes

We could optimize this further by doing a `rename` and only doing a copy if that fails, effectively a `rename_or_copy` as opposed to our `hardlink_or_copy` we normally use for uplifting.  The difference is that we don't do change tracking for `.crate` files but fully re-generate, so we don't benefit from keeping the `.crate` around in the original location.