### PR TITLE
Fix unsafe_op_in_unsafe_fn for Windows

### DIFF
--- a/crates/cargo-util/src/read2.rs
+++ b/crates/cargo-util/src/read2.rs
@@ -141,17 +141,21 @@ mod imp {
 
     impl<'a> Pipe<'a> {
         unsafe fn new<P: IntoRawHandle>(p: P, dst: &'a mut Vec<u8>) -> Pipe<'a> {
+            // SAFETY: Handle must be owned, open, and closeable with CloseHandle.
+            let pipe = unsafe { NamedPipe::from_raw_handle(p.into_raw_handle()) };
             Pipe {
                 dst,
-                pipe: NamedPipe::from_raw_handle(p.into_raw_handle()),
+                pipe,
                 overlapped: Overlapped::zero(),
                 done: false,
             }
         }
 
         unsafe fn read(&mut self) -> io::Result<()> {
-            let dst = slice_to_end(self.dst);
-            match self.pipe.read_overlapped(dst, self.overlapped.raw()) {
+            let dst = unsafe { slice_to_end(self.dst) };
+            // SAFETY: The buffer must be valid until the end of the I/O,
+            // which is handled in `read2`.
+            match unsafe { self.pipe.read_overlapped(dst, self.overlapped.raw()) } {
                 Ok(_) => Ok(()),
                 Err(e) => {
                     if e.raw_os_error() == Some(ERROR_BROKEN_PIPE as i32) {
@@ -166,7 +170,7 @@ mod imp {
 
         unsafe fn complete(&mut self, status: &CompletionStatus) {
             let prev = self.dst.len();
-            self.dst.set_len(prev + status.bytes_transferred() as usize);
+            unsafe { self.dst.set_len(prev + status.bytes_transferred() as usize) };
             if status.bytes_transferred() == 0 {
                 self.done = true;
             }
@@ -180,6 +184,6 @@ mod imp {
         if v.capacity() == v.len() {
             v.reserve(1);
         }
-        slice::from_raw_parts_mut(v.as_mut_ptr().add(v.len()), v.capacity() - v.len())
+        unsafe { slice::from_raw_parts_mut(v.as_mut_ptr().add(v.len()), v.capacity() - v.len()) }
     }
 }


### PR DESCRIPTION
Windows builds are generating a bunch of warnings about unsafe_op_in_unsafe_fn. This fixes those warnings by making sure the relevant parts are wrapped in unsafe.
