### PR TITLE
Warn when installing with a non-default toolchain

### DIFF
--- a/tests/testsuite/rustup.rs
+++ b/tests/testsuite/rustup.rs
@@ -59,6 +59,13 @@ fn real_rustc_wrapper(bin_dir: &Path, message: &str) -> PathBuf {
     // The toolchain rustc needs to call the real rustc. In order to do that,
     // it needs to restore or clear the RUSTUP environment variables so that
     // if rustup is installed, it will call the correct rustc.
+    let rustup_toolchain_source_setup = match std::env::var_os("RUSTUP_TOOLCHAIN_SOURCE") {
+        Some(t) => format!(
+            ".env(\"RUSTUP_TOOLCHAIN_SOURCE\", \"{}\")",
+            t.into_string().unwrap()
+        ),
+        None => String::new(),
+    };
     let rustup_toolchain_setup = match std::env::var_os("RUSTUP_TOOLCHAIN") {
         Some(t) => format!(
             ".env(\"RUSTUP_TOOLCHAIN\", \"{}\")",
@@ -82,6 +89,7 @@ fn real_rustc_wrapper(bin_dir: &Path, message: &str) -> PathBuf {
                 eprintln!("{message}");
                 let r = std::process::Command::new(env!("CARGO_RUSTUP_TEST_real_rustc"))
                     .args(std::env::args_os().skip(1))
+                    {rustup_toolchain_source_setup}
                     {rustup_toolchain_setup}
                     {rustup_home_setup}
                     .status();
@@ -390,6 +398,10 @@ fn cargo_install_with_toolchain_source_env() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
 [INSTALLING] foo v0.0.1
+[WARNING] default toolchain implicitly overridden with `test-toolchain` by environment variable
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v0.0.1
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 [INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
@@ -410,6 +422,10 @@ fn cargo_install_with_toolchain_source_path_override() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
 [INSTALLING] foo v0.0.1
+[WARNING] default toolchain implicitly overridden with `test-toolchain` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v0.0.1
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 [INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
@@ -430,6 +446,10 @@ fn cargo_install_with_toolchain_source_toolchain_file() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
 [INSTALLING] foo v0.0.1
+[WARNING] default toolchain implicitly overridden with `test-toolchain` by rustup toolchain file
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v0.0.1
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 [INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/cargo/pull/16131)*

This PR implements the cargo changes for #11036. The rustup changes were implemented in https://github.com/rust-lang/rustup/pull/4518.

The PR is currently organized as four commits:

- The first expands the rustup tests to set `RUSTUP_TOOLCHAIN_SOURCE`. This change is not strictly necessary, but it improves the rustup tests' fidelity.
- The second moves the `pkg` function to a location where the next commit can use it.
- The third implements a test to check the fourth commit's fix.
- The fourth warns when `cargo install` is invoked with a non-default toolchain, as indicated by `RUSTUP_TOOLCHAIN_SOURCE`.

In the third commit, two significant changes were made to `simulated_rustup_environment`:

- Previously, the constructed proxy would call an always-panicking executable whenever it was asked to run cargo. Now, the proxy can be made to run the cargo under test.
- The proxy can now be made to set additional environment variables (e.g., `RUSTUP_TOOLCHAIN_SOURCE`) before calling the proxied tool.

The PR is currently marked as draft because https://github.com/rust-lang/rustup/pull/4518 has not yet been released. Technically, this PR could be merged before then. But testing it with a fixed rustup would seem to make sense.

Nits are welcome.

cc: @epage