### PR TITLE
fix: Sparse URLs in `TomlLockfileSourceId`

### DIFF
--- a/crates/cargo-util-schemas/src/lockfile.rs
+++ b/crates/cargo-util-schemas/src/lockfile.rs
@@ -109,9 +109,13 @@ impl TomlLockfileSourceId {
             EncodableSourceIdError(EncodableSourceIdErrorKind::InvalidSource(source.clone()).into())
         })?;
 
-        let url = Url::parse(url).map_err(|msg| EncodableSourceIdErrorKind::InvalidUrl {
-            url: url.to_string(),
-            msg: msg.to_string(),
+        // Sparse URLs store the kind prefix (sparse+) in the URL. Therefore, for sparse kinds, we
+        // want to use the raw `source` instead of the splitted `url`.
+        let url = Url::parse(if kind == "sparse" { &source } else { url }).map_err(|msg| {
+            EncodableSourceIdErrorKind::InvalidUrl {
+                url: url.to_string(),
+                msg: msg.to_string(),
+            }
         })?;
 
         let kind = match kind {


### PR DESCRIPTION
### What does this PR try to resolve?

Sparse registries have their IDs prefixed with their kind (sparse+). This PR fixes the current implementation of `TomlLockfileSourceId` where it incorrectly splits the kind and URL for sparse registries.

This change itself shouldn't affect cargo. It does, however, affect users of `cargo-util-schemas`, i.e. cargo plumbing commands. See https://github.com/crate-ci/cargo-plumbing/pull/111

### How to test and review this PR?

Verify how source IDs are made, especially their URLs.