### PR TITLE
chore(ci): add rustfmt for docs job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -277,6 +277,7 @@ jobs:
     - run: rustup update nightly && rustup default nightly
     - run: rustup update stable
     - run: rustup component add rust-docs
+    - run: rustup component add rustfmt --toolchain stable
     - run: ci/validate-man.sh
     # This requires rustfmt, use stable.
     - name: Run semver-check


### PR DESCRIPTION
### What does this PR try to resolve?

Unclear why it wasn't missing before.

The line was added five years ago.
Seems it should be available.
https://github.com/actions/runner-images/blob/75ec4229/images/ubuntu/scripts/build/install-rust.sh#L19-L20

Maybe due to recent pin/unpin 1.89 issue?
https://github.com/actions/runner-images/commit/69c94f5b

### How to test and review this PR?

Job passes.