### PR TITLE
fix(package): all tar entries timestamp be the same

### DIFF
--- a/src/cargo/ops/cargo_package/mod.rs
+++ b/src/cargo/ops/cargo_package/mod.rs
@@ -917,8 +917,12 @@ fn tar(
                 header.set_entry_type(EntryType::file());
                 header.set_mode(0o644);
                 header.set_size(contents.len() as u64);
-                // use something nonzero to avoid rust-lang/cargo#9512
-                header.set_mtime(1);
+                // We need to have the same DETERMINISTIC_TIMESTAMP for generated files
+                // https://github.com/alexcrichton/tar-rs/blob/d0261f1f6cc959ba0758e7236b3fd81e90dd1dc6/src/header.rs#L18-L24
+                // Unfortunately tar-rs doesn't expose that so we harcode the timestamp here.
+                // Hardcoded value be removed once alexcrichton/tar-rs#420 is merged and released.
+                // See also rust-lang/cargo#16237
+                header.set_mtime(1153704088);
                 header.set_cksum();
                 ar.append_data(&mut header, &ar_path, contents.as_bytes())
                     .with_context(|| format!("could not archive source file `{}`", rel_str))?;

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -3171,18 +3171,7 @@ fn reproducible_output() {
         println!("checking {:?}", ent.path());
         let header = ent.header();
         assert_eq!(header.mode().unwrap(), 0o644);
-        assert!(header.mtime().unwrap() != 0);
-        // Generated files do not have deterministic timestamp (yet).
-        let path = ent.path().unwrap();
-        let file_name = path.file_name().unwrap().to_str().unwrap();
-        if ["Cargo.toml", "Cargo.lock", ".cargo_vcs_info.json"]
-            .into_iter()
-            .any(|f| f == file_name)
-        {
-            assert!(header.mtime().unwrap() != DETERMINISTIC_TIMESTAMP);
-        } else {
-            assert!(header.mtime().unwrap() == DETERMINISTIC_TIMESTAMP);
-        }
+        assert!(header.mtime().unwrap() == DETERMINISTIC_TIMESTAMP);
         assert_eq!(header.username().unwrap().unwrap(), "");
         assert_eq!(header.groupname().unwrap().unwrap(), "");
     }


### PR DESCRIPTION
### What does this PR try to resolve?

With this commit, all tar entries' timestamp is the same,
all set to DETERMINISTIC_TIMESTAMP in tar-rs.

This fixes the first half of https://github.com/rust-lang/cargo/issues/16237
that `cargo package` should tar everything in the same timestamp.

### How to test and review this PR?

Test passes.