### PR TITLE
docs(index): Clarify what we mean by omitting features

### DIFF
--- a/src/doc/src/reference/registry-index.md
+++ b/src/doc/src/reference/registry-index.md
@@ -139,7 +139,7 @@ explaining the format of the entry.
             // https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html.
             "req": "^0.6",
             // Array of features (as strings) enabled for this dependency.
-            // May be omitted since Cargo 1.84.
+            // Since Cargo 1.84, defaults to `[]` if not specified.
             "features": ["i128_support"],
             // Boolean of whether or not this is an optional dependency.
             // Since Cargo 1.84, defaults to `false` if not specified.
@@ -169,7 +169,7 @@ explaining the format of the entry.
     "cksum": "d867001db0e2b6e0496f9fac96930e2d42233ecd3ca0413e0753d4c7695d289c",
     // Set of features defined for the package.
     // Each feature maps to an array of features or dependencies it enables.
-    // May be omitted since Cargo 1.84.
+    // Since Cargo 1.84, defaults to `{}` if not specified.
     "features": {
         "extras": ["rand/simd_support"]
     },


### PR DESCRIPTION
### What does this PR try to resolve?

The current wording (from #14839) makes it sound like new Cargo doesn't care about the `features` entries when in reality Cargo does care still, the field is just defaulted.

Closes #15408
### How to test and review this PR?

