### PR TITLE
fix(config-include): disallow glob and template syntax

### DIFF
--- a/tests/testsuite/config_include.rs
+++ b/tests/testsuite/config_include.rs
@@ -698,13 +698,7 @@ fn disallow_glob_syntax() {
 could not load Cargo configuration
 
 Caused by:
-  failed to load config include `config-*.toml` from `[ROOT]/.cargo/config.toml`
-
-Caused by:
-  failed to read configuration file `[ROOT]/.cargo/config-*.toml`
-
-Caused by:
-  [NOT_FOUND]
+  expected a config include path without glob patterns, but found `config-*.toml` from `[ROOT]/.cargo/config.toml`
 "#]],
     );
 }
@@ -722,13 +716,7 @@ fn disallow_template_syntax() {
 could not load Cargo configuration
 
 Caused by:
-  failed to load config include `{workspace-root}/config.toml` from `[ROOT]/.cargo/config.toml`
-
-Caused by:
-  failed to read configuration file `[ROOT]/.cargo/{workspace-root}/config.toml`
-
-Caused by:
-  [NOT_FOUND]
+  expected a config include path without template braces, but found `{workspace-root}/config.toml` from `[ROOT]/.cargo/config.toml`
 "#]],
     );
 }


### PR DESCRIPTION
### What does this PR try to resolve?

This reserves future possibility for us to support globa syntax and
templated paths.

Addressing https://github.com/rust-lang/cargo/pull/16284#discussion_r2550499932