### PR TITLE
Allow to rustfix unused_variables lint.

### DIFF
--- a/tests/testsuite/cache_messages.rs
+++ b/tests/testsuite/cache_messages.rs
@@ -507,7 +507,7 @@ fn wacky_hashless_fingerprint() {
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [WARNING] unused variable: `unused`
 ...
-[WARNING] `foo` (bin "a") generated 1 warning
+[WARNING] `foo` (bin "a") generated 1 warning[..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])

--- a/tests/testsuite/warning_override.rs
+++ b/tests/testsuite/warning_override.rs
@@ -50,7 +50,7 @@ fn rustc_caching_allow_first() {
   |
   = [NOTE] `#[warn(unused_variables)]` [..]on by default
 
-[WARNING] `foo` (bin "foo") generated 1 warning
+[WARNING] `foo` (bin "foo") generated 1 warning[..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [ERROR] warnings are denied by `build.warnings` configuration
 
@@ -77,7 +77,7 @@ fn rustc_caching_deny_first() {
   |
   = [NOTE] `#[warn(unused_variables)]` [..]on by default
 
-[WARNING] `foo` (bin "foo") generated 1 warning
+[WARNING] `foo` (bin "foo") generated 1 warning[..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [ERROR] warnings are denied by `build.warnings` configuration
 
@@ -114,7 +114,7 @@ fn config() {
   |
   = [NOTE] `#[warn(unused_variables)]` [..]on by default
 
-[WARNING] `foo` (bin "foo") generated 1 warning
+[WARNING] `foo` (bin "foo") generated 1 warning[..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [ERROR] warnings are denied by `build.warnings` configuration
 
@@ -138,7 +138,7 @@ fn config() {
   |
   = [NOTE] `#[warn(unused_variables)]` [..]on by default
 
-[WARNING] `foo` (bin "foo") generated 1 warning
+[WARNING] `foo` (bin "foo") generated 1 warning[..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -162,7 +162,7 @@ fn requires_nightly() {
   |
   = [NOTE] `#[warn(unused_variables)]` [..]on by default
 
-[WARNING] `foo` (bin "foo") generated 1 warning
+[WARNING] `foo` (bin "foo") generated 1 warning[..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])


### PR DESCRIPTION
### What does this PR try to resolve?

The rest cases `cache_messages::wacky_hashless_fingerprint`, `warning_override::config`, `warning_override::requires_nightly`, `warning_override::rustc_caching_deny_first` and `warning_override::rustc_caching_allow_first` are too strict and prevent merging https://github.com/rust-lang/rust/pull/142390.

This PR relaxes the expected output to allow for the `cargo fix` suggestion.

### How to test and review this PR?

Checkout rustc at https://github.com/rust-lang/rust/pull/142390, change `src/tools/cargo` to this branch, and verify that cargo tests pass.