### PR TITLE
test(build-std): Add test for LTO

### DIFF
--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -188,6 +188,37 @@ fn basic() {
 }
 
 #[cargo_test(build_std_real)]
+fn lto() {
+    // Checks that `-Zbuild-std` can work with `lto = "thin"`.
+    // This regression is from https://github.com/rust-lang/rust/issues/146109.
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2021"
+
+                [profile.dev]
+                lto = "thin"
+            "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+            fn main() {}
+            "#,
+        )
+        .build();
+
+    p.cargo("build")
+        .build_std_arg("std")
+        .env("RUSTFLAGS", "-C linker-features=-lld")
+        .run();
+}
+
+#[cargo_test(build_std_real)]
 fn host_proc_macro() {
     let p = project()
         .file(


### PR DESCRIPTION
Add a test for https://github.com/rust-lang/rust/pull/146133. `cargo +nightly-2025-08-29 test --test build-std -- lto` can reproduce the regression.
This is not a bug from Cargo, but it requires `-Zbuild-std` in most use cases.
The test case is from https://github.com/rust-lang/rust/issues/146109. The point is that when rustc is invoked with -Clto=fat or -Clto=thin, it should perform LTO with ALL bitcodes. However, https://github.com/rust-lang/rust/pull/145368 emits bitcodes for compiler_builtins but excludes it from LTO participation.
As a result, the compiler_builtins bitcodes library is passed to the linker, but the linkers, such as the GNU ld or older versions of LLD, are unable to process bitcodes.