### PR TITLE
fix(completions): don't wrap completion item help in parenthesis

### DIFF
--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -1218,7 +1218,7 @@ fn get_feature_candidates() -> CargoResult<Vec<clap_complete::CompletionCandidat
             feature_candidates.push(
                 clap_complete::CompletionCandidate::new(feature_name)
                     .display_order(Some(order))
-                    .help(Some(format!("(from {})", package_name).into())),
+                    .help(Some(format!("from {}", package_name).into())),
             );
         }
     }
@@ -1243,7 +1243,7 @@ fn get_crate_candidates(kind: TargetKind) -> CargoResult<Vec<clap_complete::Comp
             };
             clap_complete::CompletionCandidate::new(target.name())
                 .display_order(Some(order))
-                .help(Some(format!("(from {})", pkg_name).into()))
+                .help(Some(format!("from {}", pkg_name).into()))
         })
         .collect::<Vec<_>>();
 


### PR DESCRIPTION
### What does this PR try to resolve?

Fish shell automatically wraps the help text in parenthesis, so this wil result in them being applied twice.

<img width="1426" height="197" alt="image" src="https://github.com/user-attachments/assets/cc9529b3-beb4-473d-908a-7f467b6bb4bf" />


On zsh it previously looked like this
```
--target-dir                          -- Directory for all generated artifacts
--timings                             -- Timing output formats (unstable) (comma separated): html, json
--unit-graph                          -- Output build graph in JSON (unstable)
--verbose                             -- Use verbose output (-vv very verbose/build.rs output)
-Z                                    -- Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
fix-json                              -- (from rustfix)
matches                               -- (from cargo-platform)
stdout-redirected      file-provider  -- (from cargo-credential)
```
and will now be
```
fix-json                              -- from rustfix
matches                               -- from cargo-platform
stdout-redirected      file-provider  -- from cargo-credential
```

Bash doesn't show the help text at all so it doesn't matter.