### PR TITLE
Change argument name to --precise option in cargo update.

### DIFF
--- a/src/doc/src/commands/cargo-update.md
+++ b/src/doc/src/commands/cargo-update.md
@@ -38,7 +38,7 @@ Cannot be used with <code>--precise</code>.</p>
 </dd>
 
 
-<dt class="option-term" id="option-cargo-update---precise"><a class="option-anchor" href="#option-cargo-update---precise"><code>--precise</code> <em>precise</em></a></dt>
+<dt class="option-term" id="option-cargo-update---precise"><a class="option-anchor" href="#option-cargo-update---precise"><code>--precise</code> <em>version</em></a></dt>
 <dd class="option-desc"><p>When used with <em>spec</em>, allows you to specify a specific version number to set
 the package to. If the package comes from a git repository, this can be a git
 revision (such as a SHA hash or tag).</p>


### PR DESCRIPTION
### What does this PR try to resolve?

The argument of the `cargo update` flag `--precise` is currently also named `precise` in the docs. This doesn't really make sense. Therefore it's changed to `version` because a version is what needs to specified.

### How to test and review this PR?

No tests needed.