### PR TITLE
test(build-std): move away from panic_immediate_abort 

### DIFF
--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -396,7 +396,9 @@ fn test_proc_macro() {
 }
 
 #[cargo_test(build_std_real)]
-fn test_panic_abort() {
+fn default_features_still_included_with_extra_build_std_features() {
+    // This is a regression test to ensure when adding extra `build-std-features`,
+    // the default feature set is still respected and included.
     // See rust-lang/cargo#14935
     let p = project()
         .file(
@@ -413,7 +415,7 @@ fn test_panic_abort() {
     p.cargo("check")
         .build_std_arg("std,panic_abort")
         .env("RUSTFLAGS", "-C panic=abort")
-        .arg("-Zbuild-std-features=panic_immediate_abort")
+        .arg("-Zbuild-std-features=optimize_for_size")
         .run();
 }
 


### PR DESCRIPTION
### What does this PR try to resolve?

The test exercises a regression of extra `-Zbuild-std-features`
overriding the entire default-features set.
However, after rust-lang/rust#146317 panic_immediate_abort
became a codegen flag not a Cargo feature anymore.
We pick another `optimize_for_size` feature flag to ensure the
regression case is still covered.

### How to test and review this PR?

To verify `optimize_for_size` actually triggers the regression,
git revert f004691aa41449fa06b764683385558edee51428
and changes to `-Zbuild-std-features=optimize_for_size`.

Alternatively, we can just drop this test.
