### PR TITLE
Make get requests Unauthorized

### DIFF
--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -376,7 +376,7 @@ impl Registry {
 
     fn get(&mut self, path: &str) -> Result<String> {
         self.handle.get(true)?;
-        self.req(path, None, Auth::Authorized)
+        self.req(path, None, Auth::Unauthorized)
     }
 
     fn delete(&mut self, path: &str, b: Option<&[u8]>) -> Result<String> {


### PR DESCRIPTION
### Problem

list_owners calls `self.get`: https://github.com/rust-lang/cargo/blob/113761f27a8a9cff35540a291dd4f06cc0ad6e2c/crates/crates-io/lib.rs#L259-L262

Which, surprisingly, is configured to send `Auth::Authorized`:
https://github.com/rust-lang/cargo/blob/113761f27a8a9cff35540a291dd4f06cc0ad6e2c/crates/crates-io/lib.rs#L377-L380

But the endpoint does _not_ require auth:
https://crates.io/api/v1/crates/serde/owners

Fixes #16007