### PR TITLE
Mention cargo wizard in build performance guide

### DIFF
--- a/src/doc/src/guide/build-performance.md
+++ b/src/doc/src/guide/build-performance.md
@@ -23,6 +23,8 @@ Common locations to override defaults are:
 - [`$CARGO_HOME/.cargo/config.toml` configuration file](../reference/config.md)
   - For a developer to control the defaults for their development
 
+You can use third-party tools like [cargo-wizard](https://crates.io/crates/cargo-wizard) to automatically configure options optimized for build performance in your project.
+
 ### Reduce amount of generated debug information
 
 Recommendation: Add to your `Cargo.toml` or `.cargo/config.toml`:


### PR DESCRIPTION
I figured that since we already mention other third-party Cargo subcommands, we could also mention my cargo-wizard tool, as it's (IMO) highly relevant here.

r? @epage
