### PR TITLE
feat: emit a warning when both `package.publish` and `--index` are specified

### DIFF
--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -1016,6 +1016,8 @@ fn publish_when_both_publish_and_index_specified() {
         .arg(registry.token())
         .with_stderr_data(str![[r#"
 [WARNING] `cargo publish --token` is deprecated in favor of using `cargo login` and environment variables
+[WARNING] `--index` will ignore registries set by `package.publish` in Cargo.toml, and may cause unexpected push to prohibited registry
+[HELP] use `--registry` instead or set `publish = true` in Cargo.toml to suppress this warning
 [UPDATING] [..] index
 [PACKAGING] foo v0.0.1 ([ROOT]/foo)
 [PACKAGED] 5 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
@@ -1066,6 +1068,7 @@ fn publish_failed_with_index_and_only_allowed_registry() {
         .arg(registry.index_url().as_str())
         .with_status(101)
         .with_stderr_data(str![[r#"
+...
 [ERROR] command-line argument --index requires --token to be specified
 
 "#]])


### PR DESCRIPTION
Partially adresses #16231.

### What does this PR try to resolve?

`cargo publish` will fail, if `--registry` is passed and that index isn't included in `package.publish` in Cargo.toml. However, as described in linked issue, `--index` bypasses that check and may cause unexpected publication of packages.

This PR implements warning that is shown when `--index` and `package.publish` is set at the same time.