### PR TITLE
fix(config-include): reserve more paths for future

### DIFF
--- a/tests/testsuite/config_include.rs
+++ b/tests/testsuite/config_include.rs
@@ -704,8 +704,16 @@ fn user_config_toml_reserved() {
 
     let gctx = GlobalContextBuilder::new()
         .unstable_flag("config-include")
-        .build();
-    assert_eq!(gctx.get::<i32>("key1").unwrap(), 1);
+        .build_err();
+    assert_error(
+        gctx.unwrap_err(),
+        str![[r#"
+could not load Cargo configuration
+
+Caused by:
+  `.cargo/user.config.toml` is a reserved configuration path, but was included in `[ROOT]/.cargo/config.toml`
+"#]],
+    );
 }
 
 #[cargo_test]


### PR DESCRIPTION
### What does this PR try to resolve?

These paths are reserved for future extension:

* `.cargo/config.toml.d` -> configuration fragment support
* `.cargo/user.config.toml` -> auto-include user local config
* `.cargo/user.config.toml.d` -> a combination of the above

This is kinda modeled after `system.conf.d`:
https://www.freedesktop.org/software/systemd/man/latest/system.conf.d.html

### How to test and review this PR?

Maybe this need some bikeshedding?
See also [#t-cargo > Built-in &#96;.cargo/config.local.toml&#96;for non-committed config](https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/Built-in.20.60.2Ecargo.2Fconfig.2Elocal.2Etoml.60for.20non-committed.20config/with/558100758)