### PR TITLE
chore(triagebot): enable range-diff and review-changes-since

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -42,6 +42,11 @@ label = "O-windows"
 # Documentation at: https://forge.rust-lang.org/triagebot/range-diff.html
 [range-diff]
 
+# Adds at the end of a review body a link to view the changes that happened
+# since the review
+# Documentation at: https://forge.rust-lang.org/triagebot/review-changes-since.html
+[review-changes-since]
+
 [merge-conflicts]
 remove = []
 add = ["S-waiting-on-author"]


### PR DESCRIPTION
### What does this PR try to resolve?

Enable two new triagebot features, which are already adopted in rust-lang/rust.

**range-diff**:

Enable comments linking to triagebot range-diff when a PR is rebased
onto a different base commit
Documentation at: https://forge.rust-lang.org/triagebot/range-diff.html

**review-changes-since**:

Adds at the end of a review body a link
to view the changes that happened since the review
Documentation at: https://forge.rust-lang.org/triagebot/review-changes-since.html

<!-- TRIAGEBOT_START -->

<!-- TRIAGEBOT_SUMMARY_START -->

### Summary Notes

- [range-diff example comments](https://github.com/rust-lang/cargo/pull/16152#issuecomment-3446880892) by [weihanglo](https://github.com/weihanglo)
- [review-changes-since example comments](https://github.com/rust-lang/cargo/pull/16152#issuecomment-3446882975) by [weihanglo](https://github.com/weihanglo)

*Managed by `@rustbot`—see [help](https://forge.rust-lang.org/triagebot/note.html) for details*

<!-- TRIAGEBOT_SUMMARY_END -->
<!-- TRIAGEBOT_END -->