### PR TITLE
Remove libc pin message

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ itertools = "0.14.0"
 jiff = { version = "0.2.15", default-features = false, features = [ "std" ] }
 jobserver = "0.1.34"
 lazycell = "1.3.0"
-libc = "0.2.174" # Please ensure in lockfile it stays as 0.2.174 until bytecodealliance/rustix#1496 resolved
+libc = "0.2.174"
 libgit2-sys = "0.18.2"
 libloading = "0.8.9"
 memchr = "2.7.6"


### PR DESCRIPTION
This was resolved via https://github.com/rust-lang/cargo/pull/16044, but this message wasn't removed at the time.
