### PR TITLE
test(docker): openssh requires a newer libcrypto3

### DIFF
--- a/crates/cargo-test-support/containers/sshd/Dockerfile
+++ b/crates/cargo-test-support/containers/sshd/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.22
 
 RUN apk add --no-cache openssh git
+RUN apk upgrade --no-cache libcrypto3
 RUN ssh-keygen -A
 
 RUN addgroup -S testuser && adduser -S testuser -G testuser -s /bin/ash


### PR DESCRIPTION
### What does this PR try to resolve?

libcrypto3 is required because openssh-10.0_p1-r8 needs a newer
version of libcrypto3 (3.5.3-r1 as of this writing).
However, the pre-installed one on the image is 3.3.2-r4,
and the one the registry is 3.5.1-r0
Hence an `apk upgrade` is required.
We should remove this someday when upstream fixes it.

Also, I've tried `alpine:edge`,
but edge hasn't yet upgrade the pre-installed libssl3 nor the registry

### How to test and review this PR?

To repro what I found:

```console
/ # apk info openssh
openssh-10.0_p1-r8 description:
Port of OpenBSD's free SSH release

openssh-10.0_p1-r8 webpage:
https://www.openssh.com/portable.html

openssh-10.0_p1-r8 installed size:
330 KiB

/ # apk info -R openssh
openssh-10.0_p1-r8 depends on:
openssh-client
openssh-sftp-server
openssh-server
so:libc.musl-x86_64.so.1
so:libcrypto.so.3

/ # apk info libcrypto3
libcrypto3-3.5.1-r0 description:
Crypto library from openssl

libcrypto3-3.5.1-r0 webpage:
https://www.openssl.org/

libcrypto3-3.5.1-r0 installed size:
5091 KiB

libcrypto3-3.5.3-r0 description:
Crypto library from openssl

libcrypto3-3.5.3-r0 webpage:
https://www.openssl.org/

libcrypto3-3.5.3-r0 installed size:
5091 KiB

/ # strings /usr/lib/libcrypto.so.3 | grep -i "OpenSSL"
...
OpenSSL 3.5.1 1 Jul 2025
...
```
