### PR TITLE
Remove equals from `--timings` docs

### DIFF
--- a/src/doc/man/generated_txt/cargo-bench.txt
+++ b/src/doc/man/generated_txt/cargo-bench.txt
@@ -253,7 +253,7 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/profiles.html> for more
            details on profiles.
 
-       --timings=fmts
+       --timings fmts
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
            comma-separated list of output formats; --timings without an

--- a/src/doc/man/generated_txt/cargo-build.txt
+++ b/src/doc/man/generated_txt/cargo-build.txt
@@ -174,7 +174,7 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/profiles.html> for more
            details on profiles.
 
-       --timings=fmts
+       --timings fmts
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
            comma-separated list of output formats; --timings without an

--- a/src/doc/man/generated_txt/cargo-check.txt
+++ b/src/doc/man/generated_txt/cargo-check.txt
@@ -178,7 +178,7 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/profiles.html> for more
            details on profiles.
 
-       --timings=fmts
+       --timings fmts
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
            comma-separated list of output formats; --timings without an

--- a/src/doc/man/generated_txt/cargo-doc.txt
+++ b/src/doc/man/generated_txt/cargo-doc.txt
@@ -153,7 +153,7 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/profiles.html> for more
            details on profiles.
 
-       --timings=fmts
+       --timings fmts
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
            comma-separated list of output formats; --timings without an

--- a/src/doc/man/generated_txt/cargo-fix.txt
+++ b/src/doc/man/generated_txt/cargo-fix.txt
@@ -252,7 +252,7 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/profiles.html> for more
            details on profiles.
 
-       --timings=fmts
+       --timings fmts
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
            comma-separated list of output formats; --timings without an

--- a/src/doc/man/generated_txt/cargo-install.txt
+++ b/src/doc/man/generated_txt/cargo-install.txt
@@ -234,7 +234,7 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/profiles.html> for more
            details on profiles.
 
-       --timings=fmts
+       --timings fmts
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
            comma-separated list of output formats; --timings without an

--- a/src/doc/man/generated_txt/cargo-run.txt
+++ b/src/doc/man/generated_txt/cargo-run.txt
@@ -98,7 +98,7 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/profiles.html> for more
            details on profiles.
 
-       --timings=fmts
+       --timings fmts
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
            comma-separated list of output formats; --timings without an

--- a/src/doc/man/generated_txt/cargo-rustc.txt
+++ b/src/doc/man/generated_txt/cargo-rustc.txt
@@ -182,7 +182,7 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/profiles.html> for more
            details on profiles.
 
-       --timings=fmts
+       --timings fmts
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
            comma-separated list of output formats; --timings without an

--- a/src/doc/man/generated_txt/cargo-rustdoc.txt
+++ b/src/doc/man/generated_txt/cargo-rustdoc.txt
@@ -165,7 +165,7 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/profiles.html> for more
            details on profiles.
 
-       --timings=fmts
+       --timings fmts
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
            comma-separated list of output formats; --timings without an

--- a/src/doc/man/generated_txt/cargo-test.txt
+++ b/src/doc/man/generated_txt/cargo-test.txt
@@ -279,7 +279,7 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/profiles.html> for more
            details on profiles.
 
-       --timings=fmts
+       --timings fmts
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
            comma-separated list of output formats; --timings without an

--- a/src/doc/man/includes/options-timings.md
+++ b/src/doc/man/includes/options-timings.md
@@ -1,4 +1,4 @@
-{{#option "`--timings=`_fmts_"}}
+{{#option "`--timings` _fmts_"}}
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
 formats; `--timings` without an argument will default to `--timings=html`.

--- a/src/doc/src/commands/cargo-bench.md
+++ b/src/doc/src/commands/cargo-bench.md
@@ -296,7 +296,7 @@ See <a href="../reference/profiles.html">the reference</a> for more details on p
 </dd>
 
 
-<dt class="option-term" id="option-cargo-bench---timings=fmts"><a class="option-anchor" href="#option-cargo-bench---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
+<dt class="option-term" id="option-cargo-bench---timings"><a class="option-anchor" href="#option-cargo-bench---timings"></a><code>--timings</code> <em>fmts</em></dt>
 <dd class="option-desc"><p>Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
 formats; <code>--timings</code> without an argument will default to <code>--timings=html</code>.

--- a/src/doc/src/commands/cargo-build.md
+++ b/src/doc/src/commands/cargo-build.md
@@ -216,7 +216,7 @@ See <a href="../reference/profiles.html">the reference</a> for more details on p
 </dd>
 
 
-<dt class="option-term" id="option-cargo-build---timings=fmts"><a class="option-anchor" href="#option-cargo-build---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
+<dt class="option-term" id="option-cargo-build---timings"><a class="option-anchor" href="#option-cargo-build---timings"></a><code>--timings</code> <em>fmts</em></dt>
 <dd class="option-desc"><p>Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
 formats; <code>--timings</code> without an argument will default to <code>--timings=html</code>.

--- a/src/doc/src/commands/cargo-check.md
+++ b/src/doc/src/commands/cargo-check.md
@@ -216,7 +216,7 @@ detail.</p>
 </dd>
 
 
-<dt class="option-term" id="option-cargo-check---timings=fmts"><a class="option-anchor" href="#option-cargo-check---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
+<dt class="option-term" id="option-cargo-check---timings"><a class="option-anchor" href="#option-cargo-check---timings"></a><code>--timings</code> <em>fmts</em></dt>
 <dd class="option-desc"><p>Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
 formats; <code>--timings</code> without an argument will default to <code>--timings=html</code>.

--- a/src/doc/src/commands/cargo-doc.md
+++ b/src/doc/src/commands/cargo-doc.md
@@ -191,7 +191,7 @@ See <a href="../reference/profiles.html">the reference</a> for more details on p
 </dd>
 
 
-<dt class="option-term" id="option-cargo-doc---timings=fmts"><a class="option-anchor" href="#option-cargo-doc---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
+<dt class="option-term" id="option-cargo-doc---timings"><a class="option-anchor" href="#option-cargo-doc---timings"></a><code>--timings</code> <em>fmts</em></dt>
 <dd class="option-desc"><p>Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
 formats; <code>--timings</code> without an argument will default to <code>--timings=html</code>.

--- a/src/doc/src/commands/cargo-fix.md
+++ b/src/doc/src/commands/cargo-fix.md
@@ -302,7 +302,7 @@ detail.</p>
 </dd>
 
 
-<dt class="option-term" id="option-cargo-fix---timings=fmts"><a class="option-anchor" href="#option-cargo-fix---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
+<dt class="option-term" id="option-cargo-fix---timings"><a class="option-anchor" href="#option-cargo-fix---timings"></a><code>--timings</code> <em>fmts</em></dt>
 <dd class="option-desc"><p>Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
 formats; <code>--timings</code> without an argument will default to <code>--timings=html</code>.

--- a/src/doc/src/commands/cargo-install.md
+++ b/src/doc/src/commands/cargo-install.md
@@ -271,7 +271,7 @@ See <a href="../reference/profiles.html">the reference</a> for more details on p
 </dd>
 
 
-<dt class="option-term" id="option-cargo-install---timings=fmts"><a class="option-anchor" href="#option-cargo-install---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
+<dt class="option-term" id="option-cargo-install---timings"><a class="option-anchor" href="#option-cargo-install---timings"></a><code>--timings</code> <em>fmts</em></dt>
 <dd class="option-desc"><p>Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
 formats; <code>--timings</code> without an argument will default to <code>--timings=html</code>.

--- a/src/doc/src/commands/cargo-run.md
+++ b/src/doc/src/commands/cargo-run.md
@@ -122,7 +122,7 @@ See <a href="../reference/profiles.html">the reference</a> for more details on p
 </dd>
 
 
-<dt class="option-term" id="option-cargo-run---timings=fmts"><a class="option-anchor" href="#option-cargo-run---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
+<dt class="option-term" id="option-cargo-run---timings"><a class="option-anchor" href="#option-cargo-run---timings"></a><code>--timings</code> <em>fmts</em></dt>
 <dd class="option-desc"><p>Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
 formats; <code>--timings</code> without an argument will default to <code>--timings=html</code>.

--- a/src/doc/src/commands/cargo-rustc.md
+++ b/src/doc/src/commands/cargo-rustc.md
@@ -213,7 +213,7 @@ similar to the <code>test</code> profile.</li>
 </dd>
 
 
-<dt class="option-term" id="option-cargo-rustc---timings=fmts"><a class="option-anchor" href="#option-cargo-rustc---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
+<dt class="option-term" id="option-cargo-rustc---timings"><a class="option-anchor" href="#option-cargo-rustc---timings"></a><code>--timings</code> <em>fmts</em></dt>
 <dd class="option-desc"><p>Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
 formats; <code>--timings</code> without an argument will default to <code>--timings=html</code>.

--- a/src/doc/src/commands/cargo-rustdoc.md
+++ b/src/doc/src/commands/cargo-rustdoc.md
@@ -209,7 +209,7 @@ See <a href="../reference/profiles.html">the reference</a> for more details on p
 </dd>
 
 
-<dt class="option-term" id="option-cargo-rustdoc---timings=fmts"><a class="option-anchor" href="#option-cargo-rustdoc---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
+<dt class="option-term" id="option-cargo-rustdoc---timings"><a class="option-anchor" href="#option-cargo-rustdoc---timings"></a><code>--timings</code> <em>fmts</em></dt>
 <dd class="option-desc"><p>Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
 formats; <code>--timings</code> without an argument will default to <code>--timings=html</code>.

--- a/src/doc/src/commands/cargo-test.md
+++ b/src/doc/src/commands/cargo-test.md
@@ -326,7 +326,7 @@ See <a href="../reference/profiles.html">the reference</a> for more details on p
 </dd>
 
 
-<dt class="option-term" id="option-cargo-test---timings=fmts"><a class="option-anchor" href="#option-cargo-test---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
+<dt class="option-term" id="option-cargo-test---timings"><a class="option-anchor" href="#option-cargo-test---timings"></a><code>--timings</code> <em>fmts</em></dt>
 <dd class="option-desc"><p>Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
 formats; <code>--timings</code> without an argument will default to <code>--timings=html</code>.

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -297,7 +297,7 @@ Benchmark with the given profile.
 See \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles.html> for more details on profiles.
 .RE
 .sp
-\fB\-\-timings=\fR\fIfmts\fR
+\fB\-\-timings\fR \fIfmts\fR
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output

--- a/src/etc/man/cargo-build.1
+++ b/src/etc/man/cargo-build.1
@@ -203,7 +203,7 @@ Build with the given profile.
 See \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles.html> for more details on profiles.
 .RE
 .sp
-\fB\-\-timings=\fR\fIfmts\fR
+\fB\-\-timings\fR \fIfmts\fR
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output

--- a/src/etc/man/cargo-check.1
+++ b/src/etc/man/cargo-check.1
@@ -205,7 +205,7 @@ detail.
 See \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles.html> for more details on profiles.
 .RE
 .sp
-\fB\-\-timings=\fR\fIfmts\fR
+\fB\-\-timings\fR \fIfmts\fR
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -174,7 +174,7 @@ Document with the given profile.
 See \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles.html> for more details on profiles.
 .RE
 .sp
-\fB\-\-timings=\fR\fIfmts\fR
+\fB\-\-timings\fR \fIfmts\fR
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output

--- a/src/etc/man/cargo-fix.1
+++ b/src/etc/man/cargo-fix.1
@@ -300,7 +300,7 @@ detail.
 See \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles.html> for more details on profiles.
 .RE
 .sp
-\fB\-\-timings=\fR\fIfmts\fR
+\fB\-\-timings\fR \fIfmts\fR
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output

--- a/src/etc/man/cargo-install.1
+++ b/src/etc/man/cargo-install.1
@@ -291,7 +291,7 @@ Install with the given profile.
 See \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles.html> for more details on profiles.
 .RE
 .sp
-\fB\-\-timings=\fR\fIfmts\fR
+\fB\-\-timings\fR \fIfmts\fR
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output

--- a/src/etc/man/cargo-run.1
+++ b/src/etc/man/cargo-run.1
@@ -109,7 +109,7 @@ Run with the given profile.
 See \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles.html> for more details on profiles.
 .RE
 .sp
-\fB\-\-timings=\fR\fIfmts\fR
+\fB\-\-timings\fR \fIfmts\fR
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output

--- a/src/etc/man/cargo-rustc.1
+++ b/src/etc/man/cargo-rustc.1
@@ -209,7 +209,7 @@ similar to the \fBtest\fR profile.
 See \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles.html> for more details on profiles.
 .RE
 .sp
-\fB\-\-timings=\fR\fIfmts\fR
+\fB\-\-timings\fR \fIfmts\fR
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output

--- a/src/etc/man/cargo-rustdoc.1
+++ b/src/etc/man/cargo-rustdoc.1
@@ -191,7 +191,7 @@ Document with the given profile.
 See \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles.html> for more details on profiles.
 .RE
 .sp
-\fB\-\-timings=\fR\fIfmts\fR
+\fB\-\-timings\fR \fIfmts\fR
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -324,7 +324,7 @@ Test with the given profile.
 See \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles.html> for more details on profiles.
 .RE
 .sp
-\fB\-\-timings=\fR\fIfmts\fR
+\fB\-\-timings\fR \fIfmts\fR
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output


### PR DESCRIPTION
This is to bring the docs for the `--timings` option in line with the style of all the other options. When an option takes a value, they are listed with a space, not an equals.
