### PR TITLE
docs(guide): When suggesting alt dev profile, link to related issue

### DIFF
--- a/src/doc/src/guide/build-performance.md
+++ b/src/doc/src/guide/build-performance.md
@@ -45,6 +45,8 @@ This will:
   - Avoid generating any debug information for dependencies
 - Provide an opt-in for when debugging via [`--profile debugging`](../reference/profiles.md#custom-profiles)
 
+> **Note:** re-evaluating the `dev` profile is being tracked in [#15931](https://github.com/rust-lang/cargo/issues/15931).
+
 Trade-offs:
 - ✅ Faster code generation (`cargo build`)
 - ✅ Faster link times


### PR DESCRIPTION
### What does this PR try to resolve?

Having sections in the build performance chapter link out to their issues is helpful for:
- giving hope that things will improve
- providing a place for people to subscribe to for updates
- raise visibility for ensuring we get appropriaet feedback (e.g. on degrading the debugger experience)

Noticed this was missing while writing up about this new chapter on the blog post.

### How to test and review this PR?
