### PR TITLE
fix(completions): include `all` in `cargo tree --target` candidates

### DIFF
--- a/src/bin/cargo/commands/tree.rs
+++ b/src/bin/cargo/commands/tree.rs
@@ -108,9 +108,10 @@ pub fn cli() -> Command {
         )
         .arg_features()
         .arg(flag("all-targets", "Deprecated, use --target=all instead").hide(true))
-        .arg_target_triple(
+        .arg_target_triple_with_candidates(
             "Filter dependencies matching the given target-triple (default host platform). \
             Pass `all` to include all targets.",
+            ArgValueCandidates::new(get_target_triples_with_all),
         )
         .arg_manifest_path()
         .arg_lockfile_path()

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -327,6 +327,14 @@ pub trait CommandExt: Sized {
     }
 
     fn arg_target_triple(self, target: &'static str) -> Self {
+        self.arg_target_triple_with_candidates(target, ArgValueCandidates::new(get_target_triples))
+    }
+
+    fn arg_target_triple_with_candidates(
+        self,
+        target: &'static str,
+        target_completion: ArgValueCandidates,
+    ) -> Self {
         let unsupported_short_arg = {
             let value_parser = UnknownArgumentValueParser::suggest_arg("--target");
             Arg::new("unsupported-short-target-flag")
@@ -339,7 +347,7 @@ pub trait CommandExt: Sized {
         self._arg(
             optional_multi_opt("target", "TRIPLE", target)
                 .help_heading(heading::COMPILATION_OPTIONS)
-                .add(clap_complete::ArgValueCandidates::new(get_target_triples)),
+                .add(target_completion),
         )
         ._arg(unsupported_short_arg)
     }
@@ -1280,6 +1288,14 @@ fn get_target_triples() -> Vec<clap_complete::CompletionCandidate> {
         )),
     );
 
+    candidates
+}
+
+pub fn get_target_triples_with_all() -> Vec<clap_complete::CompletionCandidate> {
+    let mut candidates = vec![
+        clap_complete::CompletionCandidate::new("all").help(Some("Include all targets".into())),
+    ];
+    candidates.extend(get_target_triples());
     candidates
 }
 


### PR DESCRIPTION
The `all` meta-target was missing from native completions for `cargo tree --target`.

Added `arg_target_triple_with_candidates` to allow commands to provide custom completion candidates, following the pattern established for `--package`.

Fixes #16295