### PR TITLE
fix: wrong variable name in documentation

### DIFF
--- a/src/doc/src/reference/resolver.md
+++ b/src/doc/src/reference/resolver.md
@@ -24,7 +24,7 @@ This pseudo-code approximates what Cargo's resolver does:
 pub fn resolve(workspace: &[Package], policy: Policy) -> Option<ResolveGraph> {
     let dep_queue = Queue::new(workspace);
     let resolved = ResolveGraph::new();
-    resolve_next(pkq_queue, resolved, policy)
+    resolve_next(dep_queue, resolved, policy)
 }
 
 fn resolve_next(dep_queue: Queue, resolved: ResolveGraph, policy: Policy) -> Option<ResolveGraph> {


### PR DESCRIPTION
Within a function in the _Constraints and Heuristics_ section, a variable `pkg_queue` was used, which does not exist. I replaced it with similiarly named `dep_queue`, as I believe that is what was meant.