### PR TITLE
Remove legacy tmpdir support

### DIFF
--- a/crates/cargo-test-macro/src/lib.rs
+++ b/crates/cargo-test-macro/src/lib.rs
@@ -219,7 +219,7 @@ pub fn cargo_test(attr: TokenStream, item: TokenStream) -> TokenStream {
 
         let mut new_body = to_token_stream(
             r#"let _test_guard = {
-                let tmp_dir = option_env!("CARGO_TARGET_TMPDIR");
+                let tmp_dir = env!("CARGO_TARGET_TMPDIR");
                 cargo_test_support::paths::init_root(tmp_dir)
             };"#,
         );


### PR DESCRIPTION
This removes the legacy tmp directory support in cargo's integration test. This has been around since 2021, and I'm pretty sure is no longer needed.
