### PR TITLE
Don't read the config file twice when $CARGO_HOME is a symlink

### DIFF
--- a/src/cargo/util/context/mod.rs
+++ b/src/cargo/util/context/mod.rs
@@ -1678,13 +1678,17 @@ impl GlobalContext {
             if let Some(path) = self.get_file_path(&config_root, "config", true)? {
                 walk(&path)?;
             }
-            seen_dir.insert(config_root);
+
+            let canonical_root = config_root.canonicalize().unwrap_or(config_root);
+            seen_dir.insert(canonical_root);
         }
+
+        let canonical_home = home.canonicalize().unwrap_or(home.to_path_buf());
 
         // Once we're done, also be sure to walk the home directory even if it's not
         // in our history to be sure we pick up that standard location for
         // information.
-        if !seen_dir.contains(home) {
+        if !seen_dir.contains(&canonical_home) && !seen_dir.contains(home) {
             if let Some(path) = self.get_file_path(home, "config", true)? {
                 walk(&path)?;
             }

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -2591,7 +2591,7 @@ fn mixed_type_array() {
 }
 
 #[cargo_test]
-fn config_symlink_home_duplicate_load_bug() {
+fn config_symlink_home_duplicate_load() {
     // Test that when CARGO_HOME is accessed via a symlink that points to a directory
     // already in the config search path, the config file is not loaded twice.
 
@@ -2647,13 +2647,5 @@ rustdocflags = ["--default-theme=dark"]
     p.cargo("doc")
         .cwd(&project_in_b)
         .env("CARGO_HOME", &cargo_home)
-        .with_status(101)
-        .with_stderr_data(str![[r#"
-[DOCUMENTING] foo v0.1.0 ([ROOT]/foo/a/b/foo)
-[ERROR] Option 'default-theme' given more than once
-
-[ERROR] could not document `foo`
-
-"#]])
         .run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?
Cargo should not load configuration twice if the config is symlinked

resolves #16206 

### How to test and review this PR?
> ### Steps
> 
> on unix:
> 
> 1. `mkdir -p a/b`
> 
> 2. `ln -s a c`
> 
> 3. `mkdir a/.cargo`
> 
> 4. `echo "[build]\nrustdocflags = [\"--default-theme=dark\"]" > a/.cargo/config.toml`
> 
> 5. `cd a/b`
> 
> 6. `CARGO_HOME=../../c/.cargo cargo doc`
> 
> 7. notice (with `strace` or by having a project at `a/b`) that the config file is read twice and the build fails
