### PR TITLE
test(git): add more fetch-index backend interop 

### DIFF
--- a/tests/testsuite/git_shallow.rs
+++ b/tests/testsuite/git_shallow.rs
@@ -345,11 +345,71 @@ fn gitoxide_fetch_shallow_index_then_git2_fetch_complete() -> anyhow::Result<()>
 }
 
 #[cargo_test]
+fn gitoxide_fetch_shallow_index_then_git_cli_fetch_shallow() -> anyhow::Result<()> {
+    fetch_index_then_fetch(
+        Backend::Gitoxide,
+        RepoMode::Shallow,
+        Backend::GitCli,
+        RepoMode::Shallow,
+    )
+}
+
+#[cargo_test]
+fn gitoxide_fetch_complete_index_then_git_cli_fetch_shallow() -> anyhow::Result<()> {
+    fetch_index_then_fetch(
+        Backend::Gitoxide,
+        RepoMode::Complete,
+        Backend::GitCli,
+        RepoMode::Shallow,
+    )
+}
+
+#[cargo_test]
+fn gitoxide_fetch_shallow_index_then_git_cli_fetch_complete() -> anyhow::Result<()> {
+    fetch_index_then_fetch(
+        Backend::Gitoxide,
+        RepoMode::Shallow,
+        Backend::GitCli,
+        RepoMode::Complete,
+    )
+}
+
+#[cargo_test]
 fn git_cli_fetch_shallow_index_then_git2_fetch_complete() -> anyhow::Result<()> {
     fetch_index_then_fetch(
         Backend::GitCli,
         RepoMode::Shallow,
         Backend::Git2,
+        RepoMode::Complete,
+    )
+}
+
+#[cargo_test]
+fn git_cli_fetch_shallow_index_then_gitoxide_fetch_shallow() -> anyhow::Result<()> {
+    fetch_index_then_fetch(
+        Backend::GitCli,
+        RepoMode::Shallow,
+        Backend::Gitoxide,
+        RepoMode::Shallow,
+    )
+}
+
+#[cargo_test]
+fn git_cli_fetch_shallow_complete_then_gitoxide_fetch_complete() -> anyhow::Result<()> {
+    fetch_index_then_fetch(
+        Backend::GitCli,
+        RepoMode::Complete,
+        Backend::Gitoxide,
+        RepoMode::Shallow,
+    )
+}
+
+#[cargo_test]
+fn git_cli_fetch_shallow_index_then_gitoxide_fetch_complete() -> anyhow::Result<()> {
+    fetch_index_then_fetch(
+        Backend::GitCli,
+        RepoMode::Shallow,
+        Backend::Gitoxide,
         RepoMode::Complete,
     )
 }


### PR DESCRIPTION
### What does this PR try to resolve?

Cherry-pick some test generalization from <https://github.com/epage/cargo/commit/9af85fd51109f2988d1a4eeef5073f833e088b08>

See <https://github.com/rust-lang/cargo/pull/16156#issuecomment-3451875953>

`fetch_dep_then_fetch` is a bit tricky to generalize, so leave it there.

### How to test and review this PR?




