### PR TITLE
[beta-1.92] fix: force update mtime of cargo-check artifacts

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -499,6 +499,25 @@ fn rustc(
             paths::set_file_time_no_err(dep_info_loc, timestamp);
         }
 
+        // This mtime shift for .rmeta is a workaround as rustc incremental build
+        // since rust-lang/rust#114669 (1.90.0) skips unnecessary rmeta generation.
+        //
+        // The situation is like this:
+        //
+        // 1. When build script execution's external dependendies
+        //    (rerun-if-changed, rerun-if-env-changed) got updated,
+        //    the execution unit reran and got a newer mtime.
+        // 2. rustc type-checked the associated crate, though with incremental
+        //    compilation, no rmeta regeneration. Its `.rmeta` stays old.
+        // 3. Run `cargo check` again. Cargo found build script execution had
+        //    a new mtime than existing crate rmeta, so re-checking the crate.
+        //    However the check is a no-op (input has no change), so stuck.
+        if mode.is_check() {
+            for output in outputs.iter() {
+                paths::set_file_time_no_err(&output.path, timestamp);
+            }
+        }
+
         Ok(())
     }));
 

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -3229,9 +3229,7 @@ fn incremental_build_script_execution_got_new_mtime_and_cargo_check() {
     p.cargo("check -v")
         .env("CARGO_INCREMENTAL", "1")
         .with_stderr_data(str![[r#"
-[DIRTY] foo v0.0.1 ([ROOT]/foo): the dependency build_script_build was rebuilt ([TIME_DIFF_AFTER_LAST_BUILD])
-[CHECKING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo [..]`
+[FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -3240,9 +3238,7 @@ fn incremental_build_script_execution_got_new_mtime_and_cargo_check() {
     p.cargo("check -v")
         .env("CARGO_INCREMENTAL", "1")
         .with_stderr_data(str![[r#"
-[DIRTY] foo v0.0.1 ([ROOT]/foo): the dependency build_script_build was rebuilt ([TIME_DIFF_AFTER_LAST_BUILD])
-[CHECKING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo [..]`
+[FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])

--- a/tests/testsuite/freshness_checksum.rs
+++ b/tests/testsuite/freshness_checksum.rs
@@ -3007,9 +3007,7 @@ fn incremental_build_script_execution_got_new_mtime_and_cargo_check() {
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .env("CARGO_INCREMENTAL", "1")
         .with_stderr_data(str![[r#"
-[DIRTY] foo v0.0.1 ([ROOT]/foo): the dependency build_script_build was rebuilt ([TIME_DIFF_AFTER_LAST_BUILD])
-[CHECKING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo [..]`
+[FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -3019,9 +3017,7 @@ fn incremental_build_script_execution_got_new_mtime_and_cargo_check() {
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .env("CARGO_INCREMENTAL", "1")
         .with_stderr_data(str![[r#"
-[DIRTY] foo v0.0.1 ([ROOT]/foo): the dependency build_script_build was rebuilt ([TIME_DIFF_AFTER_LAST_BUILD])
-[CHECKING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo [..]`
+[FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])


### PR DESCRIPTION
Beta backports
- https://github.com/rust-lang/cargo/pull/16262

In order to make CI pass, the following PRs are also cherry-picked: