### PR TITLE
chore: bump to 0.93.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "cargo"
-version = "0.92.0"
+version = "0.93.0"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ self_named_module_files = "warn"
 
 [package]
 name = "cargo"
-version = "0.92.0"
+version = "0.93.0"
 edition.workspace = true
 license.workspace = true
 rust-version = "1.90"  # MSRV:1


### PR DESCRIPTION
Extract from rust-lang/cargo#15986