### PR TITLE
docs(config-include): prepare for doc stabilization 

### DIFF
--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -660,14 +660,24 @@ rustflags = ["-W", "unsafe-code"]
 
 ### Documentation updates
 
-#### `include`
+> put this after `## Command-line overrides` before `## Config-relative paths`
+> to emphasize its special nature than other config keys.
+
+#### Including extra configuration files
+
+Configuration can include other configuration files using the top-level `include` key.
+This allows sharing configuration across multiple projects
+or splitting complex configurations into multiple files.
+
+##### `include`
 
 * Type: array of strings or tables
 * Default: none
 * Environment: not supported
 
-Loads additional config files. Paths are relative to the config file that
-includes them. Only paths ending with `.toml` are accepted.
+Loads additional configuration files.
+Paths are relative to the configuration file that includes them.
+Only paths ending with `.toml` are accepted.
 
 Supports the following formats:
 


### PR DESCRIPTION
### What does this PR try to resolve?

Discussed in 2025-11-25 t-cargo meeting.
We prefer inline tables over array of tables for `include`.

* `include` is special and should appear early in config files,
  before other configuration keys
* Array-of-tables syntax allows interleaving with other config,
  which creates confusion about merge order and precedence
* Inline tables keep all `include` declarations together at the top,
  making the load order behavior clearer

Part of rust-lang/cargo#7723 and rust-lang/cargo#16284

### How to test and review this PR?