### PR TITLE
Remove extra apostrophe in environment-variables.md

### DIFF
--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -76,7 +76,7 @@ system:
   detail.
 * `TERM` --- If this is set to `dumb`, it disables the progress bar.
 * `BROWSER` --- The web browser to execute to open documentation with [`cargo
-  doc`]'s' `--open` flag, see [`doc.browser`] for more details.
+  doc`]'s `--open` flag, see [`doc.browser`] for more details.
 * `RUSTFMT` --- Instead of running `rustfmt`,
   [`cargo fmt`](https://github.com/rust-lang/rustfmt) will execute this specified
   `rustfmt` instance instead.


### PR DESCRIPTION
### What does this PR try to resolve?

I think this extra apostrophe is a typo and should be removed.