### PR TITLE
fix(completion): Put host-tuple before actual tuples

### DIFF
--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -1282,7 +1282,8 @@ fn get_target_triples() -> Vec<clap_complete::CompletionCandidate> {
     }
 
     // Allow tab-completion for `host-tuple` as the desired target.
-    candidates.push(
+    candidates.insert(
+        0,
         clap_complete::CompletionCandidate::new("host-tuple").help(Some(
             concat!("alias for: ", env!("RUST_HOST_TARGET")).into(),
         )),


### PR DESCRIPTION
### What does this PR try to resolve?

We did this for `all` and so making this consistent

By having special values first, they don't get buried and help raise awareness of their existence.

<img width="1089" height="696" alt="image" src="https://github.com/user-attachments/assets/93031803-826b-4854-b76d-dfac5f06e96a" />


### How to test and review this PR?
