### PR TITLE
chore(ci): unpin libc

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,8 +8,6 @@
   ignorePaths: [
     '**/tests/**',
   ],
-  // For why we ignore, see https://github.com/bytecodealliance/rustix/issues/1496
-  ignoreDeps: ['libc'],
   customManagers: [
     {
       customType: 'regex',

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2790,9 +2790,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libgit2-sys"


### PR DESCRIPTION
### What does this PR try to resolve?

rustix@1.1.1+ seems to have fixed it, we should be good to go and unpin: [diff.rs/rustix/1.0.8/rustix/1.1.1/src%2Fbackend%2Flibc%2Fc.rs](https://diff.rs/rustix/1.0.8/rustix/1.1.1/src%2Fbackend%2Flibc%2Fc.rs)

Fixes https://github.com/rust-lang/cargo/issues/15919

### How to test and review this PR?

Same as <https://github.com/rust-lang/cargo/pull/15851>

> In rust-lang/rust, update the `src/tools/cargo` submodule accordingly, and run
> 
> ```
> cargo run --manifest-path src/ci/citool/Cargo.toml run-local dist-loongarch64-musl
> ```
> 
> With this downgrade it should compile.


I didn't run it locally though.