### PR TITLE
fix(depinfo): prevent invalid trailing backslash on Windows

### DIFF
--- a/src/cargo/core/compiler/output_depinfo.rs
+++ b/src/cargo/core/compiler/output_depinfo.rs
@@ -84,9 +84,18 @@ fn add_deps_for_unit(
                 .get(metadata)
             {
                 for path in &output.rerun_if_changed {
-                    // The paths we have saved from the unit are of arbitrary relativeness and may be
-                    // relative to the crate root of the dependency.
-                    let path = unit.pkg.root().join(path);
+                    let package_root = unit.pkg.root();
+
+                    let path = if path.as_os_str().is_empty() {
+                        // Joining with an empty path causes Rust to add a trailing path separator.
+                        // On Windows, this would add an invalid trailing backslash to the .d file.
+                        package_root.to_path_buf()
+                    } else {
+                        // The paths we have saved from the unit are of arbitrary relativeness and
+                        // may be relative to the crate root of the dependency.
+                        package_root.join(path)
+                    };
+
                     deps.insert(path);
                 }
             }

--- a/tests/testsuite/dep_info.rs
+++ b/tests/testsuite/dep_info.rs
@@ -554,7 +554,7 @@ fn non_local_build_script() {
 }
 
 #[cargo_test]
-fn trailing_separator_after_package_root_build_script() {
+fn no_trailing_separator_after_package_root_build_script() {
     let p = project()
         .file(
             "Cargo.toml",
@@ -582,14 +582,14 @@ fn trailing_separator_after_package_root_build_script() {
     assert_e2e().eq(
         &contents,
         str![[r#"
-[ROOT]/foo/target/debug/foo[EXE]: [ROOT]/foo/ [ROOT]/foo/build.rs [ROOT]/foo/src/main.rs
+[ROOT]/foo/target/debug/foo[EXE]: [ROOT]/foo [ROOT]/foo/build.rs [ROOT]/foo/src/main.rs
 
 "#]],
     );
 }
 
 #[cargo_test(nightly, reason = "proc_macro::tracked_path is unstable")]
-fn trailing_separator_after_package_root_proc_macro() {
+fn no_trailing_separator_after_package_root_proc_macro() {
     let p = project()
         .file(
             "Cargo.toml",
@@ -647,7 +647,7 @@ fn trailing_separator_after_package_root_proc_macro() {
     assert_e2e().eq(
         &contents,
         str![[r#"
-[ROOT]/foo/target/debug/foo[EXE]: [ROOT]/foo/ [ROOT]/foo/pm/src/lib.rs [ROOT]/foo/src/main.rs
+[ROOT]/foo/target/debug/foo[EXE]: [ROOT]/foo [ROOT]/foo/pm/src/lib.rs [ROOT]/foo/src/main.rs
 
 "#]],
     );


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes #16096.

Finally found some time to trace the issue to its roots:

cargo tries to convert dep paths to relative ones. If a path is either

1. `pkg_root` or `build_root` itself (see `DepInfoPathType::PackageRootRelative` and `DepInfoPathType::BuildRootRelative`), causing the `EncodedDepInfo` to store an empty path, or
2. an explicitly empty path is provided (e.g. via `println!("cargo::rerun-if-changed=");`),

then cargo will join the respecive root paths with an empty path. Joining with an empty path [adds a trailing path separator](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=d36571ed84f4cd4476097050ff167f34). On systems with a `/` main separator, this works fine. On Windows, however, this adds a trailing backslash. Trailing backslashes are incompatible with `.d` dep file paths.

This PR adds the necessary checks and ensures that instead of `foo.join("")` we return `foo` (instead of effectively `foo + std::path::MAIN_SEPARATOR_STR`).

Importantly, this PR does not change the behavior for any other paths passed in (e.g. paths explicitly ending in a backslash), and only focuses on unintentional backslashes outside of the user's control.

### How to test and review this PR?

The first commit shows the unintended behavior in two tests; the second commit fixes the issue and alters the tests to reflect the new behavior.
