### PR TITLE
Fix test that assumes `CARGO_CFG_TARGET_FAMILY` is a single value

### DIFF
--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -4448,9 +4448,9 @@ fn cfg_env_vars_available() {
                 fn main() {
                     let fam = env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
                     if cfg!(unix) {
-                        assert_eq!(fam, "unix");
-                    } else {
-                        assert_eq!(fam, "windows");
+                        assert!(fam.contains("unix"));
+                    } else if cfg!(windows) {
+                        assert!(fam.contains("windows"));
                     }
                 }
             "#,


### PR DESCRIPTION
### What does this PR try to resolve?

This test would break if/when `rustc` outputs further `target_family` cfgs.

An example of this could be `target_family = "linux"`, or `target_family = "darwin"` if we decide move forwards with https://github.com/rust-lang/rust/issues/100343.

### How to test and review this PR?

```sh
cargo test -- cfg_env_vars_available
```
