### PR TITLE
fix(compile): build.warnings=deny shouldn't block hard warnings

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -123,8 +123,8 @@ pub struct Compilation<'gctx> {
     /// The linker to use for each host or target.
     target_linkers: HashMap<CompileKind, Option<PathBuf>>,
 
-    /// The total number of warnings emitted by the compilation.
-    pub warning_count: usize,
+    /// The total number of lint warnings emitted by the compilation.
+    pub lint_warning_count: usize,
 }
 
 impl<'gctx> Compilation<'gctx> {
@@ -162,7 +162,7 @@ impl<'gctx> Compilation<'gctx> {
                 .chain(Some(&CompileKind::Host))
                 .map(|kind| Ok((*kind, target_linker(bcx, *kind)?)))
                 .collect::<CargoResult<HashMap<_, _>>>()?,
-            warning_count: 0,
+            lint_warning_count: 0,
         })
     }
 

--- a/src/cargo/core/compiler/job_queue/job_state.rs
+++ b/src/cargo/core/compiler/job_queue/job_state.rs
@@ -93,12 +93,19 @@ impl<'a, 'gctx> JobState<'a, 'gctx> {
     }
 
     /// See [`Message::Diagnostic`] and [`Message::WarningCount`].
-    pub fn emit_diag(&self, level: &str, diag: String, fixable: bool) -> CargoResult<()> {
+    pub fn emit_diag(
+        &self,
+        level: &str,
+        diag: String,
+        lint: bool,
+        fixable: bool,
+    ) -> CargoResult<()> {
         if let Some(dedupe) = self.output {
             let emitted = dedupe.emit_diag(&diag)?;
             if level == "warning" {
                 self.messages.push(Message::WarningCount {
                     id: self.id,
+                    lint,
                     emitted,
                     fixable,
                 });
@@ -108,6 +115,7 @@ impl<'a, 'gctx> JobState<'a, 'gctx> {
                 id: self.id,
                 level: level.to_string(),
                 diag,
+                lint,
                 fixable,
             });
         }

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -2162,12 +2162,14 @@ fn on_stderr_line_inner(
                     count_diagnostic(&msg.level, options);
                     if msg
                         .code
+                        .as_ref()
                         .is_some_and(|c| c.code == "exported_private_dependencies")
                         && options.format != MessageFormat::Short
                     {
                         add_pub_in_priv_diagnostic(&mut rendered);
                     }
-                    state.emit_diag(&msg.level, rendered, machine_applicable)?;
+                    let lint = msg.code.is_some();
+                    state.emit_diag(&msg.level, rendered, lint, machine_applicable)?;
                 }
                 return Ok(true);
             }

--- a/src/cargo/ops/cargo_compile/mod.rs
+++ b/src/cargo/ops/cargo_compile/mod.rs
@@ -143,7 +143,8 @@ pub fn compile_with_exec<'a>(
 ) -> CargoResult<Compilation<'a>> {
     ws.emit_warnings()?;
     let compilation = compile_ws(ws, options, exec)?;
-    if ws.gctx().warning_handling()? == WarningHandling::Deny && compilation.warning_count > 0 {
+    if ws.gctx().warning_handling()? == WarningHandling::Deny && compilation.lint_warning_count > 0
+    {
         anyhow::bail!("warnings are denied by `build.warnings` configuration")
     }
     Ok(compilation)

--- a/tests/testsuite/warning_override.rs
+++ b/tests/testsuite/warning_override.rs
@@ -253,10 +253,8 @@ fn hard_warning_deny() {
 
 [WARNING] `foo` (bin "foo") generated 2 warnings
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[ERROR] warnings are denied by `build.warnings` configuration
 
 "#]])
-        .with_status(101)
         .run();
 }
 


### PR DESCRIPTION
### What does this PR try to resolve?

Motivation for this: rustc is trying to adopt this feature but hard
warnings are getting in the way, see rust-lang/rust#148332

This is a part of #14802.

### How to test and review this PR?

Reasons to do this:
- Less flexibility in how hard warnings are resolved
- Matches Cargo not erroring for Cargo hard warnings
- This matches `-Dwarnings` behavior which this feature is meant to replace

Reasons not do this:
- A user may see a hard warning from rustc and get confused
- Cargo's hard warnings are not blocking in part because we would need
  to audit them to see if they should actually be hard warnings

We do have some flexibility on warnings evolving over time,
so this is likely a two-way door (on an unstable feature).

See also the discussion at #14802 (comment)

Ideally, we'd also test for duplicate hard warnings but unsure how to trigger that.