### PR TITLE
refactor(shell): Prepare for `Report`s being generated in more places

### DIFF
--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -411,6 +411,7 @@ impl Shell {
             .unwrap_or(annotate_snippets::renderer::DEFAULT_TERM_WIDTH);
         let rendered = Renderer::styled().term_width(term_width).render(report);
         self.err().write_all(rendered.as_bytes())?;
+        self.err().write_all("\n".as_bytes())?;
         Ok(())
     }
 }

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -405,6 +405,9 @@ impl Shell {
 
     /// Prints the passed in [`Report`] to stderr
     pub fn print_report(&mut self, report: Report<'_>) -> CargoResult<()> {
+        if self.needs_clear {
+            self.err_erase_line();
+        }
         let term_width = self
             .err_width()
             .diagnostic_terminal_width()

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -404,16 +404,14 @@ impl Shell {
     }
 
     /// Prints the passed in [`Report`] to stderr
-    pub fn print_report(&mut self, report: Report<'_>) -> std::io::Result<()> {
+    pub fn print_report(&mut self, report: Report<'_>) -> CargoResult<()> {
         let term_width = self
             .err_width()
             .diagnostic_terminal_width()
             .unwrap_or(annotate_snippets::renderer::DEFAULT_TERM_WIDTH);
-        writeln!(
-            self.err(),
-            "{}",
-            Renderer::styled().term_width(term_width).render(report)
-        )
+        let rendered = Renderer::styled().term_width(term_width).render(report);
+        self.err().write_all(rendered.as_bytes())?;
+        Ok(())
     }
 }
 

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -222,10 +222,7 @@ impl Shell {
 
     /// Prints an amber 'warning' message.
     pub fn warn<T: fmt::Display>(&mut self, message: T) -> CargoResult<()> {
-        match self.verbosity {
-            Verbosity::Quiet => Ok(()),
-            _ => self.print(&"warning", Some(&message), &WARN, false),
-        }
+        self.print(&"warning", Some(&message), &WARN, false)
     }
 
     /// Prints a cyan 'note' message.

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -404,7 +404,11 @@ impl Shell {
     }
 
     /// Prints the passed in [`Report`] to stderr
-    pub fn print_report(&mut self, report: Report<'_>) -> CargoResult<()> {
+    pub fn print_report(&mut self, report: Report<'_>, force: bool) -> CargoResult<()> {
+        if !force && matches!(self.verbosity, Verbosity::Quiet) {
+            return Ok(());
+        }
+
         if self.needs_clear {
             self.err_erase_line();
         }

--- a/src/cargo/util/lints.rs
+++ b/src/cargo/util/lints.rs
@@ -171,7 +171,7 @@ fn verify_feature_enabled(
         }
 
         *error_count += 1;
-        gctx.shell().print_report(&report)?;
+        gctx.shell().print_report(&report, true)?;
     }
     Ok(())
 }
@@ -339,6 +339,15 @@ impl LintLevel {
             LintLevel::Forbid => Level::ERROR,
         }
     }
+
+    fn force(self) -> bool {
+        match self {
+            Self::Allow => false,
+            Self::Warn => true,
+            Self::Deny => true,
+            Self::Forbid => true,
+        }
+    }
 }
 
 impl From<TomlLintLevel> for LintLevel {
@@ -459,7 +468,7 @@ pub fn check_im_a_teapot(
             )
             .element(Level::NOTE.message(&emitted_reason))];
 
-        gctx.shell().print_report(report)?;
+        gctx.shell().print_report(report, lint_level.force())?;
     }
     Ok(())
 }
@@ -568,7 +577,7 @@ fn output_unknown_lints(
             );
         }
 
-        gctx.shell().print_report(&report)?;
+        gctx.shell().print_report(&report, lint_level.force())?;
     }
 
     Ok(())

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1932,7 +1932,7 @@ fn missing_dep_diagnostic(
         group.element(snippet)
     };
 
-    if let Err(err) = gctx.shell().print_report(&[group]) {
+    if let Err(err) = gctx.shell().print_report(&[group], true) {
         return Err(err.into());
     }
     Err(AlreadyPrintedError::new(anyhow!("").into()).into())
@@ -2800,7 +2800,7 @@ fn emit_diagnostic(
             .annotation(AnnotationKind::Primary.span(span)),
     );
 
-    if let Err(err) = gctx.shell().print_report(&[group]) {
+    if let Err(err) = gctx.shell().print_report(&[group], true) {
         return err.into();
     }
     return AlreadyPrintedError::new(e.into()).into();


### PR DESCRIPTION
### What does this PR try to resolve?

This is preparation for changes like #15917 where we start to use `annotate_snippets::Report` for handling more of the rendering of our user messages to be more consistent with rustc and more feature rich in what we are able to render.

### How to test and review this PR?

