### PR TITLE
refactor(shell): Clarify we're printing transient status

### DIFF
--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -2934,7 +2934,9 @@ src/lib.rs
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(
+    ignore_windows = "temporarily disabling due to flakiness: https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/reserved_windows_name.20test.20failing/with/543085230"
+)]
 #[cfg(windows)]
 fn reserved_windows_name() {
     // If we are running on a version of Windows that allows these reserved filenames,


### PR DESCRIPTION
Beta backports
- rust-lang/cargo@e906ad91ff3ba755c7df5abbde51641a117960c7 (ignoring flaky test)

In order to make CI pass, the following PRs are also cherry-picked: