### PR TITLE
Update resolver.md: fix compile errors in pseudocode

### DIFF
--- a/src/doc/src/reference/resolver.md
+++ b/src/doc/src/reference/resolver.md
@@ -28,7 +28,7 @@ pub fn resolve(workspace: &[Package], policy: Policy) -> Option<ResolveGraph> {
 }
 
 fn resolve_next(dep_queue: Queue, resolved: ResolveGraph, policy: Policy) -> Option<ResolveGraph> {
-    let Some(dep_spec) = policy.pick_next_dep(&dep_queue) else {
+    let Some(dep_spec) = policy.pick_next_dep(&mut dep_queue) else {
         // Done
         return Some(resolved);
     };


### PR DESCRIPTION
I created a Rust project and wrote scaffolding until the dependency resolver pseudocode compiled (using rust-analyzer helpers but no LLMs). I have not done any kind of plausibility analysis, this is a pure "make all compiler errors go away" hackjob. The scaffolding might be interesting to preserve ... somewhere?


```rust
#[derive(Copy, Clone)]
struct Package;
impl Package {
    fn lookup_versions(&self) -> Option<Vec<Version>> {
        todo!()
    }
}

struct Version {
    dependencies: Vec<Package>,
}

#[derive(Copy, Clone)]
struct Policy;
impl Policy {
    fn pick_next_dep(&self, dep_queue: &Queue) -> Option<Package> {
        todo!()
    }

    fn try_unify_version(&self, dep_spec: Package, clone: ResolveGraph) -> Option<ResolveGraph> {
        todo!()
    }

    fn filter_versions(&self, dep_spec: Package, dep_versions: Vec<Version>) -> Vec<Version> {
        todo!()
    }

    fn pick_next_version(&self, dep_versions: &[Version]) -> Option<Version> {
        todo!()
    }

    fn needs_version_unification(&self, dep_version: &Version, resolved: &ResolveGraph) -> bool {
        todo!()
    }
}

#[derive(Clone)]
struct ResolveGraph;

impl ResolveGraph {
    fn new() -> Self {
        Self
    }

    fn register(&self, dep_version: Version) {
        todo!()
    }
}
struct Workspace;

#[derive(Clone)]
struct Queue;
impl Queue {
    fn new(workspace: &[Package]) -> Self {
        Self
    }

    fn enqueue(&self, dependencies: &Vec<Package>) {
        todo!()
    }
}
```

_Thanks for the pull request 🎉!_
_Please read the contribution guide: <https://doc.crates.io/contrib/>._

### What does this PR try to resolve?

the dependency resolver is explained using pseudocode which *almost* compiles. This PR makes it compile completely.

### How to test and review this PR?

- create a new Rust project
- copy the resolver pseudocode from the book into it
- observe many compiler errors resulting from the lack of struct definitions
- copy the scaffolding above into the Rust source file to make the resolver functions compile