### PR TITLE
docs(cargo-yank): clarify yank behavior with leaked credentials

### DIFF
--- a/src/doc/man/cargo-yank.md
+++ b/src/doc/man/cargo-yank.md
@@ -68,9 +68,10 @@ them at <help@crates.io>.
 
 If credentials have been leaked, the recommended course of action is to revoke
 them immediately. Once a crate has been published, it is impossible to determine
-if the leaked credentials have been copied. Yanking the crate only prevents new
-users from downloading it, but cannot stop those who have already downloaded it
-from keeping or even spreading the leaked credentials.
+if the leaked credentials have been copied. Yanking only prevents Cargo from
+selecting this version when resolving dependencies by default. Existing lock
+files or direct downloads are not affected, so yanking cannot stop further
+spreading of the leaked credentials.
 
 [RustSec]: https://rustsec.org/
 [policies]: https://crates.io/policies

--- a/src/doc/man/generated_txt/cargo-yank.txt
+++ b/src/doc/man/generated_txt/cargo-yank.txt
@@ -75,9 +75,10 @@ DESCRIPTION
        If credentials have been leaked, the recommended course of action is to
        revoke them immediately. Once a crate has been published, it is
        impossible to determine if the leaked credentials have been copied.
-       Yanking the crate only prevents new users from downloading it, but
-       cannot stop those who have already downloaded it from keeping or even
-       spreading the leaked credentials.
+       Yanking only prevents Cargo from selecting this version when resolving
+       dependencies by default. Existing lock files or direct downloads are not
+       affected, so yanking cannot stop further spreading of the leaked
+       credentials.
 
 OPTIONS
    Yank Options

--- a/src/doc/src/commands/cargo-yank.md
+++ b/src/doc/src/commands/cargo-yank.md
@@ -68,9 +68,10 @@ them at <help@crates.io>.
 
 If credentials have been leaked, the recommended course of action is to revoke
 them immediately. Once a crate has been published, it is impossible to determine
-if the leaked credentials have been copied. Yanking the crate only prevents new
-users from downloading it, but cannot stop those who have already downloaded it
-from keeping or even spreading the leaked credentials.
+if the leaked credentials have been copied. Yanking only prevents Cargo from
+selecting this version when resolving dependencies by default. Existing lock
+files or direct downloads are not affected, so yanking cannot stop further
+spreading of the leaked credentials.
 
 [RustSec]: https://rustsec.org/
 [policies]: https://crates.io/policies

--- a/src/etc/man/cargo-yank.1
+++ b/src/etc/man/cargo-yank.1
@@ -99,9 +99,10 @@ them at <help@crates.io>\&.
 .sp
 If credentials have been leaked, the recommended course of action is to revoke
 them immediately. Once a crate has been published, it is impossible to determine
-if the leaked credentials have been copied. Yanking the crate only prevents new
-users from downloading it, but cannot stop those who have already downloaded it
-from keeping or even spreading the leaked credentials.
+if the leaked credentials have been copied. Yanking only prevents Cargo from
+selecting this version when resolving dependencies by default. Existing lock
+files or direct downloads are not affected, so yanking cannot stop further
+spreading of the leaked credentials.
 .SH "OPTIONS"
 .SS "Yank Options"
 .sp


### PR DESCRIPTION
Clarifies that yanking only affects Cargo's dependency resolution, not crate availability.
Yanked crates remain fully downloadable, so yanking cannot prevent the spread of leaked credentials.

Closes #16266 
