### PR TITLE
docs: fix comments for alternative registry fns

### DIFF
--- a/crates/cargo-test-support/src/registry.rs
+++ b/crates/cargo-test-support/src/registry.rs
@@ -282,14 +282,14 @@ impl RegistryBuilder {
         self
     }
 
-    /// Sets whether or not to initialize as an alternative registry.
+    /// Initializes as an alternative registry with the given name.
     #[must_use]
     pub fn alternative_named(mut self, alt: &str) -> Self {
         self.alternative = Some(alt.to_string());
         self
     }
 
-    /// Sets whether or not to initialize as an alternative registry.
+    /// Initializes as an alternative registry named "alternative".
     #[must_use]
     pub fn alternative(self) -> Self {
         self.alternative_named("alternative")


### PR DESCRIPTION
### What does this PR try to resolve?

The comments added in https://github.com/rust-lang/cargo/commit/340656e2, but after we change its implementations a couple of times, it no longer accepts a bool. So, it would be better to fix the comments for them.

### How to test and review this PR?

It is just a comment change, so no need to test.
