### PR TITLE
chore(ci): reject uncanonicalized issue link in commits

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -61,6 +61,9 @@ review_labels = ["S-waiting-on-review"]
 remove_labels = ["S-waiting-on-author"]
 add_labels = ["S-waiting-on-review"]
 
+[issue-links]
+check-commits = "uncanonicalized"
+
 [autolabel."A-build-execution"]
 trigger_files = [
   "src/cargo/core/compiler/compilation.rs",


### PR DESCRIPTION
### What does this PR try to resolve?

This is needed if we want to turn cargo submodule into a subtree in
the rust-lang/rust repository (rust-lang/cargo#15882), because
commits are cherry-picked with their messages left as-is, and the magic keyword
like `fixes #99999` may unintentionally close issues in rust-lang/rust
while it was intended only for rust-lang/cargo issues.

Unlike `check-commits = false`, instead of rejecting any issue links
in commit messages, the `"uncanonicalized"` option still allows issues
in a canonicalized form, such as

* `https://github.com/rust-lang/cargo/issues/15882`
* `rust-lang/cargo#15882`

but the bare issue number like `#15882` will be warned by triagebot
in a PR comment.

### Drawbacks

It is bad because contributors will be forced to write commit messages
in a specific style. Worse if we decide not to be a subtree and then
this change puts unnecessary works on contributors.

### Is it the last step towards rust-lang/cargo#15882?

Personally I consider not. Because merge commit still contains
the PR number in the uncanonicalized form, as we use GitHub merge queue
and it hasn't yet support [merge commit template][1].

However, this change on its own makes issue link more obvious and
less ambiguous, especially when reading from outside GitHub web UI.
It also stops us from adding more uncanonicalized issue links in the
future, which we already have too many in the past commits [2]

There are some other concerns in <https://github.com/rust-lang/cargo/issues/15882#issuecomment-3224806645> and <https://github.com/rust-lang/cargo/issues/15882#issuecomment-3267730188>. Until we resolve them and feel this is the only thing left, we might not want to merge this.

For discussions, see

* https://forge.rust-lang.org/triagebot/issue-links.html
* https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/Turning.20cargo.20into.20a.20subtree/near/537951273
* https://github.com/rust-lang/cargo/issues/15882

[1]: https://github.com/orgs/community/discussions/5955
[2]: https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/Turning.20cargo.20into.20a.20subtree/near/537560661
