### PR TITLE
fix(cli): Refer to commands, not subcommands

### DIFF
--- a/src/bin/cargo/commands/help.rs
+++ b/src/bin/cargo/commands/help.rs
@@ -14,7 +14,7 @@ const COMPRESSED_MAN: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/man.tgz"
 
 pub fn cli() -> Command {
     subcommand("help")
-        .about("Displays help for a cargo subcommand")
+        .about("Displays help for a cargo command")
         .arg(Arg::new("COMMAND").action(ArgAction::Set).add(
             clap_complete::ArgValueCandidates::new(|| {
                 super::builtin()

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -212,7 +212,7 @@ fn list_commands(gctx: &GlobalContext) -> BTreeMap<String, CommandInfo> {
     commands.insert(
         "help".to_string(),
         CommandInfo::BuiltIn {
-            about: Some("Displays help for a cargo subcommand".to_string()),
+            about: Some("Displays help for a cargo command".to_string()),
         },
     );
 

--- a/tests/testsuite/cargo_help/help/stdout.term.svg
+++ b/tests/testsuite/cargo_help/help/stdout.term.svg
@@ -1,7 +1,7 @@
 <svg width="827px" height="398px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-cyan { fill: #55FFFF }
     .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
@@ -20,7 +20,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>Displays help for a cargo subcommand</tspan>
+    <tspan x="10px" y="28px"><tspan>Displays help for a cargo command</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>


### PR DESCRIPTION
### What does this PR try to resolve?

This makes us completely consistent on referring to cargo commands for the top-level commands.

Fixes #10195

### How to test and review this PR?
