### PR TITLE
Add validation for example target paths with clearer error messages

### DIFF
--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -3786,6 +3786,11 @@ path = "examples/fuzz"
         .build();
     p.cargo("check --example fuzz")
         .with_status(101)
-        .with_stderr_contains("[ERROR] couldn't read `examples/fuzz`: Is a directory (os error 21)")
-        .run();
+        .with_stderr_data(str![[r#"[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
+
+Caused by:
+  path `[ROOT]/foo/examples/fuzz` for example `fuzz` is a directory, but a source file was expected.
+  Consider setting the path to the intended entrypoint file instead: `[ROOT]/foo/examples/fuzz/.../main.rs`
+
+"#]]).run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?

Addresses #10173 

When directory paths are specified for example targets in Cargo.toml, cargo emits unhelpful os errors:

```
> cargo check --example fuzz                                                                                                                             
    Checking faulty-example v0.1.0 (/home/tanmay/Documents/CodingRepos/faulty-example)
error: couldn't read `examples/fuzz`: Is a directory (os error 21)
```

This PR fixes this by adding a validation function that checks if the target path is a valid source file. If not, emits an instructive error message:

```
> ../cargo/target/debug/cargo check --examples                                                                                                    
error: failed to parse manifest at `/home/tanmay/Documents/CodingRepos/faulty-example/Cargo.toml`

Caused by:
  path `/home/tanmay/Documents/CodingRepos/faulty-example/examples/fuzz` for example `fuzz` is a directory, but a source file was expected.
  Consider setting the path to the intended entrypoint file instead: `/home/tanmay/Documents/CodingRepos/faulty-example/examples/fuzz/.../main.rs`
```

