### PR TITLE
Convert a few more diagnostics to reports

### DIFF
--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -22,6 +22,7 @@ use crate::sources::source::SourceMap;
 use crate::util::errors::CargoResult;
 use crate::util::interning::InternedString;
 use crate::util::{CanonicalUrl, GlobalContext};
+use annotate_snippets::Level;
 use anyhow::{Context as _, bail};
 use tracing::{debug, trace};
 use url::Url;
@@ -387,16 +388,19 @@ impl<'gctx> PackageRegistry<'gctx> {
                     unused_fields.push("`default-features`")
                 }
                 if !unused_fields.is_empty() {
-                    let mut shell = self.source_config.gctx().shell();
-                    shell.warn(format!(
-                        "unused field in patch for `{}`: {}",
-                        dep.package_name(),
-                        unused_fields.join(", ")
-                    ))?;
-                    shell.note(format!(
-                        "configure {} in the `dependencies` entry",
-                        unused_fields.join(", ")
-                    ))?;
+                    self.source_config.gctx().shell().print_report(
+                        &[Level::WARNING
+                            .secondary_title(format!(
+                                "unused field in patch for `{}`: {}",
+                                dep.package_name(),
+                                unused_fields.join(", ")
+                            ))
+                            .element(Level::HELP.message(format!(
+                                "configure {} in the `dependencies` entry",
+                                unused_fields.join(", ")
+                            )))],
+                        false,
+                    )?;
                 }
 
                 // Go straight to the source for resolving `dep`. Load it as we

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -191,6 +191,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::task::{Poll, ready};
 
+use annotate_snippets::Level;
 use anyhow::Context as _;
 use cargo_util::paths::{self, exclude_from_backups_and_indexing};
 use flate2::read::GzDecoder;
@@ -832,10 +833,17 @@ impl<'gctx> Source for RegistrySource<'gctx> {
                     .expect("--precise <yanked-version> in use");
                 if self.selected_precise_yanked.insert((name, version.clone())) {
                     let mut shell = self.gctx.shell();
-                    shell.warn(format_args!(
-                        "selected package `{name}@{version}` was yanked by the author"
-                    ))?;
-                    shell.note("if possible, try a compatible non-yanked version")?;
+                    shell.print_report(
+                        &[Level::WARNING
+                            .secondary_title(format!(
+                                "selected package `{name}@{version}` was yanked by the author"
+                            ))
+                            .element(
+                                Level::HELP
+                                    .message("if possible, try a compatible non-yanked version"),
+                            )],
+                        false,
+                    )?;
                 }
             }
             if called {

--- a/src/cargo/util/context/mod.rs
+++ b/src/cargo/util/context/mod.rs
@@ -79,6 +79,7 @@ use crate::util::network::http::configure_http_handle;
 use crate::util::network::http::http_handle;
 use crate::util::{CanonicalUrl, closest_msg, internal};
 use crate::util::{Filesystem, IntoUrl, IntoUrlWithBase, Rustc};
+use annotate_snippets::Level;
 use anyhow::{Context as _, anyhow, bail, format_err};
 use cargo_credential::Secret;
 use cargo_util::paths;
@@ -1582,13 +1583,15 @@ impl GlobalContext {
                         ))?;
                     }
                 } else {
-                    self.shell().warn(format!(
+                    self.shell().print_report(&[
+                        Level::WARNING.secondary_title(
+                        format!(
                         "`{}` is deprecated in favor of `{filename_without_extension}.toml`",
                         possible.display(),
-                    ))?;
-                    self.shell().note(
-                        format!("if you need to support cargo 1.38 or earlier, you can symlink `{filename_without_extension}` to `{filename_without_extension}.toml`"),
-                    )?;
+                    )).element(Level::HELP.message(
+                        format!("if you need to support cargo 1.38 or earlier, you can symlink `{filename_without_extension}` to `{filename_without_extension}.toml`")))
+
+                    ], false)?;
                 }
             }
 

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -294,7 +294,8 @@ f1 = 1
     let output = read_output(gctx);
     let expected = str![[r#"
 [WARNING] `[ROOT]/.cargo/config` is deprecated in favor of `config.toml`
-[NOTE] if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
+  |
+  = [HELP] if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
 
 "#]];
     assert_e2e().eq(&output, expected);
@@ -314,7 +315,8 @@ f1 = 1
     p.cargo("-vV")
         .with_stderr_data(str![[r#"
 [WARNING] `[ROOT]/home/.cargo/config` is deprecated in favor of `config.toml`
-[NOTE] if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
+  |
+  = [HELP] if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
 
 "#]])
         .run();

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -7450,8 +7450,9 @@ fn git_core_symlinks_false() {
     p.cargo("package --allow-dirty")
         .with_stderr_data(str![[r#"
 [WARNING] found symbolic links that may be checked out as regular files for git repo at `[ROOT]/foo/`
-This might cause the `.crate` file to include incorrect or incomplete files
-[NOTE] to avoid this, set the Git config `core.symlinks` to `true`
+  |
+  = [NOTE] this might cause the `.crate` file to include incorrect or incomplete files
+  = [HELP] to avoid this, set the Git config `core.symlinks` to `true`
 ...
 [PACKAGING] bar v0.0.0 ([ROOT]/foo)
 [PACKAGED] 7 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -931,7 +931,8 @@ fn add_patch_with_features() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [WARNING] unused field in patch for `bar`: `features`
-[NOTE] configure `features` in the `dependencies` entry
+  |
+  = [HELP] configure `features` in the `dependencies` entry
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
@@ -943,7 +944,8 @@ fn add_patch_with_features() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [WARNING] unused field in patch for `bar`: `features`
-[NOTE] configure `features` in the `dependencies` entry
+  |
+  = [HELP] configure `features` in the `dependencies` entry
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -979,7 +981,8 @@ fn add_patch_with_setting_default_features() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [WARNING] unused field in patch for `bar`: `features`, `default-features`
-[NOTE] configure `features`, `default-features` in the `dependencies` entry
+  |
+  = [HELP] configure `features`, `default-features` in the `dependencies` entry
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
@@ -991,7 +994,8 @@ fn add_patch_with_setting_default_features() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [WARNING] unused field in patch for `bar`: `features`, `default-features`
-[NOTE] configure `features`, `default-features` in the `dependencies` entry
+  |
+  = [HELP] configure `features`, `default-features` in the `dependencies` entry
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -1438,7 +1438,8 @@ fn precise_yanked() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [WARNING] selected package `bar@0.1.1` was yanked by the author
-[NOTE] if possible, try a compatible non-yanked version
+  |
+  = [HELP] if possible, try a compatible non-yanked version
 [UPDATING] bar v0.1.0 -> v0.1.1
 
 "#]])
@@ -1478,7 +1479,8 @@ fn precise_yanked_multiple_presence() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [WARNING] selected package `bar@0.1.1` was yanked by the author
-[NOTE] if possible, try a compatible non-yanked version
+  |
+  = [HELP] if possible, try a compatible non-yanked version
 [UPDATING] bar v0.1.0 -> v0.1.1
 
 "#]])


### PR DESCRIPTION
Here I'm continuing to slowly work through multi-part diagnostics and convert them to reports.

Like #16035, this converts a warning + note into a single `Group` with a warning title containing note elements. Based on [this comment](https://github.com/rust-lang/cargo/pull/16035#discussion_r2395448027) I'm not sure if this is actually what you want, mostly because these notes are typically shorter than the ones in #16035.

For comparison, I'll open another PR that does multiple groups. Edit: #16065 

This is part of #15944