### PR TITLE
feat(publish): idempotent workspace publish

### DIFF
--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -4038,10 +4038,28 @@ Caused by:
     // Publishing the whole workspace now will fail, as `a` is already published.
     p.cargo("publish")
         .replace_crates_io(registry.index_url())
-        .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] crates.io index
-[ERROR] crate a@0.0.1 already exists on crates.io index
+[WARNING] crate a@0.0.1 already exists on crates.io index
+[PACKAGING] a v0.0.1 ([ROOT]/foo/a)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGING] b v0.0.1 ([ROOT]/foo/b)
+[UPDATING] crates.io index
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[VERIFYING] a v0.0.1 ([ROOT]/foo/a)
+[COMPILING] a v0.0.1 ([ROOT]/foo/target/package/a-0.0.1)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[VERIFYING] b v0.0.1 ([ROOT]/foo/b)
+[UNPACKING] a v0.0.1 (registry `[ROOT]/foo/target/package/tmp-registry`)
+[COMPILING] a v0.0.1
+[COMPILING] b v0.0.1 ([ROOT]/foo/target/package/b-0.0.1)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[WARNING] skipping upload for crate a@0.0.1: already exists on crates.io index
+[UPLOADING] b v0.0.1 ([ROOT]/foo/b)
+[UPLOADED] b v0.0.1 to registry `crates-io`
+[NOTE] waiting for b v0.0.1 to be available at registry `crates-io`
+[HELP] you may press ctrl-c to skip waiting; the crate should be available shortly
+[PUBLISHED] b v0.0.1 at registry `crates-io`
 
 "#]])
         .run();
@@ -4476,10 +4494,16 @@ fn all_published_packages() {
     // Publishing all members again works
     p.cargo("publish --workspace --no-verify")
         .replace_crates_io(registry.index_url())
-        .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] crates.io index
-[ERROR] crate foo@0.0.0 already exists on crates.io index
+[WARNING] crate foo@0.0.0 already exists on crates.io index
+[WARNING] crate bar@0.0.0 already exists on crates.io index
+[PACKAGING] bar v0.0.0 ([ROOT]/foo/bar)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGING] foo v0.0.0 ([ROOT]/foo/foo)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[WARNING] skipping upload for crate bar@0.0.0: already exists on crates.io index
+[WARNING] skipping upload for crate foo@0.0.0: already exists on crates.io index
 
 "#]])
         .run();
@@ -4487,10 +4511,16 @@ fn all_published_packages() {
     // Without `--workspace` works as it is a virtual workspace
     p.cargo("publish --no-verify")
         .replace_crates_io(registry.index_url())
-        .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] crates.io index
-[ERROR] crate foo@0.0.0 already exists on crates.io index
+[WARNING] crate foo@0.0.0 already exists on crates.io index
+[WARNING] crate bar@0.0.0 already exists on crates.io index
+[PACKAGING] bar v0.0.0 ([ROOT]/foo/bar)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGING] foo v0.0.0 ([ROOT]/foo/foo)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[WARNING] skipping upload for crate bar@0.0.0: already exists on crates.io index
+[WARNING] skipping upload for crate foo@0.0.0: already exists on crates.io index
 
 "#]])
         .run();
@@ -4502,7 +4532,14 @@ fn all_published_packages() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] crates.io index
-[ERROR] crate foo@0.0.0 already exists on crates.io index
+[WARNING] crate foo@0.0.0 already exists on crates.io index
+[WARNING] crate bar@0.0.0 already exists on crates.io index
+[PACKAGING] bar v0.0.0 ([ROOT]/foo/bar)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGING] foo v0.0.0 ([ROOT]/foo/foo)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[ERROR] crate bar@0.0.0 already exists on crates.io index but tarball checksum mismatched
+perhaps local files have changed but forgot to bump the version?
 
 "#]])
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

Before this, `cargo publish --workspace` would fail
if any member packages were already published.

After this, it skips already published packages
and continues with the rest.

To make sure the local package is really published,
we verify the checksum of the newly packed `.crate` tarball
against the checksum from the registry index.
This helps catch cases where the package contents changed
but the version wasn’t bumped,
which would otherwise be treated as already published.

fixes rust-lang/cargo#13397

### How to test and review this PR?

Need discussions, FCP, and maybe an unstable flag.

Some other design questions:

* Is this a breaking change to `--workspace` publish?
* We might want to skip `--verify` for already published packages.
* Better diagnostics.
