### PR TITLE
Cache submodule into git db

### DIFF
--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -4361,7 +4361,6 @@ fn dep_with_cached_submodule() {
 [UPDATING] git repository `[ROOTURL]/dep1`
 [UPDATING] git submodule `[ROOTURL]/dep3`
 [UPDATING] git repository `[ROOTURL]/dep2`
-[UPDATING] git submodule `[ROOTURL]/dep3`
 [LOCKING] 2 packages to latest compatible versions
 [CHECKING] dep[..] v0.5.0 ([ROOTURL]/dep[..]#[..])
 [CHECKING] dep[..] v0.5.0 ([ROOTURL]/dep[..]#[..])


### PR DESCRIPTION
### What does this PR try to resolve?

My attempt to continue https://github.com/rust-lang/cargo/pull/10279.

This:
  - Moves the code for creating git db into `GitSource::fetch_db`
  - Creates GitSource for each submodules
  - Replaces fetch inside update_submodule by `GitSource::fetch_db` and `db.copy_to`
  - Removes recursive update_submodules calls cos `db.copy_to` already recursive.

Fixes https://github.com/rust-lang/cargo/issues/7987.

### How to test and review this PR?

I tested using the original pull method:
```
~/.cargo/target/debug/cargo update -p boring --precise 46787b7b6909cadf81cf3a8cd9dc351c9efdfdbd
~/.cargo/target/debug/cargo update -p boring --precise c037a438f8d7b91533524570237afcfeffffe496
```
and confirmed that the time to do the second update is negligible.
Also test if it can fetch submodule offline using the downloaded git db
```
git clone https://github.com/pop-os/cosmic-files && cd cosmic-files
~/.cargo/target/debug/cargo fetch --locked --target=$(rustc --print host-tuple)
rm -rf ~/.cargo/git/checkout ~/.cargo/target/debug/cargo fetch --locked --target=$(rustc --print host-tuple) --offline
```