### PR TITLE
fix: Switch from --nocapture to --no-capture

### DIFF
--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -427,11 +427,11 @@ fn report_test_error(
     crate::display_error(&err, &mut ws.gctx().shell());
 
     let harness: bool = unit_err.unit.target.harness();
-    let nocapture: bool = test_args.contains(&"--nocapture");
+    let nocapture: bool = test_args.contains(&"--nocapture") || test_args.contains(&"--no-capture");
 
     if !is_simple && executed && harness && !nocapture {
         drop(ws.gctx().shell().note(
-            "test exited abnormally; to see the full output pass --nocapture to the harness.",
+            "test exited abnormally; to see the full output pass --no-capture to the harness.",
         ));
     }
 }

--- a/src/doc/man/cargo-bench.md
+++ b/src/doc/man/cargo-bench.md
@@ -126,9 +126,9 @@ for more information on per-target settings.
 
 By default the Rust test harness hides output from benchmark execution to keep
 results readable. Benchmark output can be recovered (e.g., for debugging) by
-passing `--nocapture` to the benchmark binaries:
+passing `--no-capture` to the benchmark binaries:
 
-    cargo bench -- --nocapture
+    cargo bench -- --no-capture
 
 {{#options}}
 

--- a/src/doc/man/cargo-test.md
+++ b/src/doc/man/cargo-test.md
@@ -150,9 +150,9 @@ target options.
 
 By default the Rust test harness hides output from test execution to keep
 results readable. Test output can be recovered (e.g., for debugging) by passing
-`--nocapture` to the test binaries:
+`--no-capture` to the test binaries:
 
-    cargo test -- --nocapture
+    cargo test -- --no-capture
 
 {{#options}}
 

--- a/src/doc/man/generated_txt/cargo-bench.txt
+++ b/src/doc/man/generated_txt/cargo-bench.txt
@@ -283,9 +283,9 @@ OPTIONS
    Display Options
        By default the Rust test harness hides output from benchmark execution
        to keep results readable. Benchmark output can be recovered (e.g., for
-       debugging) by passing --nocapture to the benchmark binaries:
+       debugging) by passing --no-capture to the benchmark binaries:
 
-           cargo bench -- --nocapture
+           cargo bench -- --no-capture
 
        -v, --verbose
            Use verbose output. May be specified twice for “very verbose”

--- a/src/doc/man/generated_txt/cargo-test.txt
+++ b/src/doc/man/generated_txt/cargo-test.txt
@@ -309,9 +309,9 @@ OPTIONS
    Display Options
        By default the Rust test harness hides output from test execution to
        keep results readable. Test output can be recovered (e.g., for
-       debugging) by passing --nocapture to the test binaries:
+       debugging) by passing --no-capture to the test binaries:
 
-           cargo test -- --nocapture
+           cargo test -- --no-capture
 
        -v, --verbose
            Use verbose output. May be specified twice for “very verbose”

--- a/src/doc/src/commands/cargo-bench.md
+++ b/src/doc/src/commands/cargo-bench.md
@@ -310,9 +310,9 @@ Defaults to <code>target</code> in the root of the workspace.</dd>
 
 By default the Rust test harness hides output from benchmark execution to keep
 results readable. Benchmark output can be recovered (e.g., for debugging) by
-passing `--nocapture` to the benchmark binaries:
+passing `--no-capture` to the benchmark binaries:
 
-    cargo bench -- --nocapture
+    cargo bench -- --no-capture
 
 <dl>
 

--- a/src/doc/src/commands/cargo-test.md
+++ b/src/doc/src/commands/cargo-test.md
@@ -338,9 +338,9 @@ Defaults to <code>target</code> in the root of the workspace.</dd>
 
 By default the Rust test harness hides output from test execution to keep
 results readable. Test output can be recovered (e.g., for debugging) by passing
-`--nocapture` to the test binaries:
+`--no-capture` to the test binaries:
 
-    cargo test -- --nocapture
+    cargo test -- --no-capture
 
 <dl>
 

--- a/src/etc/cargo.bashcomp.sh
+++ b/src/etc/cargo.bashcomp.sh
@@ -91,7 +91,7 @@ _cargo()
 	local opt__vendor="$opt_common $opt_mani $opt_lock $opt_sync --no-delete --respect-source-config --versioned-dirs"
 	local opt__version="$opt_common $opt_lock"
 	local opt__yank="$opt_common $opt_lock --version --undo --index --token --registry"
-	local opt__libtest="--help --include-ignored --ignored --test --bench --list --logfile --nocapture --test-threads --skip -q --quiet --exact --color --format"
+	local opt__libtest="--help --include-ignored --ignored --test --bench --list --logfile --no-capture --test-threads --skip -q --quiet --exact --color --format"
 
 	if [[ $cword -gt $dd_i ]]; then
 		# Completion after -- separator.

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -330,11 +330,11 @@ Defaults to \fBtarget\fR in the root of the workspace.
 .SS "Display Options"
 By default the Rust test harness hides output from benchmark execution to keep
 results readable. Benchmark output can be recovered (e.g., for debugging) by
-passing \fB\-\-nocapture\fR to the benchmark binaries:
+passing \fB\-\-no\-capture\fR to the benchmark binaries:
 .sp
 .RS 4
 .nf
-cargo bench \-\- \-\-nocapture
+cargo bench \-\- \-\-no\-capture
 .fi
 .RE
 .sp

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -357,11 +357,11 @@ Defaults to \fBtarget\fR in the root of the workspace.
 .SS "Display Options"
 By default the Rust test harness hides output from test execution to keep
 results readable. Test output can be recovered (e.g., for debugging) by passing
-\fB\-\-nocapture\fR to the test binaries:
+\fB\-\-no\-capture\fR to the test binaries:
 .sp
 .RS 4
 .nf
-cargo test \-\- \-\-nocapture
+cargo test \-\- \-\-no\-capture
 .fi
 .RE
 .sp

--- a/tests/testsuite/old_cargos.rs
+++ b/tests/testsuite/old_cargos.rs
@@ -7,7 +7,7 @@
 //! tested 1.0 to 1.51. Run this with:
 //!
 //! ```console
-//! cargo test --test testsuite -- old_cargos --nocapture --ignored
+//! cargo test --test testsuite -- old_cargos --no-capture --ignored
 //! ```
 
 use std::fs;

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -3075,7 +3075,7 @@ fn long_file_names() {
         let test_path = test_path.join(long_name);
         if let Err(e) = File::create(&test_path) {
             // write to stderr directly to avoid output from being captured
-            // and always display text, even without --nocapture
+            // and always display text, even without --no-capture
             use std::io::Write;
             writeln!(
                 std::io::stderr(),

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -2001,7 +2001,7 @@ fn test_no_harness() {
         .file("foo.rs", "fn main() {}")
         .build();
 
-    p.cargo("test -- --nocapture")
+    p.cargo("test -- --no-capture")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -3901,7 +3901,7 @@ fn cargo_test_env() {
             .unwrap()
             .replace(rustc_host, "[HOST_TARGET]")
     );
-    p.cargo("test --lib -- --nocapture")
+    p.cargo("test --lib -- --no-capture")
         .with_stderr_contains(cargo)
         .with_stdout_data(str![[r#"
 ...
@@ -3923,7 +3923,7 @@ test env_test ... ok
             .replace(p.root().parent().unwrap().to_str().unwrap(), "[ROOT]")
     );
     p.process(other_cargo_path)
-        .args(&["test", "--lib", "--", "--nocapture"])
+        .args(&["test", "--lib", "--", "--no-capture"])
         .with_stderr_contains(stderr_other_cargo)
         .with_stdout_data(str![[r#"
 ...
@@ -5398,20 +5398,20 @@ this is a normal error
 
 Caused by:
   process didn't exit successfully: `[ROOT]/foo/target/debug/deps/t2-[HASH][EXE]` ([EXIT_STATUS]: 4)
-[NOTE] test exited abnormally; to see the full output pass --nocapture to the harness.
+[NOTE] test exited abnormally; to see the full output pass --no-capture to the harness.
 
 "#]])
         .with_status(4)
         .run();
 
-    p.cargo("test --test t2 -- --nocapture")
+    p.cargo("test --test t2 -- --no-capture")
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] tests/t2.rs (target/debug/deps/t2-[HASH][EXE])
 [ERROR] test failed, to rerun pass `--test t2`
 
 Caused by:
-  process didn't exit successfully: `[ROOT]/foo/target/debug/deps/t2-[HASH][EXE] --nocapture` ([EXIT_STATUS]: 4)
+  process didn't exit successfully: `[ROOT]/foo/target/debug/deps/t2-[HASH][EXE] --no-capture` ([EXIT_STATUS]: 4)
 
 "#]])
         .with_status(4)
@@ -5428,7 +5428,7 @@ Caused by:
 
 Caused by:
   process didn't exit successfully: `[ROOT]/foo/target/debug/deps/t2-[HASH][EXE]` ([EXIT_STATUS]: 4)
-[NOTE] test exited abnormally; to see the full output pass --nocapture to the harness.
+[NOTE] test exited abnormally; to see the full output pass --no-capture to the harness.
 [ERROR] 2 targets failed:
     `--test t1`
     `--test t2`
@@ -5437,15 +5437,15 @@ Caused by:
         .with_status(101)
         .run();
 
-    p.cargo("test --no-fail-fast -- --nocapture")
+    p.cargo("test --no-fail-fast -- --no-capture")
         .with_stderr_does_not_contain(
-            "test exited abnormally; to see the full output pass --nocapture to the harness.",
+            "test exited abnormally; to see the full output pass --no-capture to the harness.",
         )
         .with_stderr_data(str![[r#"
 [..]thread [..]panicked [..] tests/t1.rs[..]
 [NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 Caused by:
-  process didn't exit successfully: `[ROOT]/foo/target/debug/deps/t2-[HASH][EXE] --nocapture` ([EXIT_STATUS]: 4)
+  process didn't exit successfully: `[ROOT]/foo/target/debug/deps/t2-[HASH][EXE] --no-capture` ([EXIT_STATUS]: 4)
 ...
 "#]].unordered())
         .with_status(101)
@@ -5513,6 +5513,6 @@ fn cargo_test_set_out_dir_env_var() {
         .build();
 
     p.cargo("test").run();
-    p.cargo("test --package foo --test case -- tests::test_add --exact --nocapture")
+    p.cargo("test --package foo --test case -- tests::test_add --exact --no-capture")
         .run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?

`--no-capture` was added in 1.88, with `--nocapture` being soft-deprecated.

### How to test and review this PR?
