### PR TITLE
test: null-terminated path for reserved windows name detection

### DIFF
--- a/crates/cargo-test-support/src/paths.rs
+++ b/crates/cargo-test-support/src/paths.rs
@@ -451,7 +451,7 @@ pub fn windows_reserved_names_are_allowed() -> bool {
     use std::ptr;
     use windows_sys::Win32::Storage::FileSystem::GetFullPathNameW;
 
-    let test_file_name: Vec<_> = OsStr::new("aux.rs").encode_wide().collect();
+    let test_file_name: Vec<_> = OsStr::new("aux.rs").encode_wide().chain([0]).collect();
 
     let buffer_length =
         unsafe { GetFullPathNameW(test_file_name.as_ptr(), 0, ptr::null_mut(), ptr::null_mut()) };

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -2935,7 +2935,8 @@ src/lib.rs
 }
 
 #[cargo_test(
-    ignore_windows = "temporarily disabling due to flakiness: https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/reserved_windows_name.20test.20failing/with/543085230"
+    nightly,
+    reason = "temporarily due to flakiness: https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/reserved_windows_name.20test.20failing/with/543085230"
 )]
 #[cfg(windows)]
 fn reserved_windows_name() {


### PR DESCRIPTION
### What does this PR try to resolve?

The test is still nightly only to avoid blocking rust-lang/rust. Once we figure it is not flaky anymore we should re-enable it.

https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/reserved_windows_name.20test.20failing/

Related: https://github.com/rust-lang/cargo/issues/16047


### How to test and review this PR?

CI passes.
