### PR TITLE
Public in private manifest errors

### DIFF
--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -1105,6 +1105,10 @@ impl<'gctx> RustcTargetData<'gctx> {
         }
         unsupported
     }
+
+    pub fn requested_kinds(&self) -> &[CompileKind] {
+        &self.requested_kinds
+    }
 }
 
 /// Structure used to deal with Rustdoc fingerprinting

--- a/src/cargo/util/lints.rs
+++ b/src/cargo/util/lints.rs
@@ -3,6 +3,7 @@ use crate::{CargoResult, GlobalContext};
 use annotate_snippets::{AnnotationKind, Group, Level, Snippet};
 use cargo_util_schemas::manifest::{TomlLintLevel, TomlToolLints};
 use pathdiff::diff_paths;
+use std::borrow::Cow;
 use std::fmt::Display;
 use std::ops::Range;
 use std::path::Path;
@@ -182,20 +183,20 @@ pub struct TomlSpan {
     pub value: Range<usize>,
 }
 
-pub fn get_key_value_span(
-    document: &toml::Spanned<toml::de::DeTable<'static>>,
+pub fn get_key_value<'doc>(
+    document: &'doc toml::Spanned<toml::de::DeTable<'static>>,
     path: &[&str],
-) -> Option<TomlSpan> {
+) -> Option<(
+    &'doc toml::Spanned<Cow<'doc, str>>,
+    &'doc toml::Spanned<toml::de::DeValue<'static>>,
+)> {
     let mut table = document.get_ref();
     let mut iter = path.into_iter().peekable();
     while let Some(key) = iter.next() {
         let key_s: &str = key.as_ref();
         let (key, item) = table.get_key_value(key_s)?;
         if iter.peek().is_none() {
-            return Some(TomlSpan {
-                key: key.span(),
-                value: item.span(),
-            });
+            return Some((key, item));
         }
         if let Some(next_table) = item.get_ref().as_table() {
             table = next_table;
@@ -204,16 +205,23 @@ pub fn get_key_value_span(
             if let Some(array) = item.get_ref().as_array() {
                 let next = iter.next().unwrap();
                 return array.iter().find_map(|item| match item.get_ref() {
-                    toml::de::DeValue::String(s) if s == next => Some(TomlSpan {
-                        key: key.span(),
-                        value: item.span(),
-                    }),
+                    toml::de::DeValue::String(s) if s == next => Some((key, item)),
                     _ => None,
                 });
             }
         }
     }
     None
+}
+
+pub fn get_key_value_span(
+    document: &toml::Spanned<toml::de::DeTable<'static>>,
+    path: &[&str],
+) -> Option<TomlSpan> {
+    get_key_value(document, path).map(|(k, v)| TomlSpan {
+        key: k.span(),
+        value: v.span(),
+    })
 }
 
 /// Gets the relative path to a manifest from the current working directory, or

--- a/tests/testsuite/pub_priv.rs
+++ b/tests/testsuite/pub_priv.rs
@@ -728,12 +728,22 @@ fn manifest_location() {
   |                     ^^^^^^^^^^^^^^^^^^
   |
   = [NOTE] `#[warn(exported_private_dependencies)]` on by default
+[NOTE] dependency `priv_dep` declared here
+ --> Cargo.toml:9:17
   |
+9 |                 priv_dep = "0.1.0"
+  |                 --------
 
 [WARNING] type `FromDep` from private dependency 'dep' in public interface
  --> src/lib.rs:4:13
+  |
 4 |             pub fn use_dep(_: dep::FromDep) {}
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[NOTE] dependency `dep` declared here
+ --> Cargo.toml:8:17
+  |
+8 |                 dep = "0.1.0"
+  |                 ---
 ...
 "#]]
             .unordered(),
@@ -786,13 +796,22 @@ fn renamed_dependency() {
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = [NOTE] `#[warn(exported_private_dependencies)]` on by default
-
+[NOTE] dependency `dep` declared here
+ --> Cargo.toml:8:54
   |
+8 |                 dep = { version = "0.1.0", package = "dep" }
+  |                                                      -----
+
 [WARNING] type `FromPriv` from private dependency 'priv_dep' in public interface
  --> src/lib.rs:5:13
+  |
 5 |             pub fn use_priv(_: renamed_dep::FromPriv) {}
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
+[NOTE] dependency `priv_dep` declared here
+ --> Cargo.toml:9:61
+  |
+9 |                 renamed_dep = {version = "0.1.0", package = "priv_dep" }
+  |                                                             ----------
 ...
 "#]]
             .unordered(),
@@ -922,12 +941,22 @@ fn dependency_location_in_target_table() {
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = [NOTE] `#[warn(exported_private_dependencies)]` on by default
+[NOTE] dependency `dep` declared here
+ --> Cargo.toml:8:17
   |
+8 |                 dep = { version = "0.1.0" }
+  |                 ---
 
 [WARNING] type `FromPriv` from private dependency 'native_priv_dep' in public interface
  --> src/lib.rs:5:13
+  |
 5 |             pub fn use_priv(_: renamed_dep::FromPriv) {}
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[NOTE] dependency `native_priv_dep` declared here
+ --> Cargo.toml:9:62
+  |
+9 |                 renamed_dep = { version = "0.1.0", package = "native_priv_dep" }
+  |                                                              -----------------
 ...
 "#]]
             .unordered(),
@@ -946,12 +975,22 @@ fn dependency_location_in_target_table() {
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = [NOTE] `#[warn(exported_private_dependencies)]` on by default
+[NOTE] dependency `dep` declared here
+  --> Cargo.toml:12:17
+   |
+12 |                 dep = { version = "0.1.0" }
+   |                 ---
 
 [WARNING] type `FromPriv` from private dependency 'alt_priv_dep' in public interface
  --> src/lib.rs:5:13
   |
 5 |             pub fn use_priv(_: renamed_dep::FromPriv) {}
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[NOTE] dependency `alt_priv_dep` declared here
+  --> Cargo.toml:13:62
+   |
+13 |                 renamed_dep = { version = "0.1.0", package = "alt_priv_dep" }
+   |                                                              --------------
 ...
 "#]]
             .unordered(),
@@ -1020,12 +1059,22 @@ fn dependency_location_in_target_table_with_cfg() {
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = [NOTE] `#[warn(exported_private_dependencies)]` on by default
+[NOTE] dependency `dep` declared here
+ --> Cargo.toml:8:17
   |
+8 |                 dep = { version = "0.1.0" }
+  |                 ---
 
 [WARNING] type `FromPriv` from private dependency 'native_priv_dep' in public interface
  --> src/lib.rs:5:13
+  |
 5 |             pub fn use_priv(_: renamed_dep::FromPriv) {}
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[NOTE] dependency `native_priv_dep` declared here
+ --> Cargo.toml:9:62
+  |
+9 |                 renamed_dep = { version = "0.1.0", package = "native_priv_dep" }
+  |                                                              -----------------
 ...
 "#]]
             .unordered(),
@@ -1044,12 +1093,22 @@ fn dependency_location_in_target_table_with_cfg() {
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = [NOTE] `#[warn(exported_private_dependencies)]` on by default
+[NOTE] dependency `dep` declared here
+  --> Cargo.toml:12:17
+   |
+12 |                 dep = { version = "0.1.0" }
+   |                 ---
 
 [WARNING] type `FromPriv` from private dependency 'alt_priv_dep' in public interface
  --> src/lib.rs:5:13
   |
 5 |             pub fn use_priv(_: renamed_dep::FromPriv) {}
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[NOTE] dependency `alt_priv_dep` declared here
+  --> Cargo.toml:13:62
+   |
+13 |                 renamed_dep = { version = "0.1.0", package = "alt_priv_dep" }
+   |                                                              --------------
 ...
 "#]]
             .unordered(),
@@ -1153,6 +1212,12 @@ fn relative_display_path() {
 3 |             pub use priv_dep::FromPriv;
   |                     ^^^^^^^^^^^^^^^^^^
   |
+  = [NOTE] `#[warn(exported_private_dependencies)]` on by default
+[NOTE] dependency `priv_dep` declared here
+ --> foo/Cargo.toml:8:17
+  |
+8 |                 priv_dep = "0.1.0"
+  |                 --------
 ...
 "#]])
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

This is a stab at #13096, adding Cargo.toml context to public-in-private errors. It intercepts public-in-private warnings from rustc and modifies them by adding a little context.

I had a bit of difficulty with renamed crates (like, `foo_renamed = { version = "0.1.0", package = "foo" }`). Surprisingly for me, rustc's errors mention the original package name (foo) and not the renamed one (foo_renamed), even though the renamed one is that one that's guaranteed unique. This PR does its best to figure out which package is the one being referred to, but if there's non-uniqueness involved then it just gives up and doesn't provide context.
