### PR TITLE
fix(shell): Use a distinct style for transient status

### DIFF
--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -168,7 +168,7 @@ impl Shell {
         self.print(&status, Some(&message), &HEADER, true)
     }
 
-    pub fn status_header<T>(&mut self, status: T) -> CargoResult<()>
+    pub fn transient_status<T>(&mut self, status: T) -> CargoResult<()>
     where
         T: fmt::Display,
     {

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -172,7 +172,7 @@ impl Shell {
     where
         T: fmt::Display,
     {
-        self.print(&status, None, &NOTE, true)
+        self.print(&status, None, &TRANSIENT, true)
     }
 
     /// Shortcut to right-align a status message.

--- a/src/cargo/util/progress.rs
+++ b/src/cargo/util/progress.rs
@@ -429,7 +429,7 @@ impl<'gctx> State<'gctx> {
         if self.gctx.shell().is_cleared() || self.last_line.as_ref() != Some(&line) {
             let mut shell = self.gctx.shell();
             shell.set_needs_clear(false);
-            shell.status_header(&self.name)?;
+            shell.transient_status(&self.name)?;
             if let Some(tb) = report {
                 write!(shell.err(), "{line}{tb}\r")?;
             } else {

--- a/src/cargo/util/style.rs
+++ b/src/cargo/util/style.rs
@@ -11,4 +11,4 @@ pub const NOTE: Style = annotate_snippets::renderer::DEFAULT_NOTE_STYLE;
 pub const GOOD: Style = AnsiColor::BrightGreen.on_default().effects(Effects::BOLD);
 pub const VALID: Style = AnsiColor::BrightCyan.on_default().effects(Effects::BOLD);
 pub const INVALID: Style = annotate_snippets::renderer::DEFAULT_WARNING_STYLE;
-pub const TRANSIENT: Style = NOTE;
+pub const TRANSIENT: Style = annotate_snippets::renderer::DEFAULT_HELP_STYLE;

--- a/src/cargo/util/style.rs
+++ b/src/cargo/util/style.rs
@@ -11,3 +11,4 @@ pub const NOTE: Style = annotate_snippets::renderer::DEFAULT_NOTE_STYLE;
 pub const GOOD: Style = AnsiColor::BrightGreen.on_default().effects(Effects::BOLD);
 pub const VALID: Style = AnsiColor::BrightCyan.on_default().effects(Effects::BOLD);
 pub const INVALID: Style = annotate_snippets::renderer::DEFAULT_WARNING_STYLE;
+pub const TRANSIENT: Style = NOTE;


### PR DESCRIPTION
### What does this PR try to resolve?

PR #15928 made `Checking` and `Building` the same style because the
transient state is `note:` and #15928 made `note:~ the same as our
regular headers.

This switches the transient state to `help:` until we can further
explore color choices with rustc.



### Notes

See also https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/colors.20removed.20in.201.2E91.20.28current.20beta.29.3F/near/541900531