### PR TITLE
test: Don't look for a specfic ANSI color

### DIFF
--- a/tests/testsuite/message_format.rs
+++ b/tests/testsuite/message_format.rs
@@ -120,7 +120,10 @@ fn cargo_renders_ansi() {
 
     p.cargo("check --message-format json-diagnostic-rendered-ansi")
         .with_status(101)
-        .with_stdout_contains("[..]\\u001b[38;5;9merror[..]")
+        // Because 1b is the start of an ANSI escape sequence, checking for it
+        // allows us to verify that ANSI colors are being emitted without
+        // looking for specific color codes, that may change over time.
+        .with_stdout_contains("[..]\\u001b[..]")
         .run();
 }
 


### PR DESCRIPTION
In rust-lang/rust#147207, I am changing `rustc` to `anstyle` for terminal styling. As part of this change, `rustc` will now be emitting `4-bit` ANSI colors instead of `8-bit` (256-color). That change is blocked on the `message_format::cargo_renders_ansi` test, which looks for a specific color sequence that `rustc` is no longer emitting and subsequently causes it to fail. To fix this, I made it so the test now looks for the start of an ANSI sequence instead of a specific sequence, as seeing the start of an ANSI escape sequence allows us to verify that ANSI colors are being emitted without the problems of looking for a specific sequence. 