### PR TITLE
Add retry for `git fetch` failures in `CARGO_NET_GIT_FETCH_WITH_CLI` path

### DIFF
--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -339,6 +339,46 @@ impl From<std::io::Error> for CliError {
 }
 
 // =============================================================================
+// Git CLI errors
+
+pub type GitCliResult = Result<(), GitCliError>;
+
+/// An error that occurred while invoking the `git` command-line tool.
+///
+/// This is used for errors from Git operations performed via CLI.
+/// It wraps a lower-level error and indicates whether the failure
+/// should be considered *spurious*.
+///
+/// Spurious failures might involve retry mechanism.
+#[derive(Debug)]
+pub struct GitCliError {
+    inner: Error,
+    is_spurious: bool,
+}
+
+impl GitCliError {
+    pub fn new(inner: Error, is_spurious: bool) -> GitCliError {
+        GitCliError { inner, is_spurious }
+    }
+
+    pub fn is_spurious(&self) -> bool {
+        self.is_spurious
+    }
+}
+
+impl std::error::Error for GitCliError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.inner.source()
+    }
+}
+
+impl fmt::Display for GitCliError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+// =============================================================================
 // Construction helpers
 
 pub fn internal<S: fmt::Display>(error: S) -> anyhow::Error {

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -4092,6 +4092,12 @@ fn github_fastpath_error_message() {
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `https://github.com/rust-lang/bitflags.git`
 fatal: remote [ERROR] upload-pack: not our ref 11111b376b93484341c68fbca3ca110ae5cd2790
+[WARNING] spurious network error (3 tries remaining): process didn't exit successfully: `git fetch --no-tags --force --update-head-ok [..]
+fatal: remote [ERROR] upload-pack: not our ref 11111b376b93484341c68fbca3ca110ae5cd2790
+[WARNING] spurious network error (2 tries remaining): process didn't exit successfully: `git fetch --no-tags --force --update-head-ok [..]
+fatal: remote [ERROR] upload-pack: not our ref 11111b376b93484341c68fbca3ca110ae5cd2790
+[WARNING] spurious network error (1 try remaining): process didn't exit successfully: `git fetch --no-tags --force --update-head-ok [..]
+fatal: remote [ERROR] upload-pack: not our ref 11111b376b93484341c68fbca3ca110ae5cd2790
 [ERROR] failed to get `bitflags` as a dependency of package `foo v0.1.0 ([ROOT]/foo)`
 
 Caused by:


### PR DESCRIPTION
### What does this PR try to resolve?

https://github.com/rust-lang/cargo/issues/15856

This PR addresses transient failures when using the `CARGO_NET_GIT_FETCH_WITH_CLI`
path by adding support for marking process failures as *spurious* and enabling
retries for `git fetch`.


#### Changes
- Introduce a new error wrap `GitCliError` with `is_spurious` meta information.
- Update the `CARGO_NET_GIT_FETCH_WITH_CLI` code path to mark `git fetch` as
  spurious and retry on failure

### How to test and review this PR?

A test project:

```toml
# ...
[dependencies]
my-dep = { git = "http://localhost:9999" }
```

```bash
CARGO_NET_GIT_FETCH_WITH_CLI=true cargo build
```
