### PR TITLE
Adds ghostty as supported terminal for term integration (OSC 9;4)

### DIFF
--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -596,8 +596,9 @@ fn supports_term_integration(stream: &dyn IsTerminal) -> bool {
     let windows_terminal = std::env::var("WT_SESSION").is_ok();
     let conemu = std::env::var("ConEmuANSI").ok() == Some("ON".into());
     let wezterm = std::env::var("TERM_PROGRAM").ok() == Some("WezTerm".into());
+    let ghostty = std::env::var("TERM_PROGRAM").ok() == Some("ghostty".into());
 
-    (windows_terminal || conemu || wezterm) && stream.is_terminal()
+    (windows_terminal || conemu || wezterm || ghostty) && stream.is_terminal()
 }
 
 pub struct Hyperlink<D: fmt::Display> {


### PR DESCRIPTION
### What does this PR try to resolve?

Adds ghostty to the list of terminals that support OSC 9;4
This is supported as of Ghostty 1.2.0 (released on September 15, 2025)

https://ghostty.org/docs/install/release-notes/1-2-0#graphical-progress-bars

### How to test and review this PR?

I just compiled cargo, then used the new cargo to try to build the repo (with another target so it actually compiled)
Ex:
`./target/debug/cargo build --target aarch64-apple-ios`

The progress bar can be seen in the top of the terminal:
<img width="833" height="585" alt="image" src="https://github.com/user-attachments/assets/494a03fe-c337-4935-9ac3-0b0144f47b2f" />
