### PR TITLE
add helper functions for autotarget settings on manifest

### DIFF
--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -120,18 +120,22 @@ impl TomlManifest {
         self.lints.as_ref().map(|l| l.normalized()).transpose()
     }
 
+    /// Whether cargo will self-infer bin targets from this manifest
     pub fn autobins(&self) -> bool {
         self.autotargets(|p| p.autobins, |m| m.bin.as_deref())
     }
 
+    /// Whether cargo will self-infer bench targets from this manifest
     pub fn autobenches(&self) -> bool {
         self.autotargets(|p| p.autobenches, |m| m.bench.as_deref())
     }
 
+    /// Whether cargo will self-infer example targets from this manifest
     pub fn autoexamples(&self) -> bool {
         self.autotargets(|p| p.autoexamples, |m| m.example.as_deref())
     }
 
+    /// Whether cargo will self-infer test targets from this manifest
     pub fn autotests(&self) -> bool {
         self.autotargets(|p| p.autotests, |m| m.test.as_deref())
     }


### PR DESCRIPTION
This transplants helper functions from cargo-manifest regarding auto-discovery behaviour.

Goal of this is to allow to easier move from cargo-manifest to cargo-util-schemas inside crates.io, so information regarding cargo's behaviour that can just be observed from the schema itself can be exposed like this.

I'll add documentation later, as I misclicked and published this PR early on accident.

If there's any problems with this little plan, please let me know