### PR TITLE
docs(contrib): Link out to rustc diagnostic style guide

### DIFF
--- a/src/doc/contrib/src/implementation/console.md
+++ b/src/doc/contrib/src/implementation/console.md
@@ -21,7 +21,17 @@ the [`JobQueue`] as it processes each message.
 [`drop_print`]: https://github.com/rust-lang/cargo/blob/e4b65bdc80f2a293447f2f6a808fa7c84bf9a357/src/cargo/util/config/mod.rs#L1820-L1848
 [`JobQueue`]: https://github.com/rust-lang/cargo/blob/master/src/cargo/core/compiler/job_queue/mod.rs
 
-## Errors
+## Diagnostics
+
+See rustc's [Errors and lints] for:
+- diagnostic structure
+- hard diagnostics vs lints
+- diagnostic style guide
+- lint naming
+- diagnostic levels
+- suggestion style guide
+
+### Errors
 
 Cargo uses [`anyhow`] for managing errors. This makes it convenient to "chain"
 errors together, so that Cargo can report how an error originated, and what it
@@ -56,3 +66,4 @@ Some guidelines for Cargo's output:
   future to be more structured.
 
 [`anyhow`]: https://docs.rs/anyhow
+[Errors and lints]: https://rustc-dev-guide.rust-lang.org/diagnostics.html


### PR DESCRIPTION
### What does this PR try to resolve?

Explicitly call out that we use rustc's diagnostic style guide, e.g. https://github.com/rust-lang/cargo/pull/16207#discussion_r2496547305

### How to test and review this PR?

