### PR TITLE
fix(fingerprint): force update mtime of cargo-check artifacts

### DIFF
--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -3229,9 +3229,7 @@ fn incremental_build_script_execution_got_new_mtime_and_cargo_check() {
     p.cargo("check -v")
         .env("CARGO_INCREMENTAL", "1")
         .with_stderr_data(str![[r#"
-[DIRTY] foo v0.0.1 ([ROOT]/foo): the dependency build_script_build was rebuilt ([TIME_DIFF_AFTER_LAST_BUILD])
-[CHECKING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo [..]`
+[FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -3240,9 +3238,7 @@ fn incremental_build_script_execution_got_new_mtime_and_cargo_check() {
     p.cargo("check -v")
         .env("CARGO_INCREMENTAL", "1")
         .with_stderr_data(str![[r#"
-[DIRTY] foo v0.0.1 ([ROOT]/foo): the dependency build_script_build was rebuilt ([TIME_DIFF_AFTER_LAST_BUILD])
-[CHECKING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo [..]`
+[FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])

--- a/tests/testsuite/freshness_checksum.rs
+++ b/tests/testsuite/freshness_checksum.rs
@@ -3007,9 +3007,7 @@ fn incremental_build_script_execution_got_new_mtime_and_cargo_check() {
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .env("CARGO_INCREMENTAL", "1")
         .with_stderr_data(str![[r#"
-[DIRTY] foo v0.0.1 ([ROOT]/foo): the dependency build_script_build was rebuilt ([TIME_DIFF_AFTER_LAST_BUILD])
-[CHECKING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo [..]`
+[FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -3019,9 +3017,7 @@ fn incremental_build_script_execution_got_new_mtime_and_cargo_check() {
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .env("CARGO_INCREMENTAL", "1")
         .with_stderr_data(str![[r#"
-[DIRTY] foo v0.0.1 ([ROOT]/foo): the dependency build_script_build was rebuilt ([TIME_DIFF_AFTER_LAST_BUILD])
-[CHECKING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo [..]`
+[FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])


### PR DESCRIPTION
### What does this PR try to resolve?

This mtime shift for .rmeta is a workaround as rustc incremental build
since rust-lang/rust#114669 (1.90.0) skips unnecessary rmeta generation.

The situation is like this:

1. When build script execution's external dependendies
   (rerun-if-changed, rerun-if-env-changed) got updated,
   the execution unit reran and got a newer mtime.
2. rustc type-checked the associated crate, though with incremental
   compilation, no rmeta regeneration. Its `.rmeta` stays old.
3. Run `cargo check` again. Cargo found build script execution had
   a new mtime than existing crate rmeta, so re-checking the crate.
   However the check is a no-op (input has no change), so stuck.


Fixes #16104 

### How to test and review this PR?

Tests pass.

There is a reproduction in <https://github.com/rust-lang/cargo/issues/16104#issuecomment-3530739039>,but actually a minimal one is touching a file of build script dependency, than `cargo check`. It'll easily get stuck.

This is an ugly workaround. And `-Zchecksum-freshness` doesn't help because build script is involved.