### PR TITLE
fix(package): Don't verify registry for --list 

### DIFF
--- a/src/cargo/ops/cargo_package/mod.rs
+++ b/src/cargo/ops/cargo_package/mod.rs
@@ -276,7 +276,7 @@ fn do_package<'a>(
     // `package.publish`.
     let needs_local_reg = deps.has_dependencies() && (opts.include_lockfile || opts.verify);
     let verify_registry_allow_list = opts.reg_or_index.is_some();
-    let mut local_reg = if needs_local_reg || verify_registry_allow_list {
+    let mut local_reg = if !opts.list && (needs_local_reg || verify_registry_allow_list) {
         let sid = get_registry(ws.gctx(), &just_pkgs, opts.reg_or_index.clone())?;
         debug!("packaging for registry {}", sid);
         let reg_dir = ws.build_dir().join("package").join("tmp-registry");

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -6795,10 +6795,11 @@ The registry `alternative` is not listed in the `package.publish` value in Cargo
         .run();
 
     p.cargo("package --registry alternative --list")
-        .with_status(101)
-        .with_stderr_data(str![[r#"
-[ERROR] `foo` cannot be packaged.
-The registry `alternative` is not listed in the `package.publish` value in Cargo.toml.
+        .with_stdout_data(str![[r#"
+Cargo.lock
+Cargo.toml
+Cargo.toml.orig
+src/main.rs
 
 "#]])
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

Since `--list` is doing nothing with registries, imo, it shouldn't error if
`CARGO_REGISTRY_DEFAULT` is not in `package.publish`.
This also affects `--registry` and `--index` but that should be fine.

Fixes crate-ci/cargo-release#921

### How to test and review this PR?
