### PR TITLE
fix(run): Help teach about argument escaping

### DIFF
--- a/src/bin/cargo/commands/run.rs
+++ b/src/bin/cargo/commands/run.rs
@@ -43,7 +43,8 @@ pub fn cli() -> Command {
         .arg_unit_graph()
         .arg_timings()
         .after_help(color_print::cstr!(
-            "Run `<bright-cyan,bold>cargo help run</>` for more detailed information.\n"
+            "Run `<bright-cyan,bold>cargo help run</>` for more detailed information.\n\
+             To pass `--help` to the specified binary, use `<bright-cyan,bold>-- --help</>`.\n",
         ))
 }
 

--- a/tests/testsuite/cargo_run/help/stdout.term.svg
+++ b/tests/testsuite/cargo_run/help/stdout.term.svg
@@ -1,7 +1,7 @@
-<svg width="827px" height="938px" xmlns="http://www.w3.org/2000/svg">
+<svg width="827px" height="956px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-cyan { fill: #55FFFF }
     .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
@@ -120,7 +120,9 @@
 </tspan>
     <tspan x="10px" y="910px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help run</tspan><tspan class="bold">` for more detailed information.</tspan>
 </tspan>
-    <tspan x="10px" y="928px">
+    <tspan x="10px" y="928px"><tspan class="bold">To pass `--help` to the specified binary, use `</tspan><tspan class="fg-bright-cyan bold">-- --help</tspan><tspan class="bold">`.</tspan>
+</tspan>
+    <tspan x="10px" y="946px">
 </tspan>
   </text>
 


### PR DESCRIPTION
### What does this PR try to resolve?

It is not obvious that how to escape arguments to be forwarded literally to an underlying program, like `--help`.

`cargo test` has a message:
```
Run `cargo test -- --help` for test binary options.
```

Mirroring that exactly in `cargo run` isn't appropriate because we'd be saying there is `--help` when there might not be.

Instead, I took inspiration from clap's error message:
```console
$ cargo test --gfdfgdf
error: unexpected argument '--gfdfgdf' found

  tip: to pass '--gfdfgdf' as a value, use '-- --gfdfgdf'

Usage: cargo test [OPTIONS] [TESTNAME] [-- [ARGS]...]

For more information, try '--help'.
```

I checked `cargo rustc` and `cargo rustdoc` to see if they could be helped like this but they will return errors about needing to specify the specific binary, so they are a little more complicated.

Fixes #9707

### How to test and review this PR?

