### PR TITLE
fix(cli): Adjust messages to match rustc 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "annotate-snippets"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a851f39ec7e23bf1c30faf3844a496fee4db701f5f840f68d1f78f00e697892"
+checksum = "4b0f1e2f8ec4bff67c7e1867001ec452595daf315cce10c393b7d4274024f878"
 dependencies = [
  "anstyle",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ homepage = "https://github.com/rust-lang/cargo"
 repository = "https://github.com/rust-lang/cargo"
 
 [workspace.dependencies]
-annotate-snippets = { version = "0.12.1", features = ["simd"] }
+annotate-snippets = { version = "0.12.3", features = ["simd"] }
 anstream = "0.6.20"
 anstyle = "1.0.11"
 anyhow = "1.0.98"

--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -163,7 +163,7 @@ fn print_list(gctx: &GlobalContext, is_verbose: bool) {
     ]);
     drop_println!(
         gctx,
-        color_print::cstr!("<green,bold>Installed Commands:</>")
+        color_print::cstr!("<bright-green,bold>Installed Commands:</>")
     );
     for (name, command) in list_commands(gctx) {
         let known_external_desc = known_external_command_descriptions.get(name.as_str());
@@ -557,11 +557,11 @@ pub fn cli(gctx: &GlobalContext) -> Command {
 
     let usage = if is_rustup() {
         color_print::cstr!(
-            "<cyan,bold>cargo</> <cyan>[+toolchain] [OPTIONS] [COMMAND]</>\n       <cyan,bold>cargo</> <cyan>[+toolchain] [OPTIONS]</> <cyan,bold>-Zscript</> <cyan><<MANIFEST_RS>> [ARGS]...</>"
+            "<bright-cyan,bold>cargo</> <cyan>[+toolchain] [OPTIONS] [COMMAND]</>\n       <bright-cyan,bold>cargo</> <cyan>[+toolchain] [OPTIONS]</> <bright-cyan,bold>-Zscript</> <cyan><<MANIFEST_RS>> [ARGS]...</>"
         )
     } else {
         color_print::cstr!(
-            "<cyan,bold>cargo</> <cyan>[OPTIONS] [COMMAND]</>\n       <cyan,bold>cargo</> <cyan>[OPTIONS]</> <cyan,bold>-Zscript</> <cyan><<MANIFEST_RS>> [ARGS]...</>"
+            "<bright-cyan,bold>cargo</> <cyan>[OPTIONS] [COMMAND]</>\n       <bright-cyan,bold>cargo</> <cyan>[OPTIONS]</> <bright-cyan,bold>-Zscript</> <cyan><<MANIFEST_RS>> [ARGS]...</>"
         )
     };
 
@@ -592,31 +592,31 @@ pub fn cli(gctx: &GlobalContext) -> Command {
             "\
 Rust's package manager
 
-<green,bold>Usage:</> {usage}
+<bright-green,bold>Usage:</> {usage}
 
-<green,bold>Options:</>
+<bright-green,bold>Options:</>
 {options}
 
-<green,bold>Commands:</>
-    <cyan,bold>build</>, <cyan,bold>b</>    Compile the current package
-    <cyan,bold>check</>, <cyan,bold>c</>    Analyze the current package and report errors, but don't build object files
-    <cyan,bold>clean</>       Remove the target directory
-    <cyan,bold>doc</>, <cyan,bold>d</>      Build this package's and its dependencies' documentation
-    <cyan,bold>new</>         Create a new cargo package
-    <cyan,bold>init</>        Create a new cargo package in an existing directory
-    <cyan,bold>add</>         Add dependencies to a manifest file
-    <cyan,bold>remove</>      Remove dependencies from a manifest file
-    <cyan,bold>run</>, <cyan,bold>r</>      Run a binary or example of the local package
-    <cyan,bold>test</>, <cyan,bold>t</>     Run the tests
-    <cyan,bold>bench</>       Run the benchmarks
-    <cyan,bold>update</>      Update dependencies listed in Cargo.lock
-    <cyan,bold>search</>      Search registry for crates
-    <cyan,bold>publish</>     Package and upload this package to the registry
-    <cyan,bold>install</>     Install a Rust binary
-    <cyan,bold>uninstall</>   Uninstall a Rust binary
-    <cyan>...</>         See all commands with <cyan,bold>--list</>
+<bright-green,bold>Commands:</>
+    <bright-cyan,bold>build</>, <bright-cyan,bold>b</>    Compile the current package
+    <bright-cyan,bold>check</>, <bright-cyan,bold>c</>    Analyze the current package and report errors, but don't build object files
+    <bright-cyan,bold>clean</>       Remove the target directory
+    <bright-cyan,bold>doc</>, <bright-cyan,bold>d</>      Build this package's and its dependencies' documentation
+    <bright-cyan,bold>new</>         Create a new cargo package
+    <bright-cyan,bold>init</>        Create a new cargo package in an existing directory
+    <bright-cyan,bold>add</>         Add dependencies to a manifest file
+    <bright-cyan,bold>remove</>      Remove dependencies from a manifest file
+    <bright-cyan,bold>run</>, <bright-cyan,bold>r</>      Run a binary or example of the local package
+    <bright-cyan,bold>test</>, <bright-cyan,bold>t</>     Run the tests
+    <bright-cyan,bold>bench</>       Run the benchmarks
+    <bright-cyan,bold>update</>      Update dependencies listed in Cargo.lock
+    <bright-cyan,bold>search</>      Search registry for crates
+    <bright-cyan,bold>publish</>     Package and upload this package to the registry
+    <bright-cyan,bold>install</>     Install a Rust binary
+    <bright-cyan,bold>uninstall</>   Uninstall a Rust binary
+    <cyan>...</>         See all commands with <bright-cyan,bold>--list</>
 
-See '<cyan,bold>cargo help</> <cyan><<command>></>' for more information on a specific command.\n",
+See '<bright-cyan,bold>cargo help</> <cyan><<command>></>' for more information on a specific command.\n",
         ))
         .arg(flag("version", "Print version info and exit").short('V'))
         .arg(flag("list", "List installed commands"))

--- a/src/bin/cargo/commands/add.rs
+++ b/src/bin/cargo/commands/add.rs
@@ -18,11 +18,11 @@ pub fn cli() -> Command {
         .about("Add dependencies to a Cargo.toml manifest file")
         .override_usage(
             color_print::cstr!("\
-       <cyan,bold>cargo add</> <cyan>[OPTIONS] <<DEP>>[@<<VERSION>>] ...</>
-       <cyan,bold>cargo add</> <cyan>[OPTIONS]</> <cyan,bold>--path</> <cyan><<PATH>> ...</>
-       <cyan,bold>cargo add</> <cyan>[OPTIONS]</> <cyan,bold>--git</> <cyan><<URL>> ...</>"
+       <bright-cyan,bold>cargo add</> <cyan>[OPTIONS] <<DEP>>[@<<VERSION>>] ...</>
+       <bright-cyan,bold>cargo add</> <cyan>[OPTIONS]</> <bright-cyan,bold>--path</> <cyan><<PATH>> ...</>
+       <bright-cyan,bold>cargo add</> <cyan>[OPTIONS]</> <bright-cyan,bold>--git</> <cyan><<URL>> ...</>"
         ))
-        .after_help(color_print::cstr!("Run `<cyan,bold>cargo help add</>` for more detailed information.\n"))
+        .after_help(color_print::cstr!("Run `<bright-cyan,bold>cargo help add</>` for more detailed information.\n"))
         .group(clap::ArgGroup::new("selected").multiple(true).required(true))
         .args([
             clap::Arg::new("crates")

--- a/src/bin/cargo/commands/bench.rs
+++ b/src/bin/cargo/commands/bench.rs
@@ -53,7 +53,7 @@ pub fn cli() -> Command {
         .arg_lockfile_path()
         .arg_ignore_rust_version()
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help bench</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help bench</>` for more detailed information.\n"
         ))
 }
 

--- a/src/bin/cargo/commands/build.rs
+++ b/src/bin/cargo/commands/build.rs
@@ -43,7 +43,7 @@ pub fn cli() -> Command {
         .arg_lockfile_path()
         .arg_ignore_rust_version()
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help build</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help build</>` for more detailed information.\n"
         ))
 }
 

--- a/src/bin/cargo/commands/check.rs
+++ b/src/bin/cargo/commands/check.rs
@@ -40,7 +40,7 @@ pub fn cli() -> Command {
         .arg_lockfile_path()
         .arg_ignore_rust_version()
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help check</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help check</>` for more detailed information.\n"
         ))
 }
 

--- a/src/bin/cargo/commands/clean.rs
+++ b/src/bin/cargo/commands/clean.rs
@@ -122,7 +122,7 @@ pub fn cli() -> Command {
                 ),
         )
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help clean</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help clean</>` for more detailed information.\n"
         ))
 }
 

--- a/src/bin/cargo/commands/doc.rs
+++ b/src/bin/cargo/commands/doc.rs
@@ -42,7 +42,7 @@ pub fn cli() -> Command {
         .arg_lockfile_path()
         .arg_ignore_rust_version()
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help doc</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help doc</>` for more detailed information.\n"
         ))
 }
 

--- a/src/bin/cargo/commands/fetch.rs
+++ b/src/bin/cargo/commands/fetch.rs
@@ -11,7 +11,7 @@ pub fn cli() -> Command {
         .arg_manifest_path()
         .arg_lockfile_path()
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help fetch</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help fetch</>` for more detailed information.\n"
         ))
 }
 

--- a/src/bin/cargo/commands/fix.rs
+++ b/src/bin/cargo/commands/fix.rs
@@ -57,7 +57,7 @@ pub fn cli() -> Command {
         .arg_lockfile_path()
         .arg_ignore_rust_version()
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help fix</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help fix</>` for more detailed information.\n"
         ))
 }
 

--- a/src/bin/cargo/commands/generate_lockfile.rs
+++ b/src/bin/cargo/commands/generate_lockfile.rs
@@ -10,7 +10,7 @@ pub fn cli() -> Command {
         .arg_lockfile_path()
         .arg_ignore_rust_version_with_help("Ignore `rust-version` specification in packages")
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help generate-lockfile</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help generate-lockfile</>` for more detailed information.\n"
         ))
 }
 

--- a/src/bin/cargo/commands/info.rs
+++ b/src/bin/cargo/commands/info.rs
@@ -17,7 +17,7 @@ pub fn cli() -> Command {
         .arg_registry("Registry to search packages in")
         .arg_silent_suggestion()
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help info</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help info</>` for more detailed information.\n"
         ))
 }
 

--- a/src/bin/cargo/commands/init.rs
+++ b/src/bin/cargo/commands/init.rs
@@ -15,7 +15,7 @@ pub fn cli() -> Command {
         .arg_registry("Registry to use")
         .arg_silent_suggestion()
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help init</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help init</>` for more detailed information.\n"
         ))
 }
 

--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -105,7 +105,7 @@ pub fn cli() -> Command {
         .arg_timings()
         .arg_lockfile_path()
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help install</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help install</>` for more detailed information.\n"
         ))
 }
 

--- a/src/bin/cargo/commands/locate_project.rs
+++ b/src/bin/cargo/commands/locate_project.rs
@@ -16,7 +16,7 @@ pub fn cli() -> Command {
         .arg_silent_suggestion()
         .arg_manifest_path()
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help locate-project</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help locate-project</>` for more detailed information.\n"
         ))
 }
 

--- a/src/bin/cargo/commands/login.rs
+++ b/src/bin/cargo/commands/login.rs
@@ -21,7 +21,7 @@ pub fn cli() -> Command {
         )
         .arg_silent_suggestion()
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help login</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help login</>` for more detailed information.\n"
         ))
 }
 

--- a/src/bin/cargo/commands/logout.rs
+++ b/src/bin/cargo/commands/logout.rs
@@ -9,7 +9,7 @@ pub fn cli() -> Command {
         .arg_registry("Registry to use")
         .arg_silent_suggestion()
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help logout</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help logout</>` for more detailed information.\n"
         ))
 }
 

--- a/src/bin/cargo/commands/metadata.rs
+++ b/src/bin/cargo/commands/metadata.rs
@@ -29,7 +29,7 @@ pub fn cli() -> Command {
         .arg_manifest_path()
         .arg_lockfile_path()
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help metadata</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help metadata</>` for more detailed information.\n"
         ))
 }
 

--- a/src/bin/cargo/commands/new.rs
+++ b/src/bin/cargo/commands/new.rs
@@ -15,7 +15,7 @@ pub fn cli() -> Command {
         .arg_registry("Registry to use")
         .arg_silent_suggestion()
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help new</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help new</>` for more detailed information.\n"
         ))
 }
 

--- a/src/bin/cargo/commands/owner.rs
+++ b/src/bin/cargo/commands/owner.rs
@@ -29,7 +29,7 @@ pub fn cli() -> Command {
         .arg(opt("token", "API token to use when authenticating").value_name("TOKEN"))
         .arg_silent_suggestion()
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help owner</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help owner</>` for more detailed information.\n"
         ))
 }
 

--- a/src/bin/cargo/commands/package.rs
+++ b/src/bin/cargo/commands/package.rs
@@ -52,7 +52,7 @@ pub fn cli() -> Command {
         .arg_manifest_path()
         .arg_lockfile_path()
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help package</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help package</>` for more detailed information.\n"
         ))
 }
 

--- a/src/bin/cargo/commands/pkgid.rs
+++ b/src/bin/cargo/commands/pkgid.rs
@@ -12,7 +12,7 @@ pub fn cli() -> Command {
         .arg_manifest_path()
         .arg_lockfile_path()
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help pkgid</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help pkgid</>` for more detailed information.\n"
         ))
 }
 

--- a/src/bin/cargo/commands/publish.rs
+++ b/src/bin/cargo/commands/publish.rs
@@ -30,7 +30,7 @@ pub fn cli() -> Command {
         .arg_manifest_path()
         .arg_lockfile_path()
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help publish</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help publish</>` for more detailed information.\n"
         ))
 }
 

--- a/src/bin/cargo/commands/read_manifest.rs
+++ b/src/bin/cargo/commands/read_manifest.rs
@@ -9,7 +9,7 @@ pub fn cli() -> Command {
             "\
 DEPRECATED: Print a JSON representation of a Cargo.toml manifest.
 
-Use `<cyan,bold>cargo metadata --no-deps</>` instead.\
+Use `<bright-cyan,bold>cargo metadata --no-deps</>` instead.\
 "
         ))
         .arg_silent_suggestion()

--- a/src/bin/cargo/commands/remove.rs
+++ b/src/bin/cargo/commands/remove.rs
@@ -56,7 +56,7 @@ pub fn cli() -> clap::Command {
         .arg_manifest_path()
         .arg_lockfile_path()
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help remove</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help remove</>` for more detailed information.\n"
         ))
 }
 

--- a/src/bin/cargo/commands/report.rs
+++ b/src/bin/cargo/commands/report.rs
@@ -6,7 +6,7 @@ pub fn cli() -> Command {
     subcommand("report")
         .about("Generate and display various kinds of reports")
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help report</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help report</>` for more detailed information.\n"
         ))
         .subcommand_required(true)
         .arg_required_else_help(true)

--- a/src/bin/cargo/commands/run.rs
+++ b/src/bin/cargo/commands/run.rs
@@ -43,7 +43,7 @@ pub fn cli() -> Command {
         .arg_unit_graph()
         .arg_timings()
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help run</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help run</>` for more detailed information.\n"
         ))
 }
 

--- a/src/bin/cargo/commands/rustc.rs
+++ b/src/bin/cargo/commands/rustc.rs
@@ -54,7 +54,7 @@ pub fn cli() -> Command {
         .arg_lockfile_path()
         .arg_ignore_rust_version()
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help rustc</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help rustc</>` for more detailed information.\n"
         ))
 }
 

--- a/src/bin/cargo/commands/rustdoc.rs
+++ b/src/bin/cargo/commands/rustdoc.rs
@@ -48,7 +48,7 @@ pub fn cli() -> Command {
         .arg_lockfile_path()
         .arg_ignore_rust_version()
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help rustdoc</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help rustdoc</>` for more detailed information.\n"
         ))
 }
 

--- a/src/bin/cargo/commands/search.rs
+++ b/src/bin/cargo/commands/search.rs
@@ -19,7 +19,7 @@ pub fn cli() -> Command {
         .arg_registry("Registry to search packages in")
         .arg_silent_suggestion()
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help search</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help search</>` for more detailed information.\n"
         ))
 }
 

--- a/src/bin/cargo/commands/test.rs
+++ b/src/bin/cargo/commands/test.rs
@@ -63,8 +63,8 @@ pub fn cli() -> Command {
         .arg_lockfile_path()
         .arg_ignore_rust_version()
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help test</>` for more detailed information.\n\
-             Run `<cyan,bold>cargo test -- --help</>` for test binary options.\n",
+            "Run `<bright-cyan,bold>cargo help test</>` for more detailed information.\n\
+             Run `<bright-cyan,bold>cargo test -- --help</>` for test binary options.\n",
         ))
 }
 

--- a/src/bin/cargo/commands/tree.rs
+++ b/src/bin/cargo/commands/tree.rs
@@ -97,7 +97,7 @@ pub fn cli() -> Command {
         .arg_manifest_path()
         .arg_lockfile_path()
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help tree</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help tree</>` for more detailed information.\n"
         ))
 }
 

--- a/src/bin/cargo/commands/uninstall.rs
+++ b/src/bin/cargo/commands/uninstall.rs
@@ -21,7 +21,7 @@ pub fn cli() -> Command {
                 .help_heading(heading::TARGET_SELECTION),
         )
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help uninstall</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help uninstall</>` for more detailed information.\n"
         ))
 }
 

--- a/src/bin/cargo/commands/update.rs
+++ b/src/bin/cargo/commands/update.rs
@@ -55,7 +55,7 @@ pub fn cli() -> Command {
         .arg_lockfile_path()
         .arg_ignore_rust_version_with_help("Ignore `rust-version` specification in packages")
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help update</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help update</>` for more detailed information.\n"
         ))
 }
 

--- a/src/bin/cargo/commands/vendor.rs
+++ b/src/bin/cargo/commands/vendor.rs
@@ -39,7 +39,7 @@ pub fn cli() -> Command {
         .arg_manifest_path()
         .arg_lockfile_path()
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help vendor</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help vendor</>` for more detailed information.\n"
         ))
 }
 

--- a/src/bin/cargo/commands/version.rs
+++ b/src/bin/cargo/commands/version.rs
@@ -6,7 +6,7 @@ pub fn cli() -> Command {
         .about("Show version information")
         .arg_silent_suggestion()
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help version</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help version</>` for more detailed information.\n"
         ))
 }
 

--- a/src/bin/cargo/commands/yank.rs
+++ b/src/bin/cargo/commands/yank.rs
@@ -22,7 +22,7 @@ pub fn cli() -> Command {
         .arg(opt("token", "API token to use when authenticating").value_name("TOKEN"))
         .arg_silent_suggestion()
         .after_help(color_print::cstr!(
-            "Run `<cyan,bold>cargo help yank</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help yank</>` for more detailed information.\n"
         ))
 }
 

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -457,13 +457,11 @@ impl ShellOut {
         style: &Style,
         justified: bool,
     ) -> CargoResult<()> {
-        let bold = anstyle::Style::new() | anstyle::Effects::BOLD;
-
         let mut buffer = Vec::new();
         if justified {
             write!(&mut buffer, "{style}{status:>12}{style:#}")?;
         } else {
-            write!(&mut buffer, "{style}{status}{style:#}{bold}:{bold:#}")?;
+            write!(&mut buffer, "{style}{status}{style:#}:")?;
         }
         match message {
             Some(message) => writeln!(buffer, " {message}")?,

--- a/src/cargo/ops/registry/info/view.rs
+++ b/src/cargo/ops/registry/info/view.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::io::Write;
 
 use crate::core::Shell;
-use crate::util::style::{ERROR, HEADER, LITERAL, NOP, NOTE, WARN};
+use crate::util::style::{ERROR, HEADER, LITERAL, NOP, WARN};
 use crate::{
     CargoResult, GlobalContext,
     core::{
@@ -26,7 +26,7 @@ pub(super) fn pretty_view(
     let header = HEADER;
     let error = ERROR;
     let warn = WARN;
-    let note = NOTE;
+    let context = annotate_snippets::renderer::DEFAULT_CONTEXT_STYLE;
 
     let mut shell = gctx.shell();
     let verbosity = shell.verbosity();
@@ -45,7 +45,7 @@ pub(super) fn pretty_view(
         } else {
             format!("#{}", metadata.keywords.join(" #"))
         };
-        write!(shell.out(), " {note}{message}{note:#}")?;
+        write!(shell.out(), " {context}{message}{context:#}")?;
     }
 
     let stdout = shell.out();
@@ -68,7 +68,7 @@ pub(super) fn pretty_view(
         (Some(latest), false) if latest.as_summary().version() != package_id.version() => {
             write!(
                 stdout,
-                " {warn}(latest {} {warn:#}{note}from {}{note:#}{warn}){warn:#}",
+                " {warn}(latest {} {warn:#}{context}from {}{context:#}{warn}){warn:#}",
                 latest.as_summary().version(),
                 pretty_source(summary.source_id(), gctx)
             )?;
@@ -83,7 +83,7 @@ pub(super) fn pretty_view(
         (_, false) => {
             write!(
                 stdout,
-                " {note}(from {}){note:#}",
+                " {context}(from {}){context:#}",
                 pretty_source(summary.source_id(), gctx)
             )?;
         }

--- a/src/cargo/ops/tree/mod.rs
+++ b/src/cargo/ops/tree/mod.rs
@@ -406,12 +406,12 @@ fn print_dependencies<'a>(
 
     let name = match kind {
         EdgeKind::Dep(DepKind::Normal) => None,
-        EdgeKind::Dep(DepKind::Build) => {
-            Some(color_print::cstr!("<blue,bold>[build-dependencies]</>"))
-        }
-        EdgeKind::Dep(DepKind::Development) => {
-            Some(color_print::cstr!("<cyan,bold>[dev-dependencies]</>"))
-        }
+        EdgeKind::Dep(DepKind::Build) => Some(color_print::cstr!(
+            "<bright-blue,bold>[build-dependencies]</>"
+        )),
+        EdgeKind::Dep(DepKind::Development) => Some(color_print::cstr!(
+            "<bright-cyan,bold>[dev-dependencies]</>"
+        )),
         EdgeKind::Feature => None,
     };
 

--- a/src/cargo/util/style.rs
+++ b/src/cargo/util/style.rs
@@ -1,13 +1,13 @@
 use anstyle::*;
 
 pub const NOP: Style = Style::new();
-pub const HEADER: Style = AnsiColor::Green.on_default().effects(Effects::BOLD);
-pub const USAGE: Style = AnsiColor::Green.on_default().effects(Effects::BOLD);
-pub const LITERAL: Style = AnsiColor::Cyan.on_default().effects(Effects::BOLD);
+pub const HEADER: Style = AnsiColor::BrightGreen.on_default().effects(Effects::BOLD);
+pub const USAGE: Style = AnsiColor::BrightGreen.on_default().effects(Effects::BOLD);
+pub const LITERAL: Style = AnsiColor::BrightCyan.on_default().effects(Effects::BOLD);
 pub const PLACEHOLDER: Style = AnsiColor::Cyan.on_default();
-pub const ERROR: Style = AnsiColor::Red.on_default().effects(Effects::BOLD);
-pub const WARN: Style = AnsiColor::Yellow.on_default().effects(Effects::BOLD);
-pub const NOTE: Style = AnsiColor::Cyan.on_default().effects(Effects::BOLD);
-pub const GOOD: Style = AnsiColor::Green.on_default().effects(Effects::BOLD);
-pub const VALID: Style = AnsiColor::Cyan.on_default().effects(Effects::BOLD);
-pub const INVALID: Style = AnsiColor::Yellow.on_default().effects(Effects::BOLD);
+pub const ERROR: Style = annotate_snippets::renderer::DEFAULT_ERROR_STYLE;
+pub const WARN: Style = annotate_snippets::renderer::DEFAULT_WARNING_STYLE;
+pub const NOTE: Style = annotate_snippets::renderer::DEFAULT_NOTE_STYLE;
+pub const GOOD: Style = AnsiColor::BrightGreen.on_default().effects(Effects::BOLD);
+pub const VALID: Style = AnsiColor::BrightCyan.on_default().effects(Effects::BOLD);
+pub const INVALID: Style = annotate_snippets::renderer::DEFAULT_WARNING_STYLE;

--- a/tests/testsuite/cargo/help/stdout.term.svg
+++ b/tests/testsuite/cargo/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,83 +24,83 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">cargo</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[..][OPTIONS] [COMMAND]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan class="bold"> </tspan><tspan class="fg-bright-cyan bold">cargo</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[+toolchain] [OPTIONS] [COMMAND]</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="bold">       </tspan><tspan class="fg-cyan bold">cargo</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[..][OPTIONS]</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">-Zscript</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">&lt;MANIFEST_RS&gt; [ARGS]...</tspan>
+    <tspan x="10px" y="82px"><tspan class="bold">       </tspan><tspan class="fg-bright-cyan bold">cargo</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[+toolchain] [OPTIONS]</tspan><tspan class="bold"> </tspan><tspan class="fg-bright-cyan bold">-Zscript</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">&lt;MANIFEST_RS&gt; [ARGS]...</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="bold">  </tspan><tspan class="fg-cyan bold">-V</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--version</tspan><tspan>                  Print version info and exit</tspan>
+    <tspan x="10px" y="136px"><tspan class="bold">  </tspan><tspan class="fg-bright-cyan bold">-V</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--version</tspan><tspan>                  Print version info and exit</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>      </tspan><tspan class="fg-cyan bold">--list</tspan><tspan>                     List installed commands</tspan>
+    <tspan x="10px" y="154px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--list</tspan><tspan>                     List installed commands</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-cyan bold">--explain</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;CODE&gt;</tspan><tspan>           Provide a detailed explanation of a rustc error message</tspan>
+    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--explain</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;CODE&gt;</tspan><tspan>           Provide a detailed explanation of a rustc error message</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-cyan bold">-C</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>                 Change to DIRECTORY before doing anything (nightly-only)</tspan>
+    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-C</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>                 Change to DIRECTORY before doing anything (nightly-only)</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                   Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>                   Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>                  Run without accessing the network</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>                  Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                   Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>                   Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="352px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="370px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="388px">
 </tspan>
-    <tspan x="10px" y="406px"><tspan class="fg-green bold">Commands:</tspan>
+    <tspan x="10px" y="406px"><tspan class="fg-bright-green bold">Commands:</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan class="bold">    </tspan><tspan class="fg-cyan bold">build</tspan><tspan class="bold">, </tspan><tspan class="fg-cyan bold">b</tspan><tspan class="bold">    Compile the current package</tspan>
+    <tspan x="10px" y="424px"><tspan class="bold">    </tspan><tspan class="fg-bright-cyan bold">build</tspan><tspan class="bold">, </tspan><tspan class="fg-bright-cyan bold">b</tspan><tspan class="bold">    Compile the current package</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan class="bold">    </tspan><tspan class="fg-cyan bold">check</tspan><tspan class="bold">, </tspan><tspan class="fg-cyan bold">c</tspan><tspan class="bold">    Analyze the current package and report errors, but don't build object files</tspan>
+    <tspan x="10px" y="442px"><tspan class="bold">    </tspan><tspan class="fg-bright-cyan bold">check</tspan><tspan class="bold">, </tspan><tspan class="fg-bright-cyan bold">c</tspan><tspan class="bold">    Analyze the current package and report errors, but don't build object files</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan class="bold">    </tspan><tspan class="fg-cyan bold">clean</tspan><tspan class="bold">       Remove the target directory</tspan>
+    <tspan x="10px" y="460px"><tspan class="bold">    </tspan><tspan class="fg-bright-cyan bold">clean</tspan><tspan class="bold">       Remove the target directory</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan class="bold">    </tspan><tspan class="fg-cyan bold">doc</tspan><tspan class="bold">, </tspan><tspan class="fg-cyan bold">d</tspan><tspan class="bold">      Build this package's and its dependencies' documentation</tspan>
+    <tspan x="10px" y="478px"><tspan class="bold">    </tspan><tspan class="fg-bright-cyan bold">doc</tspan><tspan class="bold">, </tspan><tspan class="fg-bright-cyan bold">d</tspan><tspan class="bold">      Build this package's and its dependencies' documentation</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan class="bold">    </tspan><tspan class="fg-cyan bold">new</tspan><tspan class="bold">         Create a new cargo package</tspan>
+    <tspan x="10px" y="496px"><tspan class="bold">    </tspan><tspan class="fg-bright-cyan bold">new</tspan><tspan class="bold">         Create a new cargo package</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan class="bold">    </tspan><tspan class="fg-cyan bold">init</tspan><tspan class="bold">        Create a new cargo package in an existing directory</tspan>
+    <tspan x="10px" y="514px"><tspan class="bold">    </tspan><tspan class="fg-bright-cyan bold">init</tspan><tspan class="bold">        Create a new cargo package in an existing directory</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan class="bold">    </tspan><tspan class="fg-cyan bold">add</tspan><tspan class="bold">         Add dependencies to a manifest file</tspan>
+    <tspan x="10px" y="532px"><tspan class="bold">    </tspan><tspan class="fg-bright-cyan bold">add</tspan><tspan class="bold">         Add dependencies to a manifest file</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan class="bold">    </tspan><tspan class="fg-cyan bold">remove</tspan><tspan class="bold">      Remove dependencies from a manifest file</tspan>
+    <tspan x="10px" y="550px"><tspan class="bold">    </tspan><tspan class="fg-bright-cyan bold">remove</tspan><tspan class="bold">      Remove dependencies from a manifest file</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan class="bold">    </tspan><tspan class="fg-cyan bold">run</tspan><tspan class="bold">, </tspan><tspan class="fg-cyan bold">r</tspan><tspan class="bold">      Run a binary or example of the local package</tspan>
+    <tspan x="10px" y="568px"><tspan class="bold">    </tspan><tspan class="fg-bright-cyan bold">run</tspan><tspan class="bold">, </tspan><tspan class="fg-bright-cyan bold">r</tspan><tspan class="bold">      Run a binary or example of the local package</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan class="bold">    </tspan><tspan class="fg-cyan bold">test</tspan><tspan class="bold">, </tspan><tspan class="fg-cyan bold">t</tspan><tspan class="bold">     Run the tests</tspan>
+    <tspan x="10px" y="586px"><tspan class="bold">    </tspan><tspan class="fg-bright-cyan bold">test</tspan><tspan class="bold">, </tspan><tspan class="fg-bright-cyan bold">t</tspan><tspan class="bold">     Run the tests</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan class="bold">    </tspan><tspan class="fg-cyan bold">bench</tspan><tspan class="bold">       Run the benchmarks</tspan>
+    <tspan x="10px" y="604px"><tspan class="bold">    </tspan><tspan class="fg-bright-cyan bold">bench</tspan><tspan class="bold">       Run the benchmarks</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan class="bold">    </tspan><tspan class="fg-cyan bold">update</tspan><tspan class="bold">      Update dependencies listed in Cargo.lock</tspan>
+    <tspan x="10px" y="622px"><tspan class="bold">    </tspan><tspan class="fg-bright-cyan bold">update</tspan><tspan class="bold">      Update dependencies listed in Cargo.lock</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan class="bold">    </tspan><tspan class="fg-cyan bold">search</tspan><tspan class="bold">      Search registry for crates</tspan>
+    <tspan x="10px" y="640px"><tspan class="bold">    </tspan><tspan class="fg-bright-cyan bold">search</tspan><tspan class="bold">      Search registry for crates</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan class="bold">    </tspan><tspan class="fg-cyan bold">publish</tspan><tspan class="bold">     Package and upload this package to the registry</tspan>
+    <tspan x="10px" y="658px"><tspan class="bold">    </tspan><tspan class="fg-bright-cyan bold">publish</tspan><tspan class="bold">     Package and upload this package to the registry</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan class="bold">    </tspan><tspan class="fg-cyan bold">install</tspan><tspan class="bold">     Install a Rust binary</tspan>
+    <tspan x="10px" y="676px"><tspan class="bold">    </tspan><tspan class="fg-bright-cyan bold">install</tspan><tspan class="bold">     Install a Rust binary</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan class="bold">    </tspan><tspan class="fg-cyan bold">uninstall</tspan><tspan class="bold">   Uninstall a Rust binary</tspan>
+    <tspan x="10px" y="694px"><tspan class="bold">    </tspan><tspan class="fg-bright-cyan bold">uninstall</tspan><tspan class="bold">   Uninstall a Rust binary</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan class="bold">    </tspan><tspan class="fg-cyan bold">...</tspan><tspan class="bold">         See all commands with </tspan><tspan class="fg-cyan bold">--list</tspan>
+    <tspan x="10px" y="712px"><tspan class="bold">    </tspan><tspan class="fg-cyan bold">...</tspan><tspan class="bold">         See all commands with </tspan><tspan class="fg-bright-cyan bold">--list</tspan>
 </tspan>
     <tspan x="10px" y="730px">
 </tspan>
-    <tspan x="10px" y="748px"><tspan class="bold">See '</tspan><tspan class="fg-cyan bold">cargo help</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">&lt;command&gt;</tspan><tspan class="bold">' for more information on a specific command.</tspan>
+    <tspan x="10px" y="748px"><tspan class="bold">See '</tspan><tspan class="fg-bright-cyan bold">cargo help</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">&lt;command&gt;</tspan><tspan class="bold">' for more information on a specific command.</tspan>
 </tspan>
     <tspan x="10px" y="766px">
 </tspan>

--- a/tests/testsuite/cargo_add/add_basic/stderr.term.svg
+++ b/tests/testsuite/cargo_add/add_basic/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/add_multiple/stderr.term.svg
+++ b/tests/testsuite/cargo_add/add_multiple/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,13 +18,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package1 v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package1 v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/add_no_vendored_package_with_alter_registry/stderr.term.svg
+++ b/tests/testsuite/cargo_add/add_no_vendored_package_with_alter_registry/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,29 +20,29 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `alternative` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `alternative` index</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> translating `linked_hash_map` to `linked-hash-map`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> linked-hash-map v0.5.4 to dependencies</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> linked-hash-map v0.5.4 to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan>             Features:</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> clippy</tspan>
+    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> clippy</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> heapsize</tspan>
+    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> heapsize</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> heapsize_impl</tspan>
+    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> heapsize_impl</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> nightly</tspan>
+    <tspan x="10px" y="154px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> nightly</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> serde</tspan>
+    <tspan x="10px" y="172px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> serde</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> serde_impl</tspan>
+    <tspan x="10px" y="190px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> serde_impl</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> serde_test</tspan>
+    <tspan x="10px" y="208px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> serde_test</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="226px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="244px">
 </tspan>

--- a/tests/testsuite/cargo_add/add_no_vendored_package_with_alter_registry/stderr.term.svg
+++ b/tests/testsuite/cargo_add/add_no_vendored_package_with_alter_registry/stderr.term.svg
@@ -22,7 +22,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `alternative` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> translating `linked_hash_map` to `linked-hash-map`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-yellow bold">warning</tspan><tspan>: translating `linked_hash_map` to `linked-hash-map`</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> linked-hash-map v0.5.4 to dependencies</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/add_no_vendored_package_with_vendor/stderr.term.svg
+++ b/tests/testsuite/cargo_add/add_no_vendored_package_with_vendor/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the crate `cbindgen` could not be found in registry index.</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the crate `cbindgen` could not be found in registry index.</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/add_no_vendored_package_with_vendor/stderr.term.svg
+++ b/tests/testsuite/cargo_add/add_no_vendored_package_with_vendor/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the crate `cbindgen` could not be found in registry index.</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: the crate `cbindgen` could not be found in registry index.</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/add_toolchain/stderr.term.svg
+++ b/tests/testsuite/cargo_add/add_toolchain/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> invalid character `+` in dependency name: `+nightly`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> invalid character `+` in dependency name: `+nightly`</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>    Use `cargo +nightly add` if you meant to use the `nightly` toolchain.</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/add_toolchain/stderr.term.svg
+++ b/tests/testsuite/cargo_add/add_toolchain/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> invalid character `+` in dependency name: `+nightly`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: invalid character `+` in dependency name: `+nightly`</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>    Use `cargo +nightly add` if you meant to use the `nightly` toolchain.</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/build/stderr.term.svg
+++ b/tests/testsuite/cargo_add/build/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,13 +18,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-build-package1 v99999.0.0 to build-dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-build-package1 v99999.0.0 to build-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-build-package2 v99999.0.0 to build-dependencies</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-build-package2 v99999.0.0 to build-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/build_prefer_existing_version/stderr.term.svg
+++ b/tests/testsuite/cargo_add/build_prefer_existing_version/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,15 +19,15 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to build-dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to build-dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>             Features:</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> one</tspan>
+    <tspan x="10px" y="64px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> one</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> two</tspan>
+    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> two</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/change_rename_target/stderr.term.svg
+++ b/tests/testsuite/cargo_add/change_rename_target/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,13 +18,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v99999.0.0 to optional dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v99999.0.0 to optional dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `some-package`</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> feature `some-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/cyclic_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/cyclic_features/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,17 +18,17 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> test_cyclic_features v0.1.1 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> test_cyclic_features v0.1.1 to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>             Features:</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> feature-one</tspan>
+    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> feature-one</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> feature-two</tspan>
+    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> feature-two</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_add/default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/default_features/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,15 +19,15 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package1 v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package1 v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v0.4.1 to dependencies</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v0.4.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/deprecated_default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/deprecated_default_features/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> Use of `default_features` in `my-package` is unsupported, please switch to `default-features`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: Use of `default_features` in `my-package` is unsupported, please switch to `default-features`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/deprecated_default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/deprecated_default_features/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> Use of `default_features` in `my-package` is unsupported, please switch to `default-features`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> Use of `default_features` in `my-package` is unsupported, please switch to `default-features`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/deprecated_section/stderr.term.svg
+++ b/tests/testsuite/cargo_add/deprecated_section/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> Deprecated dependency sections are unsupported: dev_dependencies, build_dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> Deprecated dependency sections are unsupported: dev_dependencies, build_dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/deprecated_section/stderr.term.svg
+++ b/tests/testsuite/cargo_add/deprecated_section/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> Deprecated dependency sections are unsupported: dev_dependencies, build_dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: Deprecated dependency sections are unsupported: dev_dependencies, build_dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/detect_workspace_inherit/stderr.term.svg
+++ b/tests/testsuite/cargo_add/detect_workspace_inherit/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> foo (workspace) to dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> foo (workspace) to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/detect_workspace_inherit_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/detect_workspace_inherit_features/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,25 +19,25 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> foo (workspace) to dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> foo (workspace) to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>             Features as of v0.0.0:</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> default-base</tspan>
+    <tspan x="10px" y="64px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> default-base</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> default-merge-base</tspan>
+    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> default-merge-base</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> default-test-base</tspan>
+    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> default-test-base</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> merge</tspan>
+    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> merge</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> merge-base</tspan>
+    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> merge-base</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> test</tspan>
+    <tspan x="10px" y="154px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> test</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> test-base</tspan>
+    <tspan x="10px" y="172px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> test-base</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> unrelated</tspan>
+    <tspan x="10px" y="190px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> unrelated</tspan>
 </tspan>
     <tspan x="10px" y="208px">
 </tspan>

--- a/tests/testsuite/cargo_add/detect_workspace_inherit_optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/detect_workspace_inherit_optional/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> foo (workspace) to optional dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> foo (workspace) to optional dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `foo`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> feature `foo`</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/detect_workspace_inherit_path_base/stderr.term.svg
+++ b/tests/testsuite/cargo_add/detect_workspace_inherit_path_base/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> foo (workspace) to dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> foo (workspace) to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/detect_workspace_inherit_public/stderr.term.svg
+++ b/tests/testsuite/cargo_add/detect_workspace_inherit_public/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> foo (workspace) to public dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> foo (workspace) to public dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/dev/stderr.term.svg
+++ b/tests/testsuite/cargo_add/dev/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,13 +18,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-dev-package1 v99999.0.0 to dev-dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-dev-package1 v99999.0.0 to dev-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-dev-package2 v99999.0.0 to dev-dependencies</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-dev-package2 v99999.0.0 to dev-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/dev_build_conflict/stderr.term.svg
+++ b/tests/testsuite/cargo_add/dev_build_conflict/stderr.term.svg
@@ -2,9 +2,10 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -21,19 +22,19 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error:</tspan><tspan> the argument '</tspan><tspan class="fg-yellow bold">--dev</tspan><tspan>' cannot be used with '</tspan><tspan class="fg-yellow bold">--build</tspan><tspan>'</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error:</tspan><tspan> the argument '</tspan><tspan class="fg-yellow bold">--dev</tspan><tspan>' cannot be used with '</tspan><tspan class="fg-yellow bold">--build</tspan><tspan>'</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo add</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[OPTIONS] &lt;DEP&gt;[@&lt;VERSION&gt;] ...</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo add</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[OPTIONS] &lt;DEP&gt;[@&lt;VERSION&gt;] ...</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="bold">       </tspan><tspan class="fg-cyan bold">cargo add</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[OPTIONS]</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">--path</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">&lt;PATH&gt; ...</tspan>
+    <tspan x="10px" y="82px"><tspan class="bold">       </tspan><tspan class="fg-bright-cyan bold">cargo add</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[OPTIONS]</tspan><tspan class="bold"> </tspan><tspan class="fg-bright-cyan bold">--path</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">&lt;PATH&gt; ...</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="bold">       </tspan><tspan class="fg-cyan bold">cargo add</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[OPTIONS]</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">--git</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">&lt;URL&gt; ...</tspan>
+    <tspan x="10px" y="100px"><tspan class="bold">       </tspan><tspan class="fg-bright-cyan bold">cargo add</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[OPTIONS]</tspan><tspan class="bold"> </tspan><tspan class="fg-bright-cyan bold">--git</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">&lt;URL&gt; ...</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="bold">For more information, try '</tspan><tspan class="fg-cyan bold">--help</tspan><tspan>'.</tspan>
+    <tspan x="10px" y="136px"><tspan class="bold">For more information, try '</tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>'.</tspan>
 </tspan>
     <tspan x="10px" y="154px">
 </tspan>

--- a/tests/testsuite/cargo_add/dev_existing_path_base/stderr.term.svg
+++ b/tests/testsuite/cargo_add/dev_existing_path_base/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dev-dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dev-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/dev_prefer_existing_version/stderr.term.svg
+++ b/tests/testsuite/cargo_add/dev_prefer_existing_version/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,15 +19,15 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dev-dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dev-dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>             Features as of v0.0.0:</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> one</tspan>
+    <tspan x="10px" y="64px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> one</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> two</tspan>
+    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> two</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/dry_run/stderr.term.svg
+++ b/tests/testsuite/cargo_add/dry_run/stderr.term.svg
@@ -23,7 +23,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> aborting add due to dry run</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-yellow bold">warning</tspan><tspan>: aborting add due to dry run</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/dry_run/stderr.term.svg
+++ b/tests/testsuite/cargo_add/dry_run/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -19,9 +19,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> aborting add due to dry run</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/empty_dep_name/stderr.term.svg
+++ b/tests/testsuite/cargo_add/empty_dep_name/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> package name cannot be empty</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: package name cannot be empty</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/empty_dep_name/stderr.term.svg
+++ b/tests/testsuite/cargo_add/empty_dep_name/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> package name cannot be empty</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> package name cannot be empty</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/feature_suggestion_multiple/stderr.term.svg
+++ b/tests/testsuite/cargo_add/feature_suggestion_multiple/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,11 +19,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> unrecognized features for crate my-package: baz, feo</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> unrecognized features for crate my-package: baz, feo</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/feature_suggestion_multiple/stderr.term.svg
+++ b/tests/testsuite/cargo_add/feature_suggestion_multiple/stderr.term.svg
@@ -23,7 +23,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> unrecognized features for crate my-package: baz, feo</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-red bold">error</tspan><tspan>: unrecognized features for crate my-package: baz, feo</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/feature_suggestion_none/stderr.term.svg
+++ b/tests/testsuite/cargo_add/feature_suggestion_none/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,11 +19,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> unrecognized feature for crate my-package: none_existent</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> unrecognized feature for crate my-package: none_existent</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/feature_suggestion_none/stderr.term.svg
+++ b/tests/testsuite/cargo_add/feature_suggestion_none/stderr.term.svg
@@ -23,7 +23,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> unrecognized feature for crate my-package: none_existent</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-red bold">error</tspan><tspan>: unrecognized feature for crate my-package: none_existent</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/feature_suggestion_single/stderr.term.svg
+++ b/tests/testsuite/cargo_add/feature_suggestion_single/stderr.term.svg
@@ -23,7 +23,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> unrecognized feature for crate my-package: baz</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-red bold">error</tspan><tspan>: unrecognized feature for crate my-package: baz</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/feature_suggestion_single/stderr.term.svg
+++ b/tests/testsuite/cargo_add/feature_suggestion_single/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,11 +19,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> unrecognized feature for crate my-package: baz</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> unrecognized feature for crate my-package: baz</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,21 +19,21 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>             Features:</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes</tspan>
+    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> ears</tspan>
+    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> ears</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> mouth</tspan>
+    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> nose</tspan>
+    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_activated_over_limit/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_activated_over_limit/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>             Features:</tspan>
 </tspan>
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan>             100 deactivated features</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_deactivated_over_limit/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_deactivated_over_limit/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,75 +18,75 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>             Features:</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes000</tspan>
+    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes000</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes001</tspan>
+    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes001</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes002</tspan>
+    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes002</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes003</tspan>
+    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes003</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes004</tspan>
+    <tspan x="10px" y="154px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes004</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes005</tspan>
+    <tspan x="10px" y="172px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes005</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes006</tspan>
+    <tspan x="10px" y="190px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes006</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes007</tspan>
+    <tspan x="10px" y="208px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes007</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes008</tspan>
+    <tspan x="10px" y="226px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes008</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes009</tspan>
+    <tspan x="10px" y="244px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes009</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes010</tspan>
+    <tspan x="10px" y="262px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes010</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes011</tspan>
+    <tspan x="10px" y="280px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes011</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes012</tspan>
+    <tspan x="10px" y="298px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes012</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes013</tspan>
+    <tspan x="10px" y="316px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes013</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes014</tspan>
+    <tspan x="10px" y="334px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes014</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes015</tspan>
+    <tspan x="10px" y="352px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes015</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes016</tspan>
+    <tspan x="10px" y="370px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes016</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes017</tspan>
+    <tspan x="10px" y="388px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes017</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes018</tspan>
+    <tspan x="10px" y="406px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes018</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes019</tspan>
+    <tspan x="10px" y="424px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes019</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes020</tspan>
+    <tspan x="10px" y="442px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes020</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes021</tspan>
+    <tspan x="10px" y="460px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes021</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes022</tspan>
+    <tspan x="10px" y="478px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes022</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes023</tspan>
+    <tspan x="10px" y="496px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes023</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes024</tspan>
+    <tspan x="10px" y="514px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes024</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes025</tspan>
+    <tspan x="10px" y="532px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes025</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes026</tspan>
+    <tspan x="10px" y="550px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes026</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes027</tspan>
+    <tspan x="10px" y="568px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes027</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes028</tspan>
+    <tspan x="10px" y="586px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes028</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes029</tspan>
+    <tspan x="10px" y="604px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes029</tspan>
 </tspan>
     <tspan x="10px" y="622px"><tspan>             170 deactivated features</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="640px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="658px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_empty/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_empty/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,21 +19,21 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>             Features:</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> ears</tspan>
+    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> ears</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> eyes</tspan>
+    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> eyes</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> mouth</tspan>
+    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> nose</tspan>
+    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_error_activated_over_limit/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_error_activated_over_limit/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,11 +19,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> unrecognized features for crate your-face: eees100, eees101</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> unrecognized features for crate your-face: eees100, eees101</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_error_activated_over_limit/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_error_activated_over_limit/stderr.term.svg
@@ -23,7 +23,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> unrecognized features for crate your-face: eees100, eees101</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-red bold">error</tspan><tspan>: unrecognized features for crate your-face: eees100, eees101</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_error_deactivated_over_limit/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_error_deactivated_over_limit/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,11 +19,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> unrecognized features for crate your-face: eees100, eees101</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> unrecognized features for crate your-face: eees100, eees101</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_error_deactivated_over_limit/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_error_deactivated_over_limit/stderr.term.svg
@@ -23,7 +23,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> unrecognized features for crate your-face: eees100, eees101</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-red bold">error</tspan><tspan>: unrecognized features for crate your-face: eees100, eees101</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_multiple_occurrences/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_multiple_occurrences/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,21 +19,21 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>             Features:</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes</tspan>
+    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> nose</tspan>
+    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> ears</tspan>
+    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> ears</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> mouth</tspan>
+    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_preserve/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_preserve/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,21 +19,21 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>             Features:</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes</tspan>
+    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> ears</tspan>
+    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> ears</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> mouth</tspan>
+    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> nose</tspan>
+    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_spaced_values/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_spaced_values/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,21 +19,21 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>             Features:</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes</tspan>
+    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> nose</tspan>
+    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> ears</tspan>
+    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> ears</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> mouth</tspan>
+    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_unknown/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_unknown/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,11 +19,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> unrecognized feature for crate your-face: noze</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> unrecognized feature for crate your-face: noze</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_unknown/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_unknown/stderr.term.svg
@@ -23,7 +23,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> unrecognized feature for crate your-face: noze</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-red bold">error</tspan><tspan>: unrecognized feature for crate your-face: noze</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_unknown_no_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_unknown_no_features/stderr.term.svg
@@ -23,7 +23,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> unrecognized feature for crate my-package: noze</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-red bold">error</tspan><tspan>: unrecognized feature for crate my-package: noze</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_unknown_no_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_unknown_no_features/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,11 +19,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> unrecognized feature for crate my-package: noze</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> unrecognized feature for crate my-package: noze</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/git/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git/stderr.term.svg
@@ -1,8 +1,8 @@
-<svg width="852px" height="110px" xmlns="http://www.w3.org/2000/svg">
+<svg width="844px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,13 +18,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> git-package (git) to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> git-package (git) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_branch/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_branch/stderr.term.svg
@@ -1,8 +1,8 @@
-<svg width="852px" height="110px" xmlns="http://www.w3.org/2000/svg">
+<svg width="844px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,13 +18,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> git-package (git) to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> git-package (git) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_conflicts_namever/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_conflicts_namever/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> cannot specify a git URL (`https://github.com/dcjanus/invalid`) with a version (`0.4.3`).</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> cannot specify a git URL (`https://github.com/dcjanus/invalid`) with a version (`0.4.3`).</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_conflicts_namever/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_conflicts_namever/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> cannot specify a git URL (`https://github.com/dcjanus/invalid`) with a version (`0.4.3`).</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: cannot specify a git URL (`https://github.com/dcjanus/invalid`) with a version (`0.4.3`).</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_dev/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_dev/stderr.term.svg
@@ -1,8 +1,8 @@
-<svg width="852px" height="110px" xmlns="http://www.w3.org/2000/svg">
+<svg width="844px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,13 +18,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> git-package (git) to dev-dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> git-package (git) to dev-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_inferred_name/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_inferred_name/stderr.term.svg
@@ -1,8 +1,8 @@
-<svg width="852px" height="128px" xmlns="http://www.w3.org/2000/svg">
+<svg width="844px" height="128px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,15 +18,15 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> git-package (git) to dependencies</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> git-package (git) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_inferred_name_multiple/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_inferred_name_multiple/stderr.term.svg
@@ -1,9 +1,9 @@
-<svg width="1012px" height="128px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1003px" height="128px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +19,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> multiple packages found at `[ROOTURL]/git-package`:</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> multiple packages found at `[ROOTURL]/git-package`:</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>    my-package1, my-package2, my-package3, my-package4, my-package5, my-package6</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/git_inferred_name_multiple/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_inferred_name_multiple/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="1003px" height="128px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1012px" height="128px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -21,7 +21,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> multiple packages found at `[ROOTURL]/git-package`:</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: multiple packages found at `[ROOTURL]/git-package`:</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>    my-package1, my-package2, my-package3, my-package4, my-package5, my-package6</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/git_multiple_names/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_multiple_names/stderr.term.svg
@@ -1,8 +1,8 @@
-<svg width="852px" height="128px" xmlns="http://www.w3.org/2000/svg">
+<svg width="844px" height="128px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,15 +18,15 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package1 (git) to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package1 (git) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 (git) to dependencies</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 (git) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_multiple_packages_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_multiple_packages_features/stderr.term.svg
@@ -1,8 +1,8 @@
-<svg width="852px" height="146px" xmlns="http://www.w3.org/2000/svg">
+<svg width="844px" height="146px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,17 +18,17 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> package-with-feature (git) to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> package-with-feature (git) to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>             Features:</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> target_feature</tspan>
+    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> target_feature</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_registry/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_registry/stderr.term.svg
@@ -1,9 +1,9 @@
-<svg width="902px" height="146px" xmlns="http://www.w3.org/2000/svg">
+<svg width="894px" height="146px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,11 +19,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/versioned-package`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/versioned-package`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> versioned-package (git) to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> versioned-package (git) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> failed to parse manifest at `[ROOT]/case/Cargo.toml`</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> failed to parse manifest at `[ROOT]/case/Cargo.toml`</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_registry/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_registry/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="894px" height="146px" xmlns="http://www.w3.org/2000/svg">
+<svg width="902px" height="146px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -23,7 +23,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> versioned-package (git) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> failed to parse manifest at `[ROOT]/case/Cargo.toml`</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-red bold">error</tspan><tspan>: failed to parse manifest at `[ROOT]/case/Cargo.toml`</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_rev/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_rev/stderr.term.svg
@@ -1,8 +1,8 @@
-<svg width="852px" height="110px" xmlns="http://www.w3.org/2000/svg">
+<svg width="844px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,13 +18,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> git-package (git) to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> git-package (git) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_tag/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_tag/stderr.term.svg
@@ -1,8 +1,8 @@
-<svg width="852px" height="110px" xmlns="http://www.w3.org/2000/svg">
+<svg width="844px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,13 +18,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> git-package (git) to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> git-package (git) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/help/stdout.term.svg
+++ b/tests/testsuite/cargo_add/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,15 +24,15 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo add</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[OPTIONS] &lt;DEP&gt;[@&lt;VERSION&gt;] ...</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo add</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[OPTIONS] &lt;DEP&gt;[@&lt;VERSION&gt;] ...</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="bold">       </tspan><tspan class="fg-cyan bold">cargo add</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[OPTIONS]</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">--path</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">&lt;PATH&gt; ...</tspan>
+    <tspan x="10px" y="82px"><tspan class="bold">       </tspan><tspan class="fg-bright-cyan bold">cargo add</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[OPTIONS]</tspan><tspan class="bold"> </tspan><tspan class="fg-bright-cyan bold">--path</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">&lt;PATH&gt; ...</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="bold">       </tspan><tspan class="fg-cyan bold">cargo add</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[OPTIONS]</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">--git</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">&lt;URL&gt; ...</tspan>
+    <tspan x="10px" y="100px"><tspan class="bold">       </tspan><tspan class="fg-bright-cyan bold">cargo add</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[OPTIONS]</tspan><tspan class="bold"> </tspan><tspan class="fg-bright-cyan bold">--git</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">&lt;URL&gt; ...</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-green bold">Arguments:</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
     <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-cyan">[DEP_ID]...</tspan>
 </tspan>
@@ -47,27 +48,27 @@
 </tspan>
     <tspan x="10px" y="262px">
 </tspan>
-    <tspan x="10px" y="280px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="280px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-default-features</tspan>
+    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-default-features</tspan>
 </tspan>
     <tspan x="10px" y="316px"><tspan>          Disable the default features</tspan>
 </tspan>
     <tspan x="10px" y="334px">
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--default-features</tspan>
+    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--default-features</tspan>
 </tspan>
     <tspan x="10px" y="370px"><tspan>          Re-enable the default features</tspan>
 </tspan>
     <tspan x="10px" y="388px">
 </tspan>
-    <tspan x="10px" y="406px"><tspan>  </tspan><tspan class="fg-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan>
+    <tspan x="10px" y="406px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan>
 </tspan>
     <tspan x="10px" y="424px"><tspan>          Space or comma separated list of features to activate</tspan>
 </tspan>
     <tspan x="10px" y="442px">
 </tspan>
-    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--optional</tspan>
+    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--optional</tspan>
 </tspan>
     <tspan x="10px" y="478px"><tspan>          Mark the dependency as optional</tspan>
 </tspan>
@@ -77,7 +78,7 @@
 </tspan>
     <tspan x="10px" y="532px">
 </tspan>
-    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-optional</tspan>
+    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-optional</tspan>
 </tspan>
     <tspan x="10px" y="568px"><tspan>          Mark the dependency as required</tspan>
 </tspan>
@@ -87,7 +88,7 @@
 </tspan>
     <tspan x="10px" y="622px">
 </tspan>
-    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--public</tspan>
+    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--public</tspan>
 </tspan>
     <tspan x="10px" y="658px"><tspan>          Mark the dependency as public (unstable)</tspan>
 </tspan>
@@ -97,7 +98,7 @@
 </tspan>
     <tspan x="10px" y="712px">
 </tspan>
-    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-public</tspan>
+    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-public</tspan>
 </tspan>
     <tspan x="10px" y="748px"><tspan>          Mark the dependency as private (unstable)</tspan>
 </tspan>
@@ -109,7 +110,7 @@
 </tspan>
     <tspan x="10px" y="820px">
 </tspan>
-    <tspan x="10px" y="838px"><tspan>      </tspan><tspan class="fg-cyan bold">--rename</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan>
+    <tspan x="10px" y="838px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--rename</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan>
 </tspan>
     <tspan x="10px" y="856px"><tspan>          Rename the dependency</tspan>
 </tspan>
@@ -123,25 +124,25 @@
 </tspan>
     <tspan x="10px" y="946px">
 </tspan>
-    <tspan x="10px" y="964px"><tspan>  </tspan><tspan class="fg-cyan bold">-n</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--dry-run</tspan>
+    <tspan x="10px" y="964px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-n</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--dry-run</tspan>
 </tspan>
     <tspan x="10px" y="982px"><tspan>          Don't actually write the manifest</tspan>
 </tspan>
     <tspan x="10px" y="1000px">
 </tspan>
-    <tspan x="10px" y="1018px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan>
+    <tspan x="10px" y="1018px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan>
 </tspan>
     <tspan x="10px" y="1036px"><tspan>          Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
     <tspan x="10px" y="1054px">
 </tspan>
-    <tspan x="10px" y="1072px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan>
+    <tspan x="10px" y="1072px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan>
 </tspan>
     <tspan x="10px" y="1090px"><tspan>          Do not print cargo log messages</tspan>
 </tspan>
     <tspan x="10px" y="1108px">
 </tspan>
-    <tspan x="10px" y="1126px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan>
+    <tspan x="10px" y="1126px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan>
 </tspan>
     <tspan x="10px" y="1144px"><tspan>          Coloring</tspan>
 </tspan>
@@ -151,85 +152,85 @@
 </tspan>
     <tspan x="10px" y="1198px">
 </tspan>
-    <tspan x="10px" y="1216px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan>
+    <tspan x="10px" y="1216px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan>
 </tspan>
     <tspan x="10px" y="1234px"><tspan>          Override a configuration value</tspan>
 </tspan>
     <tspan x="10px" y="1252px">
 </tspan>
-    <tspan x="10px" y="1270px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan>
+    <tspan x="10px" y="1270px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan>
 </tspan>
     <tspan x="10px" y="1288px"><tspan>          Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details</tspan>
 </tspan>
     <tspan x="10px" y="1306px">
 </tspan>
-    <tspan x="10px" y="1324px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan>
+    <tspan x="10px" y="1324px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan>
 </tspan>
     <tspan x="10px" y="1342px"><tspan>          Print help (see a summary with '-h')</tspan>
 </tspan>
     <tspan x="10px" y="1360px">
 </tspan>
-    <tspan x="10px" y="1378px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="1378px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="1396px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan>
+    <tspan x="10px" y="1396px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan>
 </tspan>
     <tspan x="10px" y="1414px"><tspan>          Path to Cargo.toml</tspan>
 </tspan>
     <tspan x="10px" y="1432px">
 </tspan>
-    <tspan x="10px" y="1450px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan>
+    <tspan x="10px" y="1450px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan>
 </tspan>
     <tspan x="10px" y="1468px"><tspan>          Path to Cargo.lock (unstable)</tspan>
 </tspan>
     <tspan x="10px" y="1486px">
 </tspan>
-    <tspan x="10px" y="1504px"><tspan>      </tspan><tspan class="fg-cyan bold">--ignore-rust-version</tspan>
+    <tspan x="10px" y="1504px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--ignore-rust-version</tspan>
 </tspan>
     <tspan x="10px" y="1522px"><tspan>          Ignore `rust-version` specification in packages</tspan>
 </tspan>
     <tspan x="10px" y="1540px">
 </tspan>
-    <tspan x="10px" y="1558px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan>
+    <tspan x="10px" y="1558px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan>
 </tspan>
     <tspan x="10px" y="1576px"><tspan>          Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="1594px">
 </tspan>
-    <tspan x="10px" y="1612px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan>
+    <tspan x="10px" y="1612px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan>
 </tspan>
     <tspan x="10px" y="1630px"><tspan>          Run without accessing the network</tspan>
 </tspan>
     <tspan x="10px" y="1648px">
 </tspan>
-    <tspan x="10px" y="1666px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan>
+    <tspan x="10px" y="1666px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan>
 </tspan>
     <tspan x="10px" y="1684px"><tspan>          Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="1702px">
 </tspan>
-    <tspan x="10px" y="1720px"><tspan class="fg-green bold">Package Selection:</tspan>
+    <tspan x="10px" y="1720px"><tspan class="fg-bright-green bold">Package Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="1738px"><tspan>  </tspan><tspan class="fg-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan>
+    <tspan x="10px" y="1738px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan>
 </tspan>
     <tspan x="10px" y="1756px"><tspan>          Package to modify</tspan>
 </tspan>
     <tspan x="10px" y="1774px">
 </tspan>
-    <tspan x="10px" y="1792px"><tspan class="fg-green bold">Source:</tspan>
+    <tspan x="10px" y="1792px"><tspan class="fg-bright-green bold">Source:</tspan>
 </tspan>
-    <tspan x="10px" y="1810px"><tspan>      </tspan><tspan class="fg-cyan bold">--path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan>
+    <tspan x="10px" y="1810px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan>
 </tspan>
     <tspan x="10px" y="1828px"><tspan>          Filesystem path to local crate to add</tspan>
 </tspan>
     <tspan x="10px" y="1846px">
 </tspan>
-    <tspan x="10px" y="1864px"><tspan>      </tspan><tspan class="fg-cyan bold">--base</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;BASE&gt;</tspan>
+    <tspan x="10px" y="1864px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--base</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;BASE&gt;</tspan>
 </tspan>
     <tspan x="10px" y="1882px"><tspan>          The path base to use when adding from a local crate (unstable).</tspan>
 </tspan>
     <tspan x="10px" y="1900px">
 </tspan>
-    <tspan x="10px" y="1918px"><tspan>      </tspan><tspan class="fg-cyan bold">--git</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;URI&gt;</tspan>
+    <tspan x="10px" y="1918px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--git</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;URI&gt;</tspan>
 </tspan>
     <tspan x="10px" y="1936px"><tspan>          Git repository location</tspan>
 </tspan>
@@ -239,19 +240,19 @@
 </tspan>
     <tspan x="10px" y="1990px">
 </tspan>
-    <tspan x="10px" y="2008px"><tspan>      </tspan><tspan class="fg-cyan bold">--branch</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;BRANCH&gt;</tspan>
+    <tspan x="10px" y="2008px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--branch</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;BRANCH&gt;</tspan>
 </tspan>
     <tspan x="10px" y="2026px"><tspan>          Git branch to download the crate from</tspan>
 </tspan>
     <tspan x="10px" y="2044px">
 </tspan>
-    <tspan x="10px" y="2062px"><tspan>      </tspan><tspan class="fg-cyan bold">--tag</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TAG&gt;</tspan>
+    <tspan x="10px" y="2062px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--tag</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TAG&gt;</tspan>
 </tspan>
     <tspan x="10px" y="2080px"><tspan>          Git tag to download the crate from</tspan>
 </tspan>
     <tspan x="10px" y="2098px">
 </tspan>
-    <tspan x="10px" y="2116px"><tspan>      </tspan><tspan class="fg-cyan bold">--rev</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;REV&gt;</tspan>
+    <tspan x="10px" y="2116px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--rev</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;REV&gt;</tspan>
 </tspan>
     <tspan x="10px" y="2134px"><tspan>          Git reference to download the crate from</tspan>
 </tspan>
@@ -261,15 +262,15 @@
 </tspan>
     <tspan x="10px" y="2188px">
 </tspan>
-    <tspan x="10px" y="2206px"><tspan>      </tspan><tspan class="fg-cyan bold">--registry</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan>
+    <tspan x="10px" y="2206px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--registry</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan>
 </tspan>
     <tspan x="10px" y="2224px"><tspan>          Package registry for this dependency</tspan>
 </tspan>
     <tspan x="10px" y="2242px">
 </tspan>
-    <tspan x="10px" y="2260px"><tspan class="fg-green bold">Section:</tspan>
+    <tspan x="10px" y="2260px"><tspan class="fg-bright-green bold">Section:</tspan>
 </tspan>
-    <tspan x="10px" y="2278px"><tspan>      </tspan><tspan class="fg-cyan bold">--dev</tspan>
+    <tspan x="10px" y="2278px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--dev</tspan>
 </tspan>
     <tspan x="10px" y="2296px"><tspan>          Add as development dependency</tspan>
 </tspan>
@@ -285,7 +286,7 @@
 </tspan>
     <tspan x="10px" y="2404px">
 </tspan>
-    <tspan x="10px" y="2422px"><tspan>      </tspan><tspan class="fg-cyan bold">--build</tspan>
+    <tspan x="10px" y="2422px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--build</tspan>
 </tspan>
     <tspan x="10px" y="2440px"><tspan>          Add as build dependency</tspan>
 </tspan>
@@ -297,13 +298,13 @@
 </tspan>
     <tspan x="10px" y="2512px">
 </tspan>
-    <tspan x="10px" y="2530px"><tspan>      </tspan><tspan class="fg-cyan bold">--target</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TARGET&gt;</tspan>
+    <tspan x="10px" y="2530px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TARGET&gt;</tspan>
 </tspan>
     <tspan x="10px" y="2548px"><tspan>          Add as dependency to the given target platform</tspan>
 </tspan>
     <tspan x="10px" y="2566px">
 </tspan>
-    <tspan x="10px" y="2584px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help add</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="2584px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help add</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="2602px">
 </tspan>

--- a/tests/testsuite/cargo_add/infer_prerelease/stderr.term.svg
+++ b/tests/testsuite/cargo_add/infer_prerelease/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> prerelease_only v0.2.0-alpha.1 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> prerelease_only v0.2.0-alpha.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/invalid_arg/stderr.term.svg
+++ b/tests/testsuite/cargo_add/invalid_arg/stderr.term.svg
@@ -2,9 +2,10 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -21,23 +22,23 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error:</tspan><tspan> unexpected argument '</tspan><tspan class="fg-yellow bold">--flag</tspan><tspan>' found</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error:</tspan><tspan> unexpected argument '</tspan><tspan class="fg-yellow bold">--flag</tspan><tspan>' found</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>  </tspan><tspan class="fg-cyan bold">tip:</tspan><tspan> a similar argument exists: '</tspan><tspan class="fg-cyan bold">--tag</tspan><tspan>'</tspan>
+    <tspan x="10px" y="64px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">tip:</tspan><tspan> a similar argument exists: '</tspan><tspan class="fg-bright-cyan bold">--tag</tspan><tspan>'</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo add</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[OPTIONS] &lt;DEP&gt;[@&lt;VERSION&gt;] ...</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo add</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[OPTIONS] &lt;DEP&gt;[@&lt;VERSION&gt;] ...</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="bold">       </tspan><tspan class="fg-cyan bold">cargo add</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[OPTIONS]</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">--path</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">&lt;PATH&gt; ...</tspan>
+    <tspan x="10px" y="118px"><tspan class="bold">       </tspan><tspan class="fg-bright-cyan bold">cargo add</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[OPTIONS]</tspan><tspan class="bold"> </tspan><tspan class="fg-bright-cyan bold">--path</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">&lt;PATH&gt; ...</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="bold">       </tspan><tspan class="fg-cyan bold">cargo add</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[OPTIONS]</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">--git</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">&lt;URL&gt; ...</tspan>
+    <tspan x="10px" y="136px"><tspan class="bold">       </tspan><tspan class="fg-bright-cyan bold">cargo add</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[OPTIONS]</tspan><tspan class="bold"> </tspan><tspan class="fg-bright-cyan bold">--git</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">&lt;URL&gt; ...</tspan>
 </tspan>
     <tspan x="10px" y="154px">
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="bold">For more information, try '</tspan><tspan class="fg-cyan bold">--help</tspan><tspan>'.</tspan>
+    <tspan x="10px" y="172px"><tspan class="bold">For more information, try '</tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>'.</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>

--- a/tests/testsuite/cargo_add/invalid_git_name/stderr.term.svg
+++ b/tests/testsuite/cargo_add/invalid_git_name/stderr.term.svg
@@ -1,9 +1,9 @@
-<svg width="1642px" height="74px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1625px" height="74px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +19,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the crate `not-in-git@[ROOTURL]/git-package` could not be found at `[ROOTURL]/git-package`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the crate `not-in-git@[ROOTURL]/git-package` could not be found at `[ROOTURL]/git-package`</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/invalid_git_name/stderr.term.svg
+++ b/tests/testsuite/cargo_add/invalid_git_name/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="1625px" height="74px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1642px" height="74px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -21,7 +21,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the crate `not-in-git@[ROOTURL]/git-package` could not be found at `[ROOTURL]/git-package`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: the crate `not-in-git@[ROOTURL]/git-package` could not be found at `[ROOTURL]/git-package`</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/invalid_key_inherit_dependency/stderr.term.svg
+++ b/tests/testsuite/cargo_add/invalid_key_inherit_dependency/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> cannot override workspace dependency with `--default-features`, either change `workspace.dependencies.foo.default-features` or define the dependency exclusively in the package's manifest</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: cannot override workspace dependency with `--default-features`, either change `workspace.dependencies.foo.default-features` or define the dependency exclusively in the package's manifest</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/invalid_key_inherit_dependency/stderr.term.svg
+++ b/tests/testsuite/cargo_add/invalid_key_inherit_dependency/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> cannot override workspace dependency with `--default-features`, either change `workspace.dependencies.foo.default-features` or define the dependency exclusively in the package's manifest</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> cannot override workspace dependency with `--default-features`, either change `workspace.dependencies.foo.default-features` or define the dependency exclusively in the package's manifest</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/invalid_key_overwrite_inherit_dependency/stderr.term.svg
+++ b/tests/testsuite/cargo_add/invalid_key_overwrite_inherit_dependency/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> cannot override workspace dependency with `--default-features`, either change `workspace.dependencies.foo.default-features` or define the dependency exclusively in the package's manifest</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: cannot override workspace dependency with `--default-features`, either change `workspace.dependencies.foo.default-features` or define the dependency exclusively in the package's manifest</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/invalid_key_overwrite_inherit_dependency/stderr.term.svg
+++ b/tests/testsuite/cargo_add/invalid_key_overwrite_inherit_dependency/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> cannot override workspace dependency with `--default-features`, either change `workspace.dependencies.foo.default-features` or define the dependency exclusively in the package's manifest</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> cannot override workspace dependency with `--default-features`, either change `workspace.dependencies.foo.default-features` or define the dependency exclusively in the package's manifest</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/invalid_key_rename_inherit_dependency/stderr.term.svg
+++ b/tests/testsuite/cargo_add/invalid_key_rename_inherit_dependency/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> cannot override workspace dependency with `--rename`, either change `workspace.dependencies.foo.package` or define the dependency exclusively in the package's manifest</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> cannot override workspace dependency with `--rename`, either change `workspace.dependencies.foo.package` or define the dependency exclusively in the package's manifest</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/invalid_key_rename_inherit_dependency/stderr.term.svg
+++ b/tests/testsuite/cargo_add/invalid_key_rename_inherit_dependency/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> cannot override workspace dependency with `--rename`, either change `workspace.dependencies.foo.package` or define the dependency exclusively in the package's manifest</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: cannot override workspace dependency with `--rename`, either change `workspace.dependencies.foo.package` or define the dependency exclusively in the package's manifest</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/invalid_name_external/stderr.term.svg
+++ b/tests/testsuite/cargo_add/invalid_name_external/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +19,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the crate `lets_hope_nobody_ever_publishes_this_crate` could not be found in registry index.</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the crate `lets_hope_nobody_ever_publishes_this_crate` could not be found in registry index.</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/invalid_name_external/stderr.term.svg
+++ b/tests/testsuite/cargo_add/invalid_name_external/stderr.term.svg
@@ -21,7 +21,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the crate `lets_hope_nobody_ever_publishes_this_crate` could not be found in registry index.</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: the crate `lets_hope_nobody_ever_publishes_this_crate` could not be found in registry index.</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/invalid_path/stderr.term.svg
+++ b/tests/testsuite/cargo_add/invalid_path/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="902px" height="218px" xmlns="http://www.w3.org/2000/svg">
+<svg width="911px" height="218px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> failed to load source for dependency `cargo-list-test-fixture`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: failed to load source for dependency `cargo-list-test-fixture`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/invalid_path/stderr.term.svg
+++ b/tests/testsuite/cargo_add/invalid_path/stderr.term.svg
@@ -1,8 +1,8 @@
-<svg width="911px" height="218px" xmlns="http://www.w3.org/2000/svg">
+<svg width="902px" height="218px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> failed to load source for dependency `cargo-list-test-fixture`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> failed to load source for dependency `cargo-list-test-fixture`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/invalid_path_name/stderr.term.svg
+++ b/tests/testsuite/cargo_add/invalid_path_name/stderr.term.svg
@@ -1,8 +1,8 @@
-<svg width="1600px" height="56px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1583px" height="56px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the crate `not-at-path@[ROOT]/case/dependency` could not be found at `[ROOT]/case/dependency`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the crate `not-at-path@[ROOT]/case/dependency` could not be found at `[ROOT]/case/dependency`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/invalid_path_name/stderr.term.svg
+++ b/tests/testsuite/cargo_add/invalid_path_name/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="1583px" height="56px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1600px" height="56px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the crate `not-at-path@[ROOT]/case/dependency` could not be found at `[ROOT]/case/dependency`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: the crate `not-at-path@[ROOT]/case/dependency` could not be found at `[ROOT]/case/dependency`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/invalid_path_self/stderr.term.svg
+++ b/tests/testsuite/cargo_add/invalid_path_self/stderr.term.svg
@@ -21,7 +21,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> cargo-list-test-fixture (local) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> cannot add `cargo-list-test-fixture` as a dependency to itself</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: cannot add `cargo-list-test-fixture` as a dependency to itself</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/invalid_path_self/stderr.term.svg
+++ b/tests/testsuite/cargo_add/invalid_path_self/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +19,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture (local) to dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> cargo-list-test-fixture (local) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> cannot add `cargo-list-test-fixture` as a dependency to itself</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> cannot add `cargo-list-test-fixture` as a dependency to itself</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/invalid_target_empty/stderr.term.svg
+++ b/tests/testsuite/cargo_add/invalid_target_empty/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-red { fill: #FF5555 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,11 +20,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error:</tspan><tspan> a value is required for '</tspan><tspan class="fg-yellow bold">--target &lt;TARGET&gt;</tspan><tspan>' but none was supplied</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error:</tspan><tspan> a value is required for '</tspan><tspan class="fg-yellow bold">--target &lt;TARGET&gt;</tspan><tspan>' but none was supplied</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>For more information, try '</tspan><tspan class="fg-cyan bold">--help</tspan><tspan>'.</tspan>
+    <tspan x="10px" y="64px"><tspan>For more information, try '</tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>'.</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/invalid_vers/stderr.term.svg
+++ b/tests/testsuite/cargo_add/invalid_vers/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> invalid version requirement `invalid-version-string`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: invalid version requirement `invalid-version-string`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/invalid_vers/stderr.term.svg
+++ b/tests/testsuite/cargo_add/invalid_vers/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> invalid version requirement `invalid-version-string`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> invalid version requirement `invalid-version-string`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/list_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/list_features/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,21 +19,21 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>             Features:</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> ears</tspan>
+    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> ears</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> eyes</tspan>
+    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> eyes</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> mouth</tspan>
+    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> nose</tspan>
+    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/list_features_path/stderr.term.svg
+++ b/tests/testsuite/cargo_add/list_features_path/stderr.term.svg
@@ -2,9 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -21,23 +20,23 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> your-face (local) to dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> your-face (local) to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>             Features:</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> mouth</tspan>
+    <tspan x="10px" y="64px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> nose</tspan>
+    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> eyes</tspan>
+    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> eyes</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> optional-dependency</tspan>
+    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> optional-dependency</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>

--- a/tests/testsuite/cargo_add/list_features_path_no_default/stderr.term.svg
+++ b/tests/testsuite/cargo_add/list_features_path_no_default/stderr.term.svg
@@ -2,9 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -21,23 +20,23 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> your-face (local) to dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> your-face (local) to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>             Features:</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> eyes</tspan>
+    <tspan x="10px" y="64px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> eyes</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> mouth</tspan>
+    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> nose</tspan>
+    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> optional-dependency</tspan>
+    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> optional-dependency</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>

--- a/tests/testsuite/cargo_add/locked_changed/stderr.term.svg
+++ b/tests/testsuite/cargo_add/locked_changed/stderr.term.svg
@@ -1,9 +1,9 @@
-<svg width="1289px" height="92px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1280px" height="92px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,11 +19,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the manifest file [ROOT]/case/Cargo.toml needs to be updated but --locked was passed to prevent this</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the manifest file [ROOT]/case/Cargo.toml needs to be updated but --locked was passed to prevent this</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/locked_changed/stderr.term.svg
+++ b/tests/testsuite/cargo_add/locked_changed/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="1280px" height="92px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1289px" height="92px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -23,7 +23,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the manifest file [ROOT]/case/Cargo.toml needs to be updated but --locked was passed to prevent this</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-red bold">error</tspan><tspan>: the manifest file [ROOT]/case/Cargo.toml needs to be updated but --locked was passed to prevent this</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/locked_unchanged/stderr.term.svg
+++ b/tests/testsuite/cargo_add/locked_unchanged/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/lockfile_updated/stderr.term.svg
+++ b/tests/testsuite/cargo_add/lockfile_updated/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,13 +18,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package v99999.0.0+my-package</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0+my-package</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/manifest_path_package/stderr.term.svg
+++ b/tests/testsuite/cargo_add/manifest_path_package/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/merge_activated_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/merge_activated_features/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,25 +19,25 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> foo (workspace) to dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> foo (workspace) to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>             Features as of v0.0.0:</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> default-base</tspan>
+    <tspan x="10px" y="64px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> default-base</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> default-merge-base</tspan>
+    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> default-merge-base</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> default-test-base</tspan>
+    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> default-test-base</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> merge</tspan>
+    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> merge</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> merge-base</tspan>
+    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> merge-base</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> test</tspan>
+    <tspan x="10px" y="154px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> test</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> test-base</tspan>
+    <tspan x="10px" y="172px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> test-base</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> unrelated</tspan>
+    <tspan x="10px" y="190px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> unrelated</tspan>
 </tspan>
     <tspan x="10px" y="208px">
 </tspan>

--- a/tests/testsuite/cargo_add/missing_at_in_crate_spec/stderr.term.svg
+++ b/tests/testsuite/cargo_add/missing_at_in_crate_spec/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> invalid character `=` in package name: `my-package=1.0.0`, characters must be Unicode XID characters (numbers, `-`, `_`, or most letters)</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> invalid character `=` in package name: `my-package=1.0.0`, characters must be Unicode XID characters (numbers, `-`, `_`, or most letters)</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/missing_at_in_crate_spec/stderr.term.svg
+++ b/tests/testsuite/cargo_add/missing_at_in_crate_spec/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> invalid character `=` in package name: `my-package=1.0.0`, characters must be Unicode XID characters (numbers, `-`, `_`, or most letters)</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: invalid character `=` in package name: `my-package=1.0.0`, characters must be Unicode XID characters (numbers, `-`, `_`, or most letters)</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/multiple_conflicts_with_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/multiple_conflicts_with_features/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> feature `nose` must be qualified by the dependency it's being activated for, like `my-package1/nose`, `your-face/nose`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> feature `nose` must be qualified by the dependency it's being activated for, like `my-package1/nose`, `your-face/nose`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/multiple_conflicts_with_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/multiple_conflicts_with_features/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> feature `nose` must be qualified by the dependency it's being activated for, like `my-package1/nose`, `your-face/nose`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: feature `nose` must be qualified by the dependency it's being activated for, like `my-package1/nose`, `your-face/nose`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/multiple_conflicts_with_rename/stderr.term.svg
+++ b/tests/testsuite/cargo_add/multiple_conflicts_with_rename/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> cannot specify multiple crates with `--rename`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: cannot specify multiple crates with `--rename`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/multiple_conflicts_with_rename/stderr.term.svg
+++ b/tests/testsuite/cargo_add/multiple_conflicts_with_rename/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> cannot specify multiple crates with `--rename`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> cannot specify multiple crates with `--rename`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/namever/stderr.term.svg
+++ b/tests/testsuite/cargo_add/namever/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,17 +19,17 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package1 &gt;=0.1.1 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package1 &gt;=0.1.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v0.2.3 to dependencies</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v0.2.3 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.2.3+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v0.2.3+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_add/no_args/stderr.term.svg
+++ b/tests/testsuite/cargo_add/no_args/stderr.term.svg
@@ -2,9 +2,10 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -20,21 +21,21 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error:</tspan><tspan> the following required arguments were not provided:</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error:</tspan><tspan> the following required arguments were not provided:</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-cyan bold">&lt;DEP_ID|--path &lt;PATH&gt;|--git &lt;URI&gt;&gt;</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">&lt;DEP_ID|--path &lt;PATH&gt;|--git &lt;URI&gt;&gt;</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo add</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[OPTIONS] &lt;DEP&gt;[@&lt;VERSION&gt;] ...</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo add</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[OPTIONS] &lt;DEP&gt;[@&lt;VERSION&gt;] ...</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="bold">       </tspan><tspan class="fg-cyan bold">cargo add</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[OPTIONS]</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">--path</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">&lt;PATH&gt; ...</tspan>
+    <tspan x="10px" y="100px"><tspan class="bold">       </tspan><tspan class="fg-bright-cyan bold">cargo add</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[OPTIONS]</tspan><tspan class="bold"> </tspan><tspan class="fg-bright-cyan bold">--path</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">&lt;PATH&gt; ...</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="bold">       </tspan><tspan class="fg-cyan bold">cargo add</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[OPTIONS]</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">--git</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">&lt;URL&gt; ...</tspan>
+    <tspan x="10px" y="118px"><tspan class="bold">       </tspan><tspan class="fg-bright-cyan bold">cargo add</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[OPTIONS]</tspan><tspan class="bold"> </tspan><tspan class="fg-bright-cyan bold">--git</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">&lt;URL&gt; ...</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="bold">For more information, try '</tspan><tspan class="fg-cyan bold">--help</tspan><tspan>'.</tspan>
+    <tspan x="10px" y="154px"><tspan class="bold">For more information, try '</tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>'.</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/no_default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/no_default_features/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,15 +19,15 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package1 v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package1 v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v0.4.1 to dependencies</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v0.4.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/no_optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/no_optional/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/no_public/stderr.term.svg
+++ b/tests/testsuite/cargo_add/no_public/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/normalize_name_git/stderr.term.svg
+++ b/tests/testsuite/cargo_add/normalize_name_git/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="1633px" height="74px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1650px" height="74px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -21,7 +21,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the crate `git_package@[ROOTURL]/git-package` could not be found at `[ROOTURL]/git-package`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: the crate `git_package@[ROOTURL]/git-package` could not be found at `[ROOTURL]/git-package`</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/normalize_name_git/stderr.term.svg
+++ b/tests/testsuite/cargo_add/normalize_name_git/stderr.term.svg
@@ -1,9 +1,9 @@
-<svg width="1650px" height="74px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1633px" height="74px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +19,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the crate `git_package@[ROOTURL]/git-package` could not be found at `[ROOTURL]/git-package`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the crate `git_package@[ROOTURL]/git-package` could not be found at `[ROOTURL]/git-package`</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/normalize_name_path/stderr.term.svg
+++ b/tests/testsuite/cargo_add/normalize_name_path/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="1776px" height="56px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1793px" height="56px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the crate `cargo_list_test_fixture_dependency@[ROOT]/case/dependency` could not be found at `[ROOT]/case/dependency`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: the crate `cargo_list_test_fixture_dependency@[ROOT]/case/dependency` could not be found at `[ROOT]/case/dependency`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/normalize_name_path/stderr.term.svg
+++ b/tests/testsuite/cargo_add/normalize_name_path/stderr.term.svg
@@ -1,8 +1,8 @@
-<svg width="1793px" height="56px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1776px" height="56px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the crate `cargo_list_test_fixture_dependency@[ROOT]/case/dependency` could not be found at `[ROOT]/case/dependency`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the crate `cargo_list_test_fixture_dependency@[ROOT]/case/dependency` could not be found at `[ROOT]/case/dependency`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/normalize_name_path_existing/stderr.term.svg
+++ b/tests/testsuite/cargo_add/normalize_name_path_existing/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +19,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the crate `fuzzy-name` could not be found in registry index.</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the crate `fuzzy-name` could not be found in registry index.</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/normalize_name_path_existing/stderr.term.svg
+++ b/tests/testsuite/cargo_add/normalize_name_path_existing/stderr.term.svg
@@ -21,7 +21,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the crate `fuzzy-name` could not be found in registry index.</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: the crate `fuzzy-name` could not be found in registry index.</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/normalize_name_registry/stderr.term.svg
+++ b/tests/testsuite/cargo_add/normalize_name_registry/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,43 +20,43 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> translating `linked_hash_map` to `linked-hash-map`</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> translating `Inflector` to `inflector`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">      Adding</tspan><tspan> linked-hash-map v0.5.4 to dependencies</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> linked-hash-map v0.5.4 to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan>             Features:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> clippy</tspan>
+    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> clippy</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> heapsize</tspan>
+    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> heapsize</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> heapsize_impl</tspan>
+    <tspan x="10px" y="154px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> heapsize_impl</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> nightly</tspan>
+    <tspan x="10px" y="172px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> nightly</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> serde</tspan>
+    <tspan x="10px" y="190px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> serde</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> serde_impl</tspan>
+    <tspan x="10px" y="208px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> serde_impl</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> serde_test</tspan>
+    <tspan x="10px" y="226px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> serde_test</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan class="fg-green bold">      Adding</tspan><tspan> inflector v0.11.4 to dependencies</tspan>
+    <tspan x="10px" y="244px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> inflector v0.11.4 to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="262px"><tspan>             Features:</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> heavyweight</tspan>
+    <tspan x="10px" y="280px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> heavyweight</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> lazy_static</tspan>
+    <tspan x="10px" y="298px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> lazy_static</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> regex</tspan>
+    <tspan x="10px" y="316px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> regex</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> unstable</tspan>
+    <tspan x="10px" y="334px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> unstable</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="352px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="370px">
 </tspan>

--- a/tests/testsuite/cargo_add/normalize_name_registry/stderr.term.svg
+++ b/tests/testsuite/cargo_add/normalize_name_registry/stderr.term.svg
@@ -22,9 +22,9 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> translating `linked_hash_map` to `linked-hash-map`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-yellow bold">warning</tspan><tspan>: translating `linked_hash_map` to `linked-hash-map`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> translating `Inflector` to `inflector`</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-yellow bold">warning</tspan><tspan>: translating `Inflector` to `inflector`</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> linked-hash-map v0.5.4 to dependencies</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/normalize_name_registry_existing/stderr.term.svg
+++ b/tests/testsuite/cargo_add/normalize_name_registry_existing/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -22,21 +22,21 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> translating `your-face` to `your_face`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> your_face v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> your_face v99999.0.0 to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan>             Features:</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes</tspan>
+    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> ears</tspan>
+    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> ears</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> mouth</tspan>
+    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> nose</tspan>
+    <tspan x="10px" y="154px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>

--- a/tests/testsuite/cargo_add/normalize_name_registry_existing/stderr.term.svg
+++ b/tests/testsuite/cargo_add/normalize_name_registry_existing/stderr.term.svg
@@ -20,7 +20,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> translating `your-face` to `your_face`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan>: translating `your-face` to `your_face`</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/normalize_name_registry_yanked/stderr.term.svg
+++ b/tests/testsuite/cargo_add/normalize_name_registry_yanked/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -19,13 +19,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> translating `linked_hash_map` to `linked-hash-map`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> linked-hash-map v0.5.4 to dependencies</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> linked-hash-map v0.5.4 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/normalize_name_registry_yanked/stderr.term.svg
+++ b/tests/testsuite/cargo_add/normalize_name_registry_yanked/stderr.term.svg
@@ -21,7 +21,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> translating `linked_hash_map` to `linked-hash-map`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-yellow bold">warning</tspan><tspan>: translating `linked_hash_map` to `linked-hash-map`</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> linked-hash-map v0.5.4 to dependencies</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/normalize_name_workspace_dep/stderr.term.svg
+++ b/tests/testsuite/cargo_add/normalize_name_workspace_dep/stderr.term.svg
@@ -19,7 +19,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> translating `fuzzy-dependency` to `fuzzy_dependency`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan>: translating `fuzzy-dependency` to `fuzzy_dependency`</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/normalize_name_workspace_dep/stderr.term.svg
+++ b/tests/testsuite/cargo_add/normalize_name_workspace_dep/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -21,11 +21,11 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> translating `fuzzy-dependency` to `fuzzy_dependency`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> fuzzy_dependency (workspace) to dependencies</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> fuzzy_dependency (workspace) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/offline_empty_cache/stderr.term.svg
+++ b/tests/testsuite/cargo_add/offline_empty_cache/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the crate `my-package` could not be found in registry index.</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: the crate `my-package` could not be found in registry index.</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/offline_empty_cache/stderr.term.svg
+++ b/tests/testsuite/cargo_add/offline_empty_cache/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the crate `my-package` could not be found in registry index.</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the crate `my-package` could not be found in registry index.</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/optional/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,13 +18,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.1.0 to optional dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.0 to optional dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `my-package`</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> feature `my-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_default_features/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,15 +19,15 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package1 v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package1 v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v0.4.1 to dependencies</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v0.4.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_default_features_with_no_default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_default_features_with_no_default_features/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,15 +19,15 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package1 v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package1 v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v0.4.1 to dependencies</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v0.4.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_features/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,21 +19,21 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>             Features:</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes</tspan>
+    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> nose</tspan>
+    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> ears</tspan>
+    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> ears</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> mouth</tspan>
+    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_git_with_path/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_git_with_path/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to optional dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to optional dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `cargo-list-test-fixture-dependency`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> feature `cargo-list-test-fixture-dependency`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_inherit_features_noop/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_inherit_features_noop/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> foo (workspace) to dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> foo (workspace) to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>             Features as of v0.0.0:</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> test</tspan>
+    <tspan x="10px" y="64px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> test</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_inherit_noop/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_inherit_noop/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> foo (workspace) to dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> foo (workspace) to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_inherit_optional_noop/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_inherit_optional_noop/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> foo (workspace) to optional dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> foo (workspace) to optional dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `foo`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> feature `foo`</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_inline_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_inline_features/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,23 +18,23 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> unrelateed-crate v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> unrelateed-crate v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan>             Features:</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> ears</tspan>
+    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> ears</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes</tspan>
+    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> mouth</tspan>
+    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> nose</tspan>
+    <tspan x="10px" y="154px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_name_dev_noop/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_name_dev_noop/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,15 +18,15 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> your-face (local) to dev-dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> your-face (local) to dev-dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>             Features:</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> mouth</tspan>
+    <tspan x="10px" y="64px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> nose</tspan>
+    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_name_noop/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_name_noop/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,17 +18,17 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> your-face (local) to optional dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> your-face (local) to optional dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>             Features:</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> mouth</tspan>
+    <tspan x="10px" y="64px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> nose</tspan>
+    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `your-face`</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> feature `your-face`</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_no_default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_no_default_features/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,15 +19,15 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package1 v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package1 v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v0.4.1 to dependencies</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v0.4.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_no_default_features_with_default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_no_default_features_with_default_features/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,15 +19,15 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package1 v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package1 v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v0.4.1 to dependencies</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v0.4.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_no_optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_no_optional/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_no_optional_with_optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_no_optional_with_optional/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,13 +18,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.1.0 to optional dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.0 to optional dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `my-package`</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> feature `my-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_no_public/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_no_public/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_no_public_with_public/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_no_public_with_public/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.1.0 to public dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.0 to public dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_optional/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,13 +18,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.1.0 to optional dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.0 to optional dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `my-package`</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> feature `my-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_optional_with_no_optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_optional_with_no_optional/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,21 +19,21 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>             Features:</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> ears</tspan>
+    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> ears</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> eyes</tspan>
+    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> eyes</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> mouth</tspan>
+    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> nose</tspan>
+    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_optional_with_optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_optional_with_optional/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package1 v99999.0.0 to optional dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package1 v99999.0.0 to optional dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_path_base_with_version/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_path_base_with_version/stderr.term.svg
@@ -1,10 +1,8 @@
-<svg width="844px" height="128px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
-    .fg-yellow { fill: #AA5500 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -20,13 +18,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency v20.0 to optional dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency v20.0 to optional dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `cargo-list-test-fixture-dependency`</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> feature `cargo-list-test-fixture-dependency`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_path_noop/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_path_noop/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,17 +18,17 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> your-face (local) to optional dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> your-face (local) to optional dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>             Features:</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> mouth</tspan>
+    <tspan x="10px" y="64px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> nose</tspan>
+    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `your-face`</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> feature `your-face`</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_path_with_version/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_path_with_version/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,15 +19,15 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency v20.0 to optional dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency v20.0 to optional dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `cargo-list-test-fixture-dependency`</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> feature `cargo-list-test-fixture-dependency`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency v20.0.0+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency v20.0.0+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_preserves_inline_table/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_preserves_inline_table/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,21 +19,21 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>             Features:</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> eyes</tspan>
+    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> eyes</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> nose</tspan>
+    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> ears</tspan>
+    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> ears</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> mouth</tspan>
+    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_public/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_public/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.1.0 to public dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.0 to public dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_public_with_no_public/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_public_with_no_public/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_rename_with_no_rename/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_rename_with_no_rename/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,13 +19,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> versioned-package v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> versioned-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_rename_with_rename/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_rename_with_rename/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,13 +19,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> versioned-package v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> versioned-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_rename_with_rename_noop/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_rename_with_rename_noop/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,15 +19,15 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> versioned-package v0.1.1 to optional dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> versioned-package v0.1.1 to optional dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `a1`</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> feature `a1`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_version_with_git/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_version_with_git/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,15 +18,15 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/versioned-package`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/versioned-package`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> versioned-package (git) to optional dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> versioned-package (git) to optional dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `versioned-package`</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> feature `versioned-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/versioned-package`</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/versioned-package`</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_version_with_path/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_version_with_path/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to optional dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to optional dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `cargo-list-test-fixture-dependency`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> feature `cargo-list-test-fixture-dependency`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_with_rename/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_with_rename/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,13 +19,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> versioned-package v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> versioned-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_workspace_dep/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_workspace_dep/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> foo (local) to dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> foo (local) to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_workspace_dep_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_workspace_dep_features/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,25 +19,25 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> foo (local) to dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> foo (local) to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>             Features:</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> default-base</tspan>
+    <tspan x="10px" y="64px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> default-base</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> default-merge-base</tspan>
+    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> default-merge-base</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> default-test-base</tspan>
+    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> default-test-base</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> test</tspan>
+    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> test</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> test-base</tspan>
+    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> test-base</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> merge</tspan>
+    <tspan x="10px" y="154px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> merge</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> merge-base</tspan>
+    <tspan x="10px" y="172px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> merge-base</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> unrelated</tspan>
+    <tspan x="10px" y="190px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> unrelated</tspan>
 </tspan>
     <tspan x="10px" y="208px">
 </tspan>

--- a/tests/testsuite/cargo_add/path/stderr.term.svg
+++ b/tests/testsuite/cargo_add/path/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/path_base/stderr.term.svg
+++ b/tests/testsuite/cargo_add/path_base/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/path_base_inferred_name/stderr.term.svg
+++ b/tests/testsuite/cargo_add/path_base_inferred_name/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/path_base_missing_base_path/stderr.term.svg
+++ b/tests/testsuite/cargo_add/path_base_missing_base_path/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> path base `bad_base` is undefined. You must add an entry for `bad_base` in the Cargo configuration [path-bases] table.</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: path base `bad_base` is undefined. You must add an entry for `bad_base` in the Cargo configuration [path-bases] table.</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/path_base_missing_base_path/stderr.term.svg
+++ b/tests/testsuite/cargo_add/path_base_missing_base_path/stderr.term.svg
@@ -1,8 +1,8 @@
-<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1070px" height="56px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> path base `bad_base` is undefined. You must add an entry for `bad_base` in the Cargo configuration [path-bases] table.</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> path base `bad_base` is undefined. You must add an entry for `bad_base` in the Cargo configuration [path-bases] table.</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/path_base_unstable/stderr.term.svg
+++ b/tests/testsuite/cargo_add/path_base_unstable/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> feature `path-bases` is required</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: feature `path-bases` is required</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/path_base_unstable/stderr.term.svg
+++ b/tests/testsuite/cargo_add/path_base_unstable/stderr.term.svg
@@ -1,8 +1,8 @@
-<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1297px" height="146px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> feature `path-bases` is required</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> feature `path-bases` is required</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/path_dev/stderr.term.svg
+++ b/tests/testsuite/cargo_add/path_dev/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dev-dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dev-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/path_inferred_name/stderr.term.svg
+++ b/tests/testsuite/cargo_add/path_inferred_name/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/path_inferred_name_conflicts_full_feature/stderr.term.svg
+++ b/tests/testsuite/cargo_add/path_inferred_name_conflicts_full_feature/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> `your-face/nose` is unsupported when inferring the crate name, use `nose`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: `your-face/nose` is unsupported when inferring the crate name, use `nose`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/path_inferred_name_conflicts_full_feature/stderr.term.svg
+++ b/tests/testsuite/cargo_add/path_inferred_name_conflicts_full_feature/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> `your-face/nose` is unsupported when inferring the crate name, use `nose`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> `your-face/nose` is unsupported when inferring the crate name, use `nose`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/prefixed_v_in_version/stderr.term.svg
+++ b/tests/testsuite/cargo_add/prefixed_v_in_version/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the version provided, `v0.0.1` is not a valid SemVer requirement</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the version provided, `v0.0.1` is not a valid SemVer requirement</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/prefixed_v_in_version/stderr.term.svg
+++ b/tests/testsuite/cargo_add/prefixed_v_in_version/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the version provided, `v0.0.1` is not a valid SemVer requirement</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: the version provided, `v0.0.1` is not a valid SemVer requirement</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/preserve_dep_std_table/stderr.term.svg
+++ b/tests/testsuite/cargo_add/preserve_dep_std_table/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,21 +19,21 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>             Features:</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> ears</tspan>
+    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> ears</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> eyes</tspan>
+    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> eyes</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> mouth</tspan>
+    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> nose</tspan>
+    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/preserve_features_sorted/stderr.term.svg
+++ b/tests/testsuite/cargo_add/preserve_features_sorted/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,23 +18,23 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>             Features:</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> a</tspan>
+    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> a</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> b</tspan>
+    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> b</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> c</tspan>
+    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> c</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> d</tspan>
+    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> d</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> e</tspan>
+    <tspan x="10px" y="154px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> e</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>

--- a/tests/testsuite/cargo_add/preserve_features_table/stderr.term.svg
+++ b/tests/testsuite/cargo_add/preserve_features_table/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,21 +19,21 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>             Features:</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> ears</tspan>
+    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> ears</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> eyes</tspan>
+    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> eyes</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> mouth</tspan>
+    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> nose</tspan>
+    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/preserve_features_unsorted/stderr.term.svg
+++ b/tests/testsuite/cargo_add/preserve_features_unsorted/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,23 +18,23 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>             Features:</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> a</tspan>
+    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> a</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> b</tspan>
+    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> b</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> c</tspan>
+    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> c</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> d</tspan>
+    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> d</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> e</tspan>
+    <tspan x="10px" y="154px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> e</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>

--- a/tests/testsuite/cargo_add/preserve_sorted/stderr.term.svg
+++ b/tests/testsuite/cargo_add/preserve_sorted/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,15 +19,15 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> toml v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> toml v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/preserve_unsorted/stderr.term.svg
+++ b/tests/testsuite/cargo_add/preserve_unsorted/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,15 +19,15 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> toml v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> toml v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/public/stderr.term.svg
+++ b/tests/testsuite/cargo_add/public/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.1.0 to public dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.0 to public dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/registry/stderr.term.svg
+++ b/tests/testsuite/cargo_add/registry/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,13 +18,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `alternative` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `alternative` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package1 v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package1 v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/rename/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rename/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/require_weak/stderr.term.svg
+++ b/tests/testsuite/cargo_add/require_weak/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,21 +19,21 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> your-face v99999.0.0 to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>             Features:</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> ears</tspan>
+    <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> ears</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> eyes</tspan>
+    <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> eyes</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> mouth</tspan>
+    <tspan x="10px" y="118px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> nose</tspan>
+    <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/rust_version_ignore/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rust_version_ignore/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> rust-version-user v0.2.1 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> rust-version-user v0.2.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/rust_version_incompatible/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rust_version_incompatible/stderr.term.svg
@@ -21,7 +21,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> no version of crate `rust-version-user` can maintain cargo-list-test-fixture's rust-version of 1.56</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: no version of crate `rust-version-user` can maintain cargo-list-test-fixture's rust-version of 1.56</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>help: pass `--ignore-rust-version` to select rust-version-user@0.2.1 which requires rustc 1.72</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/rust_version_incompatible/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rust_version_incompatible/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +19,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> no version of crate `rust-version-user` can maintain cargo-list-test-fixture's rust-version of 1.56</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> no version of crate `rust-version-user` can maintain cargo-list-test-fixture's rust-version of 1.56</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>help: pass `--ignore-rust-version` to select rust-version-user@0.2.1 which requires rustc 1.72</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/rust_version_latest/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rust_version_latest/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> rust-version-user v0.2.1 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> rust-version-user v0.2.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest Rust 1.72 compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest Rust 1.72 compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/rust_version_older/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rust_version_older/stderr.term.svg
@@ -21,7 +21,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> ignoring rust-version-user@0.2.1 (which requires rustc 1.72) to maintain cargo-list-test-fixture's rust-version of 1.70</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-yellow bold">warning</tspan><tspan>: ignoring rust-version-user@0.2.1 (which requires rustc 1.72) to maintain cargo-list-test-fixture's rust-version of 1.70</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> rust-version-user v0.1.0 to dependencies</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/rust_version_older/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rust_version_older/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,15 +19,15 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> ignoring rust-version-user@0.2.1 (which requires rustc 1.72) to maintain cargo-list-test-fixture's rust-version of 1.70</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> rust-version-user v0.1.0 to dependencies</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> rust-version-user v0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest Rust 1.70 compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest Rust 1.70 compatible version</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> rust-version-user v0.1.0 (available: v0.2.1, requires Rust 1.72)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> rust-version-user v0.1.0 (available: v0.2.1, requires Rust 1.72)</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/rustc_ignore/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rustc_ignore/stderr.term.svg
@@ -2,9 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -20,13 +19,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> rust-version-user v0.2.1 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> rust-version-user v0.2.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> rust-version-user v0.2.1 </tspan><tspan class="fg-red bold">(requires Rust 1.2345)</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> rust-version-user v0.2.1 </tspan><tspan class="fg-bright-red bold">(requires Rust 1.2345)</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/rustc_incompatible/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rustc_incompatible/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +19,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> no version of crate `rust-version-user` is compatible with rustc [..]</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> no version of crate `rust-version-user` is compatible with rustc [..]</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>help: pass `--ignore-rust-version` to select rust-version-user@0.2.1 which requires rustc 1.2345</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/rustc_incompatible/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rustc_incompatible/stderr.term.svg
@@ -21,7 +21,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> no version of crate `rust-version-user` is compatible with rustc [..]</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: no version of crate `rust-version-user` is compatible with rustc [..]</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>help: pass `--ignore-rust-version` to select rust-version-user@0.2.1 which requires rustc 1.2345</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/rustc_latest/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rustc_latest/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,15 +19,15 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> ignoring rust-version-user@0.2.1 (which requires rustc 1.2345) as it is incompatible with rustc [..]</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> rust-version-user v0.1.1 to dependencies</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> rust-version-user v0.1.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> rust-version-user v0.1.1 (available: v0.2.1, requires Rust 1.2345)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> rust-version-user v0.1.1 (available: v0.2.1, requires Rust 1.2345)</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/rustc_latest/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rustc_latest/stderr.term.svg
@@ -21,7 +21,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> ignoring rust-version-user@0.2.1 (which requires rustc 1.2345) as it is incompatible with rustc [..]</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-yellow bold">warning</tspan><tspan>: ignoring rust-version-user@0.2.1 (which requires rustc 1.2345) as it is incompatible with rustc [..]</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> rust-version-user v0.1.1 to dependencies</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/rustc_older/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rustc_older/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,15 +19,15 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> ignoring rust-version-user@0.2.1 (which requires rustc 1.2345) as it is incompatible with rustc [..]</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> rust-version-user v0.1.1 to dependencies</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> rust-version-user v0.1.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> rust-version-user v0.1.1 (available: v0.2.1, requires Rust 1.2345)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> rust-version-user v0.1.1 (available: v0.2.1, requires Rust 1.2345)</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/rustc_older/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rustc_older/stderr.term.svg
@@ -21,7 +21,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> ignoring rust-version-user@0.2.1 (which requires rustc 1.2345) as it is incompatible with rustc [..]</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-yellow bold">warning</tspan><tspan>: ignoring rust-version-user@0.2.1 (which requires rustc 1.2345) as it is incompatible with rustc [..]</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> rust-version-user v0.1.1 to dependencies</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/script_bare/stderr.term.svg
+++ b/tests/testsuite/cargo_add/script_bare/stderr.term.svg
@@ -19,13 +19,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> `package.edition` is unspecified, defaulting to `[..]`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to `2024`</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> `package.edition` is unspecified, defaulting to `[..]`</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to `2024`</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/script_bare/stderr.term.svg
+++ b/tests/testsuite/cargo_add/script_bare/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -21,13 +21,13 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> `package.edition` is unspecified, defaulting to `[..]`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> `package.edition` is unspecified, defaulting to `[..]`</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest [..]compatible version</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/script_escape/stderr.term.svg
+++ b/tests/testsuite/cargo_add/script_escape/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest [..]compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/script_frontmatter/stderr.term.svg
+++ b/tests/testsuite/cargo_add/script_frontmatter/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest [..]compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/script_frontmatter_empty/stderr.term.svg
+++ b/tests/testsuite/cargo_add/script_frontmatter_empty/stderr.term.svg
@@ -19,13 +19,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> `package.edition` is unspecified, defaulting to `2024`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to `2024`</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> `package.edition` is unspecified, defaulting to `2024`</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to `2024`</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/script_frontmatter_empty/stderr.term.svg
+++ b/tests/testsuite/cargo_add/script_frontmatter_empty/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -21,13 +21,13 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> `package.edition` is unspecified, defaulting to `2024`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> `package.edition` is unspecified, defaulting to `2024`</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/script_shebang/stderr.term.svg
+++ b/tests/testsuite/cargo_add/script_shebang/stderr.term.svg
@@ -19,13 +19,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> `package.edition` is unspecified, defaulting to `[..]`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to `2024`</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> `package.edition` is unspecified, defaulting to `[..]`</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to `2024`</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/script_shebang/stderr.term.svg
+++ b/tests/testsuite/cargo_add/script_shebang/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -21,13 +21,13 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> `package.edition` is unspecified, defaulting to `[..]`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> `package.edition` is unspecified, defaulting to `[..]`</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest [..]compatible version</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/sorted_table_with_dotted_item/stderr.term.svg
+++ b/tests/testsuite/cargo_add/sorted_table_with_dotted_item/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,17 +19,17 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> unrelateed-crate v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> unrelateed-crate v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 4 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 4 packages to latest compatible versions</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-build-package1 v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-build-package1 v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> toml v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> toml v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_add/target/stderr.term.svg
+++ b/tests/testsuite/cargo_add/target/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,13 +18,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package1 v99999.0.0 to dependencies for target `wasm32-unknown-unknown`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package1 v99999.0.0 to dependencies for target `wasm32-unknown-unknown`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v99999.0.0 to dependencies for target `wasm32-unknown-unknown`</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v99999.0.0 to dependencies for target `wasm32-unknown-unknown`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/target_cfg/stderr.term.svg
+++ b/tests/testsuite/cargo_add/target_cfg/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,13 +18,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package1 v99999.0.0 to dependencies for target `cfg(target_os="linux")`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package1 v99999.0.0 to dependencies for target `cfg(target_os="linux")`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v99999.0.0 to dependencies for target `cfg(target_os="linux")`</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v99999.0.0 to dependencies for target `cfg(target_os="linux")`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/unknown_inherited_feature/stderr.term.svg
+++ b/tests/testsuite/cargo_add/unknown_inherited_feature/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +19,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> foo (workspace) to dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> foo (workspace) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> unrecognized feature for crate foo: not_recognized</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> unrecognized feature for crate foo: not_recognized</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/unknown_inherited_feature/stderr.term.svg
+++ b/tests/testsuite/cargo_add/unknown_inherited_feature/stderr.term.svg
@@ -21,7 +21,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> foo (workspace) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> unrecognized feature for crate foo: not_recognized</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: unrecognized feature for crate foo: not_recognized</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/vers/stderr.term.svg
+++ b/tests/testsuite/cargo_add/vers/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package &gt;=0.1.1 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package &gt;=0.1.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/workspace_name/stderr.term.svg
+++ b/tests/testsuite/cargo_add/workspace_name/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/workspace_path/stderr.term.svg
+++ b/tests/testsuite/cargo_add/workspace_path/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/workspace_path_dev/stderr.term.svg
+++ b/tests/testsuite/cargo_add/workspace_path_dev/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dev-dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dev-dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_add/yanked/stderr.term.svg
+++ b/tests/testsuite/cargo_add/yanked/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> linked-hash-map v0.5.4 to dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> linked-hash-map v0.5.4 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_bench/help/stdout.term.svg
+++ b/tests/testsuite/cargo_bench/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,11 +24,11 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] bench</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[BENCHNAME]</tspan><tspan> </tspan><tspan class="fg-cyan bold">[--</tspan><tspan> </tspan><tspan class="fg-cyan">[ARGS]...</tspan><tspan class="fg-cyan bold">]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] bench</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[BENCHNAME]</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">[--</tspan><tspan> </tspan><tspan class="fg-cyan">[ARGS]...</tspan><tspan class="fg-bright-cyan bold">]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">[BENCHNAME]</tspan><tspan>  If specified, only run benches containing this string in their names</tspan>
 </tspan>
@@ -35,113 +36,113 @@
 </tspan>
     <tspan x="10px" y="154px">
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-run</tspan><tspan>                   Compile, but don't run benchmarks</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-run</tspan><tspan>                   Compile, but don't run benchmarks</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-fail-fast</tspan><tspan>             Run all benchmarks regardless of failure</tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-fail-fast</tspan><tspan>             Run all benchmarks regardless of failure</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-cyan bold">--message-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>     Error format [possible values: human, short, json,</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--message-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>     Error format [possible values: human, short, json,</tspan>
 </tspan>
     <tspan x="10px" y="244px"><tspan>                                 json-diagnostic-short, json-diagnostic-rendered-ansi,</tspan>
 </tspan>
     <tspan x="10px" y="262px"><tspan>                                 json-render-diagnostics]</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="370px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="388px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="406px">
 </tspan>
-    <tspan x="10px" y="424px"><tspan class="fg-green bold">Package Selection:</tspan>
+    <tspan x="10px" y="424px"><tspan class="fg-bright-green bold">Package Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>  </tspan><tspan class="fg-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package to run benchmarks for</tspan>
+    <tspan x="10px" y="442px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package to run benchmarks for</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--workspace</tspan><tspan>         Benchmark all packages in the workspace</tspan>
+    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--workspace</tspan><tspan>         Benchmark all packages in the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--exclude</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>    Exclude packages from the benchmark</tspan>
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--exclude</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>    Exclude packages from the benchmark</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--all</tspan><tspan>               Alias for --workspace (deprecated)</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all</tspan><tspan>               Alias for --workspace (deprecated)</tspan>
 </tspan>
     <tspan x="10px" y="514px">
 </tspan>
-    <tspan x="10px" y="532px"><tspan class="fg-green bold">Target Selection:</tspan>
+    <tspan x="10px" y="532px"><tspan class="fg-bright-green bold">Target Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-cyan bold">--lib</tspan><tspan>               Benchmark only this package's library</tspan>
+    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lib</tspan><tspan>               Benchmark only this package's library</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-cyan bold">--bins</tspan><tspan>              Benchmark all binaries</tspan>
+    <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bins</tspan><tspan>              Benchmark all binaries</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-cyan bold">--bin</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>      Benchmark only the specified binary</tspan>
+    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bin</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>      Benchmark only the specified binary</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-cyan bold">--examples</tspan><tspan>          Benchmark all examples</tspan>
+    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--examples</tspan><tspan>          Benchmark all examples</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Benchmark only the specified example</tspan>
+    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Benchmark only the specified example</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--tests</tspan><tspan>             Benchmark all targets that have `test = true` set</tspan>
+    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--tests</tspan><tspan>             Benchmark all targets that have `test = true` set</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-cyan bold">--test</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>     Benchmark only the specified test target</tspan>
+    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--test</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>     Benchmark only the specified test target</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan>      </tspan><tspan class="fg-cyan bold">--benches</tspan><tspan>           Benchmark all targets that have `bench = true` set</tspan>
+    <tspan x="10px" y="676px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--benches</tspan><tspan>           Benchmark all targets that have `bench = true` set</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan>      </tspan><tspan class="fg-cyan bold">--bench</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>    Benchmark only the specified bench target</tspan>
+    <tspan x="10px" y="694px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bench</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>    Benchmark only the specified bench target</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-targets</tspan><tspan>       Benchmark all targets</tspan>
+    <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all-targets</tspan><tspan>       Benchmark all targets</tspan>
 </tspan>
     <tspan x="10px" y="730px">
 </tspan>
-    <tspan x="10px" y="748px"><tspan class="fg-green bold">Feature Selection:</tspan>
+    <tspan x="10px" y="748px"><tspan class="fg-bright-green bold">Feature Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="766px"><tspan>  </tspan><tspan class="fg-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
+    <tspan x="10px" y="766px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
+    <tspan x="10px" y="784px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
+    <tspan x="10px" y="802px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
 </tspan>
     <tspan x="10px" y="820px">
 </tspan>
-    <tspan x="10px" y="838px"><tspan class="fg-green bold">Compilation Options:</tspan>
+    <tspan x="10px" y="838px"><tspan class="fg-bright-green bold">Compilation Options:</tspan>
 </tspan>
-    <tspan x="10px" y="856px"><tspan>  </tspan><tspan class="fg-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
+    <tspan x="10px" y="856px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
 </tspan>
-    <tspan x="10px" y="874px"><tspan>      </tspan><tspan class="fg-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Build artifacts with the specified profile</tspan>
+    <tspan x="10px" y="874px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Build artifacts with the specified profile</tspan>
 </tspan>
-    <tspan x="10px" y="892px"><tspan>      </tspan><tspan class="fg-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Build for the target triple</tspan>
+    <tspan x="10px" y="892px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Build for the target triple</tspan>
 </tspan>
-    <tspan x="10px" y="910px"><tspan>      </tspan><tspan class="fg-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
+    <tspan x="10px" y="910px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
 </tspan>
-    <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-cyan bold">--unit-graph</tspan><tspan>              Output build graph in JSON (unstable)</tspan>
+    <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--unit-graph</tspan><tspan>              Output build graph in JSON (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
+    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
 </tspan>
     <tspan x="10px" y="964px">
 </tspan>
-    <tspan x="10px" y="982px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="982px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
+    <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="1036px"><tspan>      </tspan><tspan class="fg-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
+    <tspan x="10px" y="1036px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
 </tspan>
-    <tspan x="10px" y="1054px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="1054px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="1072px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="1072px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="1090px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="1090px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="1108px">
 </tspan>
-    <tspan x="10px" y="1126px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help bench</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="1126px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help bench</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="1144px">
 </tspan>

--- a/tests/testsuite/cargo_bench/no_keep_going/stderr.term.svg
+++ b/tests/testsuite/cargo_bench/no_keep_going/stderr.term.svg
@@ -2,9 +2,10 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -21,19 +22,19 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error:</tspan><tspan> unexpected argument '</tspan><tspan class="fg-yellow bold">--keep-going</tspan><tspan>' found</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error:</tspan><tspan> unexpected argument '</tspan><tspan class="fg-yellow bold">--keep-going</tspan><tspan>' found</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>  </tspan><tspan class="fg-cyan bold">tip:</tspan><tspan> use `--no-fail-fast` to run as many tests as possible regardless of failure</tspan>
+    <tspan x="10px" y="64px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">tip:</tspan><tspan> use `--no-fail-fast` to run as many tests as possible regardless of failure</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] bench</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[BENCHNAME]</tspan><tspan> </tspan><tspan class="fg-cyan bold">[--</tspan><tspan> </tspan><tspan class="fg-cyan">[ARGS]...</tspan><tspan class="fg-cyan bold">]</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] bench</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[BENCHNAME]</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">[--</tspan><tspan> </tspan><tspan class="fg-cyan">[ARGS]...</tspan><tspan class="fg-bright-cyan bold">]</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>
-    <tspan x="10px" y="136px"><tspan>For more information, try '</tspan><tspan class="fg-cyan bold">--help</tspan><tspan>'.</tspan>
+    <tspan x="10px" y="136px"><tspan>For more information, try '</tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>'.</tspan>
 </tspan>
     <tspan x="10px" y="154px">
 </tspan>

--- a/tests/testsuite/cargo_build/help/stdout.term.svg
+++ b/tests/testsuite/cargo_build/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,123 +24,123 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] build</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] build</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>      </tspan><tspan class="fg-cyan bold">--future-incompat-report</tspan><tspan>   Outputs a future incompatibility report at the end of the build</tspan>
+    <tspan x="10px" y="118px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--future-incompat-report</tspan><tspan>   Outputs a future incompatibility report at the end of the build</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>      </tspan><tspan class="fg-cyan bold">--message-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>     Error format [possible values: human, short, json,</tspan>
+    <tspan x="10px" y="136px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--message-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>     Error format [possible values: human, short, json,</tspan>
 </tspan>
     <tspan x="10px" y="154px"><tspan>                                 json-diagnostic-short, json-diagnostic-rendered-ansi,</tspan>
 </tspan>
     <tspan x="10px" y="172px"><tspan>                                 json-render-diagnostics]</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="280px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="316px">
 </tspan>
-    <tspan x="10px" y="334px"><tspan class="fg-green bold">Package Selection:</tspan>
+    <tspan x="10px" y="334px"><tspan class="fg-bright-green bold">Package Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package to build (see `cargo help pkgid`)</tspan>
+    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package to build (see `cargo help pkgid`)</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--workspace</tspan><tspan>         Build all packages in the workspace</tspan>
+    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--workspace</tspan><tspan>         Build all packages in the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--exclude</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>    Exclude packages from the build</tspan>
+    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--exclude</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>    Exclude packages from the build</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--all</tspan><tspan>               Alias for --workspace (deprecated)</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all</tspan><tspan>               Alias for --workspace (deprecated)</tspan>
 </tspan>
     <tspan x="10px" y="424px">
 </tspan>
-    <tspan x="10px" y="442px"><tspan class="fg-green bold">Target Selection:</tspan>
+    <tspan x="10px" y="442px"><tspan class="fg-bright-green bold">Target Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--lib</tspan><tspan>               Build only this package's library</tspan>
+    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lib</tspan><tspan>               Build only this package's library</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--bins</tspan><tspan>              Build all binaries</tspan>
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bins</tspan><tspan>              Build all binaries</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--bin</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>      Build only the specified binary</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bin</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>      Build only the specified binary</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--examples</tspan><tspan>          Build all examples</tspan>
+    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--examples</tspan><tspan>          Build all examples</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Build only the specified example</tspan>
+    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Build only the specified example</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-cyan bold">--tests</tspan><tspan>             Build all targets that have `test = true` set</tspan>
+    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--tests</tspan><tspan>             Build all targets that have `test = true` set</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-cyan bold">--test</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>     Build only the specified test target</tspan>
+    <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--test</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>     Build only the specified test target</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-cyan bold">--benches</tspan><tspan>           Build all targets that have `bench = true` set</tspan>
+    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--benches</tspan><tspan>           Build all targets that have `bench = true` set</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-cyan bold">--bench</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>    Build only the specified bench target</tspan>
+    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bench</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>    Build only the specified bench target</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-targets</tspan><tspan>       Build all targets</tspan>
+    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all-targets</tspan><tspan>       Build all targets</tspan>
 </tspan>
     <tspan x="10px" y="640px">
 </tspan>
-    <tspan x="10px" y="658px"><tspan class="fg-green bold">Feature Selection:</tspan>
+    <tspan x="10px" y="658px"><tspan class="fg-bright-green bold">Feature Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan>  </tspan><tspan class="fg-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
+    <tspan x="10px" y="676px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
+    <tspan x="10px" y="694px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
+    <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
 </tspan>
     <tspan x="10px" y="730px">
 </tspan>
-    <tspan x="10px" y="748px"><tspan class="fg-green bold">Compilation Options:</tspan>
+    <tspan x="10px" y="748px"><tspan class="fg-bright-green bold">Compilation Options:</tspan>
 </tspan>
-    <tspan x="10px" y="766px"><tspan>  </tspan><tspan class="fg-cyan bold">-r</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--release</tspan><tspan>                 Build artifacts in release mode, with optimizations</tspan>
+    <tspan x="10px" y="766px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-r</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--release</tspan><tspan>                 Build artifacts in release mode, with optimizations</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan>      </tspan><tspan class="fg-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Build artifacts with the specified profile</tspan>
+    <tspan x="10px" y="784px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Build artifacts with the specified profile</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan>  </tspan><tspan class="fg-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
+    <tspan x="10px" y="802px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
 </tspan>
-    <tspan x="10px" y="820px"><tspan>      </tspan><tspan class="fg-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
+    <tspan x="10px" y="820px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
 </tspan>
-    <tspan x="10px" y="838px"><tspan>      </tspan><tspan class="fg-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Build for the target triple</tspan>
+    <tspan x="10px" y="838px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Build for the target triple</tspan>
 </tspan>
-    <tspan x="10px" y="856px"><tspan>      </tspan><tspan class="fg-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
+    <tspan x="10px" y="856px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
 </tspan>
-    <tspan x="10px" y="874px"><tspan>      </tspan><tspan class="fg-cyan bold">--artifact-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>     Copy final artifacts to this directory (unstable)</tspan>
+    <tspan x="10px" y="874px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--artifact-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>     Copy final artifacts to this directory (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="892px"><tspan>      </tspan><tspan class="fg-cyan bold">--build-plan</tspan><tspan>              Output the build plan in JSON (unstable)</tspan>
+    <tspan x="10px" y="892px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--build-plan</tspan><tspan>              Output the build plan in JSON (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="910px"><tspan>      </tspan><tspan class="fg-cyan bold">--unit-graph</tspan><tspan>              Output build graph in JSON (unstable)</tspan>
+    <tspan x="10px" y="910px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--unit-graph</tspan><tspan>              Output build graph in JSON (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
+    <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
 </tspan>
     <tspan x="10px" y="946px">
 </tspan>
-    <tspan x="10px" y="964px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="964px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
+    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
+    <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
 </tspan>
-    <tspan x="10px" y="1036px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="1036px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="1054px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="1054px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="1072px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="1072px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="1090px">
 </tspan>
-    <tspan x="10px" y="1108px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help build</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="1108px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help build</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="1126px">
 </tspan>

--- a/tests/testsuite/cargo_check/help/stdout.term.svg
+++ b/tests/testsuite/cargo_check/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,119 +24,119 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] check</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] check</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>      </tspan><tspan class="fg-cyan bold">--future-incompat-report</tspan><tspan>   Outputs a future incompatibility report at the end of the build</tspan>
+    <tspan x="10px" y="118px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--future-incompat-report</tspan><tspan>   Outputs a future incompatibility report at the end of the build</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>      </tspan><tspan class="fg-cyan bold">--message-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>     Error format [possible values: human, short, json,</tspan>
+    <tspan x="10px" y="136px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--message-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>     Error format [possible values: human, short, json,</tspan>
 </tspan>
     <tspan x="10px" y="154px"><tspan>                                 json-diagnostic-short, json-diagnostic-rendered-ansi,</tspan>
 </tspan>
     <tspan x="10px" y="172px"><tspan>                                 json-render-diagnostics]</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="280px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="316px">
 </tspan>
-    <tspan x="10px" y="334px"><tspan class="fg-green bold">Package Selection:</tspan>
+    <tspan x="10px" y="334px"><tspan class="fg-bright-green bold">Package Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package(s) to check</tspan>
+    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package(s) to check</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--workspace</tspan><tspan>         Check all packages in the workspace</tspan>
+    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--workspace</tspan><tspan>         Check all packages in the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--exclude</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>    Exclude packages from the check</tspan>
+    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--exclude</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>    Exclude packages from the check</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--all</tspan><tspan>               Alias for --workspace (deprecated)</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all</tspan><tspan>               Alias for --workspace (deprecated)</tspan>
 </tspan>
     <tspan x="10px" y="424px">
 </tspan>
-    <tspan x="10px" y="442px"><tspan class="fg-green bold">Target Selection:</tspan>
+    <tspan x="10px" y="442px"><tspan class="fg-bright-green bold">Target Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--lib</tspan><tspan>               Check only this package's library</tspan>
+    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lib</tspan><tspan>               Check only this package's library</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--bins</tspan><tspan>              Check all binaries</tspan>
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bins</tspan><tspan>              Check all binaries</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--bin</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>      Check only the specified binary</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bin</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>      Check only the specified binary</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--examples</tspan><tspan>          Check all examples</tspan>
+    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--examples</tspan><tspan>          Check all examples</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Check only the specified example</tspan>
+    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Check only the specified example</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-cyan bold">--tests</tspan><tspan>             Check all targets that have `test = true` set</tspan>
+    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--tests</tspan><tspan>             Check all targets that have `test = true` set</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-cyan bold">--test</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>     Check only the specified test target</tspan>
+    <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--test</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>     Check only the specified test target</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-cyan bold">--benches</tspan><tspan>           Check all targets that have `bench = true` set</tspan>
+    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--benches</tspan><tspan>           Check all targets that have `bench = true` set</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-cyan bold">--bench</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>    Check only the specified bench target</tspan>
+    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bench</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>    Check only the specified bench target</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-targets</tspan><tspan>       Check all targets</tspan>
+    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all-targets</tspan><tspan>       Check all targets</tspan>
 </tspan>
     <tspan x="10px" y="640px">
 </tspan>
-    <tspan x="10px" y="658px"><tspan class="fg-green bold">Feature Selection:</tspan>
+    <tspan x="10px" y="658px"><tspan class="fg-bright-green bold">Feature Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan>  </tspan><tspan class="fg-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
+    <tspan x="10px" y="676px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
+    <tspan x="10px" y="694px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
+    <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
 </tspan>
     <tspan x="10px" y="730px">
 </tspan>
-    <tspan x="10px" y="748px"><tspan class="fg-green bold">Compilation Options:</tspan>
+    <tspan x="10px" y="748px"><tspan class="fg-bright-green bold">Compilation Options:</tspan>
 </tspan>
-    <tspan x="10px" y="766px"><tspan>  </tspan><tspan class="fg-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
+    <tspan x="10px" y="766px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan>      </tspan><tspan class="fg-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
+    <tspan x="10px" y="784px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan>  </tspan><tspan class="fg-cyan bold">-r</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--release</tspan><tspan>                 Check artifacts in release mode, with optimizations</tspan>
+    <tspan x="10px" y="802px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-r</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--release</tspan><tspan>                 Check artifacts in release mode, with optimizations</tspan>
 </tspan>
-    <tspan x="10px" y="820px"><tspan>      </tspan><tspan class="fg-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Check artifacts with the specified profile</tspan>
+    <tspan x="10px" y="820px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Check artifacts with the specified profile</tspan>
 </tspan>
-    <tspan x="10px" y="838px"><tspan>      </tspan><tspan class="fg-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Check for the target triple</tspan>
+    <tspan x="10px" y="838px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Check for the target triple</tspan>
 </tspan>
-    <tspan x="10px" y="856px"><tspan>      </tspan><tspan class="fg-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
+    <tspan x="10px" y="856px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
 </tspan>
-    <tspan x="10px" y="874px"><tspan>      </tspan><tspan class="fg-cyan bold">--unit-graph</tspan><tspan>              Output build graph in JSON (unstable)</tspan>
+    <tspan x="10px" y="874px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--unit-graph</tspan><tspan>              Output build graph in JSON (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="892px"><tspan>      </tspan><tspan class="fg-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
+    <tspan x="10px" y="892px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
 </tspan>
     <tspan x="10px" y="910px">
 </tspan>
-    <tspan x="10px" y="928px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="928px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
+    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
+    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
 </tspan>
-    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="1036px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="1036px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="1054px">
 </tspan>
-    <tspan x="10px" y="1072px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help check</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="1072px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help check</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="1090px">
 </tspan>

--- a/tests/testsuite/cargo_clean/help/stdout.term.svg
+++ b/tests/testsuite/cargo_clean/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,65 +24,65 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] clean</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] clean</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>      </tspan><tspan class="fg-cyan bold">--doc</tspan><tspan>                      Whether or not to clean just the documentation directory</tspan>
+    <tspan x="10px" y="118px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--doc</tspan><tspan>                      Whether or not to clean just the documentation directory</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-cyan bold">-n</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--dry-run</tspan><tspan>                  Display what would be deleted without deleting anything</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-n</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--dry-run</tspan><tspan>                  Display what would be deleted without deleting anything</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="244px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="280px">
 </tspan>
-    <tspan x="10px" y="298px"><tspan class="fg-green bold">Package Selection:</tspan>
+    <tspan x="10px" y="298px"><tspan class="fg-bright-green bold">Package Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>  </tspan><tspan class="fg-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package to clean artifacts for</tspan>
+    <tspan x="10px" y="316px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package to clean artifacts for</tspan>
 </tspan>
     <tspan x="10px" y="334px">
 </tspan>
-    <tspan x="10px" y="352px"><tspan class="fg-green bold">Compilation Options:</tspan>
+    <tspan x="10px" y="352px"><tspan class="fg-bright-green bold">Compilation Options:</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>  </tspan><tspan class="fg-cyan bold">-r</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--release</tspan><tspan>                 Whether or not to clean release artifacts</tspan>
+    <tspan x="10px" y="370px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-r</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--release</tspan><tspan>                 Whether or not to clean release artifacts</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Clean artifacts of the specified profile</tspan>
+    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Clean artifacts of the specified profile</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Target triple to clean output for</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Target triple to clean output for</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
+    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
 </tspan>
     <tspan x="10px" y="442px">
 </tspan>
-    <tspan x="10px" y="460px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="460px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="568px">
 </tspan>
-    <tspan x="10px" y="586px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help clean</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="586px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help clean</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="604px">
 </tspan>

--- a/tests/testsuite/cargo_config/help/stdout.term.svg
+++ b/tests/testsuite/cargo_config/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,41 +24,41 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] config</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;COMMAND&gt;</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] config</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;COMMAND&gt;</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Commands:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Commands:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan bold">get</tspan><tspan>  </tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">get</tspan><tspan>  </tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="262px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="298px">
 </tspan>
-    <tspan x="10px" y="316px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="316px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
+    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="388px">
 </tspan>

--- a/tests/testsuite/cargo_doc/help/stdout.term.svg
+++ b/tests/testsuite/cargo_doc/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,113 +24,113 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] doc</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] doc</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>      </tspan><tspan class="fg-cyan bold">--open</tspan><tspan>                     Opens the docs in a browser after the operation</tspan>
+    <tspan x="10px" y="118px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--open</tspan><tspan>                     Opens the docs in a browser after the operation</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-deps</tspan><tspan>                  Don't build documentation for dependencies</tspan>
+    <tspan x="10px" y="136px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-deps</tspan><tspan>                  Don't build documentation for dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>      </tspan><tspan class="fg-cyan bold">--document-private-items</tspan><tspan>   Document private items</tspan>
+    <tspan x="10px" y="154px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--document-private-items</tspan><tspan>   Document private items</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-cyan bold">--message-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>     Error format [possible values: human, short, json,</tspan>
+    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--message-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>     Error format [possible values: human, short, json,</tspan>
 </tspan>
     <tspan x="10px" y="190px"><tspan>                                 json-diagnostic-short, json-diagnostic-rendered-ansi,</tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan>                                 json-render-diagnostics]</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="316px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="352px">
 </tspan>
-    <tspan x="10px" y="370px"><tspan class="fg-green bold">Package Selection:</tspan>
+    <tspan x="10px" y="370px"><tspan class="fg-bright-green bold">Package Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>  </tspan><tspan class="fg-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package to document</tspan>
+    <tspan x="10px" y="388px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package to document</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--workspace</tspan><tspan>         Document all packages in the workspace</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--workspace</tspan><tspan>         Document all packages in the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--exclude</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>    Exclude packages from the build</tspan>
+    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--exclude</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>    Exclude packages from the build</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--all</tspan><tspan>               Alias for --workspace (deprecated)</tspan>
+    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all</tspan><tspan>               Alias for --workspace (deprecated)</tspan>
 </tspan>
     <tspan x="10px" y="460px">
 </tspan>
-    <tspan x="10px" y="478px"><tspan class="fg-green bold">Feature Selection:</tspan>
+    <tspan x="10px" y="478px"><tspan class="fg-bright-green bold">Feature Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>  </tspan><tspan class="fg-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
+    <tspan x="10px" y="496px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
+    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
+    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
 </tspan>
     <tspan x="10px" y="550px">
 </tspan>
-    <tspan x="10px" y="568px"><tspan class="fg-green bold">Target Selection:</tspan>
+    <tspan x="10px" y="568px"><tspan class="fg-bright-green bold">Target Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-cyan bold">--lib</tspan><tspan>               Document only this package's library</tspan>
+    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lib</tspan><tspan>               Document only this package's library</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-cyan bold">--bins</tspan><tspan>              Document all binaries</tspan>
+    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bins</tspan><tspan>              Document all binaries</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-cyan bold">--bin</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>      Document only the specified binary</tspan>
+    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bin</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>      Document only the specified binary</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--examples</tspan><tspan>          Document all examples</tspan>
+    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--examples</tspan><tspan>          Document all examples</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Document only the specified example</tspan>
+    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Document only the specified example</tspan>
 </tspan>
     <tspan x="10px" y="676px">
 </tspan>
-    <tspan x="10px" y="694px"><tspan class="fg-green bold">Compilation Options:</tspan>
+    <tspan x="10px" y="694px"><tspan class="fg-bright-green bold">Compilation Options:</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>  </tspan><tspan class="fg-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
+    <tspan x="10px" y="712px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
+    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
 </tspan>
-    <tspan x="10px" y="748px"><tspan>  </tspan><tspan class="fg-cyan bold">-r</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--release</tspan><tspan>                 Build artifacts in release mode, with optimizations</tspan>
+    <tspan x="10px" y="748px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-r</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--release</tspan><tspan>                 Build artifacts in release mode, with optimizations</tspan>
 </tspan>
-    <tspan x="10px" y="766px"><tspan>      </tspan><tspan class="fg-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Build artifacts with the specified profile</tspan>
+    <tspan x="10px" y="766px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Build artifacts with the specified profile</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan>      </tspan><tspan class="fg-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Build for the target triple</tspan>
+    <tspan x="10px" y="784px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Build for the target triple</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan>      </tspan><tspan class="fg-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
+    <tspan x="10px" y="802px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
 </tspan>
-    <tspan x="10px" y="820px"><tspan>      </tspan><tspan class="fg-cyan bold">--unit-graph</tspan><tspan>              Output build graph in JSON (unstable)</tspan>
+    <tspan x="10px" y="820px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--unit-graph</tspan><tspan>              Output build graph in JSON (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="838px"><tspan>      </tspan><tspan class="fg-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
+    <tspan x="10px" y="838px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
 </tspan>
     <tspan x="10px" y="856px">
 </tspan>
-    <tspan x="10px" y="874px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="874px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="892px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="892px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="910px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
+    <tspan x="10px" y="910px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
+    <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
 </tspan>
-    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="1000px">
 </tspan>
-    <tspan x="10px" y="1018px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help doc</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="1018px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help doc</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="1036px">
 </tspan>

--- a/tests/testsuite/cargo_fetch/help/stdout.term.svg
+++ b/tests/testsuite/cargo_fetch/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,49 +24,49 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] fetch</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] fetch</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="154px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="244px">
 </tspan>
-    <tspan x="10px" y="262px"><tspan class="fg-green bold">Compilation Options:</tspan>
+    <tspan x="10px" y="262px"><tspan class="fg-bright-green bold">Compilation Options:</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Fetch dependencies for the target triple</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Fetch dependencies for the target triple</tspan>
 </tspan>
     <tspan x="10px" y="298px">
 </tspan>
-    <tspan x="10px" y="316px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="316px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
+    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="424px">
 </tspan>
-    <tspan x="10px" y="442px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help fetch</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="442px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help fetch</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="460px">
 </tspan>

--- a/tests/testsuite/cargo_fix/help/stdout.term.svg
+++ b/tests/testsuite/cargo_fix/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,129 +24,129 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] fix</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] fix</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>      </tspan><tspan class="fg-cyan bold">--edition</tspan><tspan>                  Fix in preparation for the next edition</tspan>
+    <tspan x="10px" y="118px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--edition</tspan><tspan>                  Fix in preparation for the next edition</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>      </tspan><tspan class="fg-cyan bold">--edition-idioms</tspan><tspan>           Fix warnings to migrate to the idioms of an edition</tspan>
+    <tspan x="10px" y="136px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--edition-idioms</tspan><tspan>           Fix warnings to migrate to the idioms of an edition</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>      </tspan><tspan class="fg-cyan bold">--broken-code</tspan><tspan>              Fix code even if it already has compiler errors</tspan>
+    <tspan x="10px" y="154px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--broken-code</tspan><tspan>              Fix code even if it already has compiler errors</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-cyan bold">--allow-no-vcs</tspan><tspan>             Fix code even if a VCS was not detected</tspan>
+    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--allow-no-vcs</tspan><tspan>             Fix code even if a VCS was not detected</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-cyan bold">--allow-dirty</tspan><tspan>              Fix code even if the working directory is dirty or has staged</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--allow-dirty</tspan><tspan>              Fix code even if the working directory is dirty or has staged</tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan>                                 changes</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-cyan bold">--allow-staged</tspan><tspan>             Fix code even if the working directory has staged changes</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--allow-staged</tspan><tspan>             Fix code even if the working directory has staged changes</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-cyan bold">--message-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>     Error format [possible values: human, short, json,</tspan>
+    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--message-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>     Error format [possible values: human, short, json,</tspan>
 </tspan>
     <tspan x="10px" y="262px"><tspan>                                 json-diagnostic-short, json-diagnostic-rendered-ansi,</tspan>
 </tspan>
     <tspan x="10px" y="280px"><tspan>                                 json-render-diagnostics]</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="316px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="370px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="388px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="406px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="424px">
 </tspan>
-    <tspan x="10px" y="442px"><tspan class="fg-green bold">Package Selection:</tspan>
+    <tspan x="10px" y="442px"><tspan class="fg-bright-green bold">Package Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>  </tspan><tspan class="fg-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package(s) to fix</tspan>
+    <tspan x="10px" y="460px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package(s) to fix</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--workspace</tspan><tspan>         Fix all packages in the workspace</tspan>
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--workspace</tspan><tspan>         Fix all packages in the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--exclude</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>    Exclude packages from the fixes</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--exclude</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>    Exclude packages from the fixes</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--all</tspan><tspan>               Alias for --workspace (deprecated)</tspan>
+    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all</tspan><tspan>               Alias for --workspace (deprecated)</tspan>
 </tspan>
     <tspan x="10px" y="532px">
 </tspan>
-    <tspan x="10px" y="550px"><tspan class="fg-green bold">Target Selection:</tspan>
+    <tspan x="10px" y="550px"><tspan class="fg-bright-green bold">Target Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-cyan bold">--lib</tspan><tspan>               Fix only this package's library</tspan>
+    <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lib</tspan><tspan>               Fix only this package's library</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-cyan bold">--bins</tspan><tspan>              Fix all binaries</tspan>
+    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bins</tspan><tspan>              Fix all binaries</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-cyan bold">--bin</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>      Fix only the specified binary</tspan>
+    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bin</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>      Fix only the specified binary</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-cyan bold">--examples</tspan><tspan>          Fix all examples</tspan>
+    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--examples</tspan><tspan>          Fix all examples</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Fix only the specified example</tspan>
+    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Fix only the specified example</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-cyan bold">--tests</tspan><tspan>             Fix all targets that have `test = true` set</tspan>
+    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--tests</tspan><tspan>             Fix all targets that have `test = true` set</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan>      </tspan><tspan class="fg-cyan bold">--test</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>     Fix only the specified test target</tspan>
+    <tspan x="10px" y="676px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--test</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>     Fix only the specified test target</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan>      </tspan><tspan class="fg-cyan bold">--benches</tspan><tspan>           Fix all targets that have `bench = true` set</tspan>
+    <tspan x="10px" y="694px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--benches</tspan><tspan>           Fix all targets that have `bench = true` set</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-cyan bold">--bench</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>    Fix only the specified bench target</tspan>
+    <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bench</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>    Fix only the specified bench target</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-targets</tspan><tspan>       Fix all targets (default)</tspan>
+    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all-targets</tspan><tspan>       Fix all targets (default)</tspan>
 </tspan>
     <tspan x="10px" y="748px">
 </tspan>
-    <tspan x="10px" y="766px"><tspan class="fg-green bold">Feature Selection:</tspan>
+    <tspan x="10px" y="766px"><tspan class="fg-bright-green bold">Feature Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan>  </tspan><tspan class="fg-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
+    <tspan x="10px" y="784px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
+    <tspan x="10px" y="802px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
 </tspan>
-    <tspan x="10px" y="820px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
+    <tspan x="10px" y="820px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
 </tspan>
     <tspan x="10px" y="838px">
 </tspan>
-    <tspan x="10px" y="856px"><tspan class="fg-green bold">Compilation Options:</tspan>
+    <tspan x="10px" y="856px"><tspan class="fg-bright-green bold">Compilation Options:</tspan>
 </tspan>
-    <tspan x="10px" y="874px"><tspan>  </tspan><tspan class="fg-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
+    <tspan x="10px" y="874px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
 </tspan>
-    <tspan x="10px" y="892px"><tspan>      </tspan><tspan class="fg-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
+    <tspan x="10px" y="892px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
 </tspan>
-    <tspan x="10px" y="910px"><tspan>  </tspan><tspan class="fg-cyan bold">-r</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--release</tspan><tspan>                 Fix artifacts in release mode, with optimizations</tspan>
+    <tspan x="10px" y="910px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-r</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--release</tspan><tspan>                 Fix artifacts in release mode, with optimizations</tspan>
 </tspan>
-    <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Build artifacts with the specified profile</tspan>
+    <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Build artifacts with the specified profile</tspan>
 </tspan>
-    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Fix for the target triple</tspan>
+    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Fix for the target triple</tspan>
 </tspan>
-    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
+    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
 </tspan>
-    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
+    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
 </tspan>
     <tspan x="10px" y="1000px">
 </tspan>
-    <tspan x="10px" y="1018px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="1018px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="1036px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="1036px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="1054px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
+    <tspan x="10px" y="1054px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="1072px"><tspan>      </tspan><tspan class="fg-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
+    <tspan x="10px" y="1072px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
 </tspan>
-    <tspan x="10px" y="1090px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="1090px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="1108px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="1108px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="1126px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="1126px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="1144px">
 </tspan>
-    <tspan x="10px" y="1162px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help fix</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="1162px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help fix</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="1180px">
 </tspan>

--- a/tests/testsuite/cargo_generate_lockfile/help/stdout.term.svg
+++ b/tests/testsuite/cargo_generate_lockfile/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,45 +24,45 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] generate-lockfile</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] generate-lockfile</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="154px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="244px">
 </tspan>
-    <tspan x="10px" y="262px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="262px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
+    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="388px">
 </tspan>
-    <tspan x="10px" y="406px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help generate-lockfile</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="406px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help generate-lockfile</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="424px">
 </tspan>

--- a/tests/testsuite/cargo_help/help/stdout.term.svg
+++ b/tests/testsuite/cargo_help/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,41 +24,41 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] help</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[COMMAND]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] help</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[COMMAND]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">[COMMAND]</tspan><tspan>  </tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="262px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="298px">
 </tspan>
-    <tspan x="10px" y="316px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="316px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
+    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="388px">
 </tspan>

--- a/tests/testsuite/cargo_info/basic/stderr.term.svg
+++ b/tests/testsuite/cargo_info/basic/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold"> Downloading</tspan><tspan> crates ...</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold"> Downloading</tspan><tspan> crates ...</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v0.1.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> my-package v0.1.0 (registry `dummy-registry`)</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_info/basic/stdout.term.svg
+++ b/tests/testsuite/cargo_info/basic/stdout.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -20,23 +20,23 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">my-package</tspan><tspan> </tspan><tspan class="fg-cyan bold">#foo #bar #baz</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">my-package</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">#foo #bar #baz</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>A package for testing</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">version:</tspan><tspan> 0.1.0 </tspan><tspan class="fg-cyan bold">(from registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">version:</tspan><tspan> 0.1.0 </tspan><tspan class="fg-bright-blue bold">(from registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">license:</tspan><tspan> MIT</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">license:</tspan><tspan> MIT</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">rust-version:</tspan><tspan> 1.50.0</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">rust-version:</tspan><tspan> 1.50.0</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">documentation:</tspan><tspan> https://docs.rs/my-package/0.1.0</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">documentation:</tspan><tspan> https://docs.rs/my-package/0.1.0</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-green bold">repository:</tspan><tspan> https://github.com/hi-rustin/cargo-infromation</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-green bold">repository:</tspan><tspan> https://github.com/hi-rustin/cargo-infromation</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">features:</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">features:</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan> </tspan><tspan class="fg-green bold">+</tspan><tspan>default  = [feature1]</tspan>
+    <tspan x="10px" y="172px"><tspan> </tspan><tspan class="fg-bright-green bold">+</tspan><tspan>default  = [feature1]</tspan>
 </tspan>
     <tspan x="10px" y="190px"><tspan>  feature1 = []</tspan>
 </tspan>

--- a/tests/testsuite/cargo_info/features/stderr.term.svg
+++ b/tests/testsuite/cargo_info/features/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold"> Downloading</tspan><tspan> crates ...</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold"> Downloading</tspan><tspan> crates ...</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v0.1.1 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> my-package v0.1.1 (registry `dummy-registry`)</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_info/features/stdout.term.svg
+++ b/tests/testsuite/cargo_info/features/stdout.term.svg
@@ -2,9 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -21,17 +21,17 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">my-package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">my-package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">version:</tspan><tspan> 0.1.1 </tspan><tspan class="fg-cyan bold">(from registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">version:</tspan><tspan> 0.1.1 </tspan><tspan class="fg-bright-blue bold">(from registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">license:</tspan><tspan> </tspan><tspan class="fg-red bold">unknown</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">license:</tspan><tspan> </tspan><tspan class="fg-bright-red bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">features:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">features:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan> </tspan><tspan class="fg-green bold">+</tspan><tspan>default  = [feature1, feature2]</tspan>
+    <tspan x="10px" y="118px"><tspan> </tspan><tspan class="fg-bright-green bold">+</tspan><tspan>default  = [feature1, feature2]</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan>  feature1 = []</tspan>
 </tspan>

--- a/tests/testsuite/cargo_info/features_activated_over_limit/stderr.term.svg
+++ b/tests/testsuite/cargo_info/features_activated_over_limit/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold"> Downloading</tspan><tspan> crates ...</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold"> Downloading</tspan><tspan> crates ...</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> your-face v99999.0.0+my-package (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> your-face v99999.0.0+my-package (registry `dummy-registry`)</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_info/features_activated_over_limit/stdout.term.svg
+++ b/tests/testsuite/cargo_info/features_activated_over_limit/stdout.term.svg
@@ -2,9 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -22,15 +22,15 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">your-face</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">your-face</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">version:</tspan><tspan> 99999.0.0+my-package </tspan><tspan class="fg-cyan bold">(from registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">version:</tspan><tspan> 99999.0.0+my-package </tspan><tspan class="fg-bright-blue bold">(from registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">license:</tspan><tspan> </tspan><tspan class="fg-red bold">unknown</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">license:</tspan><tspan> </tspan><tspan class="fg-bright-red bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">features:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">features:</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="italic">101 activated features</tspan>
 </tspan>

--- a/tests/testsuite/cargo_info/features_activated_over_limit_verbose/stderr.term.svg
+++ b/tests/testsuite/cargo_info/features_activated_over_limit_verbose/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold"> Downloading</tspan><tspan> crates ...</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold"> Downloading</tspan><tspan> crates ...</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> your-face v99999.0.0+my-package (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> your-face v99999.0.0+my-package (registry `dummy-registry`)</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_info/features_activated_over_limit_verbose/stdout.term.svg
+++ b/tests/testsuite/cargo_info/features_activated_over_limit_verbose/stdout.term.svg
@@ -2,9 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -22,17 +22,17 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">your-face</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">your-face</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">version:</tspan><tspan> 99999.0.0+my-package </tspan><tspan class="fg-cyan bold">(from registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">version:</tspan><tspan> 99999.0.0+my-package </tspan><tspan class="fg-bright-blue bold">(from registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">license:</tspan><tspan> </tspan><tspan class="fg-red bold">unknown</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">license:</tspan><tspan> </tspan><tspan class="fg-bright-red bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">features:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">features:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan> </tspan><tspan class="fg-green bold">+</tspan><tspan>default = [eyes000, eyes001, eyes002, eyes003, eyes004, eyes005, eyes006, eyes007, eyes008, eyes009, eyes010, eyes011, eyes012, eyes013, eyes014, eyes015, eyes016, eyes017, eyes018, eyes019, eyes020, eyes021, eyes022, eyes023, eyes024, eyes025, eyes026, eyes027, eyes028, eyes029, eyes030, eyes031, eyes032, eyes033, eyes034, eyes035, eyes036, eyes037, eyes038, eyes039, eyes040, eyes041, eyes042, eyes043, eyes044, eyes045, eyes046, eyes047, eyes048, eyes049, eyes050, eyes051, eyes052, eyes053, eyes054, eyes055, eyes056, eyes057, eyes058, eyes059, eyes060, eyes061, eyes062, eyes063, eyes064, eyes065, eyes066, eyes067, eyes068, eyes069, eyes070, eyes071, eyes072, eyes073, eyes074, eyes075, eyes076, eyes077, eyes078, eyes079, eyes080, eyes081, eyes082, eyes083, eyes084, eyes085, eyes086, eyes087, eyes088, eyes089, eyes090, eyes091, eyes092, eyes093, eyes094, eyes095, eyes096, eyes097, eyes098, eyes099]</tspan>
+    <tspan x="10px" y="118px"><tspan> </tspan><tspan class="fg-bright-green bold">+</tspan><tspan>default = [eyes000, eyes001, eyes002, eyes003, eyes004, eyes005, eyes006, eyes007, eyes008, eyes009, eyes010, eyes011, eyes012, eyes013, eyes014, eyes015, eyes016, eyes017, eyes018, eyes019, eyes020, eyes021, eyes022, eyes023, eyes024, eyes025, eyes026, eyes027, eyes028, eyes029, eyes030, eyes031, eyes032, eyes033, eyes034, eyes035, eyes036, eyes037, eyes038, eyes039, eyes040, eyes041, eyes042, eyes043, eyes044, eyes045, eyes046, eyes047, eyes048, eyes049, eyes050, eyes051, eyes052, eyes053, eyes054, eyes055, eyes056, eyes057, eyes058, eyes059, eyes060, eyes061, eyes062, eyes063, eyes064, eyes065, eyes066, eyes067, eyes068, eyes069, eyes070, eyes071, eyes072, eyes073, eyes074, eyes075, eyes076, eyes077, eyes078, eyes079, eyes080, eyes081, eyes082, eyes083, eyes084, eyes085, eyes086, eyes087, eyes088, eyes089, eyes090, eyes091, eyes092, eyes093, eyes094, eyes095, eyes096, eyes097, eyes098, eyes099]</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan>  eyes000 = []</tspan>
 </tspan>

--- a/tests/testsuite/cargo_info/features_deactivated_over_limit/stderr.term.svg
+++ b/tests/testsuite/cargo_info/features_deactivated_over_limit/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold"> Downloading</tspan><tspan> crates ...</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold"> Downloading</tspan><tspan> crates ...</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> your-face v99999.0.0+my-package (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> your-face v99999.0.0+my-package (registry `dummy-registry`)</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_info/features_deactivated_over_limit/stdout.term.svg
+++ b/tests/testsuite/cargo_info/features_deactivated_over_limit/stdout.term.svg
@@ -2,9 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -22,17 +22,17 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">your-face</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">your-face</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">version:</tspan><tspan> 99999.0.0+my-package </tspan><tspan class="fg-cyan bold">(from registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">version:</tspan><tspan> 99999.0.0+my-package </tspan><tspan class="fg-bright-blue bold">(from registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">license:</tspan><tspan> </tspan><tspan class="fg-red bold">unknown</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">license:</tspan><tspan> </tspan><tspan class="fg-bright-red bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">features:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">features:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan> </tspan><tspan class="fg-green bold">+</tspan><tspan>default = [eyes000, eyes001, eyes002, eyes003, eyes004, eyes005, eyes006, eyes007, eyes008, eyes009, eyes010, eyes011, eyes012, eyes013, eyes014, eyes015, eyes016, eyes017, eyes018, eyes019]</tspan>
+    <tspan x="10px" y="118px"><tspan> </tspan><tspan class="fg-bright-green bold">+</tspan><tspan>default = [eyes000, eyes001, eyes002, eyes003, eyes004, eyes005, eyes006, eyes007, eyes008, eyes009, eyes010, eyes011, eyes012, eyes013, eyes014, eyes015, eyes016, eyes017, eyes018, eyes019]</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan>  eyes000 = []</tspan>
 </tspan>

--- a/tests/testsuite/cargo_info/git_dependency/stdout.term.svg
+++ b/tests/testsuite/cargo_info/git_dependency/stdout.term.svg
@@ -2,9 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -21,17 +21,17 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">foo</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">foo</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">version:</tspan><tspan> 0.1.0 </tspan><tspan class="fg-cyan bold">(from ./)</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">version:</tspan><tspan> 0.1.0 </tspan><tspan class="fg-bright-blue bold">(from ./)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">license:</tspan><tspan> </tspan><tspan class="fg-red bold">unknown</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">license:</tspan><tspan> </tspan><tspan class="fg-bright-red bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">dependencies:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">dependencies:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan> </tspan><tspan class="fg-green bold">+</tspan><tspan>baz ([ROOTURL]/baz)</tspan>
+    <tspan x="10px" y="118px"><tspan> </tspan><tspan class="fg-bright-green bold">+</tspan><tspan>baz ([ROOTURL]/baz)</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_info/help/stdout.term.svg
+++ b/tests/testsuite/cargo_info/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,49 +24,49 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] info</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] info</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>      </tspan><tspan class="fg-cyan bold">--index</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;INDEX&gt;</tspan><tspan>            Registry index URL to search packages in</tspan>
+    <tspan x="10px" y="118px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--index</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;INDEX&gt;</tspan><tspan>            Registry index URL to search packages in</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>      </tspan><tspan class="fg-cyan bold">--registry</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;REGISTRY&gt;</tspan><tspan>      Registry to search packages in</tspan>
+    <tspan x="10px" y="136px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--registry</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;REGISTRY&gt;</tspan><tspan>      Registry to search packages in</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="244px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="280px">
 </tspan>
-    <tspan x="10px" y="298px"><tspan class="fg-green bold">Package Selection:</tspan>
+    <tspan x="10px" y="298px"><tspan class="fg-bright-green bold">Package Selection:</tspan>
 </tspan>
     <tspan x="10px" y="316px"><tspan>  </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>  Package to inspect</tspan>
 </tspan>
     <tspan x="10px" y="334px">
 </tspan>
-    <tspan x="10px" y="352px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="352px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
+    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="424px">
 </tspan>
-    <tspan x="10px" y="442px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help info</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="442px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help info</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="460px">
 </tspan>

--- a/tests/testsuite/cargo_info/not_found/stderr.term.svg
+++ b/tests/testsuite/cargo_info/not_found/stderr.term.svg
@@ -1,9 +1,9 @@
-<svg width="877px" height="74px" xmlns="http://www.w3.org/2000/svg">
+<svg width="953px" height="74px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +19,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> could not find `unknown` in registry `[ROOTURL]/registry`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> could not find `unknown` in registry `[ROOTURL]/registry`</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_info/not_found/stderr.term.svg
+++ b/tests/testsuite/cargo_info/not_found/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="953px" height="74px" xmlns="http://www.w3.org/2000/svg">
+<svg width="961px" height="74px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -21,7 +21,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> could not find `unknown` in registry `[ROOTURL]/registry`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: could not find `unknown` in registry `[ROOTURL]/registry`</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_info/path_dependency/stdout.term.svg
+++ b/tests/testsuite/cargo_info/path_dependency/stdout.term.svg
@@ -2,9 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -21,17 +21,17 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">foo</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">foo</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">version:</tspan><tspan> 0.0.0 </tspan><tspan class="fg-cyan bold">(from ./)</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">version:</tspan><tspan> 0.0.0 </tspan><tspan class="fg-bright-blue bold">(from ./)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">license:</tspan><tspan> </tspan><tspan class="fg-red bold">unknown</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">license:</tspan><tspan> </tspan><tspan class="fg-bright-red bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">dependencies:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">dependencies:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan> </tspan><tspan class="fg-green bold">+</tspan><tspan>crate1 (./crates/crate1)</tspan>
+    <tspan x="10px" y="118px"><tspan> </tspan><tspan class="fg-bright-green bold">+</tspan><tspan>crate1 (./crates/crate1)</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_info/pick_msrv_compatible_package/stderr.term.svg
+++ b/tests/testsuite/cargo_info/pick_msrv_compatible_package/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold"> Downloading</tspan><tspan> crates ...</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold"> Downloading</tspan><tspan> crates ...</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v0.1.1+my-package (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> my-package v0.1.1+my-package (registry `dummy-registry`)</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_info/pick_msrv_compatible_package/stdout.term.svg
+++ b/tests/testsuite/cargo_info/pick_msrv_compatible_package/stdout.term.svg
@@ -2,9 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -21,13 +21,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">my-package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">my-package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">version:</tspan><tspan> 0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest 0.2.0+my-package </tspan><tspan class="fg-cyan bold">from registry `dummy-registry`</tspan><tspan class="fg-yellow bold">)</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">version:</tspan><tspan> 0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest 0.2.0+my-package </tspan><tspan class="fg-bright-blue bold">from registry `dummy-registry`</tspan><tspan class="fg-yellow bold">)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">license:</tspan><tspan> </tspan><tspan class="fg-red bold">unknown</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">license:</tspan><tspan> </tspan><tspan class="fg-bright-red bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">rust-version:</tspan><tspan> 1.0.0</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">rust-version:</tspan><tspan> 1.0.0</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_info/pick_msrv_compatible_package_within_ws/stderr.term.svg
+++ b/tests/testsuite/cargo_info/pick_msrv_compatible_package_within_ws/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold"> Downloading</tspan><tspan> crates ...</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold"> Downloading</tspan><tspan> crates ...</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v0.2.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> my-package v0.2.0 (registry `dummy-registry`)</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_info/pick_msrv_compatible_package_within_ws/stdout.term.svg
+++ b/tests/testsuite/cargo_info/pick_msrv_compatible_package_within_ws/stdout.term.svg
@@ -2,9 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -21,13 +21,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">my-package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">my-package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">version:</tspan><tspan> 0.2.0 </tspan><tspan class="fg-yellow bold">(latest 0.2.1 </tspan><tspan class="fg-cyan bold">from registry `dummy-registry`</tspan><tspan class="fg-yellow bold">)</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">version:</tspan><tspan> 0.2.0 </tspan><tspan class="fg-yellow bold">(latest 0.2.1 </tspan><tspan class="fg-bright-blue bold">from registry `dummy-registry`</tspan><tspan class="fg-yellow bold">)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">license:</tspan><tspan> </tspan><tspan class="fg-red bold">unknown</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">license:</tspan><tspan> </tspan><tspan class="fg-bright-red bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">rust-version:</tspan><tspan> 1.0.0</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">rust-version:</tspan><tspan> 1.0.0</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_info/pick_msrv_compatible_package_within_ws_and_use_msrv_from_ws/stderr.term.svg
+++ b/tests/testsuite/cargo_info/pick_msrv_compatible_package_within_ws_and_use_msrv_from_ws/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold"> Downloading</tspan><tspan> crates ...</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold"> Downloading</tspan><tspan> crates ...</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v0.2.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> my-package v0.2.0 (registry `dummy-registry`)</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_info/pick_msrv_compatible_package_within_ws_and_use_msrv_from_ws/stdout.term.svg
+++ b/tests/testsuite/cargo_info/pick_msrv_compatible_package_within_ws_and_use_msrv_from_ws/stdout.term.svg
@@ -2,9 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -21,13 +21,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">my-package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">my-package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">version:</tspan><tspan> 0.2.0 </tspan><tspan class="fg-yellow bold">(latest 0.2.1 </tspan><tspan class="fg-cyan bold">from registry `dummy-registry`</tspan><tspan class="fg-yellow bold">)</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">version:</tspan><tspan> 0.2.0 </tspan><tspan class="fg-yellow bold">(latest 0.2.1 </tspan><tspan class="fg-bright-blue bold">from registry `dummy-registry`</tspan><tspan class="fg-yellow bold">)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">license:</tspan><tspan> </tspan><tspan class="fg-red bold">unknown</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">license:</tspan><tspan> </tspan><tspan class="fg-bright-red bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">rust-version:</tspan><tspan> 1.0.0</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">rust-version:</tspan><tspan> 1.0.0</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_info/specify_empty_version_with_url/stderr.term.svg
+++ b/tests/testsuite/cargo_info/specify_empty_version_with_url/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> invalid package ID specification: `https://crates.io`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> invalid package ID specification: `https://crates.io`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_info/specify_empty_version_with_url/stderr.term.svg
+++ b/tests/testsuite/cargo_info/specify_empty_version_with_url/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> invalid package ID specification: `https://crates.io`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: invalid package ID specification: `https://crates.io`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_info/specify_version_outside_ws/stderr.term.svg
+++ b/tests/testsuite/cargo_info/specify_version_outside_ws/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold"> Downloading</tspan><tspan> crates ...</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold"> Downloading</tspan><tspan> crates ...</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v0.2.3+my-package (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> my-package v0.2.3+my-package (registry `dummy-registry`)</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_info/specify_version_outside_ws/stdout.term.svg
+++ b/tests/testsuite/cargo_info/specify_version_outside_ws/stdout.term.svg
@@ -2,9 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -21,13 +21,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">my-package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">my-package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">version:</tspan><tspan> 0.2.3+my-package </tspan><tspan class="fg-cyan bold">(from registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">version:</tspan><tspan> 0.2.3+my-package </tspan><tspan class="fg-bright-blue bold">(from registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">license:</tspan><tspan> </tspan><tspan class="fg-red bold">unknown</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">license:</tspan><tspan> </tspan><tspan class="fg-bright-red bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_info/specify_version_with_url_but_registry_is_not_matched/stderr.term.svg
+++ b/tests/testsuite/cargo_info/specify_version_with_url_but_registry_is_not_matched/stderr.term.svg
@@ -1,9 +1,9 @@
-<svg width="1163px" height="74px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1230px" height="74px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +19,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `alternative` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `alternative` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> could not find `https://crates.io/my-package` in registry `[ROOTURL]/alternative-registry`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> could not find `https://crates.io/my-package` in registry `[ROOTURL]/alternative-registry`</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_info/specify_version_with_url_but_registry_is_not_matched/stderr.term.svg
+++ b/tests/testsuite/cargo_info/specify_version_with_url_but_registry_is_not_matched/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="1230px" height="74px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1238px" height="74px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -21,7 +21,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `alternative` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> could not find `https://crates.io/my-package` in registry `[ROOTURL]/alternative-registry`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: could not find `https://crates.io/my-package` in registry `[ROOTURL]/alternative-registry`</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_info/specify_version_within_ws_and_conflict_with_lockfile/stderr.term.svg
+++ b/tests/testsuite/cargo_info/specify_version_within_ws_and_conflict_with_lockfile/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold"> Downloading</tspan><tspan> crates ...</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold"> Downloading</tspan><tspan> crates ...</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v0.4.1+my-package (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> my-package v0.4.1+my-package (registry `dummy-registry`)</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_info/specify_version_within_ws_and_conflict_with_lockfile/stdout.term.svg
+++ b/tests/testsuite/cargo_info/specify_version_within_ws_and_conflict_with_lockfile/stdout.term.svg
@@ -2,9 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -21,13 +21,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">my-package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">my-package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">version:</tspan><tspan> 0.4.1+my-package </tspan><tspan class="fg-yellow bold">(latest 99999.0.0+my-package </tspan><tspan class="fg-cyan bold">from registry `dummy-registry`</tspan><tspan class="fg-yellow bold">)</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">version:</tspan><tspan> 0.4.1+my-package </tspan><tspan class="fg-yellow bold">(latest 99999.0.0+my-package </tspan><tspan class="fg-bright-blue bold">from registry `dummy-registry`</tspan><tspan class="fg-yellow bold">)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">license:</tspan><tspan> </tspan><tspan class="fg-red bold">unknown</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">license:</tspan><tspan> </tspan><tspan class="fg-bright-red bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_info/specify_version_within_ws_and_match_with_lockfile/stderr.term.svg
+++ b/tests/testsuite/cargo_info/specify_version_within_ws_and_match_with_lockfile/stderr.term.svg
@@ -25,7 +25,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> my-package v0.1.1+my-package (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@0.1.1+my-package</tspan><tspan>`</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">note</tspan><tspan>: to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@0.1.1+my-package</tspan><tspan>`</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_info/specify_version_within_ws_and_match_with_lockfile/stderr.term.svg
+++ b/tests/testsuite/cargo_info/specify_version_within_ws_and_match_with_lockfile/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,13 +19,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold"> Downloading</tspan><tspan> crates ...</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold"> Downloading</tspan><tspan> crates ...</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v0.1.1+my-package (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> my-package v0.1.1+my-package (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-cyan bold">cargo tree --invert --package my-package@0.1.1+my-package</tspan><tspan>`</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@0.1.1+my-package</tspan><tspan>`</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_info/specify_version_within_ws_and_match_with_lockfile/stdout.term.svg
+++ b/tests/testsuite/cargo_info/specify_version_within_ws_and_match_with_lockfile/stdout.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,17 +20,17 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">my-package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">my-package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">version:</tspan><tspan> 0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest 99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">version:</tspan><tspan> 0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest 99999.0.0+my-package)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">license:</tspan><tspan> </tspan><tspan class="fg-red bold">unknown</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">license:</tspan><tspan> </tspan><tspan class="fg-bright-red bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">documentation:</tspan><tspan> https://docs.rs/my-package/0.1.1+my-package</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">documentation:</tspan><tspan> https://docs.rs/my-package/0.1.1+my-package</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">crates.io:</tspan><tspan> https://crates.io/crates/my-package/0.1.1+my-package</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">crates.io:</tspan><tspan> https://crates.io/crates/my-package/0.1.1+my-package</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/direct1-stderr.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/direct1-stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,11 +19,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold"> Downloading</tspan><tspan> crates ...</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold"> Downloading</tspan><tspan> crates ...</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> my-package v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-cyan bold">cargo tree --invert --package my-package@1.0.0</tspan><tspan>`</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@1.0.0</tspan><tspan>`</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/direct1-stderr.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/direct1-stderr.term.svg
@@ -23,7 +23,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> my-package v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@1.0.0</tspan><tspan>`</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan>: to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@1.0.0</tspan><tspan>`</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/direct1-stdout.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/direct1-stdout.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,17 +20,17 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">my-package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">my-package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">version:</tspan><tspan> 1.0.0 </tspan><tspan class="fg-yellow bold">(latest 99.0.0)</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">version:</tspan><tspan> 1.0.0 </tspan><tspan class="fg-yellow bold">(latest 99.0.0)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">license:</tspan><tspan> </tspan><tspan class="fg-red bold">unknown</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">license:</tspan><tspan> </tspan><tspan class="fg-bright-red bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">documentation:</tspan><tspan> https://docs.rs/my-package/1.0.0</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">documentation:</tspan><tspan> https://docs.rs/my-package/1.0.0</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">crates.io:</tspan><tspan> https://crates.io/crates/my-package/1.0.0</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">crates.io:</tspan><tspan> https://crates.io/crates/my-package/1.0.0</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/direct2-stderr.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/direct2-stderr.term.svg
@@ -2,7 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +19,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-cyan bold">cargo tree --invert --package my-package@2.0.0</tspan><tspan>`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@2.0.0</tspan><tspan>`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/direct2-stderr.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/direct2-stderr.term.svg
@@ -19,7 +19,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@2.0.0</tspan><tspan>`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">note</tspan><tspan>: to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@2.0.0</tspan><tspan>`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/direct2-stdout.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/direct2-stdout.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,17 +20,17 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">my-package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">my-package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">version:</tspan><tspan> 2.0.0 </tspan><tspan class="fg-yellow bold">(latest 99.0.0)</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">version:</tspan><tspan> 2.0.0 </tspan><tspan class="fg-yellow bold">(latest 99.0.0)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">license:</tspan><tspan> </tspan><tspan class="fg-red bold">unknown</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">license:</tspan><tspan> </tspan><tspan class="fg-bright-red bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">documentation:</tspan><tspan> https://docs.rs/my-package/2.0.0</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">documentation:</tspan><tspan> https://docs.rs/my-package/2.0.0</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">crates.io:</tspan><tspan> https://crates.io/crates/my-package/2.0.0</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">crates.io:</tspan><tspan> https://crates.io/crates/my-package/2.0.0</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/transitive1-stderr.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/transitive1-stderr.term.svg
@@ -2,7 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +19,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-cyan bold">cargo tree --invert --package my-package@2.0.0</tspan><tspan>`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@2.0.0</tspan><tspan>`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/transitive1-stderr.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/transitive1-stderr.term.svg
@@ -19,7 +19,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@2.0.0</tspan><tspan>`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">note</tspan><tspan>: to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@2.0.0</tspan><tspan>`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/transitive1-stdout.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/transitive1-stdout.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,17 +20,17 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">my-package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">my-package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">version:</tspan><tspan> 2.0.0 </tspan><tspan class="fg-yellow bold">(latest 99.0.0)</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">version:</tspan><tspan> 2.0.0 </tspan><tspan class="fg-yellow bold">(latest 99.0.0)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">license:</tspan><tspan> </tspan><tspan class="fg-red bold">unknown</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">license:</tspan><tspan> </tspan><tspan class="fg-bright-red bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">documentation:</tspan><tspan> https://docs.rs/my-package/2.0.0</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">documentation:</tspan><tspan> https://docs.rs/my-package/2.0.0</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">crates.io:</tspan><tspan> https://crates.io/crates/my-package/2.0.0</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">crates.io:</tspan><tspan> https://crates.io/crates/my-package/2.0.0</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/transitive2-stderr.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/transitive2-stderr.term.svg
@@ -2,7 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +19,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-cyan bold">cargo tree --invert --package my-package@2.0.0</tspan><tspan>`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@2.0.0</tspan><tspan>`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/transitive2-stderr.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/transitive2-stderr.term.svg
@@ -19,7 +19,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@2.0.0</tspan><tspan>`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">note</tspan><tspan>: to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@2.0.0</tspan><tspan>`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/transitive2-stdout.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/transitive2-stdout.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,17 +20,17 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">my-package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">my-package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">version:</tspan><tspan> 2.0.0 </tspan><tspan class="fg-yellow bold">(latest 99.0.0)</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">version:</tspan><tspan> 2.0.0 </tspan><tspan class="fg-yellow bold">(latest 99.0.0)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">license:</tspan><tspan> </tspan><tspan class="fg-red bold">unknown</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">license:</tspan><tspan> </tspan><tspan class="fg-bright-red bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">documentation:</tspan><tspan> https://docs.rs/my-package/2.0.0</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">documentation:</tspan><tspan> https://docs.rs/my-package/2.0.0</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">crates.io:</tspan><tspan> https://crates.io/crates/my-package/2.0.0</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">crates.io:</tspan><tspan> https://crates.io/crates/my-package/2.0.0</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/ws-stderr.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/ws-stderr.term.svg
@@ -25,7 +25,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> my-package v2.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@2.0.0</tspan><tspan>`</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">note</tspan><tspan>: to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@2.0.0</tspan><tspan>`</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/ws-stderr.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/ws-stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,13 +19,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold"> Downloading</tspan><tspan> crates ...</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold"> Downloading</tspan><tspan> crates ...</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v2.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> my-package v2.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-cyan bold">cargo tree --invert --package my-package@2.0.0</tspan><tspan>`</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@2.0.0</tspan><tspan>`</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/ws-stdout.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/ws-stdout.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,17 +20,17 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">my-package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">my-package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">version:</tspan><tspan> 2.0.0 </tspan><tspan class="fg-yellow bold">(latest 99.0.0)</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">version:</tspan><tspan> 2.0.0 </tspan><tspan class="fg-yellow bold">(latest 99.0.0)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">license:</tspan><tspan> </tspan><tspan class="fg-red bold">unknown</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">license:</tspan><tspan> </tspan><tspan class="fg-bright-red bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">documentation:</tspan><tspan> https://docs.rs/my-package/2.0.0</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">documentation:</tspan><tspan> https://docs.rs/my-package/2.0.0</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">crates.io:</tspan><tspan> https://crates.io/crates/my-package/2.0.0</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">crates.io:</tspan><tspan> https://crates.io/crates/my-package/2.0.0</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_info/verbose/stderr.term.svg
+++ b/tests/testsuite/cargo_info/verbose/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold"> Downloading</tspan><tspan> crates ...</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold"> Downloading</tspan><tspan> crates ...</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v0.1.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> my-package v0.1.0 (registry `dummy-registry`)</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_info/verbose/stdout.term.svg
+++ b/tests/testsuite/cargo_info/verbose/stdout.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -20,23 +20,23 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">my-package</tspan><tspan> </tspan><tspan class="fg-cyan bold">#foo #bar #baz</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">my-package</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">#foo #bar #baz</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>A package for testing</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">version:</tspan><tspan> 0.1.0 </tspan><tspan class="fg-cyan bold">(from registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">version:</tspan><tspan> 0.1.0 </tspan><tspan class="fg-bright-blue bold">(from registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">license:</tspan><tspan> MIT</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">license:</tspan><tspan> MIT</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">rust-version:</tspan><tspan> 1.50.0</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">rust-version:</tspan><tspan> 1.50.0</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">documentation:</tspan><tspan> https://docs.rs/my-package/0.1.0</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">documentation:</tspan><tspan> https://docs.rs/my-package/0.1.0</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-green bold">repository:</tspan><tspan> https://github.com/hi-rustin/cargo-infromation</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-green bold">repository:</tspan><tspan> https://github.com/hi-rustin/cargo-infromation</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">features:</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">features:</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan> </tspan><tspan class="fg-green bold">+</tspan><tspan>default  = [feature1]</tspan>
+    <tspan x="10px" y="172px"><tspan> </tspan><tspan class="fg-bright-green bold">+</tspan><tspan>default  = [feature1]</tspan>
 </tspan>
     <tspan x="10px" y="190px"><tspan>  feature1 = []</tspan>
 </tspan>
@@ -44,11 +44,11 @@
 </tspan>
     <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="dimmed">feature2</tspan><tspan> = []</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan class="fg-green bold">dependencies:</tspan>
+    <tspan x="10px" y="244px"><tspan class="fg-bright-green bold">dependencies:</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan> </tspan><tspan class="fg-green bold">+</tspan><tspan>bar@0.2.0</tspan>
+    <tspan x="10px" y="262px"><tspan> </tspan><tspan class="fg-bright-green bold">+</tspan><tspan>bar@0.2.0</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan> </tspan><tspan class="fg-green bold">+</tspan><tspan>foo@0.1.0</tspan>
+    <tspan x="10px" y="280px"><tspan> </tspan><tspan class="fg-bright-green bold">+</tspan><tspan>foo@0.1.0</tspan>
 </tspan>
     <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="dimmed">baz@0.3.0</tspan>
 </tspan>

--- a/tests/testsuite/cargo_info/with_frozen_outside_ws/stderr.term.svg
+++ b/tests/testsuite/cargo_info/with_frozen_outside_ws/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the option `--frozen` can only be used within a workspace</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the option `--frozen` can only be used within a workspace</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_info/with_frozen_outside_ws/stderr.term.svg
+++ b/tests/testsuite/cargo_info/with_frozen_outside_ws/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the option `--frozen` can only be used within a workspace</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: the option `--frozen` can only be used within a workspace</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_info/with_frozen_within_ws/stderr.term.svg
+++ b/tests/testsuite/cargo_info/with_frozen_within_ws/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="953px" height="56px" xmlns="http://www.w3.org/2000/svg">
+<svg width="961px" height="56px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> could not find `unknown` in registry `[ROOTURL]/registry`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: could not find `unknown` in registry `[ROOTURL]/registry`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_info/with_frozen_within_ws/stderr.term.svg
+++ b/tests/testsuite/cargo_info/with_frozen_within_ws/stderr.term.svg
@@ -1,8 +1,8 @@
-<svg width="886px" height="56px" xmlns="http://www.w3.org/2000/svg">
+<svg width="953px" height="56px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> could not find `unknown` in registry `[ROOTURL]/registry`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> could not find `unknown` in registry `[ROOTURL]/registry`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_info/with_locked_outside_ws/stderr.term.svg
+++ b/tests/testsuite/cargo_info/with_locked_outside_ws/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the option `--locked` can only be used within a workspace</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the option `--locked` can only be used within a workspace</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_info/with_locked_outside_ws/stderr.term.svg
+++ b/tests/testsuite/cargo_info/with_locked_outside_ws/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the option `--locked` can only be used within a workspace</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: the option `--locked` can only be used within a workspace</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_info/with_locked_within_ws/stderr.term.svg
+++ b/tests/testsuite/cargo_info/with_locked_within_ws/stderr.term.svg
@@ -1,9 +1,9 @@
-<svg width="886px" height="74px" xmlns="http://www.w3.org/2000/svg">
+<svg width="953px" height="74px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +19,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> could not find `unknown` in registry `[ROOTURL]/registry`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> could not find `unknown` in registry `[ROOTURL]/registry`</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_info/with_locked_within_ws/stderr.term.svg
+++ b/tests/testsuite/cargo_info/with_locked_within_ws/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="953px" height="74px" xmlns="http://www.w3.org/2000/svg">
+<svg width="961px" height="74px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -21,7 +21,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> could not find `unknown` in registry `[ROOTURL]/registry`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: could not find `unknown` in registry `[ROOTURL]/registry`</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_info/with_locked_within_ws_and_pick_the_package/stderr.term.svg
+++ b/tests/testsuite/cargo_info/with_locked_within_ws_and_pick_the_package/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold"> Downloading</tspan><tspan> crates ...</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold"> Downloading</tspan><tspan> crates ...</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v99999.0.0+my-package (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> my-package v99999.0.0+my-package (registry `dummy-registry`)</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_info/with_locked_within_ws_and_pick_the_package/stdout.term.svg
+++ b/tests/testsuite/cargo_info/with_locked_within_ws_and_pick_the_package/stdout.term.svg
@@ -2,9 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -21,13 +21,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">my-package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">my-package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">version:</tspan><tspan> 99999.0.0+my-package </tspan><tspan class="fg-cyan bold">(from registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">version:</tspan><tspan> 99999.0.0+my-package </tspan><tspan class="fg-bright-blue bold">(from registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">license:</tspan><tspan> </tspan><tspan class="fg-red bold">unknown</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">license:</tspan><tspan> </tspan><tspan class="fg-bright-red bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_info/with_offline/stderr.term.svg
+++ b/tests/testsuite/cargo_info/with_offline/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="978px" height="56px" xmlns="http://www.w3.org/2000/svg">
+<svg width="986px" height="56px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> could not find `my-package` in registry `[ROOTURL]/registry`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: could not find `my-package` in registry `[ROOTURL]/registry`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_info/with_offline/stderr.term.svg
+++ b/tests/testsuite/cargo_info/with_offline/stderr.term.svg
@@ -1,8 +1,8 @@
-<svg width="911px" height="56px" xmlns="http://www.w3.org/2000/svg">
+<svg width="978px" height="56px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> could not find `my-package` in registry `[ROOTURL]/registry`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> could not find `my-package` in registry `[ROOTURL]/registry`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_info/with_quiet/stdout.term.svg
+++ b/tests/testsuite/cargo_info/with_quiet/stdout.term.svg
@@ -2,9 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -21,13 +21,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">my-package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">my-package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">version:</tspan><tspan> 99999.0.0+my-package </tspan><tspan class="fg-cyan bold">(from registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">version:</tspan><tspan> 99999.0.0+my-package </tspan><tspan class="fg-bright-blue bold">(from registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">license:</tspan><tspan> </tspan><tspan class="fg-red bold">unknown</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">license:</tspan><tspan> </tspan><tspan class="fg-bright-red bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_info/within_ws/stderr.term.svg
+++ b/tests/testsuite/cargo_info/within_ws/stderr.term.svg
@@ -25,7 +25,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> my-package v0.1.1+my-package (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@0.1.1+my-package</tspan><tspan>`</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">note</tspan><tspan>: to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@0.1.1+my-package</tspan><tspan>`</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_info/within_ws/stderr.term.svg
+++ b/tests/testsuite/cargo_info/within_ws/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,13 +19,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold"> Downloading</tspan><tspan> crates ...</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold"> Downloading</tspan><tspan> crates ...</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v0.1.1+my-package (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> my-package v0.1.1+my-package (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-cyan bold">cargo tree --invert --package my-package@0.1.1+my-package</tspan><tspan>`</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@0.1.1+my-package</tspan><tspan>`</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_info/within_ws/stdout.term.svg
+++ b/tests/testsuite/cargo_info/within_ws/stdout.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,17 +20,17 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">my-package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">my-package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">version:</tspan><tspan> 0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest 99999.0.0+my-package)</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">version:</tspan><tspan> 0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest 99999.0.0+my-package)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">license:</tspan><tspan> </tspan><tspan class="fg-red bold">unknown</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">license:</tspan><tspan> </tspan><tspan class="fg-bright-red bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">documentation:</tspan><tspan> https://docs.rs/my-package/0.1.1+my-package</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">documentation:</tspan><tspan> https://docs.rs/my-package/0.1.1+my-package</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">crates.io:</tspan><tspan> https://crates.io/crates/my-package/0.1.1+my-package</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">crates.io:</tspan><tspan> https://crates.io/crates/my-package/0.1.1+my-package</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_info/within_ws_and_pick_ws_package/stdout.term.svg
+++ b/tests/testsuite/cargo_info/within_ws_and_pick_ws_package/stdout.term.svg
@@ -2,9 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -21,13 +21,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">cargo-list-test-fixture</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">cargo-list-test-fixture</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">version:</tspan><tspan> 0.2.0 </tspan><tspan class="fg-cyan bold">(from ./)</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">version:</tspan><tspan> 0.2.0 </tspan><tspan class="fg-bright-blue bold">(from ./)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">license:</tspan><tspan> </tspan><tspan class="fg-red bold">unknown</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">license:</tspan><tspan> </tspan><tspan class="fg-bright-red bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_info/within_ws_with_alternative_registry/stderr.term.svg
+++ b/tests/testsuite/cargo_info/within_ws_with_alternative_registry/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,13 +18,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">    Updating</tspan><tspan> `alternative` index</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `alternative` index</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold"> Downloading</tspan><tspan> crates ...</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold"> Downloading</tspan><tspan> crates ...</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v99999.0.0-alpha.1+my-package (registry `alternative`)</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> my-package v99999.0.0-alpha.1+my-package (registry `alternative`)</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_info/within_ws_with_alternative_registry/stdout.term.svg
+++ b/tests/testsuite/cargo_info/within_ws_with_alternative_registry/stdout.term.svg
@@ -2,9 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -21,13 +21,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">my-package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">my-package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">version:</tspan><tspan> 99999.0.0-alpha.1+my-package </tspan><tspan class="fg-cyan bold">(from registry `alternative`)</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">version:</tspan><tspan> 99999.0.0-alpha.1+my-package </tspan><tspan class="fg-bright-blue bold">(from registry `alternative`)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">license:</tspan><tspan> </tspan><tspan class="fg-red bold">unknown</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">license:</tspan><tspan> </tspan><tspan class="fg-bright-red bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_info/within_ws_without_lockfile/stderr.term.svg
+++ b/tests/testsuite/cargo_info/within_ws_without_lockfile/stderr.term.svg
@@ -30,7 +30,7 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> my-package v0.2.3+my-package (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@0.2.3+my-package</tspan><tspan>`</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">note</tspan><tspan>: to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@0.2.3+my-package</tspan><tspan>`</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_info/within_ws_without_lockfile/stderr.term.svg
+++ b/tests/testsuite/cargo_info/within_ws_without_lockfile/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,17 +20,17 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package v0.2.3+my-package </tspan><tspan class="fg-yellow bold">(available: v0.4.1+my-package)</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.2.3+my-package </tspan><tspan class="fg-yellow bold">(available: v0.4.1+my-package)</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold"> Downloading</tspan><tspan> crates ...</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold"> Downloading</tspan><tspan> crates ...</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v0.2.3+my-package (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> my-package v0.2.3+my-package (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-cyan bold">cargo tree --invert --package my-package@0.2.3+my-package</tspan><tspan>`</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@0.2.3+my-package</tspan><tspan>`</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_info/within_ws_without_lockfile/stdout.term.svg
+++ b/tests/testsuite/cargo_info/within_ws_without_lockfile/stdout.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,17 +20,17 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">my-package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">my-package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">version:</tspan><tspan> 0.2.3+my-package </tspan><tspan class="fg-yellow bold">(latest 0.4.1+my-package)</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">version:</tspan><tspan> 0.2.3+my-package </tspan><tspan class="fg-yellow bold">(latest 0.4.1+my-package)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">license:</tspan><tspan> </tspan><tspan class="fg-red bold">unknown</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">license:</tspan><tspan> </tspan><tspan class="fg-bright-red bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">documentation:</tspan><tspan> https://docs.rs/my-package/0.2.3+my-package</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">documentation:</tspan><tspan> https://docs.rs/my-package/0.2.3+my-package</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">crates.io:</tspan><tspan> https://crates.io/crates/my-package/0.2.3+my-package</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">crates.io:</tspan><tspan> https://crates.io/crates/my-package/0.2.3+my-package</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_info/without_requiring_registry_auth/stderr.term.svg
+++ b/tests/testsuite/cargo_info/without_requiring_registry_auth/stderr.term.svg
@@ -25,7 +25,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> my-package v0.1.1+my-package (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@0.1.1+my-package</tspan><tspan>`</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">note</tspan><tspan>: to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@0.1.1+my-package</tspan><tspan>`</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_info/without_requiring_registry_auth/stderr.term.svg
+++ b/tests/testsuite/cargo_info/without_requiring_registry_auth/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,13 +19,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold"> Downloading</tspan><tspan> crates ...</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold"> Downloading</tspan><tspan> crates ...</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v0.1.1+my-package (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> my-package v0.1.1+my-package (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-cyan bold">cargo tree --invert --package my-package@0.1.1+my-package</tspan><tspan>`</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@0.1.1+my-package</tspan><tspan>`</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_info/without_requiring_registry_auth/stdout.term.svg
+++ b/tests/testsuite/cargo_info/without_requiring_registry_auth/stdout.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,17 +20,17 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">my-package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">my-package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">version:</tspan><tspan> 0.1.1+my-package</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">version:</tspan><tspan> 0.1.1+my-package</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">license:</tspan><tspan> </tspan><tspan class="fg-red bold">unknown</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">license:</tspan><tspan> </tspan><tspan class="fg-bright-red bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">rust-version:</tspan><tspan> </tspan><tspan class="fg-yellow bold">unknown</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">documentation:</tspan><tspan> https://docs.rs/my-package/0.1.1+my-package</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">documentation:</tspan><tspan> https://docs.rs/my-package/0.1.1+my-package</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">crates.io:</tspan><tspan> https://crates.io/crates/my-package/0.1.1+my-package</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">crates.io:</tspan><tspan> https://crates.io/crates/my-package/0.1.1+my-package</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_init/auto_git/stderr.term.svg
+++ b/tests/testsuite/cargo_init/auto_git/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> library package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/auto_git/stderr.term.svg
+++ b/tests/testsuite/cargo_init/auto_git/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/bin_already_exists_explicit/stderr.term.svg
+++ b/tests/testsuite/cargo_init/bin_already_exists_explicit/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/bin_already_exists_explicit/stderr.term.svg
+++ b/tests/testsuite/cargo_init/bin_already_exists_explicit/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/bin_already_exists_explicit_nosrc/stderr.term.svg
+++ b/tests/testsuite/cargo_init/bin_already_exists_explicit_nosrc/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/bin_already_exists_explicit_nosrc/stderr.term.svg
+++ b/tests/testsuite/cargo_init/bin_already_exists_explicit_nosrc/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/bin_already_exists_implicit/stderr.term.svg
+++ b/tests/testsuite/cargo_init/bin_already_exists_implicit/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/bin_already_exists_implicit/stderr.term.svg
+++ b/tests/testsuite/cargo_init/bin_already_exists_implicit/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/bin_already_exists_implicit_namenosrc/stderr.term.svg
+++ b/tests/testsuite/cargo_init/bin_already_exists_implicit_namenosrc/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/bin_already_exists_implicit_namenosrc/stderr.term.svg
+++ b/tests/testsuite/cargo_init/bin_already_exists_implicit_namenosrc/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/bin_already_exists_implicit_namesrc/stderr.term.svg
+++ b/tests/testsuite/cargo_init/bin_already_exists_implicit_namesrc/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/bin_already_exists_implicit_namesrc/stderr.term.svg
+++ b/tests/testsuite/cargo_init/bin_already_exists_implicit_namesrc/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/bin_already_exists_implicit_nosrc/stderr.term.svg
+++ b/tests/testsuite/cargo_init/bin_already_exists_implicit_nosrc/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/bin_already_exists_implicit_nosrc/stderr.term.svg
+++ b/tests/testsuite/cargo_init/bin_already_exists_implicit_nosrc/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/both_lib_and_bin/stderr.term.svg
+++ b/tests/testsuite/cargo_init/both_lib_and_bin/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> can't specify both lib and binary outputs</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> can't specify both lib and binary outputs</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_init/both_lib_and_bin/stderr.term.svg
+++ b/tests/testsuite/cargo_init/both_lib_and_bin/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> can't specify both lib and binary outputs</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: can't specify both lib and binary outputs</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_init/cant_create_library_when_both_binlib_present/stderr.term.svg
+++ b/tests/testsuite/cargo_init/cant_create_library_when_both_binlib_present/stderr.term.svg
@@ -21,7 +21,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> cannot have a package with multiple libraries, found both `case.rs` and `lib.rs`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: cannot have a package with multiple libraries, found both `case.rs` and `lib.rs`</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/cant_create_library_when_both_binlib_present/stderr.term.svg
+++ b/tests/testsuite/cargo_init/cant_create_library_when_both_binlib_present/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +19,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> library package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> cannot have a package with multiple libraries, found both `case.rs` and `lib.rs`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> cannot have a package with multiple libraries, found both `case.rs` and `lib.rs`</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/confused_by_multiple_lib_files/stderr.term.svg
+++ b/tests/testsuite/cargo_init/confused_by_multiple_lib_files/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> cannot have a package with multiple libraries, found both `src/lib.rs` and `lib.rs`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: cannot have a package with multiple libraries, found both `src/lib.rs` and `lib.rs`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_init/confused_by_multiple_lib_files/stderr.term.svg
+++ b/tests/testsuite/cargo_init/confused_by_multiple_lib_files/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> cannot have a package with multiple libraries, found both `src/lib.rs` and `lib.rs`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> cannot have a package with multiple libraries, found both `src/lib.rs` and `lib.rs`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_init/creates_binary_when_both_binlib_present/stderr.term.svg
+++ b/tests/testsuite/cargo_init/creates_binary_when_both_binlib_present/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/creates_binary_when_both_binlib_present/stderr.term.svg
+++ b/tests/testsuite/cargo_init/creates_binary_when_both_binlib_present/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/creates_binary_when_instructed_and_has_lib_file/stderr.term.svg
+++ b/tests/testsuite/cargo_init/creates_binary_when_instructed_and_has_lib_file/stderr.term.svg
@@ -21,9 +21,9 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> file `case.rs` seems to be a library file</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-yellow bold">warning</tspan><tspan>: file `case.rs` seems to be a library file</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_init/creates_binary_when_instructed_and_has_lib_file/stderr.term.svg
+++ b/tests/testsuite/cargo_init/creates_binary_when_instructed_and_has_lib_file/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,11 +19,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> file `case.rs` seems to be a library file</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_init/creates_library_when_instructed_and_has_bin_file/stderr.term.svg
+++ b/tests/testsuite/cargo_init/creates_library_when_instructed_and_has_bin_file/stderr.term.svg
@@ -21,9 +21,9 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> file `case.rs` seems to be a binary (application) file</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-yellow bold">warning</tspan><tspan>: file `case.rs` seems to be a binary (application) file</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_init/creates_library_when_instructed_and_has_bin_file/stderr.term.svg
+++ b/tests/testsuite/cargo_init/creates_library_when_instructed_and_has_bin_file/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,11 +19,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> library package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> file `case.rs` seems to be a binary (application) file</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_init/explicit_bin_with_git/stderr.term.svg
+++ b/tests/testsuite/cargo_init/explicit_bin_with_git/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/explicit_bin_with_git/stderr.term.svg
+++ b/tests/testsuite/cargo_init/explicit_bin_with_git/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/formats_source/stderr.term.svg
+++ b/tests/testsuite/cargo_init/formats_source/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> library package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/formats_source/stderr.term.svg
+++ b/tests/testsuite/cargo_init/formats_source/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/fossil_autodetect/stderr.term.svg
+++ b/tests/testsuite/cargo_init/fossil_autodetect/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> library package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/fossil_autodetect/stderr.term.svg
+++ b/tests/testsuite/cargo_init/fossil_autodetect/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/git_autodetect/stderr.term.svg
+++ b/tests/testsuite/cargo_init/git_autodetect/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> library package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/git_autodetect/stderr.term.svg
+++ b/tests/testsuite/cargo_init/git_autodetect/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/git_ignore_exists_no_conflicting_entries/stderr.term.svg
+++ b/tests/testsuite/cargo_init/git_ignore_exists_no_conflicting_entries/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> library package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/git_ignore_exists_no_conflicting_entries/stderr.term.svg
+++ b/tests/testsuite/cargo_init/git_ignore_exists_no_conflicting_entries/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/help/stdout.term.svg
+++ b/tests/testsuite/cargo_init/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,63 +24,63 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] init</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[PATH]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] init</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[PATH]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">[PATH]</tspan><tspan>  [default: .]</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-cyan bold">--vcs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;VCS&gt;</tspan><tspan>                Initialize a new repository for the given version control system,</tspan>
+    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--vcs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;VCS&gt;</tspan><tspan>                Initialize a new repository for the given version control system,</tspan>
 </tspan>
     <tspan x="10px" y="190px"><tspan>                                 overriding a global configuration. [possible values: git, hg,</tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan>                                 pijul, fossil, none]</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-cyan bold">--bin</tspan><tspan>                      Use a binary (application) template [default]</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bin</tspan><tspan>                      Use a binary (application) template [default]</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-cyan bold">--lib</tspan><tspan>                      Use a library template</tspan>
+    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lib</tspan><tspan>                      Use a library template</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--edition</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;YEAR&gt;</tspan><tspan>           Edition to set for the crate generated [possible values: 2015,</tspan>
+    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--edition</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;YEAR&gt;</tspan><tspan>           Edition to set for the crate generated [possible values: 2015,</tspan>
 </tspan>
     <tspan x="10px" y="280px"><tspan>                                 2018, 2021, 2024]</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--name</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan>              Set the resulting package name, defaults to the directory name</tspan>
+    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--name</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan>              Set the resulting package name, defaults to the directory name</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--registry</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;REGISTRY&gt;</tspan><tspan>      Registry to use</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--registry</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;REGISTRY&gt;</tspan><tspan>      Registry to use</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="406px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="424px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="442px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="460px">
 </tspan>
-    <tspan x="10px" y="478px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="478px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
+    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="550px">
 </tspan>
-    <tspan x="10px" y="568px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help init</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="568px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help init</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="586px">
 </tspan>

--- a/tests/testsuite/cargo_init/ignores_failure_to_format_source/stderr.term.svg
+++ b/tests/testsuite/cargo_init/ignores_failure_to_format_source/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> library package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/ignores_failure_to_format_source/stderr.term.svg
+++ b/tests/testsuite/cargo_init/ignores_failure_to_format_source/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/inferred_bin_with_git/stderr.term.svg
+++ b/tests/testsuite/cargo_init/inferred_bin_with_git/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/inferred_bin_with_git/stderr.term.svg
+++ b/tests/testsuite/cargo_init/inferred_bin_with_git/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/inferred_lib_with_git/stderr.term.svg
+++ b/tests/testsuite/cargo_init/inferred_lib_with_git/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/inferred_lib_with_git/stderr.term.svg
+++ b/tests/testsuite/cargo_init/inferred_lib_with_git/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/inherit_workspace_package_table/stderr.term.svg
+++ b/tests/testsuite/cargo_init/inherit_workspace_package_table/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/inherit_workspace_package_table/stderr.term.svg
+++ b/tests/testsuite/cargo_init/inherit_workspace_package_table/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/invalid_dir_name/stderr.term.svg
+++ b/tests/testsuite/cargo_init/invalid_dir_name/stderr.term.svg
@@ -21,7 +21,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> invalid character `.` in package name: `foo.bar`, characters must be Unicode XID characters (numbers, `-`, `_`, or most letters)</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: invalid character `.` in package name: `foo.bar`, characters must be Unicode XID characters (numbers, `-`, `_`, or most letters)</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>If you need a package name to not match the directory name, consider using --name flag.</tspan>
 </tspan>

--- a/tests/testsuite/cargo_init/invalid_dir_name/stderr.term.svg
+++ b/tests/testsuite/cargo_init/invalid_dir_name/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +19,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> invalid character `.` in package name: `foo.bar`, characters must be Unicode XID characters (numbers, `-`, `_`, or most letters)</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> invalid character `.` in package name: `foo.bar`, characters must be Unicode XID characters (numbers, `-`, `_`, or most letters)</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>If you need a package name to not match the directory name, consider using --name flag.</tspan>
 </tspan>

--- a/tests/testsuite/cargo_init/lib_already_exists_nosrc/stderr.term.svg
+++ b/tests/testsuite/cargo_init/lib_already_exists_nosrc/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/lib_already_exists_nosrc/stderr.term.svg
+++ b/tests/testsuite/cargo_init/lib_already_exists_nosrc/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/lib_already_exists_src/stderr.term.svg
+++ b/tests/testsuite/cargo_init/lib_already_exists_src/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/lib_already_exists_src/stderr.term.svg
+++ b/tests/testsuite/cargo_init/lib_already_exists_src/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/mercurial_autodetect/stderr.term.svg
+++ b/tests/testsuite/cargo_init/mercurial_autodetect/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> library package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/mercurial_autodetect/stderr.term.svg
+++ b/tests/testsuite/cargo_init/mercurial_autodetect/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/multibin_project_name_clash/stderr.term.svg
+++ b/tests/testsuite/cargo_init/multibin_project_name_clash/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> multiple possible binary sources found:</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: multiple possible binary sources found:</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>  main.rs</tspan>
 </tspan>

--- a/tests/testsuite/cargo_init/multibin_project_name_clash/stderr.term.svg
+++ b/tests/testsuite/cargo_init/multibin_project_name_clash/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> multiple possible binary sources found:</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> multiple possible binary sources found:</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>  main.rs</tspan>
 </tspan>

--- a/tests/testsuite/cargo_init/no_filename/stderr.term.svg
+++ b/tests/testsuite/cargo_init/no_filename/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> cannot auto-detect package name from path "/" ; use --name to override</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> cannot auto-detect package name from path "/" ; use --name to override</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_init/no_filename/stderr.term.svg
+++ b/tests/testsuite/cargo_init/no_filename/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> cannot auto-detect package name from path "/" ; use --name to override</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: cannot auto-detect package name from path "/" ; use --name to override</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_init/path_contains_separator/stderr.term.svg
+++ b/tests/testsuite/cargo_init/path_contains_separator/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -20,13 +19,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> the path `[ROOT]/case/test:ing/.` contains invalid PATH characters (usually `:`, `;`, or `"`)</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>It is recommended to use a different name to avoid problems.</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_init/path_contains_separator/stderr.term.svg
+++ b/tests/testsuite/cargo_init/path_contains_separator/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="1247px" height="110px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1255px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -21,11 +21,11 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> the path `[ROOT]/case/test:ing/.` contains invalid PATH characters (usually `:`, `;`, or `"`)</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-yellow bold">warning</tspan><tspan>: the path `[ROOT]/case/test:ing/.` contains invalid PATH characters (usually `:`, `;`, or `"`)</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>It is recommended to use a different name to avoid problems.</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_init/pijul_autodetect/stderr.term.svg
+++ b/tests/testsuite/cargo_init/pijul_autodetect/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> library package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/pijul_autodetect/stderr.term.svg
+++ b/tests/testsuite/cargo_init/pijul_autodetect/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/reserved_name/stderr.term.svg
+++ b/tests/testsuite/cargo_init/reserved_name/stderr.term.svg
@@ -21,7 +21,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the name `test` cannot be used as a package name, it conflicts with Rust's built-in test library</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: the name `test` cannot be used as a package name, it conflicts with Rust's built-in test library</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>If you need a package name to not match the directory name, consider using --name flag.</tspan>
 </tspan>

--- a/tests/testsuite/cargo_init/reserved_name/stderr.term.svg
+++ b/tests/testsuite/cargo_init/reserved_name/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +19,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the name `test` cannot be used as a package name, it conflicts with Rust's built-in test library</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the name `test` cannot be used as a package name, it conflicts with Rust's built-in test library</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>If you need a package name to not match the directory name, consider using --name flag.</tspan>
 </tspan>

--- a/tests/testsuite/cargo_init/simple_bin/stderr.term.svg
+++ b/tests/testsuite/cargo_init/simple_bin/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/simple_bin/stderr.term.svg
+++ b/tests/testsuite/cargo_init/simple_bin/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/simple_git/stderr.term.svg
+++ b/tests/testsuite/cargo_init/simple_git/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> library package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/simple_git/stderr.term.svg
+++ b/tests/testsuite/cargo_init/simple_git/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/simple_git_ignore_exists/stderr.term.svg
+++ b/tests/testsuite/cargo_init/simple_git_ignore_exists/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> library package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/simple_git_ignore_exists/stderr.term.svg
+++ b/tests/testsuite/cargo_init/simple_git_ignore_exists/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/simple_hg/stderr.term.svg
+++ b/tests/testsuite/cargo_init/simple_hg/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> library package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/simple_hg/stderr.term.svg
+++ b/tests/testsuite/cargo_init/simple_hg/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/simple_hg_ignore_exists/stderr.term.svg
+++ b/tests/testsuite/cargo_init/simple_hg_ignore_exists/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> library package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/simple_hg_ignore_exists/stderr.term.svg
+++ b/tests/testsuite/cargo_init/simple_hg_ignore_exists/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/simple_lib/stderr.term.svg
+++ b/tests/testsuite/cargo_init/simple_lib/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> library package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/simple_lib/stderr.term.svg
+++ b/tests/testsuite/cargo_init/simple_lib/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/unknown_flags/stderr.term.svg
+++ b/tests/testsuite/cargo_init/unknown_flags/stderr.term.svg
@@ -2,9 +2,10 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -21,19 +22,19 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error:</tspan><tspan> unexpected argument '</tspan><tspan class="fg-yellow bold">--flag</tspan><tspan>' found</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error:</tspan><tspan> unexpected argument '</tspan><tspan class="fg-yellow bold">--flag</tspan><tspan>' found</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>  </tspan><tspan class="fg-cyan bold">tip:</tspan><tspan> to pass '</tspan><tspan class="fg-yellow bold">--flag</tspan><tspan>' as a value, use '</tspan><tspan class="fg-cyan bold">-- --flag</tspan><tspan>'</tspan>
+    <tspan x="10px" y="64px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">tip:</tspan><tspan> to pass '</tspan><tspan class="fg-yellow bold">--flag</tspan><tspan>' as a value, use '</tspan><tspan class="fg-bright-cyan bold">-- --flag</tspan><tspan>'</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] init</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] init</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>
-    <tspan x="10px" y="136px"><tspan>For more information, try '</tspan><tspan class="fg-cyan bold">--help</tspan><tspan>'.</tspan>
+    <tspan x="10px" y="136px"><tspan>For more information, try '</tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>'.</tspan>
 </tspan>
     <tspan x="10px" y="154px">
 </tspan>

--- a/tests/testsuite/cargo_init/with_argument/stderr.term.svg
+++ b/tests/testsuite/cargo_init/with_argument/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/with_argument/stderr.term.svg
+++ b/tests/testsuite/cargo_init/with_argument/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_init/workspace_add_member/stderr.term.svg
+++ b/tests/testsuite/cargo_init/workspace_add_member/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> `foo` as member of workspace at `[ROOT]/case`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> `foo` as member of workspace at `[ROOT]/case`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_init/workspace_add_member/stderr.term.svg
+++ b/tests/testsuite/cargo_init/workspace_add_member/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> `foo` as member of workspace at `[ROOT]/case`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_install/help/stdout.term.svg
+++ b/tests/testsuite/cargo_install/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,123 +24,123 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] install</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[CRATE[@&lt;VER&gt;]]...</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] install</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[CRATE[@&lt;VER&gt;]]...</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">[CRATE[@&lt;VER&gt;]]...</tspan><tspan>  Select the package from the given source</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-cyan bold">--version</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;VERSION&gt;</tspan><tspan>        Specify a version to install</tspan>
+    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--version</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;VERSION&gt;</tspan><tspan>        Specify a version to install</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-cyan bold">--index</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;INDEX&gt;</tspan><tspan>            Registry index to install from</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--index</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;INDEX&gt;</tspan><tspan>            Registry index to install from</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-cyan bold">--registry</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;REGISTRY&gt;</tspan><tspan>      Registry to use</tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--registry</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;REGISTRY&gt;</tspan><tspan>      Registry to use</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-cyan bold">--git</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;URL&gt;</tspan><tspan>                Git URL to install the specified crate from</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--git</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;URL&gt;</tspan><tspan>                Git URL to install the specified crate from</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-cyan bold">--branch</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;BRANCH&gt;</tspan><tspan>          Branch to use when installing from git</tspan>
+    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--branch</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;BRANCH&gt;</tspan><tspan>          Branch to use when installing from git</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--tag</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TAG&gt;</tspan><tspan>                Tag to use when installing from git</tspan>
+    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--tag</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TAG&gt;</tspan><tspan>                Tag to use when installing from git</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--rev</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SHA&gt;</tspan><tspan>                Specific commit to use when installing from git</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--rev</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SHA&gt;</tspan><tspan>                Specific commit to use when installing from git</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>              Filesystem path to local crate to install from</tspan>
+    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>              Filesystem path to local crate to install from</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--root</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIR&gt;</tspan><tspan>               Directory to install packages into</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--root</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIR&gt;</tspan><tspan>               Directory to install packages into</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-cyan bold">-f</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--force</tspan><tspan>                    Force overwriting existing crates or binaries</tspan>
+    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-f</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--force</tspan><tspan>                    Force overwriting existing crates or binaries</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-cyan bold">-n</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--dry-run</tspan><tspan>                  Perform all checks without installing (unstable)</tspan>
+    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-n</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--dry-run</tspan><tspan>                  Perform all checks without installing (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-track</tspan><tspan>                 Do not save tracking information</tspan>
+    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-track</tspan><tspan>                 Do not save tracking information</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--list</tspan><tspan>                     List all installed packages and their versions</tspan>
+    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--list</tspan><tspan>                     List all installed packages and their versions</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--message-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>     Error format [possible values: human, short, json,</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--message-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>     Error format [possible values: human, short, json,</tspan>
 </tspan>
     <tspan x="10px" y="424px"><tspan>                                 json-diagnostic-short, json-diagnostic-rendered-ansi,</tspan>
 </tspan>
     <tspan x="10px" y="442px"><tspan>                                 json-render-diagnostics]</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--debug</tspan><tspan>                    Build in debug mode (with the 'dev' profile) instead of release</tspan>
+    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--debug</tspan><tspan>                    Build in debug mode (with the 'dev' profile) instead of release</tspan>
 </tspan>
     <tspan x="10px" y="478px"><tspan>                                 mode</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="496px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="514px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="568px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="586px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="604px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="622px">
 </tspan>
-    <tspan x="10px" y="640px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="640px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
+    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
+    <tspan x="10px" y="676px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="694px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="748px">
 </tspan>
-    <tspan x="10px" y="766px"><tspan class="fg-green bold">Target Selection:</tspan>
+    <tspan x="10px" y="766px"><tspan class="fg-bright-green bold">Target Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan>      </tspan><tspan class="fg-cyan bold">--bin</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>      Install only the specified binary</tspan>
+    <tspan x="10px" y="784px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bin</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>      Install only the specified binary</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan>      </tspan><tspan class="fg-cyan bold">--bins</tspan><tspan>              Install all binaries</tspan>
+    <tspan x="10px" y="802px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bins</tspan><tspan>              Install all binaries</tspan>
 </tspan>
-    <tspan x="10px" y="820px"><tspan>      </tspan><tspan class="fg-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Install only the specified example</tspan>
+    <tspan x="10px" y="820px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Install only the specified example</tspan>
 </tspan>
-    <tspan x="10px" y="838px"><tspan>      </tspan><tspan class="fg-cyan bold">--examples</tspan><tspan>          Install all examples</tspan>
+    <tspan x="10px" y="838px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--examples</tspan><tspan>          Install all examples</tspan>
 </tspan>
     <tspan x="10px" y="856px">
 </tspan>
-    <tspan x="10px" y="874px"><tspan class="fg-green bold">Feature Selection:</tspan>
+    <tspan x="10px" y="874px"><tspan class="fg-bright-green bold">Feature Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="892px"><tspan>  </tspan><tspan class="fg-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
+    <tspan x="10px" y="892px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
 </tspan>
-    <tspan x="10px" y="910px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
+    <tspan x="10px" y="910px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
 </tspan>
-    <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
+    <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
 </tspan>
     <tspan x="10px" y="946px">
 </tspan>
-    <tspan x="10px" y="964px"><tspan class="fg-green bold">Compilation Options:</tspan>
+    <tspan x="10px" y="964px"><tspan class="fg-bright-green bold">Compilation Options:</tspan>
 </tspan>
-    <tspan x="10px" y="982px"><tspan>  </tspan><tspan class="fg-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
+    <tspan x="10px" y="982px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
 </tspan>
-    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
+    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
 </tspan>
-    <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Install artifacts with the specified profile</tspan>
+    <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Install artifacts with the specified profile</tspan>
 </tspan>
-    <tspan x="10px" y="1036px"><tspan>      </tspan><tspan class="fg-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Build for the target triple</tspan>
+    <tspan x="10px" y="1036px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Build for the target triple</tspan>
 </tspan>
-    <tspan x="10px" y="1054px"><tspan>      </tspan><tspan class="fg-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
+    <tspan x="10px" y="1054px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
 </tspan>
-    <tspan x="10px" y="1072px"><tspan>      </tspan><tspan class="fg-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
+    <tspan x="10px" y="1072px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
 </tspan>
     <tspan x="10px" y="1090px">
 </tspan>
-    <tspan x="10px" y="1108px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help install</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="1108px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help install</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="1126px">
 </tspan>

--- a/tests/testsuite/cargo_locate_project/help/stdout.term.svg
+++ b/tests/testsuite/cargo_locate_project/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,45 +24,45 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] locate-project</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] locate-project</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>      </tspan><tspan class="fg-cyan bold">--workspace</tspan><tspan>                Locate Cargo.toml of the workspace root</tspan>
+    <tspan x="10px" y="118px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--workspace</tspan><tspan>                Locate Cargo.toml of the workspace root</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>      </tspan><tspan class="fg-cyan bold">--message-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>     Output representation [possible values: json, plain]</tspan>
+    <tspan x="10px" y="136px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--message-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>     Output representation [possible values: json, plain]</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="244px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="280px">
 </tspan>
-    <tspan x="10px" y="298px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="298px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="388px">
 </tspan>
-    <tspan x="10px" y="406px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help locate-project</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="406px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help locate-project</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="424px">
 </tspan>

--- a/tests/testsuite/cargo_login/help/stdout.term.svg
+++ b/tests/testsuite/cargo_login/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,47 +24,47 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] login</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan bold">[--</tspan><tspan> </tspan><tspan class="fg-cyan">[args]...</tspan><tspan class="fg-cyan bold">]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] login</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">[--</tspan><tspan> </tspan><tspan class="fg-cyan">[args]...</tspan><tspan class="fg-bright-cyan bold">]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">[args]...</tspan><tspan>  Additional arguments for the credential provider</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-cyan bold">--registry</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;REGISTRY&gt;</tspan><tspan>      Registry to use</tspan>
+    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--registry</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;REGISTRY&gt;</tspan><tspan>      Registry to use</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="280px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="316px">
 </tspan>
-    <tspan x="10px" y="334px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="334px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
+    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="406px">
 </tspan>
-    <tspan x="10px" y="424px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help login</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="424px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help login</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="442px">
 </tspan>

--- a/tests/testsuite/cargo_logout/help/stdout.term.svg
+++ b/tests/testsuite/cargo_logout/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,41 +24,41 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] logout</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] logout</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>      </tspan><tspan class="fg-cyan bold">--registry</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;REGISTRY&gt;</tspan><tspan>      Registry to use</tspan>
+    <tspan x="10px" y="118px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--registry</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;REGISTRY&gt;</tspan><tspan>      Registry to use</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="226px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="262px">
 </tspan>
-    <tspan x="10px" y="280px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="280px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="352px">
 </tspan>
-    <tspan x="10px" y="370px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help logout</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="370px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help logout</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="388px">
 </tspan>

--- a/tests/testsuite/cargo_metadata/help/stdout.term.svg
+++ b/tests/testsuite/cargo_metadata/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -25,61 +26,61 @@
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] metadata</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] metadata</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>      </tspan><tspan class="fg-cyan bold">--filter-platform</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan>  Only include resolve dependencies matching the given target-triple</tspan>
+    <tspan x="10px" y="136px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--filter-platform</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan>  Only include resolve dependencies matching the given target-triple</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-deps</tspan><tspan>                   Output information only about the workspace members and don't</tspan>
+    <tspan x="10px" y="154px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-deps</tspan><tspan>                   Output information only about the workspace members and don't</tspan>
 </tspan>
     <tspan x="10px" y="172px"><tspan>                                  fetch dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-cyan bold">--format-version</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;VERSION&gt;</tspan><tspan>  Format version [possible values: 1]</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--format-version</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;VERSION&gt;</tspan><tspan>  Format version [possible values: 1]</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>                Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>                Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                     Do not print cargo log messages</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                     Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>              Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>              Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>   Override a configuration value</tspan>
+    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>   Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                       Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                       Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="298px"><tspan>                                  details</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                      Print help</tspan>
+    <tspan x="10px" y="316px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                      Print help</tspan>
 </tspan>
     <tspan x="10px" y="334px">
 </tspan>
-    <tspan x="10px" y="352px"><tspan class="fg-green bold">Feature Selection:</tspan>
+    <tspan x="10px" y="352px"><tspan class="fg-bright-green bold">Feature Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>  </tspan><tspan class="fg-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
+    <tspan x="10px" y="370px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
+    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
 </tspan>
     <tspan x="10px" y="424px">
 </tspan>
-    <tspan x="10px" y="442px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="442px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="550px">
 </tspan>
-    <tspan x="10px" y="568px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help metadata</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="568px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help metadata</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="586px">
 </tspan>

--- a/tests/testsuite/cargo_new/add_members_to_non_workspace/stderr.term.svg
+++ b/tests/testsuite/cargo_new/add_members_to_non_workspace/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library `bar` package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_new/add_members_to_non_workspace/stderr.term.svg
+++ b/tests/testsuite/cargo_new/add_members_to_non_workspace/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> library `bar` package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library `bar` package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_new/add_members_to_workspace_format_previous_items/stderr.term.svg
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_format_previous_items/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) `foo` package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) `foo` package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> `foo` as member of workspace at `[ROOT]/case`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> `foo` as member of workspace at `[ROOT]/case`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_new/add_members_to_workspace_format_previous_items/stderr.term.svg
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_format_previous_items/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> `foo` as member of workspace at `[ROOT]/case`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_new/add_members_to_workspace_format_sorted/stderr.term.svg
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_format_sorted/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) `foo` package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) `foo` package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> `foo` as member of workspace at `[ROOT]/case`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> `foo` as member of workspace at `[ROOT]/case`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_new/add_members_to_workspace_format_sorted/stderr.term.svg
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_format_sorted/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> `foo` as member of workspace at `[ROOT]/case`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_new/add_members_to_workspace_with_absolute_package_path/stderr.term.svg
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_with_absolute_package_path/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) `foo` package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) `foo` package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> `foo` as member of workspace at `[ROOT]/case`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> `foo` as member of workspace at `[ROOT]/case`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_new/add_members_to_workspace_with_absolute_package_path/stderr.term.svg
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_with_absolute_package_path/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> `foo` as member of workspace at `[ROOT]/case`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_new/add_members_to_workspace_with_empty_members/stderr.term.svg
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_with_empty_members/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) `foo` package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) `foo` package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> `foo` as member of workspace at `[ROOT]/case`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> `foo` as member of workspace at `[ROOT]/case`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_new/add_members_to_workspace_with_empty_members/stderr.term.svg
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_with_empty_members/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> `foo` as member of workspace at `[ROOT]/case`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_new/add_members_to_workspace_with_exclude_list/stderr.term.svg
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_with_exclude_list/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) `foo` package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_new/add_members_to_workspace_with_exclude_list/stderr.term.svg
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_with_exclude_list/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) `foo` package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) `foo` package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_new/add_members_to_workspace_with_members_glob/stderr.term.svg
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_with_members_glob/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) `foo` package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_new/add_members_to_workspace_with_members_glob/stderr.term.svg
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_with_members_glob/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) `foo` package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) `foo` package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_new/add_members_to_workspace_without_members/stderr.term.svg
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_without_members/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> library `bar` package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library `bar` package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> `bar` as member of workspace at `[ROOT]/case`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> `bar` as member of workspace at `[ROOT]/case`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_new/add_members_to_workspace_without_members/stderr.term.svg
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_without_members/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> `bar` as member of workspace at `[ROOT]/case`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_new/empty_name/stderr.term.svg
+++ b/tests/testsuite/cargo_new/empty_name/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +19,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) `` package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) `` package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> package name cannot be empty</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> package name cannot be empty</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_new/empty_name/stderr.term.svg
+++ b/tests/testsuite/cargo_new/empty_name/stderr.term.svg
@@ -21,7 +21,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) `` package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> package name cannot be empty</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: package name cannot be empty</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_new/help/stdout.term.svg
+++ b/tests/testsuite/cargo_new/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,63 +24,63 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] new</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] new</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  </tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-cyan bold">--vcs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;VCS&gt;</tspan><tspan>                Initialize a new repository for the given version control system,</tspan>
+    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--vcs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;VCS&gt;</tspan><tspan>                Initialize a new repository for the given version control system,</tspan>
 </tspan>
     <tspan x="10px" y="190px"><tspan>                                 overriding a global configuration. [possible values: git, hg,</tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan>                                 pijul, fossil, none]</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-cyan bold">--bin</tspan><tspan>                      Use a binary (application) template [default]</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bin</tspan><tspan>                      Use a binary (application) template [default]</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-cyan bold">--lib</tspan><tspan>                      Use a library template</tspan>
+    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lib</tspan><tspan>                      Use a library template</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--edition</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;YEAR&gt;</tspan><tspan>           Edition to set for the crate generated [possible values: 2015,</tspan>
+    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--edition</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;YEAR&gt;</tspan><tspan>           Edition to set for the crate generated [possible values: 2015,</tspan>
 </tspan>
     <tspan x="10px" y="280px"><tspan>                                 2018, 2021, 2024]</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--name</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan>              Set the resulting package name, defaults to the directory name</tspan>
+    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--name</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan>              Set the resulting package name, defaults to the directory name</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--registry</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;REGISTRY&gt;</tspan><tspan>      Registry to use</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--registry</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;REGISTRY&gt;</tspan><tspan>      Registry to use</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="406px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="424px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="442px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="460px">
 </tspan>
-    <tspan x="10px" y="478px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="478px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
+    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="550px">
 </tspan>
-    <tspan x="10px" y="568px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help new</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="568px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help new</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="586px">
 </tspan>

--- a/tests/testsuite/cargo_new/ignore_current_dir_workspace/stderr.term.svg
+++ b/tests/testsuite/cargo_new/ignore_current_dir_workspace/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library `out-of-workspace` package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_new/ignore_current_dir_workspace/stderr.term.svg
+++ b/tests/testsuite/cargo_new/ignore_current_dir_workspace/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> library `out-of-workspace` package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library `out-of-workspace` package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_new/inherit_workspace_lints/stderr.term.svg
+++ b/tests/testsuite/cargo_new/inherit_workspace_lints/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) `foo` package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_new/inherit_workspace_lints/stderr.term.svg
+++ b/tests/testsuite/cargo_new/inherit_workspace_lints/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) `foo` package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) `foo` package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table/stderr.term.svg
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) `foo` package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table/stderr.term.svg
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) `foo` package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) `foo` package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table_with_edition/stderr.term.svg
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table_with_edition/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) `foo` package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table_with_edition/stderr.term.svg
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table_with_edition/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) `foo` package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) `foo` package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table_with_registry/stderr.term.svg
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table_with_registry/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) `foo` package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table_with_registry/stderr.term.svg
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table_with_registry/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) `foo` package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) `foo` package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table_without_version/stderr.term.svg
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table_without_version/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) `foo` package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table_without_version/stderr.term.svg
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table_without_version/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) `foo` package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) `foo` package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_new/not_inherit_workspace_package_table_if_not_members/stderr.term.svg
+++ b/tests/testsuite/cargo_new/not_inherit_workspace_package_table_if_not_members/stderr.term.svg
@@ -2,8 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Creating</tspan><tspan> binary (application) `bar` package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) `bar` package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-cyan bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_new/not_inherit_workspace_package_table_if_not_members/stderr.term.svg
+++ b/tests/testsuite/cargo_new/not_inherit_workspace_package_table_if_not_members/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) `bar` package</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan class="bold">:</tspan><tspan> see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_owner/help/stdout.term.svg
+++ b/tests/testsuite/cargo_owner/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,57 +24,57 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] owner</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[CRATE]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] owner</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[CRATE]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">[CRATE]</tspan><tspan>  </tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-cyan bold">-a</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--add</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;LOGIN&gt;</tspan><tspan>              Name of a user or team to invite as an owner</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-a</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--add</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;LOGIN&gt;</tspan><tspan>              Name of a user or team to invite as an owner</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-cyan bold">-r</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--remove</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;LOGIN&gt;</tspan><tspan>           Name of a user or team to remove as an owner</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-r</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--remove</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;LOGIN&gt;</tspan><tspan>           Name of a user or team to remove as an owner</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-cyan bold">-l</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--list</tspan><tspan>                     List owners of a crate</tspan>
+    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-l</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--list</tspan><tspan>                     List owners of a crate</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-cyan bold">--index</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;INDEX&gt;</tspan><tspan>            Registry index URL to modify owners for</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--index</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;INDEX&gt;</tspan><tspan>            Registry index URL to modify owners for</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-cyan bold">--registry</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;REGISTRY&gt;</tspan><tspan>      Registry to modify owners for</tspan>
+    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--registry</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;REGISTRY&gt;</tspan><tspan>      Registry to modify owners for</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--token</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TOKEN&gt;</tspan><tspan>            API token to use when authenticating</tspan>
+    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--token</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TOKEN&gt;</tspan><tspan>            API token to use when authenticating</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="370px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="388px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="406px">
 </tspan>
-    <tspan x="10px" y="424px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="424px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
+    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="496px">
 </tspan>
-    <tspan x="10px" y="514px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help owner</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="514px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help owner</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="532px">
 </tspan>

--- a/tests/testsuite/cargo_package/help/stdout.term.svg
+++ b/tests/testsuite/cargo_package/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,91 +24,91 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] package</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] package</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>      </tspan><tspan class="fg-cyan bold">--index</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;INDEX&gt;</tspan><tspan>            Registry index URL to prepare the package for</tspan>
+    <tspan x="10px" y="118px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--index</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;INDEX&gt;</tspan><tspan>            Registry index URL to prepare the package for</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>      </tspan><tspan class="fg-cyan bold">--registry</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;REGISTRY&gt;</tspan><tspan>      Registry to prepare the package for</tspan>
+    <tspan x="10px" y="136px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--registry</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;REGISTRY&gt;</tspan><tspan>      Registry to prepare the package for</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-cyan bold">-l</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--list</tspan><tspan>                     Print files included in a package without making one</tspan>
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-l</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--list</tspan><tspan>                     Print files included in a package without making one</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-verify</tspan><tspan>                Don't verify the contents by building them</tspan>
+    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-verify</tspan><tspan>                Don't verify the contents by building them</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-metadata</tspan><tspan>              Ignore warnings about a lack of human-usable metadata</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-metadata</tspan><tspan>              Ignore warnings about a lack of human-usable metadata</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-cyan bold">--allow-dirty</tspan><tspan>              Allow dirty working directories to be packaged</tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--allow-dirty</tspan><tspan>              Allow dirty working directories to be packaged</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-cyan bold">--exclude-lockfile</tspan><tspan>         Don't include the lock file when packaging</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--exclude-lockfile</tspan><tspan>         Don't include the lock file when packaging</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-cyan bold">--message-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>     Output representation (unstable) [possible values: human, json]</tspan>
+    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--message-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>     Output representation (unstable) [possible values: human, json]</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="352px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="370px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="388px">
 </tspan>
-    <tspan x="10px" y="406px"><tspan class="fg-green bold">Package Selection:</tspan>
+    <tspan x="10px" y="406px"><tspan class="fg-bright-green bold">Package Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>  </tspan><tspan class="fg-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package(s) to assemble</tspan>
+    <tspan x="10px" y="424px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package(s) to assemble</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--workspace</tspan><tspan>         Assemble all packages in the workspace</tspan>
+    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--workspace</tspan><tspan>         Assemble all packages in the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--exclude</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>    Don't assemble specified packages</tspan>
+    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--exclude</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>    Don't assemble specified packages</tspan>
 </tspan>
     <tspan x="10px" y="478px">
 </tspan>
-    <tspan x="10px" y="496px"><tspan class="fg-green bold">Feature Selection:</tspan>
+    <tspan x="10px" y="496px"><tspan class="fg-bright-green bold">Feature Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>  </tspan><tspan class="fg-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
+    <tspan x="10px" y="514px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
+    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
+    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
 </tspan>
     <tspan x="10px" y="568px">
 </tspan>
-    <tspan x="10px" y="586px"><tspan class="fg-green bold">Compilation Options:</tspan>
+    <tspan x="10px" y="586px"><tspan class="fg-bright-green bold">Compilation Options:</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Build for the target triple</tspan>
+    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Build for the target triple</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
+    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>  </tspan><tspan class="fg-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
+    <tspan x="10px" y="640px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
+    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
 </tspan>
     <tspan x="10px" y="676px">
 </tspan>
-    <tspan x="10px" y="694px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="694px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
+    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="748px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="748px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="766px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="766px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="784px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="802px">
 </tspan>
-    <tspan x="10px" y="820px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help package</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="820px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help package</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="838px">
 </tspan>

--- a/tests/testsuite/cargo_pkgid/help/stdout.term.svg
+++ b/tests/testsuite/cargo_pkgid/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,55 +24,55 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] pkgid</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[SPEC]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] pkgid</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[SPEC]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">[SPEC]</tspan><tspan>  </tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="262px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="298px">
 </tspan>
-    <tspan x="10px" y="316px"><tspan class="fg-green bold">Package Selection:</tspan>
+    <tspan x="10px" y="316px"><tspan class="fg-bright-green bold">Package Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Argument to get the package ID specifier for</tspan>
+    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Argument to get the package ID specifier for</tspan>
 </tspan>
     <tspan x="10px" y="352px">
 </tspan>
-    <tspan x="10px" y="370px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="370px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="478px">
 </tspan>
-    <tspan x="10px" y="496px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help pkgid</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="496px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help pkgid</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="514px">
 </tspan>

--- a/tests/testsuite/cargo_publish/help/stdout.term.svg
+++ b/tests/testsuite/cargo_publish/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,87 +24,87 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] publish</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] publish</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan bold">-n</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--dry-run</tspan><tspan>                  Perform all checks without uploading</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-n</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--dry-run</tspan><tspan>                  Perform all checks without uploading</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>      </tspan><tspan class="fg-cyan bold">--index</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;INDEX&gt;</tspan><tspan>            Registry index URL to upload the package to</tspan>
+    <tspan x="10px" y="136px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--index</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;INDEX&gt;</tspan><tspan>            Registry index URL to upload the package to</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>      </tspan><tspan class="fg-cyan bold">--registry</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;REGISTRY&gt;</tspan><tspan>      Registry to upload the package to</tspan>
+    <tspan x="10px" y="154px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--registry</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;REGISTRY&gt;</tspan><tspan>      Registry to upload the package to</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-cyan bold">--token</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TOKEN&gt;</tspan><tspan>            Token to use when uploading</tspan>
+    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--token</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TOKEN&gt;</tspan><tspan>            Token to use when uploading</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-verify</tspan><tspan>                Don't verify the contents by building them</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-verify</tspan><tspan>                Don't verify the contents by building them</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-cyan bold">--allow-dirty</tspan><tspan>              Allow dirty working directories to be packaged</tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--allow-dirty</tspan><tspan>              Allow dirty working directories to be packaged</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="316px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="352px">
 </tspan>
-    <tspan x="10px" y="370px"><tspan class="fg-green bold">Package Selection:</tspan>
+    <tspan x="10px" y="370px"><tspan class="fg-bright-green bold">Package Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>  </tspan><tspan class="fg-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package(s) to publish</tspan>
+    <tspan x="10px" y="388px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package(s) to publish</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--workspace</tspan><tspan>         Publish all packages in the workspace</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--workspace</tspan><tspan>         Publish all packages in the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--exclude</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>    Don't publish specified packages</tspan>
+    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--exclude</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>    Don't publish specified packages</tspan>
 </tspan>
     <tspan x="10px" y="442px">
 </tspan>
-    <tspan x="10px" y="460px"><tspan class="fg-green bold">Feature Selection:</tspan>
+    <tspan x="10px" y="460px"><tspan class="fg-bright-green bold">Feature Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>  </tspan><tspan class="fg-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
+    <tspan x="10px" y="478px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
+    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
 </tspan>
     <tspan x="10px" y="532px">
 </tspan>
-    <tspan x="10px" y="550px"><tspan class="fg-green bold">Compilation Options:</tspan>
+    <tspan x="10px" y="550px"><tspan class="fg-bright-green bold">Compilation Options:</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>  </tspan><tspan class="fg-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
+    <tspan x="10px" y="568px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
+    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Build for the target triple</tspan>
+    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Build for the target triple</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
+    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
 </tspan>
     <tspan x="10px" y="640px">
 </tspan>
-    <tspan x="10px" y="658px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="658px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="676px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
+    <tspan x="10px" y="694px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="748px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="748px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="766px">
 </tspan>
-    <tspan x="10px" y="784px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help publish</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="784px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help publish</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="802px">
 </tspan>

--- a/tests/testsuite/cargo_read_manifest/help/stdout.term.svg
+++ b/tests/testsuite/cargo_read_manifest/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,41 +24,41 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Use `</tspan><tspan class="fg-cyan bold">cargo metadata --no-deps</tspan><tspan class="bold">` instead.</tspan>
+    <tspan x="10px" y="64px"><tspan>Use `</tspan><tspan class="fg-bright-cyan bold">cargo metadata --no-deps</tspan><tspan class="bold">` instead.</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] read-manifest</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] read-manifest</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="244px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="280px">
 </tspan>
-    <tspan x="10px" y="298px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="298px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="388px">
 </tspan>

--- a/tests/testsuite/cargo_remove/avoid_empty_tables/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/avoid_empty_tables/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> clippy from dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> clippy from dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_remove/build/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/build/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> semver from build-dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> semver from build-dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_remove/dev/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/dev/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> regex from dev-dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> regex from dev-dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_remove/dry_run/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/dry_run/stderr.term.svg
@@ -21,7 +21,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> semver from dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> aborting remove due to dry run</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-yellow bold">warning</tspan><tspan>: aborting remove due to dry run</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_remove/dry_run/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/dry_run/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -19,7 +19,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> semver from dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> semver from dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> aborting remove due to dry run</tspan>
 </tspan>

--- a/tests/testsuite/cargo_remove/gc_keep_used_patch/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/gc_keep_used_patch/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> serde_derive from dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> serde_derive from dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_remove/gc_patch/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/gc_patch/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> bar from dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> bar from dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_remove/gc_profile/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/gc_profile/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> toml from dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> toml from dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_remove/gc_replace/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/gc_replace/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> toml from dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> toml from dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_remove/help/stdout.term.svg
+++ b/tests/testsuite/cargo_remove/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,67 +24,67 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] remove</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;DEP_ID&gt;...</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] remove</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;DEP_ID&gt;...</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">&lt;DEP_ID&gt;...</tspan><tspan>  Dependencies to be removed</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-cyan bold">-n</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--dry-run</tspan><tspan>                  Don't actually write the manifest</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-n</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--dry-run</tspan><tspan>                  Don't actually write the manifest</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="280px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="316px">
 </tspan>
-    <tspan x="10px" y="334px"><tspan class="fg-green bold">Section:</tspan>
+    <tspan x="10px" y="334px"><tspan class="fg-bright-green bold">Section:</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--dev</tspan><tspan>              Remove from dev-dependencies</tspan>
+    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--dev</tspan><tspan>              Remove from dev-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--build</tspan><tspan>            Remove from build-dependencies</tspan>
+    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--build</tspan><tspan>            Remove from build-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--target</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TARGET&gt;</tspan><tspan>  Remove from target-dependencies</tspan>
+    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TARGET&gt;</tspan><tspan>  Remove from target-dependencies</tspan>
 </tspan>
     <tspan x="10px" y="406px">
 </tspan>
-    <tspan x="10px" y="424px"><tspan class="fg-green bold">Package Selection:</tspan>
+    <tspan x="10px" y="424px"><tspan class="fg-bright-green bold">Package Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>  </tspan><tspan class="fg-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package to remove from</tspan>
+    <tspan x="10px" y="442px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package to remove from</tspan>
 </tspan>
     <tspan x="10px" y="460px">
 </tspan>
-    <tspan x="10px" y="478px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="478px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
+    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="586px">
 </tspan>
-    <tspan x="10px" y="604px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help remove</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="604px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help remove</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="622px">
 </tspan>

--- a/tests/testsuite/cargo_remove/invalid_arg/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/invalid_arg/stderr.term.svg
@@ -2,9 +2,10 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -21,19 +22,19 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error:</tspan><tspan> unexpected argument '</tspan><tspan class="fg-yellow bold">--flag</tspan><tspan>' found</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error:</tspan><tspan> unexpected argument '</tspan><tspan class="fg-yellow bold">--flag</tspan><tspan>' found</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>  </tspan><tspan class="fg-cyan bold">tip:</tspan><tspan> to pass '</tspan><tspan class="fg-yellow bold">--flag</tspan><tspan>' as a value, use '</tspan><tspan class="fg-cyan bold">-- --flag</tspan><tspan>'</tspan>
+    <tspan x="10px" y="64px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">tip:</tspan><tspan> to pass '</tspan><tspan class="fg-yellow bold">--flag</tspan><tspan>' as a value, use '</tspan><tspan class="fg-bright-cyan bold">-- --flag</tspan><tspan>'</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] remove</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;DEP_ID&gt;...</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] remove</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;DEP_ID&gt;...</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>
-    <tspan x="10px" y="136px"><tspan>For more information, try '</tspan><tspan class="fg-cyan bold">--help</tspan><tspan>'.</tspan>
+    <tspan x="10px" y="136px"><tspan>For more information, try '</tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>'.</tspan>
 </tspan>
     <tspan x="10px" y="154px">
 </tspan>

--- a/tests/testsuite/cargo_remove/invalid_dep/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/invalid_dep/stderr.term.svg
@@ -21,7 +21,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> invalid_dependency_name from dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the dependency `invalid_dependency_name` could not be found in `dependencies`; dependency `invalid-dependency-name` exists</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: the dependency `invalid_dependency_name` could not be found in `dependencies`; dependency `invalid-dependency-name` exists</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_remove/invalid_dep/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/invalid_dep/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +19,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> invalid_dependency_name from dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> invalid_dependency_name from dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the dependency `invalid_dependency_name` could not be found in `dependencies`; dependency `invalid-dependency-name` exists</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the dependency `invalid_dependency_name` could not be found in `dependencies`; dependency `invalid-dependency-name` exists</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_remove/invalid_package/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/invalid_package/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="911px" height="56px" xmlns="http://www.w3.org/2000/svg">
+<svg width="919px" height="56px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> package(s) `dep-c` not found in workspace `[ROOT]/case`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: package(s) `dep-c` not found in workspace `[ROOT]/case`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_remove/invalid_package/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/invalid_package/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> package(s) `dep-c` not found in workspace `[ROOT]/case`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> package(s) `dep-c` not found in workspace `[ROOT]/case`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_remove/invalid_package_multiple/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/invalid_package_multiple/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> `cargo remove` could not determine which package to modify. Use the `--package` option to specify a package. </tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> `cargo remove` could not determine which package to modify. Use the `--package` option to specify a package. </tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>available packages: dep-a, dep-b</tspan>
 </tspan>

--- a/tests/testsuite/cargo_remove/invalid_package_multiple/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/invalid_package_multiple/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> `cargo remove` could not determine which package to modify. Use the `--package` option to specify a package. </tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: `cargo remove` could not determine which package to modify. Use the `--package` option to specify a package. </tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>available packages: dep-a, dep-b</tspan>
 </tspan>

--- a/tests/testsuite/cargo_remove/invalid_section/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/invalid_section/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +19,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> docopt from build-dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> docopt from build-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the dependency `docopt` could not be found in `build-dependencies`; it is present in `dependencies`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the dependency `docopt` could not be found in `build-dependencies`; it is present in `dependencies`</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_remove/invalid_section/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/invalid_section/stderr.term.svg
@@ -21,7 +21,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> docopt from build-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the dependency `docopt` could not be found in `build-dependencies`; it is present in `dependencies`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: the dependency `docopt` could not be found in `build-dependencies`; it is present in `dependencies`</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_remove/invalid_section_dep/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/invalid_section_dep/stderr.term.svg
@@ -21,7 +21,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> semver from dev-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the dependency `semver` could not be found in `dev-dependencies`; it is present in `dependencies`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: the dependency `semver` could not be found in `dev-dependencies`; it is present in `dependencies`</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_remove/invalid_section_dep/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/invalid_section_dep/stderr.term.svg
@@ -2,8 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +19,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> semver from dev-dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> semver from dev-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the dependency `semver` could not be found in `dev-dependencies`; it is present in `dependencies`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the dependency `semver` could not be found in `dev-dependencies`; it is present in `dependencies`</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_remove/invalid_target/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/invalid_target/stderr.term.svg
@@ -1,9 +1,9 @@
-<svg width="1390px" height="74px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1373px" height="74px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +19,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> dbus from dependencies for target `powerpc-unknown-linux-gnu`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> dbus from dependencies for target `powerpc-unknown-linux-gnu`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the dependency `dbus` could not be found in `target.powerpc-unknown-linux-gnu.dependencies`; it is present in `target.wasm32-unknown-unknown.dependencies`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the dependency `dbus` could not be found in `target.powerpc-unknown-linux-gnu.dependencies`; it is present in `target.wasm32-unknown-unknown.dependencies`</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_remove/invalid_target/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/invalid_target/stderr.term.svg
@@ -21,7 +21,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> dbus from dependencies for target `powerpc-unknown-linux-gnu`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the dependency `dbus` could not be found in `target.powerpc-unknown-linux-gnu.dependencies`; it is present in `target.wasm32-unknown-unknown.dependencies`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: the dependency `dbus` could not be found in `target.powerpc-unknown-linux-gnu.dependencies`; it is present in `target.wasm32-unknown-unknown.dependencies`</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_remove/invalid_target_dep/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/invalid_target_dep/stderr.term.svg
@@ -21,7 +21,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> toml from dependencies for target `wasm32-unknown-unknown`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the dependency `toml` could not be found in `target.wasm32-unknown-unknown.dependencies`; it is present in `dependencies`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: the dependency `toml` could not be found in `target.wasm32-unknown-unknown.dependencies`; it is present in `dependencies`</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_remove/invalid_target_dep/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/invalid_target_dep/stderr.term.svg
@@ -1,9 +1,9 @@
-<svg width="1112px" height="74px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1096px" height="74px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -19,9 +19,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> toml from dependencies for target `wasm32-unknown-unknown`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> toml from dependencies for target `wasm32-unknown-unknown`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the dependency `toml` could not be found in `target.wasm32-unknown-unknown.dependencies`; it is present in `dependencies`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the dependency `toml` could not be found in `target.wasm32-unknown-unknown.dependencies`; it is present in `dependencies`</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_remove/last_dep/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/last_dep/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> docopt from dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> docopt from dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_remove/multiple_deps/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/multiple_deps/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> docopt from dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> docopt from dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">    Removing</tspan><tspan> semver from dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> semver from dependencies</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_remove/multiple_dev/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/multiple_dev/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> regex from dev-dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> regex from dev-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">    Removing</tspan><tspan> serde from dev-dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> serde from dev-dependencies</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_remove/no_arg/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/no_arg/stderr.term.svg
@@ -2,9 +2,10 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -20,17 +21,17 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error:</tspan><tspan> the following required arguments were not provided:</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error:</tspan><tspan> the following required arguments were not provided:</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-cyan bold">&lt;DEP_ID&gt;...</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">&lt;DEP_ID&gt;...</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] remove</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;DEP_ID&gt;...</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] remove</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;DEP_ID&gt;...</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>
-    <tspan x="10px" y="118px"><tspan>For more information, try '</tspan><tspan class="fg-cyan bold">--help</tspan><tspan>'.</tspan>
+    <tspan x="10px" y="118px"><tspan>For more information, try '</tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>'.</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_remove/offline/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/offline/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> docopt from dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> docopt from dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_remove/optional_dep_feature/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/optional_dep_feature/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> serde from dev-dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> serde from dev-dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_remove/optional_dep_feature_formatting/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/optional_dep_feature_formatting/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,9 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> docopt from dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> docopt from dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">    Removing</tspan><tspan> toml from dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> toml from dependencies</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_remove/optional_feature/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/optional_feature/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> semver from dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> semver from dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_remove/package/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/package/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> docopt from dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> docopt from dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_remove/remove_basic/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/remove_basic/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> docopt from dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> docopt from dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_remove/script/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/script/stderr.term.svg
@@ -19,11 +19,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> `package.edition` is unspecified, defaulting to `[..]`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to `2024`</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> docopt from dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> `package.edition` is unspecified, defaulting to `[..]`</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to `2024`</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_remove/script/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/script/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -21,7 +21,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> `package.edition` is unspecified, defaulting to `[..]`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">    Removing</tspan><tspan> docopt from dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> docopt from dependencies</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> `package.edition` is unspecified, defaulting to `[..]`</tspan>
 </tspan>

--- a/tests/testsuite/cargo_remove/script_last/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/script_last/stderr.term.svg
@@ -19,11 +19,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> `package.edition` is unspecified, defaulting to `[..]`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to `2024`</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> docopt from dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> `package.edition` is unspecified, defaulting to `[..]`</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to `2024`</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_remove/script_last/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/script_last/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -21,7 +21,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> `package.edition` is unspecified, defaulting to `[..]`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">    Removing</tspan><tspan> docopt from dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> docopt from dependencies</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-yellow bold">warning</tspan><tspan class="bold">:</tspan><tspan> `package.edition` is unspecified, defaulting to `[..]`</tspan>
 </tspan>

--- a/tests/testsuite/cargo_remove/skip_gc_glob_profile/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/skip_gc_glob_profile/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> toml from dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> toml from dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_remove/target/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/target/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> dbus from dependencies for target `wasm32-unknown-unknown`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> dbus from dependencies for target `wasm32-unknown-unknown`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_remove/target_build/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/target_build/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> semver from build-dependencies for target `wasm32-unknown-unknown`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> semver from build-dependencies for target `wasm32-unknown-unknown`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_remove/target_dev/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/target_dev/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> ncurses from dev-dependencies for target `wasm32-unknown-unknown`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> ncurses from dev-dependencies for target `wasm32-unknown-unknown`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_remove/update_lock_file/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/update_lock_file/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> rustc-serialize from dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> rustc-serialize from dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_remove/workspace/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/workspace/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> semver from build-dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> semver from build-dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_remove/workspace_non_virtual/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/workspace_non_virtual/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> semver from build-dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> semver from build-dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_remove/workspace_preserved/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/workspace_preserved/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> semver from build-dependencies</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> semver from build-dependencies</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_report/help/stdout.term.svg
+++ b/tests/testsuite/cargo_report/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,45 +24,45 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] report</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;COMMAND&gt;</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] report</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;COMMAND&gt;</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Commands:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Commands:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan bold">future-incompatibilities</tspan><tspan>  Reports any crates which will eventually stop compiling</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">future-incompatibilities</tspan><tspan>  Reports any crates which will eventually stop compiling</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="262px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="298px">
 </tspan>
-    <tspan x="10px" y="316px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="316px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
+    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="388px">
 </tspan>
-    <tspan x="10px" y="406px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help report</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="406px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help report</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="424px">
 </tspan>

--- a/tests/testsuite/cargo_run/help/stdout.term.svg
+++ b/tests/testsuite/cargo_run/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,101 +24,101 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] run</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[ARGS]...</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] run</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[ARGS]...</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">[ARGS]...</tspan><tspan>  Arguments for the binary or example to run</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-cyan bold">--message-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>     Error format [possible values: human, short, json,</tspan>
+    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--message-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>     Error format [possible values: human, short, json,</tspan>
 </tspan>
     <tspan x="10px" y="190px"><tspan>                                 json-diagnostic-short, json-diagnostic-rendered-ansi,</tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan>                                 json-render-diagnostics]</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="316px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="352px">
 </tspan>
-    <tspan x="10px" y="370px"><tspan class="fg-green bold">Package Selection:</tspan>
+    <tspan x="10px" y="370px"><tspan class="fg-bright-green bold">Package Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>  </tspan><tspan class="fg-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package with the target to run</tspan>
+    <tspan x="10px" y="388px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package with the target to run</tspan>
 </tspan>
     <tspan x="10px" y="406px">
 </tspan>
-    <tspan x="10px" y="424px"><tspan class="fg-green bold">Target Selection:</tspan>
+    <tspan x="10px" y="424px"><tspan class="fg-bright-green bold">Target Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--bin</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>      Name of the bin target to run</tspan>
+    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bin</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>      Name of the bin target to run</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Name of the example target to run</tspan>
+    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Name of the example target to run</tspan>
 </tspan>
     <tspan x="10px" y="478px">
 </tspan>
-    <tspan x="10px" y="496px"><tspan class="fg-green bold">Feature Selection:</tspan>
+    <tspan x="10px" y="496px"><tspan class="fg-bright-green bold">Feature Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>  </tspan><tspan class="fg-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
+    <tspan x="10px" y="514px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
+    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
+    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
 </tspan>
     <tspan x="10px" y="568px">
 </tspan>
-    <tspan x="10px" y="586px"><tspan class="fg-green bold">Compilation Options:</tspan>
+    <tspan x="10px" y="586px"><tspan class="fg-bright-green bold">Compilation Options:</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>  </tspan><tspan class="fg-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
+    <tspan x="10px" y="604px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
+    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>  </tspan><tspan class="fg-cyan bold">-r</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--release</tspan><tspan>                 Build artifacts in release mode, with optimizations</tspan>
+    <tspan x="10px" y="640px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-r</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--release</tspan><tspan>                 Build artifacts in release mode, with optimizations</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Build artifacts with the specified profile</tspan>
+    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Build artifacts with the specified profile</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan>      </tspan><tspan class="fg-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Build for the target triple</tspan>
+    <tspan x="10px" y="676px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Build for the target triple</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan>      </tspan><tspan class="fg-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
+    <tspan x="10px" y="694px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-cyan bold">--unit-graph</tspan><tspan>              Output build graph in JSON (unstable)</tspan>
+    <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--unit-graph</tspan><tspan>              Output build graph in JSON (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
+    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
 </tspan>
     <tspan x="10px" y="748px">
 </tspan>
-    <tspan x="10px" y="766px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="766px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="784px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
+    <tspan x="10px" y="802px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="820px"><tspan>      </tspan><tspan class="fg-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
+    <tspan x="10px" y="820px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
 </tspan>
-    <tspan x="10px" y="838px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="838px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="856px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="856px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="874px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="874px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="892px">
 </tspan>
-    <tspan x="10px" y="910px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help run</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="910px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help run</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="928px">
 </tspan>

--- a/tests/testsuite/cargo_rustc/help/stdout.term.svg
+++ b/tests/testsuite/cargo_rustc/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,123 +24,123 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] rustc</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[ARGS]...</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] rustc</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[ARGS]...</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">[ARGS]...</tspan><tspan>  Extra rustc flags</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-cyan bold">--print</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;INFO&gt;</tspan><tspan>             Output compiler information without compiling</tspan>
+    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--print</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;INFO&gt;</tspan><tspan>             Output compiler information without compiling</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-cyan bold">--crate-type</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;CRATE-TYPE&gt;</tspan><tspan>  Comma separated list of types of crates for the compiler to emit</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--crate-type</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;CRATE-TYPE&gt;</tspan><tspan>  Comma separated list of types of crates for the compiler to emit</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-cyan bold">--future-incompat-report</tspan><tspan>   Outputs a future incompatibility report at the end of the build</tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--future-incompat-report</tspan><tspan>   Outputs a future incompatibility report at the end of the build</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-cyan bold">--message-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>     Error format [possible values: human, short, json,</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--message-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>     Error format [possible values: human, short, json,</tspan>
 </tspan>
     <tspan x="10px" y="244px"><tspan>                                 json-diagnostic-short, json-diagnostic-rendered-ansi,</tspan>
 </tspan>
     <tspan x="10px" y="262px"><tspan>                                 json-render-diagnostics]</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="370px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="388px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="406px">
 </tspan>
-    <tspan x="10px" y="424px"><tspan class="fg-green bold">Package Selection:</tspan>
+    <tspan x="10px" y="424px"><tspan class="fg-bright-green bold">Package Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>  </tspan><tspan class="fg-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package to build</tspan>
+    <tspan x="10px" y="442px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package to build</tspan>
 </tspan>
     <tspan x="10px" y="460px">
 </tspan>
-    <tspan x="10px" y="478px"><tspan class="fg-green bold">Target Selection:</tspan>
+    <tspan x="10px" y="478px"><tspan class="fg-bright-green bold">Target Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--lib</tspan><tspan>               Build only this package's library</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lib</tspan><tspan>               Build only this package's library</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--bins</tspan><tspan>              Build all binaries</tspan>
+    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bins</tspan><tspan>              Build all binaries</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-cyan bold">--bin</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>      Build only the specified binary</tspan>
+    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bin</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>      Build only the specified binary</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-cyan bold">--examples</tspan><tspan>          Build all examples</tspan>
+    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--examples</tspan><tspan>          Build all examples</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Build only the specified example</tspan>
+    <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Build only the specified example</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-cyan bold">--tests</tspan><tspan>             Build all targets that have `test = true` set</tspan>
+    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--tests</tspan><tspan>             Build all targets that have `test = true` set</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-cyan bold">--test</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>     Build only the specified test target</tspan>
+    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--test</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>     Build only the specified test target</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-cyan bold">--benches</tspan><tspan>           Build all targets that have `bench = true` set</tspan>
+    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--benches</tspan><tspan>           Build all targets that have `bench = true` set</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--bench</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>    Build only the specified bench target</tspan>
+    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bench</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>    Build only the specified bench target</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-targets</tspan><tspan>       Build all targets</tspan>
+    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all-targets</tspan><tspan>       Build all targets</tspan>
 </tspan>
     <tspan x="10px" y="676px">
 </tspan>
-    <tspan x="10px" y="694px"><tspan class="fg-green bold">Feature Selection:</tspan>
+    <tspan x="10px" y="694px"><tspan class="fg-bright-green bold">Feature Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>  </tspan><tspan class="fg-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
+    <tspan x="10px" y="712px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
+    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
 </tspan>
-    <tspan x="10px" y="748px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
+    <tspan x="10px" y="748px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
 </tspan>
     <tspan x="10px" y="766px">
 </tspan>
-    <tspan x="10px" y="784px"><tspan class="fg-green bold">Compilation Options:</tspan>
+    <tspan x="10px" y="784px"><tspan class="fg-bright-green bold">Compilation Options:</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan>  </tspan><tspan class="fg-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
+    <tspan x="10px" y="802px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
 </tspan>
-    <tspan x="10px" y="820px"><tspan>      </tspan><tspan class="fg-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
+    <tspan x="10px" y="820px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
 </tspan>
-    <tspan x="10px" y="838px"><tspan>  </tspan><tspan class="fg-cyan bold">-r</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--release</tspan><tspan>                 Build artifacts in release mode, with optimizations</tspan>
+    <tspan x="10px" y="838px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-r</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--release</tspan><tspan>                 Build artifacts in release mode, with optimizations</tspan>
 </tspan>
-    <tspan x="10px" y="856px"><tspan>      </tspan><tspan class="fg-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Build artifacts with the specified profile</tspan>
+    <tspan x="10px" y="856px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Build artifacts with the specified profile</tspan>
 </tspan>
-    <tspan x="10px" y="874px"><tspan>      </tspan><tspan class="fg-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Target triple which compiles will be for</tspan>
+    <tspan x="10px" y="874px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Target triple which compiles will be for</tspan>
 </tspan>
-    <tspan x="10px" y="892px"><tspan>      </tspan><tspan class="fg-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
+    <tspan x="10px" y="892px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
 </tspan>
-    <tspan x="10px" y="910px"><tspan>      </tspan><tspan class="fg-cyan bold">--unit-graph</tspan><tspan>              Output build graph in JSON (unstable)</tspan>
+    <tspan x="10px" y="910px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--unit-graph</tspan><tspan>              Output build graph in JSON (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
+    <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
 </tspan>
     <tspan x="10px" y="946px">
 </tspan>
-    <tspan x="10px" y="964px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="964px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
+    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
+    <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
 </tspan>
-    <tspan x="10px" y="1036px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="1036px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="1054px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="1054px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="1072px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="1072px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="1090px">
 </tspan>
-    <tspan x="10px" y="1108px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help rustc</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="1108px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help rustc</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="1126px">
 </tspan>

--- a/tests/testsuite/cargo_rustdoc/help/stdout.term.svg
+++ b/tests/testsuite/cargo_rustdoc/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,121 +24,121 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] rustdoc</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[ARGS]...</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] rustdoc</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[ARGS]...</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">[ARGS]...</tspan><tspan>  Extra rustdoc flags</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-cyan bold">--open</tspan><tspan>                     Opens the docs in a browser after the operation</tspan>
+    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--open</tspan><tspan>                     Opens the docs in a browser after the operation</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-cyan bold">--message-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>     Error format [possible values: human, short, json,</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--message-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>     Error format [possible values: human, short, json,</tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan>                                 json-diagnostic-short, json-diagnostic-rendered-ansi,</tspan>
 </tspan>
     <tspan x="10px" y="226px"><tspan>                                 json-render-diagnostics]</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-cyan bold">--output-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>      The output type to write (unstable) [possible values: html, json]</tspan>
+    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--output-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>      The output type to write (unstable) [possible values: html, json]</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="352px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="370px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="388px">
 </tspan>
-    <tspan x="10px" y="406px"><tspan class="fg-green bold">Package Selection:</tspan>
+    <tspan x="10px" y="406px"><tspan class="fg-bright-green bold">Package Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>  </tspan><tspan class="fg-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package to document</tspan>
+    <tspan x="10px" y="424px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package to document</tspan>
 </tspan>
     <tspan x="10px" y="442px">
 </tspan>
-    <tspan x="10px" y="460px"><tspan class="fg-green bold">Target Selection:</tspan>
+    <tspan x="10px" y="460px"><tspan class="fg-bright-green bold">Target Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--lib</tspan><tspan>               Build only this package's library</tspan>
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lib</tspan><tspan>               Build only this package's library</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--bins</tspan><tspan>              Build all binaries</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bins</tspan><tspan>              Build all binaries</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--bin</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>      Build only the specified binary</tspan>
+    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bin</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>      Build only the specified binary</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-cyan bold">--examples</tspan><tspan>          Build all examples</tspan>
+    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--examples</tspan><tspan>          Build all examples</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Build only the specified example</tspan>
+    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Build only the specified example</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-cyan bold">--tests</tspan><tspan>             Build all targets that have `test = true` set</tspan>
+    <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--tests</tspan><tspan>             Build all targets that have `test = true` set</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-cyan bold">--test</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>     Build only the specified test target</tspan>
+    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--test</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>     Build only the specified test target</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-cyan bold">--benches</tspan><tspan>           Build all targets that have `bench = true` set</tspan>
+    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--benches</tspan><tspan>           Build all targets that have `bench = true` set</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-cyan bold">--bench</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>    Build only the specified bench target</tspan>
+    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bench</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>    Build only the specified bench target</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-targets</tspan><tspan>       Build all targets</tspan>
+    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all-targets</tspan><tspan>       Build all targets</tspan>
 </tspan>
     <tspan x="10px" y="658px">
 </tspan>
-    <tspan x="10px" y="676px"><tspan class="fg-green bold">Feature Selection:</tspan>
+    <tspan x="10px" y="676px"><tspan class="fg-bright-green bold">Feature Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan>  </tspan><tspan class="fg-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
+    <tspan x="10px" y="694px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
+    <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
+    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
 </tspan>
     <tspan x="10px" y="748px">
 </tspan>
-    <tspan x="10px" y="766px"><tspan class="fg-green bold">Compilation Options:</tspan>
+    <tspan x="10px" y="766px"><tspan class="fg-bright-green bold">Compilation Options:</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan>  </tspan><tspan class="fg-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
+    <tspan x="10px" y="784px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan>      </tspan><tspan class="fg-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
+    <tspan x="10px" y="802px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
 </tspan>
-    <tspan x="10px" y="820px"><tspan>  </tspan><tspan class="fg-cyan bold">-r</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--release</tspan><tspan>                 Build artifacts in release mode, with optimizations</tspan>
+    <tspan x="10px" y="820px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-r</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--release</tspan><tspan>                 Build artifacts in release mode, with optimizations</tspan>
 </tspan>
-    <tspan x="10px" y="838px"><tspan>      </tspan><tspan class="fg-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Build artifacts with the specified profile</tspan>
+    <tspan x="10px" y="838px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Build artifacts with the specified profile</tspan>
 </tspan>
-    <tspan x="10px" y="856px"><tspan>      </tspan><tspan class="fg-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Build for the target triple</tspan>
+    <tspan x="10px" y="856px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Build for the target triple</tspan>
 </tspan>
-    <tspan x="10px" y="874px"><tspan>      </tspan><tspan class="fg-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
+    <tspan x="10px" y="874px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
 </tspan>
-    <tspan x="10px" y="892px"><tspan>      </tspan><tspan class="fg-cyan bold">--unit-graph</tspan><tspan>              Output build graph in JSON (unstable)</tspan>
+    <tspan x="10px" y="892px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--unit-graph</tspan><tspan>              Output build graph in JSON (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="910px"><tspan>      </tspan><tspan class="fg-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
+    <tspan x="10px" y="910px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
 </tspan>
     <tspan x="10px" y="928px">
 </tspan>
-    <tspan x="10px" y="946px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="946px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
+    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
+    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
 </tspan>
-    <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="1036px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="1036px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="1054px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="1054px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="1072px">
 </tspan>
-    <tspan x="10px" y="1090px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help rustdoc</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="1090px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help rustdoc</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="1108px">
 </tspan>

--- a/tests/testsuite/cargo_search/help/stdout.term.svg
+++ b/tests/testsuite/cargo_search/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,51 +24,51 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] search</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[QUERY]...</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] search</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[QUERY]...</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">[QUERY]...</tspan><tspan>  </tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-cyan bold">--limit</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;LIMIT&gt;</tspan><tspan>            Limit the number of results (default: 10, max: 100)</tspan>
+    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--limit</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;LIMIT&gt;</tspan><tspan>            Limit the number of results (default: 10, max: 100)</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-cyan bold">--index</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;INDEX&gt;</tspan><tspan>            Registry index URL to search packages in</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--index</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;INDEX&gt;</tspan><tspan>            Registry index URL to search packages in</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-cyan bold">--registry</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;REGISTRY&gt;</tspan><tspan>      Registry to search packages in</tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--registry</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;REGISTRY&gt;</tspan><tspan>      Registry to search packages in</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="316px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="352px">
 </tspan>
-    <tspan x="10px" y="370px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="370px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="442px">
 </tspan>
-    <tspan x="10px" y="460px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help search</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="460px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help search</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="478px">
 </tspan>

--- a/tests/testsuite/cargo_test/help/stdout.term.svg
+++ b/tests/testsuite/cargo_test/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,11 +24,11 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] test</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[TESTNAME]</tspan><tspan> </tspan><tspan class="fg-cyan bold">[--</tspan><tspan> </tspan><tspan class="fg-cyan">[ARGS]...</tspan><tspan class="fg-cyan bold">]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] test</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[TESTNAME]</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">[--</tspan><tspan> </tspan><tspan class="fg-cyan">[ARGS]...</tspan><tspan class="fg-bright-cyan bold">]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">[TESTNAME]</tspan><tspan>  If specified, only run tests containing this string in their names</tspan>
 </tspan>
@@ -35,121 +36,121 @@
 </tspan>
     <tspan x="10px" y="154px">
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-run</tspan><tspan>                   Compile, but don't run tests</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-run</tspan><tspan>                   Compile, but don't run tests</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-fail-fast</tspan><tspan>             Run all tests regardless of failure</tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-fail-fast</tspan><tspan>             Run all tests regardless of failure</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-cyan bold">--future-incompat-report</tspan><tspan>   Outputs a future incompatibility report at the end of the build</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--future-incompat-report</tspan><tspan>   Outputs a future incompatibility report at the end of the build</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-cyan bold">--message-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>     Error format [possible values: human, short, json,</tspan>
+    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--message-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>     Error format [possible values: human, short, json,</tspan>
 </tspan>
     <tspan x="10px" y="262px"><tspan>                                 json-diagnostic-short, json-diagnostic-rendered-ansi,</tspan>
 </tspan>
     <tspan x="10px" y="280px"><tspan>                                 json-render-diagnostics]</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Display one character per test instead of one line</tspan>
+    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Display one character per test instead of one line</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="316px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="370px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="388px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="406px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="424px">
 </tspan>
-    <tspan x="10px" y="442px"><tspan class="fg-green bold">Package Selection:</tspan>
+    <tspan x="10px" y="442px"><tspan class="fg-bright-green bold">Package Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>  </tspan><tspan class="fg-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package to run tests for</tspan>
+    <tspan x="10px" y="460px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package to run tests for</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--workspace</tspan><tspan>         Test all packages in the workspace</tspan>
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--workspace</tspan><tspan>         Test all packages in the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--exclude</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>    Exclude packages from the test</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--exclude</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>    Exclude packages from the test</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--all</tspan><tspan>               Alias for --workspace (deprecated)</tspan>
+    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all</tspan><tspan>               Alias for --workspace (deprecated)</tspan>
 </tspan>
     <tspan x="10px" y="532px">
 </tspan>
-    <tspan x="10px" y="550px"><tspan class="fg-green bold">Target Selection:</tspan>
+    <tspan x="10px" y="550px"><tspan class="fg-bright-green bold">Target Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-cyan bold">--lib</tspan><tspan>               Test only this package's library</tspan>
+    <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lib</tspan><tspan>               Test only this package's library</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-cyan bold">--bins</tspan><tspan>              Test all binaries</tspan>
+    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bins</tspan><tspan>              Test all binaries</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-cyan bold">--bin</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>      Test only the specified binary</tspan>
+    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bin</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>      Test only the specified binary</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-cyan bold">--examples</tspan><tspan>          Test all examples</tspan>
+    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--examples</tspan><tspan>          Test all examples</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Test only the specified example</tspan>
+    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Test only the specified example</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-cyan bold">--tests</tspan><tspan>             Test all targets that have `test = true` set</tspan>
+    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--tests</tspan><tspan>             Test all targets that have `test = true` set</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan>      </tspan><tspan class="fg-cyan bold">--test</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>     Test only the specified test target</tspan>
+    <tspan x="10px" y="676px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--test</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>     Test only the specified test target</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan>      </tspan><tspan class="fg-cyan bold">--benches</tspan><tspan>           Test all targets that have `bench = true` set</tspan>
+    <tspan x="10px" y="694px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--benches</tspan><tspan>           Test all targets that have `bench = true` set</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-cyan bold">--bench</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>    Test only the specified bench target</tspan>
+    <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bench</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>    Test only the specified bench target</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-targets</tspan><tspan>       Test all targets (does not include doctests)</tspan>
+    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all-targets</tspan><tspan>       Test all targets (does not include doctests)</tspan>
 </tspan>
-    <tspan x="10px" y="748px"><tspan>      </tspan><tspan class="fg-cyan bold">--doc</tspan><tspan>               Test only this library's documentation</tspan>
+    <tspan x="10px" y="748px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--doc</tspan><tspan>               Test only this library's documentation</tspan>
 </tspan>
     <tspan x="10px" y="766px">
 </tspan>
-    <tspan x="10px" y="784px"><tspan class="fg-green bold">Feature Selection:</tspan>
+    <tspan x="10px" y="784px"><tspan class="fg-bright-green bold">Feature Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan>  </tspan><tspan class="fg-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
+    <tspan x="10px" y="802px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
 </tspan>
-    <tspan x="10px" y="820px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
+    <tspan x="10px" y="820px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
 </tspan>
-    <tspan x="10px" y="838px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
+    <tspan x="10px" y="838px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
 </tspan>
     <tspan x="10px" y="856px">
 </tspan>
-    <tspan x="10px" y="874px"><tspan class="fg-green bold">Compilation Options:</tspan>
+    <tspan x="10px" y="874px"><tspan class="fg-bright-green bold">Compilation Options:</tspan>
 </tspan>
-    <tspan x="10px" y="892px"><tspan>  </tspan><tspan class="fg-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
+    <tspan x="10px" y="892px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
 </tspan>
-    <tspan x="10px" y="910px"><tspan>  </tspan><tspan class="fg-cyan bold">-r</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--release</tspan><tspan>                 Build artifacts in release mode, with optimizations</tspan>
+    <tspan x="10px" y="910px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-r</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--release</tspan><tspan>                 Build artifacts in release mode, with optimizations</tspan>
 </tspan>
-    <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Build artifacts with the specified profile</tspan>
+    <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Build artifacts with the specified profile</tspan>
 </tspan>
-    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Build for the target triple</tspan>
+    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Build for the target triple</tspan>
 </tspan>
-    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
+    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
 </tspan>
-    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--unit-graph</tspan><tspan>              Output build graph in JSON (unstable)</tspan>
+    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--unit-graph</tspan><tspan>              Output build graph in JSON (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
+    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
 </tspan>
     <tspan x="10px" y="1018px">
 </tspan>
-    <tspan x="10px" y="1036px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="1036px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="1054px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="1054px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="1072px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
+    <tspan x="10px" y="1072px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="1090px"><tspan>      </tspan><tspan class="fg-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
+    <tspan x="10px" y="1090px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
 </tspan>
-    <tspan x="10px" y="1108px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="1108px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="1126px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="1126px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="1144px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="1144px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="1162px">
 </tspan>
-    <tspan x="10px" y="1180px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help test</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="1180px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help test</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
-    <tspan x="10px" y="1198px"><tspan class="bold">Run `</tspan><tspan class="fg-cyan bold">cargo test -- --help</tspan><tspan class="bold">` for test binary options.</tspan>
+    <tspan x="10px" y="1198px"><tspan class="bold">Run `</tspan><tspan class="fg-bright-cyan bold">cargo test -- --help</tspan><tspan class="bold">` for test binary options.</tspan>
 </tspan>
     <tspan x="10px" y="1216px">
 </tspan>

--- a/tests/testsuite/cargo_test/no_keep_going/stderr.term.svg
+++ b/tests/testsuite/cargo_test/no_keep_going/stderr.term.svg
@@ -2,9 +2,10 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
-    .fg-red { fill: #AA0000 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -21,19 +22,19 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error:</tspan><tspan> unexpected argument '</tspan><tspan class="fg-yellow bold">--keep-going</tspan><tspan>' found</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error:</tspan><tspan> unexpected argument '</tspan><tspan class="fg-yellow bold">--keep-going</tspan><tspan>' found</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>  </tspan><tspan class="fg-cyan bold">tip:</tspan><tspan> use `--no-fail-fast` to run as many tests as possible regardless of failure</tspan>
+    <tspan x="10px" y="64px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">tip:</tspan><tspan> use `--no-fail-fast` to run as many tests as possible regardless of failure</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] test</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[TESTNAME]</tspan><tspan> </tspan><tspan class="fg-cyan bold">[--</tspan><tspan> </tspan><tspan class="fg-cyan">[ARGS]...</tspan><tspan class="fg-cyan bold">]</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] test</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[TESTNAME]</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">[--</tspan><tspan> </tspan><tspan class="fg-cyan">[ARGS]...</tspan><tspan class="fg-bright-cyan bold">]</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>
-    <tspan x="10px" y="136px"><tspan>For more information, try '</tspan><tspan class="fg-cyan bold">--help</tspan><tspan>'.</tspan>
+    <tspan x="10px" y="136px"><tspan>For more information, try '</tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>'.</tspan>
 </tspan>
     <tspan x="10px" y="154px">
 </tspan>

--- a/tests/testsuite/cargo_tree/dupe/stderr.term.svg
+++ b/tests/testsuite/cargo_tree/dupe/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,17 +18,17 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold"> Downloading</tspan><tspan> crates ...</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold"> Downloading</tspan><tspan> crates ...</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> c v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> c v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> b v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> b v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> a v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> a v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_tree/edge_kind/stderr.term.svg
+++ b/tests/testsuite/cargo_tree/edge_kind/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,47 +18,47 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 18 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 18 packages to latest compatible versions</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold"> Downloading</tspan><tspan> crates ...</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold"> Downloading</tspan><tspan> crates ...</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> normal_d v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> normal_d v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> normal_c v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> normal_c v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> normal_b_build_a_normal_a v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> normal_b_build_a_normal_a v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> normal_b_build_a v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> normal_b_build_a v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> normal_b v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> normal_b v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> normal_a v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> normal_a v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> dev_d v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="190px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> dev_d v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> dev_c v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="208px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> dev_c v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> dev_b_build_a_normal_a v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="226px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> dev_b_build_a_normal_a v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> dev_b_build_a v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="244px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> dev_b_build_a v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> dev_b v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="262px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> dev_b v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> dev_a v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="280px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> dev_a v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> build_d v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="298px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> build_d v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> build_c v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="316px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> build_c v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> build_b_build_a_normal_a v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="334px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> build_b_build_a_normal_a v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> build_b_build_a v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="352px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> build_b_build_a v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> build_b v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="370px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> build_b v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> build_a v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="388px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> build_a v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
     <tspan x="10px" y="406px">
 </tspan>

--- a/tests/testsuite/cargo_tree/edge_kind/stdout.term.svg
+++ b/tests/testsuite/cargo_tree/edge_kind/stdout.term.svg
@@ -3,6 +3,8 @@
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
     .fg-blue { fill: #0000AA }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-cyan { fill: #55FFFF }
     .fg-cyan { fill: #00AAAA }
     .fg-magenta { fill: #AA00AA }
     .container {
@@ -35,7 +37,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan class="dimmed">│</tspan><tspan>   </tspan><tspan class="fg-magenta dimmed"> </tspan><tspan>   </tspan><tspan class="dimmed"> </tspan><tspan>   </tspan><tspan class="fg-magenta dimmed"> </tspan><tspan>   </tspan><tspan class="dimmed"> </tspan><tspan>   </tspan><tspan class="fg-magenta dimmed">└──</tspan><tspan> normal_c v1.0.0</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="dimmed">│</tspan><tspan>   </tspan><tspan class="fg-magenta dimmed"> </tspan><tspan>   </tspan><tspan class="dimmed"> </tspan><tspan>   </tspan><tspan class="fg-magenta dimmed"> </tspan><tspan>   </tspan><tspan class="fg-blue bold">[build-dependencies]</tspan>
+    <tspan x="10px" y="154px"><tspan class="dimmed">│</tspan><tspan>   </tspan><tspan class="fg-magenta dimmed"> </tspan><tspan>   </tspan><tspan class="dimmed"> </tspan><tspan>   </tspan><tspan class="fg-magenta dimmed"> </tspan><tspan>   </tspan><tspan class="fg-bright-blue bold">[build-dependencies]</tspan>
 </tspan>
     <tspan x="10px" y="172px"><tspan class="bold dimmed">│</tspan><tspan>   </tspan><tspan class="fg-magenta dimmed"> </tspan><tspan>   </tspan><tspan class="dimmed"> </tspan><tspan>   </tspan><tspan class="fg-magenta dimmed"> </tspan><tspan>   </tspan><tspan class="fg-blue bold">└──</tspan><tspan> normal_b_build_a feature "default"</tspan>
 </tspan>
@@ -49,7 +51,7 @@
 </tspan>
     <tspan x="10px" y="262px"><tspan class="dimmed"> </tspan><tspan>   </tspan><tspan class="fg-magenta dimmed">└──</tspan><tspan> normal_d v1.0.0</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan class="fg-blue bold">[build-dependencies]</tspan>
+    <tspan x="10px" y="280px"><tspan class="fg-bright-blue bold">[build-dependencies]</tspan>
 </tspan>
     <tspan x="10px" y="298px"><tspan class="fg-blue bold">├──</tspan><tspan> build_a feature "default"</tspan>
 </tspan>
@@ -63,7 +65,7 @@
 </tspan>
     <tspan x="10px" y="388px"><tspan class="fg-blue bold">│</tspan><tspan>   </tspan><tspan class="fg-magenta dimmed"> </tspan><tspan>   </tspan><tspan class="dimmed"> </tspan><tspan>   </tspan><tspan class="fg-magenta dimmed"> </tspan><tspan>   </tspan><tspan class="dimmed"> </tspan><tspan>   </tspan><tspan class="fg-magenta dimmed">└──</tspan><tspan> build_c v1.0.0</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan class="fg-blue bold">│</tspan><tspan>   </tspan><tspan class="fg-magenta dimmed"> </tspan><tspan>   </tspan><tspan class="dimmed"> </tspan><tspan>   </tspan><tspan class="fg-magenta dimmed"> </tspan><tspan>   </tspan><tspan class="fg-blue bold">[build-dependencies]</tspan>
+    <tspan x="10px" y="406px"><tspan class="fg-blue bold">│</tspan><tspan>   </tspan><tspan class="fg-magenta dimmed"> </tspan><tspan>   </tspan><tspan class="dimmed"> </tspan><tspan>   </tspan><tspan class="fg-magenta dimmed"> </tspan><tspan>   </tspan><tspan class="fg-bright-blue bold">[build-dependencies]</tspan>
 </tspan>
     <tspan x="10px" y="424px"><tspan class="fg-blue bold">│</tspan><tspan>   </tspan><tspan class="fg-magenta dimmed"> </tspan><tspan>   </tspan><tspan class="dimmed"> </tspan><tspan>   </tspan><tspan class="fg-magenta dimmed"> </tspan><tspan>   </tspan><tspan class="fg-blue bold">└──</tspan><tspan> build_b_build_a feature "default"</tspan>
 </tspan>
@@ -77,7 +79,7 @@
 </tspan>
     <tspan x="10px" y="514px"><tspan class="fg-blue bold"> </tspan><tspan>   </tspan><tspan class="fg-magenta dimmed">└──</tspan><tspan> build_d v1.0.0</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan class="fg-cyan bold">[dev-dependencies]</tspan>
+    <tspan x="10px" y="532px"><tspan class="fg-bright-cyan bold">[dev-dependencies]</tspan>
 </tspan>
     <tspan x="10px" y="550px"><tspan class="fg-cyan bold">├──</tspan><tspan> dev_a feature "default"</tspan>
 </tspan>
@@ -91,7 +93,7 @@
 </tspan>
     <tspan x="10px" y="640px"><tspan class="fg-cyan bold">│</tspan><tspan>   </tspan><tspan class="fg-magenta dimmed"> </tspan><tspan>   </tspan><tspan class="dimmed"> </tspan><tspan>   </tspan><tspan class="fg-magenta dimmed"> </tspan><tspan>   </tspan><tspan class="dimmed"> </tspan><tspan>   </tspan><tspan class="fg-magenta dimmed">└──</tspan><tspan> dev_c v1.0.0</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan class="fg-cyan bold">│</tspan><tspan>   </tspan><tspan class="fg-magenta dimmed"> </tspan><tspan>   </tspan><tspan class="dimmed"> </tspan><tspan>   </tspan><tspan class="fg-magenta dimmed"> </tspan><tspan>   </tspan><tspan class="fg-blue bold">[build-dependencies]</tspan>
+    <tspan x="10px" y="658px"><tspan class="fg-cyan bold">│</tspan><tspan>   </tspan><tspan class="fg-magenta dimmed"> </tspan><tspan>   </tspan><tspan class="dimmed"> </tspan><tspan>   </tspan><tspan class="fg-magenta dimmed"> </tspan><tspan>   </tspan><tspan class="fg-bright-blue bold">[build-dependencies]</tspan>
 </tspan>
     <tspan x="10px" y="676px"><tspan class="fg-cyan bold">│</tspan><tspan>   </tspan><tspan class="fg-magenta dimmed"> </tspan><tspan>   </tspan><tspan class="dimmed"> </tspan><tspan>   </tspan><tspan class="fg-magenta dimmed"> </tspan><tspan>   </tspan><tspan class="fg-blue bold">└──</tspan><tspan> dev_b_build_a feature "default"</tspan>
 </tspan>

--- a/tests/testsuite/cargo_tree/help/stdout.term.svg
+++ b/tests/testsuite/cargo_tree/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,93 +24,93 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] tree</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] tree</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan bold">-e</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--edges</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KINDS&gt;</tspan><tspan>            The kinds of dependencies to display (features, normal, build, dev,</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-e</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--edges</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KINDS&gt;</tspan><tspan>            The kinds of dependencies to display (features, normal, build, dev,</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan>                                 all, no-normal, no-build, no-dev, no-proc-macro)</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-cyan bold">-i</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--invert</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>          Invert the tree direction and focus on the given package</tspan>
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-i</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--invert</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>          Invert the tree direction and focus on the given package</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-cyan bold">--prune</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>             Prune the given package from the display of the dependency tree</tspan>
+    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--prune</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>             Prune the given package from the display of the dependency tree</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-cyan bold">--depth</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DEPTH&gt;</tspan><tspan>            Maximum display depth of the dependency tree</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--depth</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DEPTH&gt;</tspan><tspan>            Maximum display depth of the dependency tree</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-cyan bold">--prefix</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PREFIX&gt;</tspan><tspan>          Change the prefix (indentation) of how each entry is displayed</tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--prefix</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PREFIX&gt;</tspan><tspan>          Change the prefix (indentation) of how each entry is displayed</tspan>
 </tspan>
     <tspan x="10px" y="226px"><tspan>                                 [default: indent] [possible values: depth, indent, none]</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-dedupe</tspan><tspan>                Do not de-duplicate (repeats all shared dependencies)</tspan>
+    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-dedupe</tspan><tspan>                Do not de-duplicate (repeats all shared dependencies)</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-cyan bold">-d</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--duplicates</tspan><tspan>               Show only dependencies which come in multiple versions (implies -i)</tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-d</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--duplicates</tspan><tspan>               Show only dependencies which come in multiple versions (implies -i)</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--charset</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;CHARSET&gt;</tspan><tspan>        Character set to use in output [possible values: utf8, ascii]</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--charset</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;CHARSET&gt;</tspan><tspan>        Character set to use in output [possible values: utf8, ascii]</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-cyan bold">-f</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FORMAT&gt;</tspan><tspan>          Format string used for printing dependencies [default: {p}]</tspan>
+    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-f</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FORMAT&gt;</tspan><tspan>          Format string used for printing dependencies [default: {p}]</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="316px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="388px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="406px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="424px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="442px">
 </tspan>
-    <tspan x="10px" y="460px"><tspan class="fg-green bold">Package Selection:</tspan>
+    <tspan x="10px" y="460px"><tspan class="fg-bright-green bold">Package Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>  </tspan><tspan class="fg-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package to be used as the root of the tree</tspan>
+    <tspan x="10px" y="478px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package to be used as the root of the tree</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--workspace</tspan><tspan>         Display the tree for all packages in the workspace</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--workspace</tspan><tspan>         Display the tree for all packages in the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--exclude</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>    Exclude specific workspace members</tspan>
+    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--exclude</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>    Exclude specific workspace members</tspan>
 </tspan>
     <tspan x="10px" y="532px">
 </tspan>
-    <tspan x="10px" y="550px"><tspan class="fg-green bold">Feature Selection:</tspan>
+    <tspan x="10px" y="550px"><tspan class="fg-bright-green bold">Feature Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>  </tspan><tspan class="fg-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
+    <tspan x="10px" y="568px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
+    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
+    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
 </tspan>
     <tspan x="10px" y="622px">
 </tspan>
-    <tspan x="10px" y="640px"><tspan class="fg-green bold">Compilation Options:</tspan>
+    <tspan x="10px" y="640px"><tspan class="fg-bright-green bold">Compilation Options:</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Filter dependencies matching the given target-triple (default host</tspan>
+    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Filter dependencies matching the given target-triple (default host</tspan>
 </tspan>
     <tspan x="10px" y="676px"><tspan>                           platform). Pass `all` to include all targets.</tspan>
 </tspan>
     <tspan x="10px" y="694px">
 </tspan>
-    <tspan x="10px" y="712px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="712px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="748px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
+    <tspan x="10px" y="748px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="766px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="766px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="784px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="802px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="820px">
 </tspan>
-    <tspan x="10px" y="838px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help tree</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="838px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help tree</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="856px">
 </tspan>

--- a/tests/testsuite/cargo_uninstall/help/stdout.term.svg
+++ b/tests/testsuite/cargo_uninstall/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,59 +24,59 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] uninstall</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[SPEC]...</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] uninstall</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[SPEC]...</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">[SPEC]...</tspan><tspan>  </tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-cyan bold">--root</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIR&gt;</tspan><tspan>               Directory to uninstall packages from</tspan>
+    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--root</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIR&gt;</tspan><tspan>               Directory to uninstall packages from</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="280px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="316px">
 </tspan>
-    <tspan x="10px" y="334px"><tspan class="fg-green bold">Package Selection:</tspan>
+    <tspan x="10px" y="334px"><tspan class="fg-bright-green bold">Package Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package to uninstall</tspan>
+    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package to uninstall</tspan>
 </tspan>
     <tspan x="10px" y="370px">
 </tspan>
-    <tspan x="10px" y="388px"><tspan class="fg-green bold">Target Selection:</tspan>
+    <tspan x="10px" y="388px"><tspan class="fg-bright-green bold">Target Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--bin</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan>  Only uninstall the binary NAME</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bin</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan>  Only uninstall the binary NAME</tspan>
 </tspan>
     <tspan x="10px" y="424px">
 </tspan>
-    <tspan x="10px" y="442px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="442px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="514px">
 </tspan>
-    <tspan x="10px" y="532px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help uninstall</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="532px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help uninstall</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="550px">
 </tspan>

--- a/tests/testsuite/cargo_update/help/stdout.term.svg
+++ b/tests/testsuite/cargo_update/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,61 +24,61 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] update</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[SPEC]...</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] update</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[SPEC]...</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan bold">-n</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--dry-run</tspan><tspan>                  Don't actually write the lockfile</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-n</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--dry-run</tspan><tspan>                  Don't actually write the lockfile</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>      </tspan><tspan class="fg-cyan bold">--recursive</tspan><tspan>                Force updating all dependencies of [SPEC]... as well</tspan>
+    <tspan x="10px" y="136px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--recursive</tspan><tspan>                Force updating all dependencies of [SPEC]... as well</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>      </tspan><tspan class="fg-cyan bold">--precise</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PRECISE&gt;</tspan><tspan>        Update [SPEC] to exactly PRECISE</tspan>
+    <tspan x="10px" y="154px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--precise</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PRECISE&gt;</tspan><tspan>        Update [SPEC] to exactly PRECISE</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-cyan bold">-b</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--breaking</tspan><tspan>                 Update [SPEC] to latest SemVer-breaking version (unstable)</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-b</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--breaking</tspan><tspan>                 Update [SPEC] to latest SemVer-breaking version (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="280px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="316px">
 </tspan>
-    <tspan x="10px" y="334px"><tspan class="fg-green bold">Package Selection:</tspan>
+    <tspan x="10px" y="334px"><tspan class="fg-bright-green bold">Package Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-cyan bold">-w</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--workspace</tspan><tspan>  Only update the workspace packages</tspan>
+    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-w</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--workspace</tspan><tspan>  Only update the workspace packages</tspan>
 </tspan>
     <tspan x="10px" y="370px"><tspan>  </tspan><tspan class="fg-cyan">[SPEC]...</tspan><tspan>        Package to update</tspan>
 </tspan>
     <tspan x="10px" y="388px">
 </tspan>
-    <tspan x="10px" y="406px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="406px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
+    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
+    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="532px">
 </tspan>
-    <tspan x="10px" y="550px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help update</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="550px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help update</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="568px">
 </tspan>

--- a/tests/testsuite/cargo_update/toolchain_pkgname/stderr.term.svg
+++ b/tests/testsuite/cargo_update/toolchain_pkgname/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> invalid character `+` in package name: `+stable`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: invalid character `+` in package name: `+stable`</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>    Use `cargo +stable update` if you meant to use the `stable` toolchain.</tspan>
 </tspan>

--- a/tests/testsuite/cargo_update/toolchain_pkgname/stderr.term.svg
+++ b/tests/testsuite/cargo_update/toolchain_pkgname/stderr.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
-    .fg-red { fill: #AA0000 }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> invalid character `+` in package name: `+stable`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> invalid character `+` in package name: `+stable`</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>    Use `cargo +stable update` if you meant to use the `stable` toolchain.</tspan>
 </tspan>

--- a/tests/testsuite/cargo_vendor/help/stdout.term.svg
+++ b/tests/testsuite/cargo_vendor/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,57 +24,57 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] vendor</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[path]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] vendor</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[path]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">[path]</tspan><tspan>  Where to vendor crates (`vendor` by default)</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-cyan bold">--no-delete</tspan><tspan>                Don't delete older crates in the vendor directory</tspan>
+    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-delete</tspan><tspan>                Don't delete older crates in the vendor directory</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-cyan bold">-s</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--sync</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TOML&gt;</tspan><tspan>              Additional `Cargo.toml` to sync and vendor</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-s</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--sync</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TOML&gt;</tspan><tspan>              Additional `Cargo.toml` to sync and vendor</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-cyan bold">--respect-source-config</tspan><tspan>    Respect `[source]` config in `.cargo/config`</tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--respect-source-config</tspan><tspan>    Respect `[source]` config in `.cargo/config`</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-cyan bold">--versioned-dirs</tspan><tspan>           Always include version in subdir name</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--versioned-dirs</tspan><tspan>           Always include version in subdir name</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="316px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="334px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="370px">
 </tspan>
-    <tspan x="10px" y="388px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="388px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
+    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lockfile-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.lock (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="496px">
 </tspan>
-    <tspan x="10px" y="514px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help vendor</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="514px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help vendor</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="532px">
 </tspan>

--- a/tests/testsuite/cargo_verify_project/help/stdout.term.svg
+++ b/tests/testsuite/cargo_verify_project/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -27,37 +28,37 @@
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] verify-project</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] verify-project</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="244px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="280px">
 </tspan>
-    <tspan x="10px" y="298px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="298px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="388px">
 </tspan>

--- a/tests/testsuite/cargo_version/help/stdout.term.svg
+++ b/tests/testsuite/cargo_version/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,39 +24,39 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] version</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] version</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="154px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="244px">
 </tspan>
-    <tspan x="10px" y="262px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="262px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
+    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="334px">
 </tspan>
-    <tspan x="10px" y="352px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help version</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="352px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help version</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="370px">
 </tspan>

--- a/tests/testsuite/cargo_yank/help/stdout.term.svg
+++ b/tests/testsuite/cargo_yank/help/stdout.term.svg
@@ -2,8 +2,9 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,55 +24,55 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-cyan bold">cargo[EXE] yank</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[CRATE]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo[EXE] yank</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[CRATE]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">[CRATE]</tspan><tspan>  </tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">Options:</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-cyan bold">--version</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;VERSION&gt;</tspan><tspan>        The version to yank or un-yank</tspan>
+    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--version</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;VERSION&gt;</tspan><tspan>        The version to yank or un-yank</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-cyan bold">--undo</tspan><tspan>                     Undo a yank, putting a version back into the index</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--undo</tspan><tspan>                     Undo a yank, putting a version back into the index</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-cyan bold">--index</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;INDEX&gt;</tspan><tspan>            Registry index URL to yank from</tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--index</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;INDEX&gt;</tspan><tspan>            Registry index URL to yank from</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-cyan bold">--registry</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;REGISTRY&gt;</tspan><tspan>      Registry to yank from</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--registry</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;REGISTRY&gt;</tspan><tspan>      Registry to yank from</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-cyan bold">--token</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TOKEN&gt;</tspan><tspan>            API token to use when authenticating</tspan>
+    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--token</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TOKEN&gt;</tspan><tspan>            API token to use when authenticating</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
     <tspan x="10px" y="352px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>  </tspan><tspan class="fg-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="370px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
     <tspan x="10px" y="388px">
 </tspan>
-    <tspan x="10px" y="406px"><tspan class="fg-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="406px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
+    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="478px">
 </tspan>
-    <tspan x="10px" y="496px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help yank</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="496px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help yank</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
     <tspan x="10px" y="514px">
 </tspan>

--- a/tests/testsuite/lints/inherited/stderr.term.svg
+++ b/tests/testsuite/lints/inherited/stderr.term.svg
@@ -44,7 +44,7 @@
 </tspan>
     <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">----------------</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> encountered 1 errors(s) while verifying lints</tspan>
+    <tspan x="10px" y="244px"><tspan class="fg-bright-red bold">error</tspan><tspan>: encountered 1 errors(s) while verifying lints</tspan>
 </tspan>
     <tspan x="10px" y="262px">
 </tspan>

--- a/tests/testsuite/lints/inherited/stderr.term.svg
+++ b/tests/testsuite/lints/inherited/stderr.term.svg
@@ -5,7 +5,6 @@
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-green { fill: #55FF55 }
     .fg-bright-red { fill: #FF5555 }
-    .fg-red { fill: #AA0000 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -45,7 +44,7 @@
 </tspan>
     <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">----------------</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> encountered 1 errors(s) while verifying lints</tspan>
+    <tspan x="10px" y="244px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">:</tspan><tspan> encountered 1 errors(s) while verifying lints</tspan>
 </tspan>
     <tspan x="10px" y="262px">
 </tspan>

--- a/tests/testsuite/lints/warning/stderr.term.svg
+++ b/tests/testsuite/lints/warning/stderr.term.svg
@@ -3,7 +3,7 @@
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
     .fg-bright-blue { fill: #5555FF }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -34,9 +34,9 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-blue bold">= </tspan><tspan class="bold">note</tspan><tspan>: `cargo::im_a_teapot` is set to `warn` in `[lints]`</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">    Checking</tspan><tspan> foo v0.0.1 ([ROOT]/foo)</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">    Checking</tspan><tspan> foo v0.0.1 ([ROOT]/foo)</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-green bold">    Finished</tspan><tspan> </tspan><tspan><a href="https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles">`dev` profile [unoptimized + debuginfo]</a></tspan><tspan> target(s) in [ELAPSED]s</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">    Finished</tspan><tspan> </tspan><tspan><a href="https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles">`dev` profile [unoptimized + debuginfo]</a></tspan><tspan> target(s) in [ELAPSED]s</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes #12740

This is also prep for #15917, #15922

Changes:
- `note` changes from Cyan to Bright Green
  - `cargo info` had to be changed because the header and context colors became the same
- Switch to Bright colors which is usually redundant with Bold but that is theme dependent
  - `warning`  only changes to Bright on Windows which is to work around a shell issue on some Windows versions
  - except for `PLACEHOLDER` to tell it apart from `LITERAL`
- the `:` in `note:` is no longer bolded to match rustc

### How to test and review this PR?

### Notes

While annotate-snippets does not have a style for every one of our styles, I updated our manual styles to be similar to annotate snippets.

For annotate snippets color definitions, see https://github.com/rust-lang/annotate-snippets-rs/blob/d38b08b81d7d574369ecfd30124195a970b37fd3/src/renderer/mod.rs#L41-L78