### PR TITLE
Bump openssl-src to 300.3.5.4+3.5.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3128,9 +3128,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.3+3.5.4"
+version = "300.5.4+3.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6bad8cd0233b63971e232cc9c5e83039375b8586d2312f31fda85db8f888c2"
+checksum = "a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION
### What does this PR try to resolve?

Switches to a version of openssl-src that works on 
sparc64-unknown-linux-gnu. This makes it easier to build cargo for that 
platform as you no longer need to build OpenSSL by hand first.

### How to test and review this PR?

On PopOS 22.04 x86-64:

```console
$ sudo apt install gcc-sparc64-linux-gnu
$ RUSTFLAGS="-Clinker=sparc64-linux-gnu-gcc" \
  CC_sparc64_unknown_linux_gnu=sparc64-linux-gnu-gcc \
  cargo build --target=sparc64-unknown-linux-gnu --features=vendored-openssl --release
$ scp ./target/sparc64-unknown-linux-gnu/release/cargo user@sparc-machine:
$ ssh user@sparc-machine uname -a
Linux sparc-machine 6.17.0-rc5+ #1 SMP Fri Sep 12 20:37:32 UTC 2025 sparc64 GNU/Linux
$ ssh user@sparc-machine ./cargo -V
cargo 1.92.0 (85a381333 2025-10-22)
```
