### PR TITLE
doc: make it clearer that `target.<cfg>.linker` is supported

### DIFF
--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -182,6 +182,7 @@ rustflags = ["…", "…"]    # custom flags for `rustc`
 rustdocflags = ["…", "…"] # custom flags for `rustdoc`
 
 [target.<cfg>]
+linker = "…"            # linker to use
 runner = "…"            # wrapper to run executables
 rustflags = ["…", "…"]  # custom flags for `rustc`
 


### PR DESCRIPTION
### What does this PR try to resolve?

I have often found myself skimming the "configuration format" section instead of reading the reference in depth, and thus I think it makes sense to have [the `target.<cfg>.linker`](https://doc.rust-lang.org/cargo/reference/config.html#targetcfglinker) configuration key documented there as well.

### How to test and review this PR?

Documentation-only.