### PR TITLE
Fix: avoid -C prefer-dynamic for test harnesses of proc-macro crates

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1214,9 +1214,12 @@ fn build_base_args(
             cmd.arg("--emit=dep-info,link");
         }
     }
+    let prefer_dynamic =
+        (unit.target.for_host() && !unit.target.is_custom_build())
+        || (contains_dy_lib
+            && !build_runner.is_primary_package(unit)
+            && !unit.mode.is_any_test());
 
-    let prefer_dynamic = (unit.target.for_host() && !unit.target.is_custom_build())
-        || (contains_dy_lib && !build_runner.is_primary_package(unit));
     if prefer_dynamic {
         cmd.arg("-C").arg("prefer-dynamic");
     }

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1214,7 +1214,7 @@ fn build_base_args(
             cmd.arg("--emit=dep-info,link");
         }
     }
-    
+
     let prefer_dynamic = (unit.target.for_host() && !unit.target.is_custom_build())
         || (contains_dy_lib && !build_runner.is_primary_package(unit) && !unit.mode.is_any_test());
 

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1214,11 +1214,9 @@ fn build_base_args(
             cmd.arg("--emit=dep-info,link");
         }
     }
-    let prefer_dynamic =
-        (unit.target.for_host() && !unit.target.is_custom_build())
-        || (contains_dy_lib
-            && !build_runner.is_primary_package(unit)
-            && !unit.mode.is_any_test());
+    
+    let prefer_dynamic = (unit.target.for_host() && !unit.target.is_custom_build())
+        || (contains_dy_lib && !build_runner.is_primary_package(unit) && !unit.mode.is_any_test());
 
     if prefer_dynamic {
         cmd.arg("-C").arg("prefer-dynamic");


### PR DESCRIPTION
Fixes [#16000](https://github.com/rust-lang/cargo/issues/16000).

When running `cargo test --no-run` on a proc-macro crate with a dev-dependency on a `dylib`, Cargo was incorrectly passing `-C prefer-dynamic` to the **test harness**.

That caused rustc to try to link both `rlib` and `dylib` forms of `std` and its transitive crates, resulting in errors like:

```
error: cannot satisfy dependencies so `std` only shows up once
```

#### What changed

* Adjusted the logic in `core/compiler` so that `-C prefer-dynamic` is only applied when compiling an actual proc-macro crate.
* Test harnesses (even for proc-macro crates) no longer receive `-C prefer-dynamic`.

#### Why

This resolves the duplicate `std/core/alloc` linkage errors and makes `cargo test --no-run` consistent with `cargo build`.