### PR TITLE
fix(script): Store cargo script lockfiles in build-dir

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -668,7 +668,7 @@ impl<'gctx> Workspace<'gctx> {
 
     fn default_lock_root(&self) -> Filesystem {
         if self.root_maybe().is_embedded() {
-            self.target_dir()
+            self.build_dir()
         } else {
             Filesystem::new(self.root().to_owned())
         }


### PR DESCRIPTION
### What does this PR try to resolve?

`Cargo.lock` is not a final artifact, and so it should be in `build-dir`.  This was missed when examining intermediate vs final artifacts for #14125.

The downside is that if people decide to share a `build-dir` across projects,
it will wreak havoc on their cargo script builds.  I'll call this out in #12207 in case we want to re-visit this.

### How to test and review this PR?

