### PR TITLE
feat: emit help messages for github pull request url in dependency

### DIFF
--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -2291,6 +2291,11 @@ Caused by:
 Caused by:
   Unable to update https://github.com/rust-lang/does-not-exist/pull/123
 ...
+  [NOTE] GitHub url https://github.com/rust-lang/does-not-exist/pull/123 is not a repository. 
+  [HELP] Replace the dependency with 
+         `git = "https://github.com/rust-lang/does-not-exist.git" rev = "refs/pull/123/head"` 
+     to specify pull requests as dependencies' revision.
+...
 "#]])
         .run();
 }

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -402,6 +402,11 @@ Caused by:
   if a proxy or similar is necessary `net.git-fetch-with-cli` may help here
   https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
 
+  [NOTE] GitHub url https://github.com/rust-lang/does-not-exist/pull/123 is not a repository. 
+  [HELP] Replace the dependency with 
+         `git = "https://github.com/rust-lang/does-not-exist.git" rev = "refs/pull/123/head"` 
+     to specify pull requests as dependencies' revision.
+
 Caused by:
 ...
 "#


### PR DESCRIPTION
Succeeding #15003.

Piror to this, using a GitHub pull request URLs as dependencies would just fail because of HTTP errors as it's simply not a git repository. This PR implements some help messages on such cases for users to know why it's failing, and how to fix it.

Close #15001.