### PR TITLE
declare version of windows-sys by range set to fix compile under win7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ unicode-width = "0.2.2"
 url = "2.5.7"
 varisat = "0.2.2"
 walkdir = "2.5.0"
-windows-sys = "0.61"
+windows-sys = ">=0.59, <=0.61"
 winnow = "0.7.14"
 
 [workspace.lints.rust]


### PR DESCRIPTION
Declaration with range is a [recommended way](https://crates.io/crates/windows-sys/0.61.2) to add `windows-sys` crate as dependency:

> Using a range instead of the default Caret requirements helps avoid duplicate versions in downstream graphs and improves resolver flexibility.

**Additionally**, `windows-sys@0.61+` has a bug that causes compilation errors under `*-win7-windows-*` targets, so this change will allow your users to choose & lock older version of `windows-sys` in theirs `Cargo.lock` to avoid this bug and continue support Windows 7.

I faced with compile errors causes from home@0.5.12 (0.5.11 works fine).