### PR TITLE
feat(test-support): Use test name for dir when running tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,7 @@ version = "0.4.9"
 
 [[package]]
 name = "cargo-test-support"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ cargo-credential-macos-keychain = { version = "0.4.20", path = "credential/cargo
 cargo-credential-wincred = { version = "0.4.20", path = "credential/cargo-credential-wincred" }
 cargo-platform = { path = "crates/cargo-platform", version = "0.3.0" }
 cargo-test-macro = { version = "0.4.9", path = "crates/cargo-test-macro" }
-cargo-test-support = { version = "0.9.2", path = "crates/cargo-test-support" }
+cargo-test-support = { version = "0.10.0", path = "crates/cargo-test-support" }
 cargo-util = { version = "0.2.27", path = "crates/cargo-util" }
 cargo-util-schemas = { version = "0.12.0", path = "crates/cargo-util-schemas" }
 cargo_metadata = "0.23.1"

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-test-support"
-version = "0.9.2"
+version = "0.10.0"
 edition.workspace = true
 rust-version = "1.92"  # MSRV:1
 license.workspace = true

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1423,7 +1423,13 @@ pub trait TestEnvCommandExt: Sized {
             .env("__CARGO_TEST_DISABLE_GLOBAL_KNOWN_HOST", "1")
             // Set retry sleep to 1 millisecond.
             .env("__CARGO_TEST_FIXED_RETRY_SLEEP_MS", "1")
-            .env("__CARGO_TEST_TTY_WIDTH_DO_NOT_USE_THIS", "200")
+            // Setting this to a large number helps avoid problems with long
+            // paths getting trimmed in snapshot tests.
+            //
+            // When updating this value, keep in mind that the `CARGO_TARGET_DIR`
+            // that gets set when Cargo's tests get run in `rust-lang/rust` can
+            // easily cause path lengths to exceed 200 characters.
+            .env("__CARGO_TEST_TTY_WIDTH_DO_NOT_USE_THIS", "400")
             // Incremental generates a huge amount of data per test, which we
             // don't particularly need. Tests that specifically need to check
             // the incremental behavior should turn this back on.

--- a/src/doc/contrib/src/tests/writing.md
+++ b/src/doc/contrib/src/tests/writing.md
@@ -200,8 +200,10 @@ Then populate
 - This is used in place of `#[test]`
 - This attribute injects code which does some setup before starting the
   test, creating a filesystem "sandbox" under the "cargo integration test"
-  directory for each test such as
-  `/path/to/cargo/target/cit/t123/`
+  directory for each test. The directory for each test is based on the
+  integration test name, module (if there is one), and function name[^1]:
+
+  `/path/to/cargo/target/tmp/cit/<integration test>/<module>/<fn name>/`
 - The sandbox will contain a `home` directory that will be used instead of your normal home directory
 
 `Project`:
@@ -258,6 +260,11 @@ or overwrite a binary immediately after running it. Under some conditions
 Windows will fail with errors like "directory not empty" or "failed to remove"
 or "access is denied".
 
+On Windows, to avoid path length limitations, the tests use the following
+directory structure instead:
+
+`/path/to/cargo/target/tmp/cit/t123/`
+
 ## Debugging tests
 
 In some cases, you may need to dig into a test that is not working as you
@@ -268,7 +275,7 @@ environment. The general process is:
 
    `cargo test --test testsuite -- features2::inactivate_targets`.
 2. In another terminal, head into the sandbox directory to inspect the files and run `cargo` directly.
-    1. The sandbox directories start with `t0` for the first test.
+    1. The first test's sandbox directory is called `t0`.
 
        `cd target/tmp/cit/t0`
     2. Set up the environment so that the sandbox configuration takes effect:
@@ -299,3 +306,6 @@ environment. The general process is:
 [`Command`]: https://docs.rs/snapbox/latest/snapbox/cmd/struct.Command.html
 [`OutputAssert`]: https://docs.rs/snapbox/latest/snapbox/cmd/struct.OutputAssert.html
 [`Assert`]: https://docs.rs/snapbox/latest/snapbox/struct.Assert.html
+
+[^1]: Windows uses a separate directory layout, see [Platform-Specific Notes](#platform-specific-notes)
+    for more details.

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -212,3 +212,52 @@ fn aaa_trigger_cross_compile_disabled_check() {
     // This triggers the cross compile disabled check to run ASAP, see #5141
     crate::utils::cross_compile::disabled();
 }
+
+// This is placed here as running tests in `cargo-test-support` would rebuild it
+#[cargo_test]
+#[cfg(not(windows))]
+fn check_test_dir() {
+    let tests = vec![
+        (
+            "tests/testsuite/workspaces.rs",
+            "workspace_in_git",
+            "testsuite/workspaces/workspace_in_git",
+        ),
+        (
+            "tests/testsuite/cargo_remove/invalid_arg/mod.rs",
+            "case",
+            "testsuite/cargo_remove/invalid_arg/case",
+        ),
+        (
+            "tests/build-std/main.rs",
+            "cross_custom",
+            "build-std/main/cross_custom",
+        ),
+        (
+            "src/tools/cargo/tests/testsuite/build.rs",
+            "cargo_compile_simple",
+            "src/tools/cargo/testsuite/build/cargo_compile_simple",
+        ),
+        (
+            "src/tools/cargo/tests/testsuite/cargo_add/add_basic/mod.rs",
+            "case",
+            "src/tools/cargo/testsuite/cargo_add/add_basic/case",
+        ),
+        (
+            "src/tools/cargo/tests/build-std/main.rs",
+            "cross_custom",
+            "src/tools/cargo/build-std/main/cross_custom",
+        ),
+        (
+            "workspace/more/src/tools/cargo/tests/testsuite/build.rs",
+            "cargo_compile_simple",
+            "src/tools/cargo/testsuite/build/cargo_compile_simple",
+        ),
+    ];
+    for (path, name, expected) in tests {
+        assert_eq!(
+            cargo_test_support::paths::test_dir(path, name),
+            std::path::PathBuf::from(expected)
+        );
+    }
+}


### PR DESCRIPTION
In #11738, I made a test's "sandbox" folder based on its name instead of a generated number, which can change from run to run. #11812 reverted this change due to problems with path length limits on Windows. After getting frustrated with the generated folders while trying to debug a test recently, I decided that it would be a good idea to bring back name-based folders to platforms that support them.