### PR TITLE
Suppress metadata warnings for non–crates.io publishable packages

### DIFF
--- a/src/cargo/ops/cargo_package/mod.rs
+++ b/src/cargo/ops/cargo_package/mod.rs
@@ -483,7 +483,7 @@ fn prepare_archive(
     src.load()?;
 
     if opts.check_metadata {
-        check_metadata(pkg, gctx)?;
+        check_metadata(pkg, opts.reg_or_index.as_ref(), gctx)?;
     }
 
     if !pkg.manifest().exclude().is_empty() && !pkg.manifest().include().is_empty() {
@@ -808,7 +808,11 @@ fn build_lock(
 
 // Checks that the package has some piece of metadata that a human can
 // use to tell what the package is about.
-fn check_metadata(pkg: &Package, gctx: &GlobalContext) -> CargoResult<()> {
+fn check_metadata(
+    pkg: &Package,
+    reg_or_index: Option<&RegistryOrIndex>,
+    gctx: &GlobalContext,
+) -> CargoResult<()> {
     let md = pkg.manifest().metadata();
 
     let mut missing = vec![];
@@ -829,20 +833,29 @@ fn check_metadata(pkg: &Package, gctx: &GlobalContext) -> CargoResult<()> {
     );
 
     if !missing.is_empty() {
-        let mut things = missing[..missing.len() - 1].join(", ");
-        // `things` will be empty if and only if its length is 1 (i.e., the only case
-        // to have no `or`).
-        if !things.is_empty() {
-            things.push_str(" or ");
-        }
-        things.push_str(missing.last().unwrap());
+        // Only warn if publishing to crates.io based on resolved registry
+        let should_warn = match reg_or_index {
+            Some(RegistryOrIndex::Registry(reg_name)) => reg_name == CRATES_IO_REGISTRY,
+            None => true,                             // Default is crates.io
+            Some(RegistryOrIndex::Index(_)) => false, // Custom index, not crates.io
+        };
 
-        gctx.shell().print_report(&[
-            Level::WARNING.secondary_title(format!("manifest has no {things}"))
-                .element(Level::NOTE.message("see https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info"))
-         ],
-             false
-        )?
+        if should_warn {
+            let mut things = missing[..missing.len() - 1].join(", ");
+            // `things` will be empty if and only if its length is 1 (i.e., the only case
+            // to have no `or`).
+            if !things.is_empty() {
+                things.push_str(" or ");
+            }
+            things.push_str(missing.last().unwrap());
+
+            gctx.shell().print_report(&[
+                Level::WARNING.secondary_title(format!("manifest has no {things}"))
+                    .element(Level::NOTE.message("see https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info"))
+             ],
+                 false
+            )?
+        }
     }
 
     Ok(())

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -350,9 +350,6 @@ fn publish_with_registry_dependency() {
     p.cargo("publish --registry alternative")
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[WARNING] manifest has no description, license, license-file, documentation, homepage or repository
-  |
-  = [NOTE] see https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info
 [PACKAGING] foo v0.0.1 ([ROOT]/foo)
 [UPDATING] `alternative` index
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
@@ -518,9 +515,6 @@ fn publish_to_alt_registry() {
     p.cargo("publish --registry alternative")
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[WARNING] manifest has no description, license, license-file, documentation, homepage or repository
-  |
-  = [NOTE] see https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info
 [PACKAGING] foo v0.0.1 ([ROOT]/foo)
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [VERIFYING] foo v0.0.1 ([ROOT]/foo)
@@ -597,9 +591,6 @@ fn publish_with_crates_io_dep() {
     p.cargo("publish --registry alternative")
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[WARNING] manifest has no documentation, homepage or repository
-  |
-  = [NOTE] see https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info
 [PACKAGING] foo v0.0.1 ([ROOT]/foo)
 [UPDATING] `dummy-registry` index
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -7739,3 +7739,75 @@ Caused by:
 "#]])
         .run();
 }
+
+#[cargo_test]
+fn publish_to_crates_io_warns() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                description = "foo"
+                edition = "2015"
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo(&format!("publish --dry-run"))
+        .with_stderr_data(str![[r#"
+[UPDATING] crates.io index
+[WARNING] manifest has no license, license-file, documentation, homepage or repository
+  |
+  = [NOTE] see https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info
+[PACKAGING] foo v0.1.0 ([ROOT]/foo)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[VERIFYING] foo v0.1.0 ([ROOT]/foo)
+[COMPILING] foo v0.1.0 ([ROOT]/foo/target/package/foo-0.1.0)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[UPLOADING] foo v0.1.0 ([ROOT]/foo)
+[WARNING] aborting upload due to dry run
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn publish_to_alt_registry_warns() {
+    let _alt_reg = registry::RegistryBuilder::new().alternative().build();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                description = "foo"
+                edition = "2015"
+                publish = ["alternative"]
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    // There will be no warnings for alternative registry in the next commit
+    p.cargo("publish --dry-run --registry alternative")
+        .with_stderr_data(str![[r#"
+[UPDATING] `alternative` index
+[WARNING] manifest has no license, license-file, documentation, homepage or repository
+  |
+  = [NOTE] see https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info
+[PACKAGING] foo v0.1.0 ([ROOT]/foo)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[VERIFYING] foo v0.1.0 ([ROOT]/foo)
+[COMPILING] foo v0.1.0 ([ROOT]/foo/target/package/foo-0.1.0)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[UPLOADING] foo v0.1.0 ([ROOT]/foo)
+[WARNING] aborting upload due to dry run
+
+"#]])
+        .run();
+}

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -7793,13 +7793,9 @@ fn publish_to_alt_registry_warns() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    // There will be no warnings for alternative registry in the next commit
     p.cargo("publish --dry-run --registry alternative")
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[WARNING] manifest has no license, license-file, documentation, homepage or repository
-  |
-  = [NOTE] see https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info
 [PACKAGING] foo v0.1.0 ([ROOT]/foo)
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [VERIFYING] foo v0.1.0 ([ROOT]/foo)

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -211,9 +211,6 @@ fn simple_publish_with_http() {
         .with_stderr_data(str![[r#"
 [WARNING] `cargo publish --token` is deprecated in favor of using `cargo login` and environment variables
 [UPDATING] `dummy-registry` index
-[WARNING] manifest has no documentation, homepage or repository
-  |
-  = [NOTE] see https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info
 [PACKAGING] foo v0.0.1 ([ROOT]/foo)
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
@@ -255,9 +252,6 @@ fn simple_publish_with_asymmetric() {
         .masquerade_as_nightly_cargo(&["asymmetric-token"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[WARNING] manifest has no documentation, homepage or repository
-  |
-  = [NOTE] see https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info
 [PACKAGING] foo v0.0.1 ([ROOT]/foo)
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
@@ -359,9 +353,6 @@ fn simple_with_index() {
         .with_stderr_data(str![[r#"
 [WARNING] `cargo publish --token` is deprecated in favor of using `cargo login` and environment variables
 [UPDATING] `[ROOT]/registry` index
-[WARNING] manifest has no documentation, homepage or repository
-  |
-  = [NOTE] see https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info
 [PACKAGING] foo v0.0.1 ([ROOT]/foo)
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [UPLOADING] foo v0.0.1 ([ROOT]/foo)
@@ -789,9 +780,6 @@ fn dry_run() {
         .arg(registry.index_url().as_str())
         .with_stderr_data(str![[r#"
 [UPDATING] `[ROOT]/registry` index
-[WARNING] manifest has no documentation, homepage or repository
-  |
-  = [NOTE] see https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info
 [PACKAGING] foo v0.0.1 ([ROOT]/foo)
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [VERIFYING] foo v0.0.1 ([ROOT]/foo)


### PR DESCRIPTION
### What does this PR try to resolve?
Related issue: https://github.com/rust-lang/cargo/issues/4840

With this change, Cargo still performs full metadata checks for all packages to preserve validation consistency, but it suppresses warnings for crates that are not publishable to crates.io, such as those with `publish = false` or custom registries (`publish = ["my-registry"]`).

### How to test and review this PR?
Unit tests added in `tests/testsuite/package.rs`, can be tested locally by running `cargo test --test package`.