### PR TITLE
chore: Skip check-version-bump ci job in forks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,6 +91,7 @@ jobs:
 
   check-version-bump:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'rust-lang'
     env:
       BASE_SHA: ${{ github.event.pull_request.base.sha }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha != '' && github.event.pull_request.head.sha || github.sha  }}


### PR DESCRIPTION
### What does this PR try to resolve?

I occasionally open PRs in my fork to test CI for work in progress changes. (Trying to avoid spamming notifications to the t-cargo members)
The `check-version-bump` job [makes assumptions](https://github.com/rust-lang/cargo/blob/master/crates/xtask-bump-check/src/xtask.rs#L326) that the fork has an up to date list of release tags.
My fork (and I am guessing most others) does not contain the release tags so this CI job fails, which is a minor papercut.

My solution is to only run `check-version-bump` in PRs to `rust-lang/cargo` and skip in forks.

### How to test and review this PR?

* Verify that the CI job runs in this PR. 
* I checked that job was skipped in my fork in https://github.com/ranger-ross/cargo/actions/runs/17678491699/job/50246604369?pr=8
