### PR TITLE
Adds a manifest location to Dependency.

### DIFF
--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -621,7 +621,7 @@ https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html
 ";
 
         for dep in override_summary.dependencies() {
-            if let Some(i) = real_deps.iter().position(|d| dep == *d) {
+            if let Some(i) = real_deps.iter().position(|d| dep.eq_ignoring_location(d)) {
                 real_deps.remove(i);
                 continue;
             }

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -832,16 +832,21 @@ impl<'gctx> Source for RegistrySource<'gctx> {
                     .precise_version()
                     .expect("--precise <yanked-version> in use");
                 if self.selected_precise_yanked.insert((name, version.clone())) {
-                    let mut shell = self.gctx.shell();
-                    shell.print_report(
+                    let mut elements: Vec<annotate_snippets::Element<'_>> = Vec::new();
+                    if let Some(manifest_loc) = dep.toml_location() {
+                        elements.push(manifest_loc.to_snippet().into());
+                    }
+                    elements.push(
+                        Level::HELP
+                            .message("if possible, try a compatible non-yanked version")
+                            .into(),
+                    );
+                    self.gctx.shell().print_report(
                         &[Level::WARNING
                             .secondary_title(format!(
                                 "selected package `{name}@{version}` was yanked by the author"
                             ))
-                            .element(
-                                Level::HELP
-                                    .message("if possible, try a compatible non-yanked version"),
-                            )],
+                            .elements(elements)],
                         false,
                     )?;
                 }

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -1438,6 +1438,10 @@ fn precise_yanked() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [WARNING] selected package `bar@0.1.1` was yanked by the author
+ --> Cargo.toml:6:23
+  |
+6 |                 bar = "0.1"
+  |                       ^^^^^
   |
   = [HELP] if possible, try a compatible non-yanked version
 [UPDATING] bar v0.1.0 -> v0.1.1
@@ -1479,6 +1483,10 @@ fn precise_yanked_multiple_presence() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [WARNING] selected package `bar@0.1.1` was yanked by the author
+ --> Cargo.toml:6:23
+  |
+6 |                 bar = "0.1"
+  |                       ^^^^^
   |
   = [HELP] if possible, try a compatible non-yanked version
 [UPDATING] bar v0.1.0 -> v0.1.1


### PR DESCRIPTION
### What does this PR try to resolve?

This adds a little bit of span information to `Dependency`, to help with issuing better diagnostics.

It's a bit limited:
- it only stores the span of the entire dependency value -- it doesn't allow for finding the location of subfields
- it doesn't reference the workspace manifest if things are inherited
- it doesn't handle the `patch` table

I think it would be nice to have more comprehensive span tracking. Like, there could be a lightweight `Span` type that contains a small file identifier and a byte range. Then `TomlManifest` could have spans everywhere, and `normalize_toml` could merge spans from the workspace manifest during dependency inheritance.

But that would be a more invasive change, so I started small...