### PR TITLE
feat(tree): Support long forms for --format variables

### DIFF
--- a/src/cargo/ops/tree/format/mod.rs
+++ b/src/cargo/ops/tree/format/mod.rs
@@ -25,10 +25,10 @@ impl Pattern {
         for raw in Parser::new(format) {
             let chunk = match raw {
                 RawChunk::Text(text) => Chunk::Raw(text.to_owned()),
-                RawChunk::Argument("p") => Chunk::Package,
-                RawChunk::Argument("l") => Chunk::License,
-                RawChunk::Argument("r") => Chunk::Repository,
-                RawChunk::Argument("f") => Chunk::Features,
+                RawChunk::Argument("package") | RawChunk::Argument("p") => Chunk::Package,
+                RawChunk::Argument("license") | RawChunk::Argument("l") => Chunk::License,
+                RawChunk::Argument("repository") | RawChunk::Argument("r") => Chunk::Repository,
+                RawChunk::Argument("features") | RawChunk::Argument("f") => Chunk::Features,
                 RawChunk::Argument("lib") => Chunk::LibName,
                 RawChunk::Argument(a) => {
                     bail!("unsupported pattern `{}`", a);

--- a/src/doc/man/cargo-tree.md
+++ b/src/doc/man/cargo-tree.md
@@ -162,10 +162,10 @@ Set the format string for each package. The default is "{p}".
 This is an arbitrary string which will be used to display each package. The following
 strings will be replaced with the corresponding value:
 
-- `{p}` --- The package name.
-- `{l}` --- The package license.
-- `{r}` --- The package repository URL.
-- `{f}` --- Comma-separated list of package features that are enabled.
+- `{p}`, `{package}` --- The package name.
+- `{l}`, `{license}` --- The package license.
+- `{r}`, `{repository}` --- The package repository URL.
+- `{f}`, `{features}` --- Comma-separated list of package features that are enabled.
 - `{lib}` --- The name, as used in a `use` statement, of the package's library.
 {{/option}}
 

--- a/src/doc/man/generated_txt/cargo-tree.txt
+++ b/src/doc/man/generated_txt/cargo-tree.txt
@@ -154,14 +154,14 @@ OPTIONS
            package. The following strings will be replaced with the
            corresponding value:
 
-           o  {p} — The package name.
+           o  {p}, {package} — The package name.
 
-           o  {l} — The package license.
+           o  {l}, {license} — The package license.
 
-           o  {r} — The package repository URL.
+           o  {r}, {repository} — The package repository URL.
 
-           o  {f} — Comma-separated list of package features that are
-              enabled.
+           o  {f}, {features} — Comma-separated list of package features that
+              are enabled.
 
            o  {lib} — The name, as used in a use statement, of the
               package’s library.

--- a/src/doc/src/commands/cargo-tree.md
+++ b/src/doc/src/commands/cargo-tree.md
@@ -165,10 +165,10 @@ The default is the host platform. Use the value <code>all</code> to include <em>
 <p>This is an arbitrary string which will be used to display each package. The following
 strings will be replaced with the corresponding value:</p>
 <ul>
-<li><code>{p}</code> — The package name.</li>
-<li><code>{l}</code> — The package license.</li>
-<li><code>{r}</code> — The package repository URL.</li>
-<li><code>{f}</code> — Comma-separated list of package features that are enabled.</li>
+<li><code>{p}</code>, <code>{package}</code> — The package name.</li>
+<li><code>{l}</code>, <code>{license}</code> — The package license.</li>
+<li><code>{r}</code>, <code>{repository}</code> — The package repository URL.</li>
+<li><code>{f}</code>, <code>{features}</code> — Comma-separated list of package features that are enabled.</li>
 <li><code>{lib}</code> — The name, as used in a <code>use</code> statement, of the package’s library.</li>
 </ul>
 </dd>

--- a/src/etc/man/cargo-tree.1
+++ b/src/etc/man/cargo-tree.1
@@ -190,19 +190,19 @@ This is an arbitrary string which will be used to display each package. The foll
 strings will be replaced with the corresponding value:
 .sp
 .RS 4
-\h'-04'\(bu\h'+03'\fB{p}\fR \[em] The package name.
+\h'-04'\(bu\h'+03'\fB{p}\fR, \fB{package}\fR \[em] The package name.
 .RE
 .sp
 .RS 4
-\h'-04'\(bu\h'+03'\fB{l}\fR \[em] The package license.
+\h'-04'\(bu\h'+03'\fB{l}\fR, \fB{license}\fR \[em] The package license.
 .RE
 .sp
 .RS 4
-\h'-04'\(bu\h'+03'\fB{r}\fR \[em] The package repository URL.
+\h'-04'\(bu\h'+03'\fB{r}\fR, \fB{repository}\fR \[em] The package repository URL.
 .RE
 .sp
 .RS 4
-\h'-04'\(bu\h'+03'\fB{f}\fR \[em] Comma\-separated list of package features that are enabled.
+\h'-04'\(bu\h'+03'\fB{f}\fR, \fB{features}\fR \[em] Comma\-separated list of package features that are enabled.
 .RE
 .sp
 .RS 4


### PR DESCRIPTION
### What does this PR try to resolve?

This came out of https://github.com/rust-lang/cargo/pull/16192#discussion_r2487156634

### How to test and review this PR?

As for testing, I was unsure if it was worth exhaustively testing every variant of every format option