### PR TITLE
Fix: correctly pluralize 'target'/'targets' in finished message

### DIFF
--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -844,8 +844,10 @@ impl<'gctx> DrainState<'gctx> {
             let profile_link = build_runner.bcx.gctx.shell().err_hyperlink(
                 "https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles",
             );
+            let target_count = self.counts.len();
             let message = format!(
-                "{profile_link}`{profile_name}` profile [{opt_type}]{profile_link:#} target(s) in {time_elapsed}",
+                "{profile_link}`{profile_name}` profile [{opt_type}]{profile_link:#} target{} in {time_elapsed}",
+                (target_count == 1).then(|| "").unwrap_or("s")
             );
             if !build_runner.bcx.build_config.build_plan {
                 // It doesn't really matter if this fails.


### PR DESCRIPTION
This change ensures that the finished message correctly uses "target" or "targets"
based on the number of targets built, improving clarity in multi-target builds.