### PR TITLE
Make shell completion variables private.

### DIFF
--- a/src/etc/_cargo
+++ b/src/etc/_cargo
@@ -4,7 +4,7 @@ autoload -U regexp-replace
 
 _cargo() {
     local curcontext="$curcontext" ret=1
-    local -a command_scope_spec common parallel features msgfmt triple target registry
+    local -a command_scope_spec common jobs parallel features manifest msgfmt triple target registry
     local -a state line state_descr # These are set by _arguments
     typeset -A opt_args
 


### PR DESCRIPTION
Otherwise they leak. For example type `cargo che<Tab>` in ZSH and you can see that the variables are now set in the shell (overwriting existing variables of this name).

### What does this PR try to resolve?

Avoids leaking/overwriting variables in the user's shell.

### How to test and review this PR?

Load the shell completions and run a completion.
