### PR TITLE
feat(log): track concurrency and CPU usage metrics

### DIFF
--- a/src/cargo/util/log_message.rs
+++ b/src/cargo/util/log_message.rs
@@ -101,6 +101,24 @@ pub enum LogMessage {
         /// Reason why the unit is dirty and needs rebuilding.
         cause: DirtyReason,
     },
+    /// Emitted periodically to track concurrency state.
+    ConcurrencySample {
+        /// Seconds elapsed from build start.
+        elapsed: f64,
+        /// Number of units currently running.
+        active: usize,
+        /// Number of units waiting for jobserver token.
+        waiting: usize,
+        /// Number of units waiting for dependencies.
+        inactive: usize,
+    },
+    /// Emitted periodically to track CPU usage.
+    CpuSample {
+        /// Seconds elapsed from build start.
+        elapsed: f64,
+        /// CPU usage percentage (0.0 to 100.0).
+        percentage: f64,
+    },
 }
 
 /// Cargo target information.


### PR DESCRIPTION
### What does this PR try to resolve?

These two metrics are needed for timing HTML replay,
though we could make them optional in both logging and HTML report.

Due to that we have an 100ms interval for CPU usage,
we cannot test against it as a test may complete in <100ms

Part of <https://github.com/rust-lang/cargo/issues/15844>.