### PR TITLE
Don't warn about doctests when they're explicitly off

### DIFF
--- a/src/cargo/ops/cargo_compile/unit_generator.rs
+++ b/src/cargo/ops/cargo_compile/unit_generator.rs
@@ -415,13 +415,16 @@ impl<'a> UnitGenerator<'a, '_> {
                     for proposal in self.filter_targets(Target::is_lib, false, compile_mode) {
                         let Proposal { target, pkg, .. } = proposal;
                         if matches!(self.intent, UserIntent::Doctest) && !target.doctestable() {
-                            let types = target.rustc_crate_types();
-                            let types_str: Vec<&str> = types.iter().map(|t| t.as_str()).collect();
-                            self.ws.gctx().shell().warn(format!(
-                      "doc tests are not supported for crate type(s) `{}` in package `{}`",
-                      types_str.join(", "),
-                      pkg.name()
-                  ))?;
+                            if target.doctested() {
+                                let types = target.rustc_crate_types();
+                                let types_str: Vec<&str> =
+                                    types.iter().map(|t| t.as_str()).collect();
+                                self.ws.gctx().shell().warn(format!(
+                                    "doc tests are not supported for crate type(s) `{}` in package `{}`",
+                                    types_str.join(", "),
+                                    pkg.name()
+                                ))?;
+                            }
                         } else {
                             libs.push(proposal)
                         }

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -4572,6 +4572,50 @@ fn doctest_skip_staticlib() {
 }
 
 #[cargo_test]
+fn no_doctest_warning_when_explicitly_disabled() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                edition = "2015"
+
+                [lib]
+                crate-type = ["staticlib"]
+                doctest = false
+            "#,
+        )
+        .file(
+            "src/lib.rs",
+            r#"
+            //! ```
+            //! assert_eq!(1,2);
+            //! ```
+            "#,
+        )
+        .build();
+
+    p.cargo("test --doc")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] no library targets found in package `foo`
+
+"#]])
+        .run();
+
+    p.cargo("test")
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn can_not_mix_doc_tests_and_regular_tests() {
     let p = project()
         .file(


### PR DESCRIPTION
Fixes https://github.com/rust-lang/cargo/issues/15964

### What does this PR try to resolve?

Some crate types such as `staticlib` and `cdylib` don't support doctests.

`cargo test --doc` currently warns if run against these packages, which is reasonable. However, there's no way to silence/acknowledge the warning.

With this patch, the warning isn't shown if the target has explicitly set `doctests = false`.

This lets you run `cargo test --doc --workspace` without persistent warnings about packages with targets of types that don't support doctests. 

### How to test and review this PR?

Hopefully it's obvious from the test case added; see also the nearby `doctest_skip_staticlib` showing the warning is still emitted in the default case. 