### PR TITLE
fix(command-vendor): strip_prefix panic in cp_sources method

### DIFF
--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -2109,15 +2109,13 @@ fn vendor_rename_fallback() {
     p.cargo("vendor --respect-source-config --no-delete")
         .env("CARGO_LOG", "cargo::ops::vendor=warn")
         .env("__CARGO_TEST_VENDOR_FALLBACK_CP_SOURCES", "true")
-        .with_status(101)
+        .with_status(0)
         .with_stderr_data(str![[r#"
 ...
 [..]failed to `mv "[..]vendor[..].vendor-staging[..]log-0.3.5" "[..]vendor[..]log"`: simulated rename error for testing
 ...
-[..]StripPrefixError[..]
-...
 "#]])
         .run();
 
-    assert!(!p.root().join("vendor/log/Cargo.toml").exists());
+    assert!(p.root().join("vendor/log/Cargo.toml").exists());
 }


### PR DESCRIPTION
### What does this PR try to resolve?

When executing the `cargo vendor` command, there is a probability that mv pkg fails, causing `strip_prefix` to panic. This PR aims to fix this issue.

Fix: #15875

### How to test and review this PR?

Modify the code to make the move pkg action inevitably fail. Then rebuild cargo and execute `cargo vendor` to test it.