### PR TITLE
Add native completions for `--package` on various commands

### DIFF
--- a/src/bin/cargo/commands/clean.rs
+++ b/src/bin/cargo/commands/clean.rs
@@ -6,6 +6,7 @@ use cargo::core::global_cache_tracker::GlobalCacheTracker;
 use cargo::ops::CleanContext;
 use cargo::ops::{self, CleanOptions};
 use cargo::util::print_available_packages;
+use clap_complete::ArgValueCandidates;
 use std::time::Duration;
 
 pub fn cli() -> Command {
@@ -13,7 +14,10 @@ pub fn cli() -> Command {
         .about("Remove artifacts that cargo has generated in the past")
         .arg_doc("Whether or not to clean just the documentation directory")
         .arg_silent_suggestion()
-        .arg_package_spec_simple("Package to clean artifacts for")
+        .arg_package_spec_simple(
+            "Package to clean artifacts for",
+            ArgValueCandidates::new(get_pkg_name_candidates),
+        )
         .arg_release("Whether or not to clean release artifacts")
         .arg_profile("Clean artifacts of the specified profile")
         .arg_target_triple("Target triple to clean output for")

--- a/src/bin/cargo/commands/package.rs
+++ b/src/bin/cargo/commands/package.rs
@@ -3,6 +3,7 @@ use crate::command_prelude::*;
 use cargo::ops;
 use cargo::ops::PackageMessageFormat;
 use cargo::ops::PackageOpts;
+use clap_complete::ArgValueCandidates;
 
 pub fn cli() -> Command {
     subcommand("package")
@@ -44,6 +45,7 @@ pub fn cli() -> Command {
             "Package(s) to assemble",
             "Assemble all packages in the workspace",
             "Don't assemble specified packages",
+            ArgValueCandidates::new(get_ws_member_candidates),
         )
         .arg_features()
         .arg_target_triple("Build for the target triple")

--- a/src/bin/cargo/commands/publish.rs
+++ b/src/bin/cargo/commands/publish.rs
@@ -2,6 +2,7 @@ use crate::command_prelude::*;
 
 use cargo::ops::{self, PublishOpts};
 use cargo_credential::Secret;
+use clap_complete::ArgValueCandidates;
 
 pub fn cli() -> Command {
     subcommand("publish")
@@ -27,6 +28,7 @@ pub fn cli() -> Command {
             "Package(s) to publish",
             "Publish all packages in the workspace",
             "Don't publish specified packages",
+            ArgValueCandidates::new(get_ws_member_candidates),
         )
         .arg_features()
         .arg_parallel()

--- a/src/bin/cargo/commands/tree.rs
+++ b/src/bin/cargo/commands/tree.rs
@@ -7,6 +7,7 @@ use cargo::ops::Packages;
 use cargo::ops::tree::{self, DisplayDepth, EdgeKind};
 use cargo::util::CargoResult;
 use cargo::util::print_available_packages;
+use clap_complete::ArgValueCandidates;
 use std::collections::HashSet;
 use std::str::FromStr;
 
@@ -36,7 +37,10 @@ pub fn cli() -> Command {
                 "SPEC",
                 "Invert the tree direction and focus on the given package",
             )
-            .short('i'),
+            .short('i')
+            .add(clap_complete::ArgValueCandidates::new(
+                get_pkg_id_spec_candidates,
+            )),
         )
         .arg(multi_opt(
             "prune",
@@ -88,6 +92,7 @@ pub fn cli() -> Command {
             "Package to be used as the root of the tree",
             "Display the tree for all packages in the workspace",
             "Exclude specific workspace members",
+            ArgValueCandidates::new(get_pkg_id_spec_candidates),
         )
         .arg_features()
         .arg(flag("all-targets", "Deprecated, use --target=all instead").hide(true))


### PR DESCRIPTION
### What does this PR try to resolve?

Add dynamic completions for the various `-p <package>` arguments.

Fixes https://github.com/rust-lang/cargo/issues/15004


```
cargo bench|build|check|doc|fix|test -p <tab>`
cargo package|publish -p <tab>
cargo add|pkgid|remove|report|run|rustc|rustdoc -p <tab>

cargo uninstall -p <tab>
cargo tree -p <tab> -i <tab>
cargo clean -p <tab> # not implemented
```

Supersedes https://github.com/rust-lang/cargo/pull/14553 and https://github.com/rust-lang/cargo/pull/15338

---

EDIT: the second implementation has been chosen

In the first commit I implemented the different completions for different usages by splitting the `arg_package` methods into multiple ones if necessary:
```
     * arg_package_spec
     * arg_package_spec_no_all
     * arg_installed_package_spec_no_all <- new (for cargo uninstall)
     * arg_dependency_package_spec_no_all <- new (for cargo tree)
     * arg_clean_package_spec_simple <- new (for cargo clean)
     * arg_package_spec_simple
     * arg_package
```

In the second commit I tried to instead pass an `ArgValueCandidates` into the function to prevent that duplication.
```
     * arg_package_spec
     * arg_package_spec_no_all (ArgValueCandidates)
     * arg_package_spec_simple (ArgValueCandidates)
     * arg_package
 ```

I think I have a small preference towards the latter, but no strong opinion.