### PR TITLE
feat(cli): Add support for completing `--config` argument values with `native-completions`

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -699,7 +699,10 @@ See '<bright-cyan,bold>cargo help</> <cyan><<command>></>' for more information 
             .action(ArgAction::SetTrue)
             .global(true)
             .hide(true))
-        .arg(multi_opt("config", "KEY=VALUE|PATH", "Override a configuration value").global(true))
+        .arg(multi_opt("config", "KEY=VALUE|PATH", "Override a configuration value").add(clap_complete::engine::ArgValueCompleter::new(
+                    clap_complete::engine::PathCompleter::any()
+                        .filter(|path| path.is_file() && path.extension() == Some(OsStr::new("toml"))),
+                )).global(true))
         // Better suggestion for the unsupported lowercase unstable feature flag.
         .arg( Arg::new("unsupported-lowercase-unstable-feature-flag")
             .help("")


### PR DESCRIPTION
Add `value_hint` for the global `--config` argument to allow completing its value.

The related https://github.com/rust-lang/cargo/pull/16245#issuecomment-3524529383 adds partial support to `src/etc/cargo.bashcomp.sh`.

### What does this PR try to resolve?

Currently, `native-completions` supports completing the `--config` flag itself, but not its argument value. This PR adds support for completing its value with a file path (`clap::ValueHint::FilePath`).

### How to test and review this PR?

In a shell supported by `native-completions`, run:

```
source <(CARGO_COMPLETE=bash cargo run)
```

Then, observe that the following completion behaves as expected. That is, the user is prompted with files paths.

```
cargo --config <tab>
```