### PR TITLE
fix: remove FIXME comment that's no longer a problem

### DIFF
--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -342,9 +342,6 @@ fn custom_runner_env() {
     p.cargo("run")
         .env(&key, "nonexistent-runner --foo")
         .with_status(101)
-        // FIXME: Update "Caused by" error message once rust/pull/87704 is merged.
-        // On Windows, changing to a custom executable resolver has changed the
-        // error messages.
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s


### PR DESCRIPTION
The `FIXME` comment in the tool_paths test is no longer a problem. Not only the mentioned PR is already merged, but also this comment was originally written in #10092 which is  before [migration from bespoke to snapbox](https://github.com/rust-lang/cargo/issues/14039). Since current cargo-test-support implementation (after the migration) abstracts error messages [here](https://github.com/rust-lang/cargo/blob/e3db2dcc3e85b00529354fb15de7612ad2c446fa/crates/cargo-test-support/src/compare.rs#L260), I believe this comment is safe to be removed.
