### PR TITLE
[beta-1.91] fix: use `host-tuple` for host target subsitution

### DIFF
--- a/src/cargo/core/compiler/compile_kind.rs
+++ b/src/cargo/core/compiler/compile_kind.rs
@@ -87,10 +87,10 @@ impl CompileKind {
             let deduplicated_targets = targets
                 .iter()
                 .map(|value| {
-                    // This neatly substitutes the manually-specified `host` target directive
+                    // This neatly substitutes the manually-specified `host-tuple` target directive
                     // with the compiling machine's target triple.
 
-                    if value.as_str() == "host" {
+                    if value.as_str() == "host-tuple" {
                         let host_triple = env!("RUST_HOST_TARGET");
                         Ok(CompileKind::Target(CompileTarget::new(host_triple)?))
                     } else {

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -1260,10 +1260,12 @@ fn get_target_triples() -> Vec<clap_complete::CompletionCandidate> {
         }
     }
 
-    // Allow tab-completion for `host` as the desired target.
-    candidates.push(clap_complete::CompletionCandidate::new("host").help(Some(
-        concat!("alias for: ", env!("RUST_HOST_TARGET")).into(),
-    )));
+    // Allow tab-completion for `host-tuple` as the desired target.
+    candidates.push(
+        clap_complete::CompletionCandidate::new("host-tuple").help(Some(
+            concat!("alias for: ", env!("RUST_HOST_TARGET")).into(),
+        )),
+    );
 
     candidates
 }

--- a/src/doc/man/generated_txt/cargo-bench.txt
+++ b/src/doc/man/generated_txt/cargo-bench.txt
@@ -228,8 +228,8 @@ OPTIONS
 
            o  Any supported target in rustc --print target-list.
 
-           o  "host", which will internally be substituted by the host’s
-              target. This can be particularly useful if you’re
+           o  "host-tuple", which will internally be substituted by the
+              host’s target. This can be particularly useful if you’re
               cross-compiling some crates, and don’t want to specify your
               host’s machine as a target (for instance, an xtask in a shared
               project that may be worked on by many hosts).

--- a/src/doc/man/generated_txt/cargo-build.txt
+++ b/src/doc/man/generated_txt/cargo-build.txt
@@ -145,8 +145,8 @@ OPTIONS
 
            o  Any supported target in rustc --print target-list.
 
-           o  "host", which will internally be substituted by the host’s
-              target. This can be particularly useful if you’re
+           o  "host-tuple", which will internally be substituted by the
+              host’s target. This can be particularly useful if you’re
               cross-compiling some crates, and don’t want to specify your
               host’s machine as a target (for instance, an xtask in a shared
               project that may be worked on by many hosts).

--- a/src/doc/man/generated_txt/cargo-check.txt
+++ b/src/doc/man/generated_txt/cargo-check.txt
@@ -142,8 +142,8 @@ OPTIONS
 
            o  Any supported target in rustc --print target-list.
 
-           o  "host", which will internally be substituted by the host’s
-              target. This can be particularly useful if you’re
+           o  "host-tuple", which will internally be substituted by the
+              host’s target. This can be particularly useful if you’re
               cross-compiling some crates, and don’t want to specify your
               host’s machine as a target (for instance, an xtask in a shared
               project that may be worked on by many hosts).

--- a/src/doc/man/generated_txt/cargo-clean.txt
+++ b/src/doc/man/generated_txt/cargo-clean.txt
@@ -53,8 +53,8 @@ OPTIONS
 
            o  Any supported target in rustc --print target-list.
 
-           o  "host", which will internally be substituted by the host’s
-              target. This can be particularly useful if you’re
+           o  "host-tuple", which will internally be substituted by the
+              host’s target. This can be particularly useful if you’re
               cross-compiling some crates, and don’t want to specify your
               host’s machine as a target (for instance, an xtask in a shared
               project that may be worked on by many hosts).

--- a/src/doc/man/generated_txt/cargo-doc.txt
+++ b/src/doc/man/generated_txt/cargo-doc.txt
@@ -124,8 +124,8 @@ OPTIONS
 
            o  Any supported target in rustc --print target-list.
 
-           o  "host", which will internally be substituted by the host’s
-              target. This can be particularly useful if you’re
+           o  "host-tuple", which will internally be substituted by the
+              host’s target. This can be particularly useful if you’re
               cross-compiling some crates, and don’t want to specify your
               host’s machine as a target (for instance, an xtask in a shared
               project that may be worked on by many hosts).

--- a/src/doc/man/generated_txt/cargo-fetch.txt
+++ b/src/doc/man/generated_txt/cargo-fetch.txt
@@ -33,8 +33,8 @@ OPTIONS
 
            o  Any supported target in rustc --print target-list.
 
-           o  "host", which will internally be substituted by the host’s
-              target. This can be particularly useful if you’re
+           o  "host-tuple", which will internally be substituted by the
+              host’s target. This can be particularly useful if you’re
               cross-compiling some crates, and don’t want to specify your
               host’s machine as a target (for instance, an xtask in a shared
               project that may be worked on by many hosts).

--- a/src/doc/man/generated_txt/cargo-fix.txt
+++ b/src/doc/man/generated_txt/cargo-fix.txt
@@ -216,8 +216,8 @@ OPTIONS
 
            o  Any supported target in rustc --print target-list.
 
-           o  "host", which will internally be substituted by the host’s
-              target. This can be particularly useful if you’re
+           o  "host-tuple", which will internally be substituted by the
+              host’s target. This can be particularly useful if you’re
               cross-compiling some crates, and don’t want to specify your
               host’s machine as a target (for instance, an xtask in a shared
               project that may be worked on by many hosts).

--- a/src/doc/man/generated_txt/cargo-install.txt
+++ b/src/doc/man/generated_txt/cargo-install.txt
@@ -194,8 +194,8 @@ OPTIONS
 
            o  Any supported target in rustc --print target-list.
 
-           o  "host", which will internally be substituted by the host’s
-              target. This can be particularly useful if you’re
+           o  "host-tuple", which will internally be substituted by the
+              host’s target. This can be particularly useful if you’re
               cross-compiling some crates, and don’t want to specify your
               host’s machine as a target (for instance, an xtask in a shared
               project that may be worked on by many hosts).

--- a/src/doc/man/generated_txt/cargo-package.txt
+++ b/src/doc/man/generated_txt/cargo-package.txt
@@ -196,8 +196,8 @@ OPTIONS
 
            o  Any supported target in rustc --print target-list.
 
-           o  "host", which will internally be substituted by the host’s
-              target. This can be particularly useful if you’re
+           o  "host-tuple", which will internally be substituted by the
+              host’s target. This can be particularly useful if you’re
               cross-compiling some crates, and don’t want to specify your
               host’s machine as a target (for instance, an xtask in a shared
               project that may be worked on by many hosts).

--- a/src/doc/man/generated_txt/cargo-publish.txt
+++ b/src/doc/man/generated_txt/cargo-publish.txt
@@ -117,8 +117,8 @@ OPTIONS
 
            o  Any supported target in rustc --print target-list.
 
-           o  "host", which will internally be substituted by the host’s
-              target. This can be particularly useful if you’re
+           o  "host-tuple", which will internally be substituted by the
+              host’s target. This can be particularly useful if you’re
               cross-compiling some crates, and don’t want to specify your
               host’s machine as a target (for instance, an xtask in a shared
               project that may be worked on by many hosts).

--- a/src/doc/man/generated_txt/cargo-run.txt
+++ b/src/doc/man/generated_txt/cargo-run.txt
@@ -69,8 +69,8 @@ OPTIONS
 
            o  Any supported target in rustc --print target-list.
 
-           o  "host", which will internally be substituted by the host’s
-              target. This can be particularly useful if you’re
+           o  "host-tuple", which will internally be substituted by the
+              host’s target. This can be particularly useful if you’re
               cross-compiling some crates, and don’t want to specify your
               host’s machine as a target (for instance, an xtask in a shared
               project that may be worked on by many hosts).

--- a/src/doc/man/generated_txt/cargo-rustc.txt
+++ b/src/doc/man/generated_txt/cargo-rustc.txt
@@ -136,8 +136,8 @@ OPTIONS
 
            o  Any supported target in rustc --print target-list.
 
-           o  "host", which will internally be substituted by the host’s
-              target. This can be particularly useful if you’re
+           o  "host-tuple", which will internally be substituted by the
+              host’s target. This can be particularly useful if you’re
               cross-compiling some crates, and don’t want to specify your
               host’s machine as a target (for instance, an xtask in a shared
               project that may be worked on by many hosts).

--- a/src/doc/man/generated_txt/cargo-rustdoc.txt
+++ b/src/doc/man/generated_txt/cargo-rustdoc.txt
@@ -136,8 +136,8 @@ OPTIONS
 
            o  Any supported target in rustc --print target-list.
 
-           o  "host", which will internally be substituted by the host’s
-              target. This can be particularly useful if you’re
+           o  "host-tuple", which will internally be substituted by the
+              host’s target. This can be particularly useful if you’re
               cross-compiling some crates, and don’t want to specify your
               host’s machine as a target (for instance, an xtask in a shared
               project that may be worked on by many hosts).

--- a/src/doc/man/generated_txt/cargo-test.txt
+++ b/src/doc/man/generated_txt/cargo-test.txt
@@ -250,8 +250,8 @@ OPTIONS
 
            o  Any supported target in rustc --print target-list.
 
-           o  "host", which will internally be substituted by the host’s
-              target. This can be particularly useful if you’re
+           o  "host-tuple", which will internally be substituted by the
+              host’s target. This can be particularly useful if you’re
               cross-compiling some crates, and don’t want to specify your
               host’s machine as a target (for instance, an xtask in a shared
               project that may be worked on by many hosts).

--- a/src/doc/man/includes/options-target-triple.md
+++ b/src/doc/man/includes/options-target-triple.md
@@ -7,7 +7,7 @@
 
 Possible values:
 - Any supported target in `rustc --print target-list`.
-- `"host"`, which will internally be substituted by the host's target. This can be particularly useful if you're cross-compiling some crates, and don't want to specify your host's machine as a target (for instance, an `xtask` in a shared project that may be worked on by many hosts).
+- `"host-tuple"`, which will internally be substituted by the host's target. This can be particularly useful if you're cross-compiling some crates, and don't want to specify your host's machine as a target (for instance, an `xtask` in a shared project that may be worked on by many hosts).
 - A path to a custom target specification. See [Custom Target Lookup Path](../../rustc/targets/custom.html#custom-target-lookup-path) for more information.
 
 

--- a/src/doc/src/commands/cargo-bench.md
+++ b/src/doc/src/commands/cargo-bench.md
@@ -261,7 +261,7 @@ be specified multiple times, which enables all specified features.</dd>
 <p>Possible values:</p>
 <ul>
 <li>Any supported target in <code>rustc --print target-list</code>.</li>
-<li><code>"host"</code>, which will internally be substituted by the host’s target. This can be particularly useful if you’re cross-compiling some crates, and don’t want to specify your host’s machine as a target (for instance, an <code>xtask</code> in a shared project that may be worked on by many hosts).</li>
+<li><code>"host-tuple"</code>, which will internally be substituted by the host’s target. This can be particularly useful if you’re cross-compiling some crates, and don’t want to specify your host’s machine as a target (for instance, an <code>xtask</code> in a shared project that may be worked on by many hosts).</li>
 <li>A path to a custom target specification. See <a href="../../rustc/targets/custom.html#custom-target-lookup-path">Custom Target Lookup Path</a> for more information.</li>
 </ul>
 <p>This may also be specified with the <code>build.target</code> <a href="../reference/config.html">config value</a>.</p>

--- a/src/doc/src/commands/cargo-build.md
+++ b/src/doc/src/commands/cargo-build.md
@@ -176,7 +176,7 @@ be specified multiple times, which enables all specified features.</dd>
 <p>Possible values:</p>
 <ul>
 <li>Any supported target in <code>rustc --print target-list</code>.</li>
-<li><code>"host"</code>, which will internally be substituted by the host’s target. This can be particularly useful if you’re cross-compiling some crates, and don’t want to specify your host’s machine as a target (for instance, an <code>xtask</code> in a shared project that may be worked on by many hosts).</li>
+<li><code>"host-tuple"</code>, which will internally be substituted by the host’s target. This can be particularly useful if you’re cross-compiling some crates, and don’t want to specify your host’s machine as a target (for instance, an <code>xtask</code> in a shared project that may be worked on by many hosts).</li>
 <li>A path to a custom target specification. See <a href="../../rustc/targets/custom.html#custom-target-lookup-path">Custom Target Lookup Path</a> for more information.</li>
 </ul>
 <p>This may also be specified with the <code>build.target</code> <a href="../reference/config.html">config value</a>.</p>

--- a/src/doc/src/commands/cargo-check.md
+++ b/src/doc/src/commands/cargo-check.md
@@ -172,7 +172,7 @@ be specified multiple times, which enables all specified features.</dd>
 <p>Possible values:</p>
 <ul>
 <li>Any supported target in <code>rustc --print target-list</code>.</li>
-<li><code>"host"</code>, which will internally be substituted by the host’s target. This can be particularly useful if you’re cross-compiling some crates, and don’t want to specify your host’s machine as a target (for instance, an <code>xtask</code> in a shared project that may be worked on by many hosts).</li>
+<li><code>"host-tuple"</code>, which will internally be substituted by the host’s target. This can be particularly useful if you’re cross-compiling some crates, and don’t want to specify your host’s machine as a target (for instance, an <code>xtask</code> in a shared project that may be worked on by many hosts).</li>
 <li>A path to a custom target specification. See <a href="../../rustc/targets/custom.html#custom-target-lookup-path">Custom Target Lookup Path</a> for more information.</li>
 </ul>
 <p>This may also be specified with the <code>build.target</code> <a href="../reference/config.html">config value</a>.</p>

--- a/src/doc/src/commands/cargo-clean.md
+++ b/src/doc/src/commands/cargo-clean.md
@@ -64,7 +64,7 @@ Defaults to <code>target</code> in the root of the workspace.</dd>
 <p>Possible values:</p>
 <ul>
 <li>Any supported target in <code>rustc --print target-list</code>.</li>
-<li><code>"host"</code>, which will internally be substituted by the host’s target. This can be particularly useful if you’re cross-compiling some crates, and don’t want to specify your host’s machine as a target (for instance, an <code>xtask</code> in a shared project that may be worked on by many hosts).</li>
+<li><code>"host-tuple"</code>, which will internally be substituted by the host’s target. This can be particularly useful if you’re cross-compiling some crates, and don’t want to specify your host’s machine as a target (for instance, an <code>xtask</code> in a shared project that may be worked on by many hosts).</li>
 <li>A path to a custom target specification. See <a href="../../rustc/targets/custom.html#custom-target-lookup-path">Custom Target Lookup Path</a> for more information.</li>
 </ul>
 <p>This may also be specified with the <code>build.target</code> <a href="../reference/config.html">config value</a>.</p>

--- a/src/doc/src/commands/cargo-doc.md
+++ b/src/doc/src/commands/cargo-doc.md
@@ -153,7 +153,7 @@ be specified multiple times, which enables all specified features.</dd>
 <p>Possible values:</p>
 <ul>
 <li>Any supported target in <code>rustc --print target-list</code>.</li>
-<li><code>"host"</code>, which will internally be substituted by the host’s target. This can be particularly useful if you’re cross-compiling some crates, and don’t want to specify your host’s machine as a target (for instance, an <code>xtask</code> in a shared project that may be worked on by many hosts).</li>
+<li><code>"host-tuple"</code>, which will internally be substituted by the host’s target. This can be particularly useful if you’re cross-compiling some crates, and don’t want to specify your host’s machine as a target (for instance, an <code>xtask</code> in a shared project that may be worked on by many hosts).</li>
 <li>A path to a custom target specification. See <a href="../../rustc/targets/custom.html#custom-target-lookup-path">Custom Target Lookup Path</a> for more information.</li>
 </ul>
 <p>This may also be specified with the <code>build.target</code> <a href="../reference/config.html">config value</a>.</p>

--- a/src/doc/src/commands/cargo-fetch.md
+++ b/src/doc/src/commands/cargo-fetch.md
@@ -34,7 +34,7 @@ you plan to use Cargo without a network with the `--offline` flag.
 <p>Possible values:</p>
 <ul>
 <li>Any supported target in <code>rustc --print target-list</code>.</li>
-<li><code>"host"</code>, which will internally be substituted by the host’s target. This can be particularly useful if you’re cross-compiling some crates, and don’t want to specify your host’s machine as a target (for instance, an <code>xtask</code> in a shared project that may be worked on by many hosts).</li>
+<li><code>"host-tuple"</code>, which will internally be substituted by the host’s target. This can be particularly useful if you’re cross-compiling some crates, and don’t want to specify your host’s machine as a target (for instance, an <code>xtask</code> in a shared project that may be worked on by many hosts).</li>
 <li>A path to a custom target specification. See <a href="../../rustc/targets/custom.html#custom-target-lookup-path">Custom Target Lookup Path</a> for more information.</li>
 </ul>
 <p>This may also be specified with the <code>build.target</code> <a href="../reference/config.html">config value</a>.</p>

--- a/src/doc/src/commands/cargo-fix.md
+++ b/src/doc/src/commands/cargo-fix.md
@@ -252,7 +252,7 @@ be specified multiple times, which enables all specified features.</dd>
 <p>Possible values:</p>
 <ul>
 <li>Any supported target in <code>rustc --print target-list</code>.</li>
-<li><code>"host"</code>, which will internally be substituted by the host’s target. This can be particularly useful if you’re cross-compiling some crates, and don’t want to specify your host’s machine as a target (for instance, an <code>xtask</code> in a shared project that may be worked on by many hosts).</li>
+<li><code>"host-tuple"</code>, which will internally be substituted by the host’s target. This can be particularly useful if you’re cross-compiling some crates, and don’t want to specify your host’s machine as a target (for instance, an <code>xtask</code> in a shared project that may be worked on by many hosts).</li>
 <li>A path to a custom target specification. See <a href="../../rustc/targets/custom.html#custom-target-lookup-path">Custom Target Lookup Path</a> for more information.</li>
 </ul>
 <p>This may also be specified with the <code>build.target</code> <a href="../reference/config.html">config value</a>.</p>

--- a/src/doc/src/commands/cargo-install.md
+++ b/src/doc/src/commands/cargo-install.md
@@ -217,7 +217,7 @@ be specified multiple times, which enables all specified features.</dd>
 <p>Possible values:</p>
 <ul>
 <li>Any supported target in <code>rustc --print target-list</code>.</li>
-<li><code>"host"</code>, which will internally be substituted by the host’s target. This can be particularly useful if you’re cross-compiling some crates, and don’t want to specify your host’s machine as a target (for instance, an <code>xtask</code> in a shared project that may be worked on by many hosts).</li>
+<li><code>"host-tuple"</code>, which will internally be substituted by the host’s target. This can be particularly useful if you’re cross-compiling some crates, and don’t want to specify your host’s machine as a target (for instance, an <code>xtask</code> in a shared project that may be worked on by many hosts).</li>
 <li>A path to a custom target specification. See <a href="../../rustc/targets/custom.html#custom-target-lookup-path">Custom Target Lookup Path</a> for more information.</li>
 </ul>
 <p>This may also be specified with the <code>build.target</code> <a href="../reference/config.html">config value</a>.</p>

--- a/src/doc/src/commands/cargo-package.md
+++ b/src/doc/src/commands/cargo-package.md
@@ -207,7 +207,7 @@ single quotes or double quotes around each pattern.</dd>
 <p>Possible values:</p>
 <ul>
 <li>Any supported target in <code>rustc --print target-list</code>.</li>
-<li><code>"host"</code>, which will internally be substituted by the host’s target. This can be particularly useful if you’re cross-compiling some crates, and don’t want to specify your host’s machine as a target (for instance, an <code>xtask</code> in a shared project that may be worked on by many hosts).</li>
+<li><code>"host-tuple"</code>, which will internally be substituted by the host’s target. This can be particularly useful if you’re cross-compiling some crates, and don’t want to specify your host’s machine as a target (for instance, an <code>xtask</code> in a shared project that may be worked on by many hosts).</li>
 <li>A path to a custom target specification. See <a href="../../rustc/targets/custom.html#custom-target-lookup-path">Custom Target Lookup Path</a> for more information.</li>
 </ul>
 <p>This may also be specified with the <code>build.target</code> <a href="../reference/config.html">config value</a>.</p>

--- a/src/doc/src/commands/cargo-publish.md
+++ b/src/doc/src/commands/cargo-publish.md
@@ -127,7 +127,7 @@ single quotes or double quotes around each pattern.</dd>
 <p>Possible values:</p>
 <ul>
 <li>Any supported target in <code>rustc --print target-list</code>.</li>
-<li><code>"host"</code>, which will internally be substituted by the host’s target. This can be particularly useful if you’re cross-compiling some crates, and don’t want to specify your host’s machine as a target (for instance, an <code>xtask</code> in a shared project that may be worked on by many hosts).</li>
+<li><code>"host-tuple"</code>, which will internally be substituted by the host’s target. This can be particularly useful if you’re cross-compiling some crates, and don’t want to specify your host’s machine as a target (for instance, an <code>xtask</code> in a shared project that may be worked on by many hosts).</li>
 <li>A path to a custom target specification. See <a href="../../rustc/targets/custom.html#custom-target-lookup-path">Custom Target Lookup Path</a> for more information.</li>
 </ul>
 <p>This may also be specified with the <code>build.target</code> <a href="../reference/config.html">config value</a>.</p>

--- a/src/doc/src/commands/cargo-run.md
+++ b/src/doc/src/commands/cargo-run.md
@@ -93,7 +93,7 @@ be specified multiple times, which enables all specified features.</dd>
 <p>Possible values:</p>
 <ul>
 <li>Any supported target in <code>rustc --print target-list</code>.</li>
-<li><code>"host"</code>, which will internally be substituted by the host’s target. This can be particularly useful if you’re cross-compiling some crates, and don’t want to specify your host’s machine as a target (for instance, an <code>xtask</code> in a shared project that may be worked on by many hosts).</li>
+<li><code>"host-tuple"</code>, which will internally be substituted by the host’s target. This can be particularly useful if you’re cross-compiling some crates, and don’t want to specify your host’s machine as a target (for instance, an <code>xtask</code> in a shared project that may be worked on by many hosts).</li>
 <li>A path to a custom target specification. See <a href="../../rustc/targets/custom.html#custom-target-lookup-path">Custom Target Lookup Path</a> for more information.</li>
 </ul>
 <p>This may also be specified with the <code>build.target</code> <a href="../reference/config.html">config value</a>.</p>

--- a/src/doc/src/commands/cargo-rustc.md
+++ b/src/doc/src/commands/cargo-rustc.md
@@ -165,7 +165,7 @@ be specified multiple times, which enables all specified features.</dd>
 <p>Possible values:</p>
 <ul>
 <li>Any supported target in <code>rustc --print target-list</code>.</li>
-<li><code>"host"</code>, which will internally be substituted by the host’s target. This can be particularly useful if you’re cross-compiling some crates, and don’t want to specify your host’s machine as a target (for instance, an <code>xtask</code> in a shared project that may be worked on by many hosts).</li>
+<li><code>"host-tuple"</code>, which will internally be substituted by the host’s target. This can be particularly useful if you’re cross-compiling some crates, and don’t want to specify your host’s machine as a target (for instance, an <code>xtask</code> in a shared project that may be worked on by many hosts).</li>
 <li>A path to a custom target specification. See <a href="../../rustc/targets/custom.html#custom-target-lookup-path">Custom Target Lookup Path</a> for more information.</li>
 </ul>
 <p>This may also be specified with the <code>build.target</code> <a href="../reference/config.html">config value</a>.</p>

--- a/src/doc/src/commands/cargo-rustdoc.md
+++ b/src/doc/src/commands/cargo-rustdoc.md
@@ -171,7 +171,7 @@ be specified multiple times, which enables all specified features.</dd>
 <p>Possible values:</p>
 <ul>
 <li>Any supported target in <code>rustc --print target-list</code>.</li>
-<li><code>"host"</code>, which will internally be substituted by the host’s target. This can be particularly useful if you’re cross-compiling some crates, and don’t want to specify your host’s machine as a target (for instance, an <code>xtask</code> in a shared project that may be worked on by many hosts).</li>
+<li><code>"host-tuple"</code>, which will internally be substituted by the host’s target. This can be particularly useful if you’re cross-compiling some crates, and don’t want to specify your host’s machine as a target (for instance, an <code>xtask</code> in a shared project that may be worked on by many hosts).</li>
 <li>A path to a custom target specification. See <a href="../../rustc/targets/custom.html#custom-target-lookup-path">Custom Target Lookup Path</a> for more information.</li>
 </ul>
 <p>This may also be specified with the <code>build.target</code> <a href="../reference/config.html">config value</a>.</p>

--- a/src/doc/src/commands/cargo-test.md
+++ b/src/doc/src/commands/cargo-test.md
@@ -283,7 +283,7 @@ be specified multiple times, which enables all specified features.</dd>
 <p>Possible values:</p>
 <ul>
 <li>Any supported target in <code>rustc --print target-list</code>.</li>
-<li><code>"host"</code>, which will internally be substituted by the host’s target. This can be particularly useful if you’re cross-compiling some crates, and don’t want to specify your host’s machine as a target (for instance, an <code>xtask</code> in a shared project that may be worked on by many hosts).</li>
+<li><code>"host-tuple"</code>, which will internally be substituted by the host’s target. This can be particularly useful if you’re cross-compiling some crates, and don’t want to specify your host’s machine as a target (for instance, an <code>xtask</code> in a shared project that may be worked on by many hosts).</li>
 <li>A path to a custom target specification. See <a href="../../rustc/targets/custom.html#custom-target-lookup-path">Custom Target Lookup Path</a> for more information.</li>
 </ul>
 <p>This may also be specified with the <code>build.target</code> <a href="../reference/config.html">config value</a>.</p>

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -462,7 +462,7 @@ The default [target platform triples][target triple] to compile to.
 
 Possible values:
 - Any supported target in `rustc --print target-list`.
-- `"host"`, which will internally be substituted by the host's target. This can be particularly useful if you're cross-compiling some crates, and don't want to specify your host's machine as a target (for instance, an `xtask` in a shared project that may be worked on by many hosts).
+- `"host-tuple"`, which will internally be substituted by the host's target. This can be particularly useful if you're cross-compiling some crates, and don't want to specify your host's machine as a target (for instance, an `xtask` in a shared project that may be worked on by many hosts).
 - A path to a custom target specification. See [Custom Target Lookup Path](../../rustc/targets/custom.html#custom-target-lookup-path) for more information.
 
 Can be overridden with the `--target` CLI option.

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -277,7 +277,7 @@ Possible values:
 .RE
 .sp
 .RS 4
-\h'-04'\(bu\h'+03'\fB"host"\fR, which will internally be substituted by the host\[cq]s target. This can be particularly useful if you\[cq]re cross\-compiling some crates, and don\[cq]t want to specify your host\[cq]s machine as a target (for instance, an \fBxtask\fR in a shared project that may be worked on by many hosts).
+\h'-04'\(bu\h'+03'\fB"host\-tuple"\fR, which will internally be substituted by the host\[cq]s target. This can be particularly useful if you\[cq]re cross\-compiling some crates, and don\[cq]t want to specify your host\[cq]s machine as a target (for instance, an \fBxtask\fR in a shared project that may be worked on by many hosts).
 .RE
 .sp
 .RS 4

--- a/src/etc/man/cargo-build.1
+++ b/src/etc/man/cargo-build.1
@@ -176,7 +176,7 @@ Possible values:
 .RE
 .sp
 .RS 4
-\h'-04'\(bu\h'+03'\fB"host"\fR, which will internally be substituted by the host\[cq]s target. This can be particularly useful if you\[cq]re cross\-compiling some crates, and don\[cq]t want to specify your host\[cq]s machine as a target (for instance, an \fBxtask\fR in a shared project that may be worked on by many hosts).
+\h'-04'\(bu\h'+03'\fB"host\-tuple"\fR, which will internally be substituted by the host\[cq]s target. This can be particularly useful if you\[cq]re cross\-compiling some crates, and don\[cq]t want to specify your host\[cq]s machine as a target (for instance, an \fBxtask\fR in a shared project that may be worked on by many hosts).
 .RE
 .sp
 .RS 4

--- a/src/etc/man/cargo-check.1
+++ b/src/etc/man/cargo-check.1
@@ -172,7 +172,7 @@ Possible values:
 .RE
 .sp
 .RS 4
-\h'-04'\(bu\h'+03'\fB"host"\fR, which will internally be substituted by the host\[cq]s target. This can be particularly useful if you\[cq]re cross\-compiling some crates, and don\[cq]t want to specify your host\[cq]s machine as a target (for instance, an \fBxtask\fR in a shared project that may be worked on by many hosts).
+\h'-04'\(bu\h'+03'\fB"host\-tuple"\fR, which will internally be substituted by the host\[cq]s target. This can be particularly useful if you\[cq]re cross\-compiling some crates, and don\[cq]t want to specify your host\[cq]s machine as a target (for instance, an \fBxtask\fR in a shared project that may be worked on by many hosts).
 .RE
 .sp
 .RS 4

--- a/src/etc/man/cargo-clean.1
+++ b/src/etc/man/cargo-clean.1
@@ -67,7 +67,7 @@ Possible values:
 .RE
 .sp
 .RS 4
-\h'-04'\(bu\h'+03'\fB"host"\fR, which will internally be substituted by the host\[cq]s target. This can be particularly useful if you\[cq]re cross\-compiling some crates, and don\[cq]t want to specify your host\[cq]s machine as a target (for instance, an \fBxtask\fR in a shared project that may be worked on by many hosts).
+\h'-04'\(bu\h'+03'\fB"host\-tuple"\fR, which will internally be substituted by the host\[cq]s target. This can be particularly useful if you\[cq]re cross\-compiling some crates, and don\[cq]t want to specify your host\[cq]s machine as a target (for instance, an \fBxtask\fR in a shared project that may be worked on by many hosts).
 .RE
 .sp
 .RS 4

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -147,7 +147,7 @@ Possible values:
 .RE
 .sp
 .RS 4
-\h'-04'\(bu\h'+03'\fB"host"\fR, which will internally be substituted by the host\[cq]s target. This can be particularly useful if you\[cq]re cross\-compiling some crates, and don\[cq]t want to specify your host\[cq]s machine as a target (for instance, an \fBxtask\fR in a shared project that may be worked on by many hosts).
+\h'-04'\(bu\h'+03'\fB"host\-tuple"\fR, which will internally be substituted by the host\[cq]s target. This can be particularly useful if you\[cq]re cross\-compiling some crates, and don\[cq]t want to specify your host\[cq]s machine as a target (for instance, an \fBxtask\fR in a shared project that may be worked on by many hosts).
 .RE
 .sp
 .RS 4

--- a/src/etc/man/cargo-fetch.1
+++ b/src/etc/man/cargo-fetch.1
@@ -35,7 +35,7 @@ Possible values:
 .RE
 .sp
 .RS 4
-\h'-04'\(bu\h'+03'\fB"host"\fR, which will internally be substituted by the host\[cq]s target. This can be particularly useful if you\[cq]re cross\-compiling some crates, and don\[cq]t want to specify your host\[cq]s machine as a target (for instance, an \fBxtask\fR in a shared project that may be worked on by many hosts).
+\h'-04'\(bu\h'+03'\fB"host\-tuple"\fR, which will internally be substituted by the host\[cq]s target. This can be particularly useful if you\[cq]re cross\-compiling some crates, and don\[cq]t want to specify your host\[cq]s machine as a target (for instance, an \fBxtask\fR in a shared project that may be worked on by many hosts).
 .RE
 .sp
 .RS 4

--- a/src/etc/man/cargo-fix.1
+++ b/src/etc/man/cargo-fix.1
@@ -267,7 +267,7 @@ Possible values:
 .RE
 .sp
 .RS 4
-\h'-04'\(bu\h'+03'\fB"host"\fR, which will internally be substituted by the host\[cq]s target. This can be particularly useful if you\[cq]re cross\-compiling some crates, and don\[cq]t want to specify your host\[cq]s machine as a target (for instance, an \fBxtask\fR in a shared project that may be worked on by many hosts).
+\h'-04'\(bu\h'+03'\fB"host\-tuple"\fR, which will internally be substituted by the host\[cq]s target. This can be particularly useful if you\[cq]re cross\-compiling some crates, and don\[cq]t want to specify your host\[cq]s machine as a target (for instance, an \fBxtask\fR in a shared project that may be worked on by many hosts).
 .RE
 .sp
 .RS 4

--- a/src/etc/man/cargo-install.1
+++ b/src/etc/man/cargo-install.1
@@ -252,7 +252,7 @@ Possible values:
 .RE
 .sp
 .RS 4
-\h'-04'\(bu\h'+03'\fB"host"\fR, which will internally be substituted by the host\[cq]s target. This can be particularly useful if you\[cq]re cross\-compiling some crates, and don\[cq]t want to specify your host\[cq]s machine as a target (for instance, an \fBxtask\fR in a shared project that may be worked on by many hosts).
+\h'-04'\(bu\h'+03'\fB"host\-tuple"\fR, which will internally be substituted by the host\[cq]s target. This can be particularly useful if you\[cq]re cross\-compiling some crates, and don\[cq]t want to specify your host\[cq]s machine as a target (for instance, an \fBxtask\fR in a shared project that may be worked on by many hosts).
 .RE
 .sp
 .RS 4

--- a/src/etc/man/cargo-package.1
+++ b/src/etc/man/cargo-package.1
@@ -249,7 +249,7 @@ Possible values:
 .RE
 .sp
 .RS 4
-\h'-04'\(bu\h'+03'\fB"host"\fR, which will internally be substituted by the host\[cq]s target. This can be particularly useful if you\[cq]re cross\-compiling some crates, and don\[cq]t want to specify your host\[cq]s machine as a target (for instance, an \fBxtask\fR in a shared project that may be worked on by many hosts).
+\h'-04'\(bu\h'+03'\fB"host\-tuple"\fR, which will internally be substituted by the host\[cq]s target. This can be particularly useful if you\[cq]re cross\-compiling some crates, and don\[cq]t want to specify your host\[cq]s machine as a target (for instance, an \fBxtask\fR in a shared project that may be worked on by many hosts).
 .RE
 .sp
 .RS 4

--- a/src/etc/man/cargo-publish.1
+++ b/src/etc/man/cargo-publish.1
@@ -142,7 +142,7 @@ Possible values:
 .RE
 .sp
 .RS 4
-\h'-04'\(bu\h'+03'\fB"host"\fR, which will internally be substituted by the host\[cq]s target. This can be particularly useful if you\[cq]re cross\-compiling some crates, and don\[cq]t want to specify your host\[cq]s machine as a target (for instance, an \fBxtask\fR in a shared project that may be worked on by many hosts).
+\h'-04'\(bu\h'+03'\fB"host\-tuple"\fR, which will internally be substituted by the host\[cq]s target. This can be particularly useful if you\[cq]re cross\-compiling some crates, and don\[cq]t want to specify your host\[cq]s machine as a target (for instance, an \fBxtask\fR in a shared project that may be worked on by many hosts).
 .RE
 .sp
 .RS 4

--- a/src/etc/man/cargo-run.1
+++ b/src/etc/man/cargo-run.1
@@ -82,7 +82,7 @@ Possible values:
 .RE
 .sp
 .RS 4
-\h'-04'\(bu\h'+03'\fB"host"\fR, which will internally be substituted by the host\[cq]s target. This can be particularly useful if you\[cq]re cross\-compiling some crates, and don\[cq]t want to specify your host\[cq]s machine as a target (for instance, an \fBxtask\fR in a shared project that may be worked on by many hosts).
+\h'-04'\(bu\h'+03'\fB"host\-tuple"\fR, which will internally be substituted by the host\[cq]s target. This can be particularly useful if you\[cq]re cross\-compiling some crates, and don\[cq]t want to specify your host\[cq]s machine as a target (for instance, an \fBxtask\fR in a shared project that may be worked on by many hosts).
 .RE
 .sp
 .RS 4

--- a/src/etc/man/cargo-rustc.1
+++ b/src/etc/man/cargo-rustc.1
@@ -162,7 +162,7 @@ Possible values:
 .RE
 .sp
 .RS 4
-\h'-04'\(bu\h'+03'\fB"host"\fR, which will internally be substituted by the host\[cq]s target. This can be particularly useful if you\[cq]re cross\-compiling some crates, and don\[cq]t want to specify your host\[cq]s machine as a target (for instance, an \fBxtask\fR in a shared project that may be worked on by many hosts).
+\h'-04'\(bu\h'+03'\fB"host\-tuple"\fR, which will internally be substituted by the host\[cq]s target. This can be particularly useful if you\[cq]re cross\-compiling some crates, and don\[cq]t want to specify your host\[cq]s machine as a target (for instance, an \fBxtask\fR in a shared project that may be worked on by many hosts).
 .RE
 .sp
 .RS 4

--- a/src/etc/man/cargo-rustdoc.1
+++ b/src/etc/man/cargo-rustdoc.1
@@ -164,7 +164,7 @@ Possible values:
 .RE
 .sp
 .RS 4
-\h'-04'\(bu\h'+03'\fB"host"\fR, which will internally be substituted by the host\[cq]s target. This can be particularly useful if you\[cq]re cross\-compiling some crates, and don\[cq]t want to specify your host\[cq]s machine as a target (for instance, an \fBxtask\fR in a shared project that may be worked on by many hosts).
+\h'-04'\(bu\h'+03'\fB"host\-tuple"\fR, which will internally be substituted by the host\[cq]s target. This can be particularly useful if you\[cq]re cross\-compiling some crates, and don\[cq]t want to specify your host\[cq]s machine as a target (for instance, an \fBxtask\fR in a shared project that may be worked on by many hosts).
 .RE
 .sp
 .RS 4

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -297,7 +297,7 @@ Possible values:
 .RE
 .sp
 .RS 4
-\h'-04'\(bu\h'+03'\fB"host"\fR, which will internally be substituted by the host\[cq]s target. This can be particularly useful if you\[cq]re cross\-compiling some crates, and don\[cq]t want to specify your host\[cq]s machine as a target (for instance, an \fBxtask\fR in a shared project that may be worked on by many hosts).
+\h'-04'\(bu\h'+03'\fB"host\-tuple"\fR, which will internally be substituted by the host\[cq]s target. This can be particularly useful if you\[cq]re cross\-compiling some crates, and don\[cq]t want to specify your host\[cq]s machine as a target (for instance, an \fBxtask\fR in a shared project that may be worked on by many hosts).
 .RE
 .sp
 .RS 4

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -157,7 +157,7 @@ fn target_host_arg() {
         .file("src/lib.rs", r#""#)
         .build();
 
-    p.cargo("build -v --target host")
+    p.cargo("build -v --target host-tuple")
         .with_stderr_contains("[RUNNING] `rustc [..] --target [HOST_TARGET] [..]`")
         .run();
 }
@@ -174,7 +174,7 @@ fn target_host_config() {
             &format!(
                 r#"
                     [build]
-                    target = "host"
+                    target = "host-tuple"
                 "#,
             ),
         )


### PR DESCRIPTION
Beta backports
- rust-lang/cargo@a5c8b96f824af5b7175b4fb21d817d8ff87fbf59

In order to make CI pass, the following PRs are also cherry-picked: