### PR TITLE
fix(script): Remove name sanitiztion outside what is strictly required

### DIFF
--- a/src/cargo/util/toml/embedded.rs
+++ b/src/cargo/util/toml/embedded.rs
@@ -2,7 +2,6 @@ use cargo_util_schemas::manifest::PackageName;
 
 use crate::util::frontmatter::FrontmatterError;
 use crate::util::frontmatter::ScriptSource;
-use crate::util::restricted_names;
 
 pub(super) fn expand_manifest(content: &str) -> Result<String, FrontmatterError> {
     let source = ScriptSource::parse(content)?;
@@ -57,18 +56,7 @@ pub fn sanitize_name(name: &str) -> String {
         '-'
     };
 
-    let mut name = PackageName::sanitize(name, placeholder).into_inner();
-
-    loop {
-        if restricted_names::is_conflicting_artifact_name(&name) {
-            // Being an embedded manifest, we always assume it is a `[[bin]]`
-            name.push(placeholder);
-        } else {
-            break;
-        }
-    }
-
-    name
+    PackageName::sanitize(name, placeholder).into_inner()
 }
 
 #[cfg(test)]

--- a/tests/testsuite/script/cargo.rs
+++ b/tests/testsuite/script/cargo.rs
@@ -752,17 +752,14 @@ fn test_name_is_deps_dir_implicit() {
 
     p.cargo("-Zscript -v deps.rs")
         .masquerade_as_nightly_cargo(&["script"])
-        .with_stdout_data(str![[r#"
-current_exe: [ROOT]/home/.cargo/build/[HASH]/target/debug/deps-[EXE]
-arg0: [..]
-args: []
-
-"#]])
+        .with_status(101)
+        .with_stdout_data(str![""])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to `2024`
-[COMPILING] deps- v0.0.0 ([ROOT]/foo/deps.rs)
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/deps-[EXE]`
+[ERROR] failed to parse manifest at `[ROOT]/foo/deps.rs`
+
+Caused by:
+  the binary target name `deps` is forbidden, it conflicts with cargo's build directory names
 
 "#]])
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

Note that we are currently inconsistent in that `test` gets sanitized but nothing else in `sysroot`.

We reviewed what gets sanitized in the Cargo team meeting and found none of these really apply to cargo scripts except conflicting with artifact dirs.

For conflicting with artifact dirs, making this an error now gives us the best compatibility story.
A user can workaround this by overriding `package.name`.
Our paths forward include:
- Leave it as-is or at least improve the error message for this case
- Make it so we don't need the error message
- Add back sanitizating the name

Ideally, we make it so we don't need the error message.
The ground work was laid out for this in #16086.
The next step is to move the conflict error from manifest parsing to
compilation so we can check whether target-dir and build-dir overlap to
error.
There are unknowns with this,
including whether the usability is good enough for making this error
conditional on the target-dir and build-dir overlapping.
We may even want to wait until we change the default build-dir.

### How to test and review this PR?
