### PR TITLE
Add format option to `cargo tree` to print the package version requirement

### DIFF
--- a/src/cargo/ops/tree/format/mod.rs
+++ b/src/cargo/ops/tree/format/mod.rs
@@ -14,6 +14,7 @@ enum Chunk {
     Repository,
     Features,
     LibName,
+    VersionRequirement,
 }
 
 pub struct Pattern(Vec<Chunk>);
@@ -30,6 +31,7 @@ impl Pattern {
                 RawChunk::Argument("r") => Chunk::Repository,
                 RawChunk::Argument("f") => Chunk::Features,
                 RawChunk::Argument("lib") => Chunk::LibName,
+                RawChunk::Argument("ver-req") => Chunk::VersionRequirement,
                 RawChunk::Argument(a) => {
                     bail!("unsupported pattern `{}`", a);
                 }
@@ -109,6 +111,13 @@ impl<'a> fmt::Display for Display<'a> {
                                 .find(|target| target.is_lib())
                             {
                                 write!(fmt, "{}", target.crate_name())?;
+                            }
+                        }
+                        Chunk::VersionRequirement => {
+                            if let Some(version_req) =
+                                self.graph.version_req_for_id(package.package_id())
+                            {
+                                write!(fmt, "{}", version_req)?;
                             }
                         }
                     }

--- a/src/doc/man/cargo-tree.md
+++ b/src/doc/man/cargo-tree.md
@@ -167,6 +167,7 @@ strings will be replaced with the corresponding value:
 - `{r}` --- The package repository URL.
 - `{f}` --- Comma-separated list of package features that are enabled.
 - `{lib}` --- The name, as used in a `use` statement, of the package's library.
+- `{ver-req}` --- The version requirement resolved for the package.
 {{/option}}
 
 {{#option "`--prefix` _prefix_" }}

--- a/src/doc/man/generated_txt/cargo-tree.txt
+++ b/src/doc/man/generated_txt/cargo-tree.txt
@@ -166,6 +166,8 @@ OPTIONS
            o  {lib} — The name, as used in a use statement, of the
               package’s library.
 
+           o  {ver-req} — The version requirement resolved for the package.
+
        --prefix prefix
            Sets how each line is displayed. The prefix value can be one of:
 

--- a/src/doc/src/commands/cargo-tree.md
+++ b/src/doc/src/commands/cargo-tree.md
@@ -170,6 +170,7 @@ strings will be replaced with the corresponding value:</p>
 <li><code>{r}</code> — The package repository URL.</li>
 <li><code>{f}</code> — Comma-separated list of package features that are enabled.</li>
 <li><code>{lib}</code> — The name, as used in a <code>use</code> statement, of the package’s library.</li>
+<li><code>{ver-req}</code> — The version requirement resolved for the package.</li>
 </ul>
 </dd>
 

--- a/src/etc/man/cargo-tree.1
+++ b/src/etc/man/cargo-tree.1
@@ -208,6 +208,10 @@ strings will be replaced with the corresponding value:
 .RS 4
 \h'-04'\(bu\h'+03'\fB{lib}\fR \[em] The name, as used in a \fBuse\fR statement, of the package\[cq]s library.
 .RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+03'\fB{ver\-req}\fR \[em] The version requirement resolved for the package.
+.RE
 .RE
 .sp
 \fB\-\-prefix\fR \fIprefix\fR

--- a/tests/testsuite/cargo_tree/deps.rs
+++ b/tests/testsuite/cargo_tree/deps.rs
@@ -1248,25 +1248,25 @@ foo v0.1.0 ([ROOT]/foo) [bar,default,dep_that_is_awesome,foo,other-dep]
         .run();
 
     p.cargo("tree --all-features")
-        .arg("--format={p}")
+        .arg("--format={p} satisfies {ver-req}")
         .with_stdout_data(str![[r#"
-foo v0.1.0 ([ROOT]/foo)
-├── dep v1.0.0
-├── dep_that_is_awesome v1.0.0
-└── other-dep v1.0.0
-    └── dep v1.0.0
+foo v0.1.0 ([ROOT]/foo) satisfies 
+├── dep v1.0.0 satisfies ^1.0
+├── dep_that_is_awesome v1.0.0 satisfies >=1.0, <2
+└── other-dep v1.0.0 satisfies ^1.0
+    └── dep v1.0.0 satisfies ^1.0
 
 "#]])
         .run();
 
     p.cargo("tree --all-features")
-        .arg("--format={p}")
+        .arg("--format={p} satisfies {ver-req}")
         .arg("--invert=dep")
         .with_stdout_data(str![[r#"
-dep v1.0.0
-├── foo v0.1.0 ([ROOT]/foo)
-└── other-dep v1.0.0
-    └── foo v0.1.0 ([ROOT]/foo)
+dep v1.0.0 satisfies ^1.0
+├── foo v0.1.0 ([ROOT]/foo) satisfies 
+└── other-dep v1.0.0 satisfies ^1.0
+    └── foo v0.1.0 ([ROOT]/foo) satisfies 
 
 "#]])
         .run();


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/cargo/pull/16192)*

### Description

- Add a new formatting option `{ver-req}` to `cargo tree` that prints the resolved version requirement of packages as specified in Cargo.toml.
- Add a unit test to verify that the version constraint is printed correctly.
- Update the `cargo tree` command documentation with the new option.

As per the issue linked below, I implemented the second suggestion which was to add a new formatting option.
Adding a new flag would also be relatively simple, but I'd like to know what people think before adding a commit.

Fixes: #16163

### Example

Example output using the cargo repo:

<details>

<summary>cargo tree output</summary>

```shell-session
$ cargo tree --format '{p} satisfies {vr}'
cargo v0.93.0 (E:\dev\github.com\rust-lang\cargo) satisfies *
├── annotate-snippets v0.12.4 satisfies ^0.12.4
│   ├── anstyle v1.0.13 satisfies ^1.0.4
│   ├── memchr v2.7.6 satisfies ^2.7.4
│   └── unicode-width v0.2.1 satisfies ^0.2.0
├── anstream v0.6.20 satisfies ^0.6.20
│   ├── anstyle v1.0.13 satisfies ^1.0.0
│   ├── anstyle-parse v0.2.7 satisfies ^0.2.0
│   │   └── utf8parse v0.2.2 satisfies ^0.2.1
│   ├── anstyle-query v1.1.4 satisfies ^1.0.0
│   │   └── windows-sys v0.60.2 satisfies ^0.60.0
│   │       └── windows-targets v0.53.4 satisfies ^0.53.2
│   │           └── windows_x86_64_msvc v0.53.0 satisfies ^0.53.0
│   ├── anstyle-wincon v3.0.10 satisfies ^3.0.5
│   │   ├── anstyle v1.0.13 satisfies ^1.0.0
│   │   ├── once_cell_polyfill v1.70.1 satisfies ^1.56.0
│   │   └── windows-sys v0.60.2 satisfies ^0.60.0 (*)
│   ├── colorchoice v1.0.4 satisfies ^1.0.0
│   ├── is_terminal_polyfill v1.70.1 satisfies ^1.48
│   └── utf8parse v0.2.2 satisfies ^0.2.1
├── anstyle v1.0.13 satisfies ^1.0.13
├── anyhow v1.0.100 satisfies ^1.0.100
├── base64 v0.22.1 satisfies ^0.22.1
├── blake3 v1.8.2 satisfies ^1.8.2
│   ├── arrayref v0.3.9 satisfies ^0.3.5
│   ├── arrayvec v0.7.6 satisfies ^0.7.4
│   ├── cfg-if v1.0.3 satisfies ^1.0.0
│   └── constant_time_eq v0.3.1 satisfies ^0.3.1
│   [build-dependencies]
│   └── cc v1.2.39 satisfies ^1.1.12
│       ├── find-msvc-tools v0.1.2 satisfies ^0.1.2
│       ├── jobserver v0.1.34 satisfies ^0.1.30
│       │   └── getrandom v0.3.3 satisfies ^0.3.2
│       │       └── cfg-if v1.0.3 satisfies ^1
│       └── shlex v1.3.0 satisfies ^1.3.0
├── cargo-credential v0.4.9 (E:\dev\github.com\rust-lang\cargo\credential\cargo-credential) satisfies ^0.4.2
│   ├── anyhow v1.0.100 satisfies ^1.0.100
│   ├── serde v1.0.228 satisfies ^1.0.228
│   │   ├── serde_core v1.0.228 satisfies =1.0.228
│   │   └── serde_derive v1.0.228 (proc-macro) satisfies ^1
│   │       ├── proc-macro2 v1.0.101 satisfies ^1.0.74
│   │       │   └── unicode-ident v1.0.20 satisfies ^1.0
│   │       ├── quote v1.0.41 satisfies ^1.0.35
│   │       │   └── proc-macro2 v1.0.101 satisfies ^1.0.80
│   │       │       └── unicode-ident v1.0.20 satisfies ^1.0
│   │       └── syn v2.0.106 satisfies ^2.0.81
│   │           ├── proc-macro2 v1.0.101 satisfies ^1.0.91
│   │           │   └── unicode-ident v1.0.20 satisfies ^1.0
│   │           ├── quote v1.0.41 satisfies ^1.0.35 (*)
│   │           └── unicode-ident v1.0.20 satisfies ^1
```

</details>
