### PR TITLE
test: Adjust output for out-of-tree build-dir

### DIFF
--- a/tests/testsuite/publish_lockfile.rs
+++ b/tests/testsuite/publish_lockfile.rs
@@ -242,7 +242,7 @@ fn note_resolve_changes() {
 [ARCHIVING] Cargo.toml.orig
 [ARCHIVING] src/main.rs
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
-[WARNING] found (git) Cargo.toml ignored at `[..]/foo/Cargo.toml` in workdir `[..]`
+...
 
 "#]].unordered())
         .run();


### PR DESCRIPTION
When `build-dir` overlays `target-dir`, we pick up cargo's `.gitignore`. Ignoring the line in the output has no impact on this test's coverage.