### PR TITLE
fix(lints): show lint error number

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1299,7 +1299,8 @@ impl<'gctx> Workspace<'gctx> {
         }
 
         if error_count > 0 {
-            bail!("encountered {error_count} errors(s) while running lints")
+            let plural = if error_count == 1 { "" } else { "s" };
+            bail!("encountered {error_count} error{plural} while running lints")
         } else {
             Ok(())
         }

--- a/tests/testsuite/lints/error/stderr.term.svg
+++ b/tests/testsuite/lints/error/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-blue bold">= </tspan><tspan class="bold">note</tspan><tspan>: `cargo::im_a_teapot` is set to `deny` in `[lints]`</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-bright-red bold">error</tspan><tspan>: encountered 1 errors(s) while running lints</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-red bold">error</tspan><tspan>: encountered 1 error while running lints</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/lints/mod.rs
+++ b/tests/testsuite/lints/mod.rs
@@ -83,7 +83,7 @@ test_dummy_unstable = { level = "forbid", priority = -1 }
   | ^^^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::im_a_teapot` is set to `forbid` in `[lints]`
-[ERROR] encountered 1 errors(s) while running lints
+[ERROR] encountered 1 error while running lints
 
 "#]])
         .run();
@@ -126,7 +126,7 @@ workspace = true
    | ^^^^^^^^^^^^^^^^^^
    |
    = [NOTE] `cargo::im_a_teapot` is set to `forbid` in `[lints]`
-[ERROR] encountered 1 errors(s) while running lints
+[ERROR] encountered 1 error while running lints
 
 "#]])
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

This wasn't shown because `AlreadyPrintedError` was skipped.

Also corrected the plural form.