### PR TITLE
Lockfile schemas error cleanup

### DIFF
--- a/crates/cargo-util-schemas/src/lockfile.rs
+++ b/crates/cargo-util-schemas/src/lockfile.rs
@@ -105,11 +105,9 @@ pub struct TomlLockfileSourceId {
 impl TomlLockfileSourceId {
     pub fn new(source: String) -> Result<Self, TomlLockfileSourceIdError> {
         let source_str = source.clone();
-        let (kind, url) = source.split_once('+').ok_or_else(|| {
-            TomlLockfileSourceIdError(
-                TomlLockfileSourceIdErrorKind::InvalidSource(source.clone()).into(),
-            )
-        })?;
+        let (kind, url) = source
+            .split_once('+')
+            .ok_or_else(|| TomlLockfileSourceIdErrorKind::InvalidSource(source.clone()))?;
 
         // Sparse URLs store the kind prefix (sparse+) in the URL. Therefore, for sparse kinds, we
         // want to use the raw `source` instead of the splitted `url`.


### PR DESCRIPTION
### What does this PR try to resolve?

Cleans up some of the error handling in the lockfile schemas in `cargo-util-schemas`. This change includes renaming the error structs to follow the `TomlLockfile` naming scheme of lockfile schemas.

### How to test and review this PR?

Commit by commit.