### PR TITLE
fix(info): Suggest a more universal `cargo tree` command

### DIFF
--- a/src/cargo/ops/cargo_update.rs
+++ b/src/cargo/ops/cargo_update.rs
@@ -689,9 +689,9 @@ fn print_lockfile_updates(
     }
 
     if ws.gctx().shell().verbosity() == Verbosity::Verbose {
-        ws.gctx().shell().note(
-            "to see how you depend on a package, run `cargo tree --invert --package <dep>@<ver>`",
-        )?;
+        ws.gctx()
+            .shell()
+            .note("to see how you depend on a package, run `cargo tree --invert <dep>@<ver>`")?;
     } else {
         if 0 < unchanged_behind {
             ws.gctx().shell().note(format!(

--- a/src/cargo/ops/registry/info/view.rs
+++ b/src/cargo/ops/registry/info/view.rs
@@ -400,7 +400,7 @@ fn suggest_cargo_tree(package_id: PackageId, shell: &mut Shell) -> CargoResult<(
     let literal = LITERAL;
 
     shell.note(format_args!(
-        "to see how you depend on {name}, run `{literal}cargo tree --invert --package {name}@{version}{literal:#}`",
+        "to see how you depend on {name}, run `{literal}cargo tree --invert {name}@{version}{literal:#}`",
         name = package_id.name(),
         version = package_id.version(),
     ))

--- a/tests/testsuite/cargo_info/specify_version_within_ws_and_match_with_lockfile/stderr.term.svg
+++ b/tests/testsuite/cargo_info/specify_version_within_ws_and_match_with_lockfile/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="911px" height="110px" xmlns="http://www.w3.org/2000/svg">
+<svg width="827px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -25,7 +25,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> my-package v0.1.1+my-package (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">note</tspan><tspan>: to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@0.1.1+my-package</tspan><tspan>`</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">note</tspan><tspan>: to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert my-package@0.1.1+my-package</tspan><tspan>`</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/direct1-stderr.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/direct1-stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="818px" height="92px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="92px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -23,7 +23,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> my-package v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan>: to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@1.0.0</tspan><tspan>`</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">note</tspan><tspan>: to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert my-package@1.0.0</tspan><tspan>`</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/direct2-stderr.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/direct2-stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="818px" height="56px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -19,7 +19,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">note</tspan><tspan>: to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@2.0.0</tspan><tspan>`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">note</tspan><tspan>: to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert my-package@2.0.0</tspan><tspan>`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/transitive1-stderr.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/transitive1-stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="818px" height="56px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -19,7 +19,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">note</tspan><tspan>: to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@2.0.0</tspan><tspan>`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">note</tspan><tspan>: to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert my-package@2.0.0</tspan><tspan>`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/transitive2-stderr.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/transitive2-stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="818px" height="56px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -19,7 +19,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">note</tspan><tspan>: to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@2.0.0</tspan><tspan>`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">note</tspan><tspan>: to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert my-package@2.0.0</tspan><tspan>`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/ws-stderr.term.svg
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/ws-stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="818px" height="110px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -25,7 +25,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> my-package v2.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">note</tspan><tspan>: to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@2.0.0</tspan><tspan>`</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">note</tspan><tspan>: to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert my-package@2.0.0</tspan><tspan>`</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_info/within_ws/stderr.term.svg
+++ b/tests/testsuite/cargo_info/within_ws/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="911px" height="110px" xmlns="http://www.w3.org/2000/svg">
+<svg width="827px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -25,7 +25,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> my-package v0.1.1+my-package (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">note</tspan><tspan>: to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@0.1.1+my-package</tspan><tspan>`</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">note</tspan><tspan>: to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert my-package@0.1.1+my-package</tspan><tspan>`</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_info/within_ws_without_lockfile/stderr.term.svg
+++ b/tests/testsuite/cargo_info/within_ws_without_lockfile/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="911px" height="146px" xmlns="http://www.w3.org/2000/svg">
+<svg width="827px" height="146px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -30,7 +30,7 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> my-package v0.2.3+my-package (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">note</tspan><tspan>: to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@0.2.3+my-package</tspan><tspan>`</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">note</tspan><tspan>: to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert my-package@0.2.3+my-package</tspan><tspan>`</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_info/without_requiring_registry_auth/stderr.term.svg
+++ b/tests/testsuite/cargo_info/without_requiring_registry_auth/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="911px" height="110px" xmlns="http://www.w3.org/2000/svg">
+<svg width="827px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -25,7 +25,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> my-package v0.1.1+my-package (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">note</tspan><tspan>: to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert --package my-package@0.1.1+my-package</tspan><tspan>`</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">note</tspan><tspan>: to see how you depend on my-package, run `</tspan><tspan class="fg-bright-cyan bold">cargo tree --invert my-package@0.1.1+my-package</tspan><tspan>`</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -1536,7 +1536,7 @@ fn report_behind() {
 [UPDATING] breaking v0.1.0 -> v0.1.1 (available: v0.2.0)
 [UNCHANGED] pre v1.0.0-alpha.0 (available: v1.0.0-alpha.1)
 [UNCHANGED] two-ver v0.1.0 (available: v0.2.0)
-[NOTE] to see how you depend on a package, run `cargo tree --invert --package <dep>@<ver>`
+[NOTE] to see how you depend on a package, run `cargo tree --invert <dep>@<ver>`
 [WARNING] not updating lockfile due to dry run
 
 "#]])
@@ -1561,7 +1561,7 @@ fn report_behind() {
 [UNCHANGED] breaking v0.1.1 (available: v0.2.0)
 [UNCHANGED] pre v1.0.0-alpha.0 (available: v1.0.0-alpha.1)
 [UNCHANGED] two-ver v0.1.0 (available: v0.2.0)
-[NOTE] to see how you depend on a package, run `cargo tree --invert --package <dep>@<ver>`
+[NOTE] to see how you depend on a package, run `cargo tree --invert <dep>@<ver>`
 [WARNING] not updating lockfile due to dry run
 
 "#]])


### PR DESCRIPTION
### What does this PR try to resolve?

Passing a package to `--package` is for workspace members; we need to pass it to `--invert`.


### How to test and review this PR?

This is part of #14993

While I think we should instead improve the `cargo tree` command to help users with `--all-features`, we can at least take the other improvement from #14991.