### PR TITLE
Convert a multi-part diagnostic to a report

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -4,6 +4,7 @@ use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
+use annotate_snippets::Level;
 use anyhow::{Context as _, anyhow, bail};
 use glob::glob;
 use itertools::Itertools;
@@ -1138,18 +1139,18 @@ impl<'gctx> Workspace<'gctx> {
                         .max()
                     {
                         let resolver = edition.default_resolve_behavior().to_manifest();
-                        self.gctx.shell().warn(format_args!(
-                            "virtual workspace defaulting to `resolver = \"1\"` despite one or more workspace members being on edition {edition} which implies `resolver = \"{resolver}\"`"
-                        ))?;
-                        self.gctx.shell().note(
-                            "to keep the current resolver, specify `workspace.resolver = \"1\"` in the workspace root's manifest",
-                        )?;
-                        self.gctx.shell().note(format_args!(
-                            "to use the edition {edition} resolver, specify `workspace.resolver = \"{resolver}\"` in the workspace root's manifest"
-                        ))?;
-                        self.gctx.shell().note(
-                            "for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions",
-                        )?;
+                        let report = &[Level::WARNING
+                            .primary_title(format!(
+                                "virtual workspace defaulting to `resolver = \"1\"` despite one or more workspace members being on edition {edition} which implies `resolver = \"{resolver}\"`"
+                            ))
+                            .elements([
+                                Level::NOTE.message("to keep the current resolver, specify `workspace.resolver = \"1\"` in the workspace root's manifest"),
+                                Level::NOTE.message(
+                                    format!("to use the edition {edition} resolver, specify `workspace.resolver = \"{resolver}\"` in the workspace root's manifest"),
+                                ),
+                                Level::NOTE.message("for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions"),
+                            ])];
+                        self.gctx.shell().print_report(report, false)?;
                     }
                 }
             }

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -1553,9 +1553,10 @@ fn edition_2021_workspace_member() {
 
     p.cargo("check").with_stderr_data(str![[r#"
 [WARNING] virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
-[NOTE] to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
-[NOTE] to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
-[NOTE] for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
+  |
+  = [NOTE] to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
+  = [NOTE] to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
+  = [NOTE] for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
 [CHECKING] a v0.1.0 ([ROOT]/foo/a)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 


### PR DESCRIPTION
### What does this PR try to resolve?

This converts a `shell.warn()` followed by several `shell.note()`s into a single `shell.print_report()`.

This is just to check whether I correctly understood the conversation in office hours. If so, I can do a bunch more of these.