### PR TITLE
chore(triagebot): `A-json-output` for machine_message.rs

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -105,7 +105,6 @@ trigger_files = ["src/cargo/util/context/mod.rs"]
 [autolabel."A-console-output"]
 trigger_files = [
   "src/cargo/core/shell.rs",
-  "src/cargo/util/machine_message.rs",
   "src/cargo/util/progress.rs",
 ]
 
@@ -170,6 +169,9 @@ trigger_files = [
 
 [autolabel."A-interacts-with-crates.io"]
 trigger_files = ["crates/crates-io/", "src/cargo/ops/registry/"]
+
+[autolabel."A-json-output"]
+trigger_files = ["src/cargo/util/machine_message.rs"]
 
 [autolabel."A-layout"]
 trigger_files = [


### PR DESCRIPTION

### What does this PR try to resolve?

`src/cargo/util/machine_message.rs` defines shapes of JSON messages output, so should be labeled as `A-json-output`. `A-console-output` is more around styling and the underlying machinery.