### PR TITLE
feat(cli): Add support for completing `--config` values in Bash

### DIFF
--- a/src/etc/cargo.bashcomp.sh
+++ b/src/etc/cargo.bashcomp.sh
@@ -36,7 +36,8 @@ _cargo()
 	local opt_verbose='-v --verbose'
 	local opt_quiet='-q --quiet'
 	local opt_color='--color'
-	local opt_common="$opt_help $opt_verbose $opt_quiet $opt_color"
+	local opt_config='--config'
+	local opt_common="$opt_help $opt_verbose $opt_quiet $opt_color $opt_config"
 	local opt_pkg_spec='-p --package --all --exclude --workspace'
 	local opt_pkg='-p --package'
 	local opt_feat='-F --features --all-features --no-default-features'
@@ -142,6 +143,9 @@ _cargo()
 				;;
 			--target-dir|--path)
 				_filedir -d
+				;;
+			--config)
+				_filedir
 				;;
 			help)
 				_ensure_cargo_commands_cache_filled


### PR DESCRIPTION
### What does this PR try to resolve?

Currently, `cargo.bashcomp.sh` doesn't support completing the `--config` flag, let alone its value. This PR adds support for completing both the `--config` flag and a `_filedir` value for it. This support includes both cases where it appears before the cargo subcommand, and cases where it appears after. In the process of implementing the former, I also added support for completing values for `--color` before the cargo subcommand. Currently, completing values for `--color` is only supported after the cargo subcommand.

### How to test and review this PR?

In a Bash shell, run:

```
source src/etc/cargo.bashcomp.sh
```

Then, observe that the following completions behave as expected:

```
cargo --co<tab>
cargo --config <tab>
cargo --color <tab>
cargo build --co<tab>
cargo build --config <tab>
```