### PR TITLE
docs(resolver): Describe the role of the lockfile 

### DIFF
--- a/src/doc/src/reference/resolver.md
+++ b/src/doc/src/reference/resolver.md
@@ -204,6 +204,30 @@ ecosystem if you publish a SemVer-incompatible version of a popular library.
 [semver trick]: https://github.com/dtolnay/semver-trick
 [`downcast_ref`]: ../../std/any/trait.Any.html#method.downcast_ref
 
+### Lock file
+
+Cargo gives the highest priority to versions contained in the [`Cargo.lock` file], when used.
+This is intended to balance reproducible builds with adjusting to changes in the manifest.
+
+For example, if you had a package in the resolve graph with:
+```toml
+[dependencies]
+bitflags = "*"
+```
+If at the time your `Cargo.lock` file is generated, the greatest version of
+`bitflags` is `1.2.1`, then the package will use `1.2.1` and recorded in the `Cargo.lock` file.
+
+By the time Cargo next runs, `bitflags` `1.3.5` is out.
+When resolving dependencies,
+`1.2.1` will still be used because it is present in your `Cargo.lock` file.
+
+The package is then edited to:
+```toml
+[dependencies]
+bitflags = "1.3.0"
+```
+`bitflags` `1.2.1` does not match this version requirement and so that entry in your `Cargo.lock` file is ignored and version `1.3.5` will now be used and recorded in your `Cargo.lock` file.
+
 ### Rust version
 
 To support developing software with a minimum supported [Rust version],


### PR DESCRIPTION
### What does this PR try to resolve?

This fills a whole in our coverage of dependency resolution by specifying how a `Cargo.lock` impacts it.

### How to test and review this PR?

I put it after version numbers and version requirements as it builds on
those two topics.

Unsure whether this fully resolves the concern from #15587 of users
coming from other ecosystems that have been burned by library lockfiles
affecting them to know that they won't be subject to that.