### PR TITLE
fix(doctest): Include all search paths with new build layout 

### DIFF
--- a/src/cargo/core/compiler/build_runner/mod.rs
+++ b/src/cargo/core/compiler/build_runner/mod.rs
@@ -234,6 +234,7 @@ impl<'a, 'gctx> BuildRunner<'a, 'gctx> {
             if unit.mode.is_doc_test() {
                 let mut unstable_opts = false;
                 let mut args = compiler::extern_args(&self, unit, &mut unstable_opts)?;
+                args.extend(compiler::lib_search_paths(&self, unit)?);
                 args.extend(compiler::lto_args(&self, unit));
                 args.extend(compiler::features_args(unit));
                 args.extend(compiler::check_cfg_args(unit));

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1820,7 +1820,7 @@ fn add_custom_flags(
 }
 
 /// Generate a list of `-L` arguments
-fn lib_search_paths(
+pub fn lib_search_paths(
     build_runner: &BuildRunner<'_, '_>,
     unit: &Unit,
 ) -> CargoResult<Vec<OsString>> {

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -229,15 +229,6 @@ fn run_doc_tests(
             p.arg("-C").arg(format!("panic={}", unit.profile.panic));
         }
 
-        for &rust_dep in &[
-            &compilation.deps_output[&unit.kind],
-            &compilation.deps_output[&CompileKind::Host],
-        ] {
-            let mut arg = OsString::from("dependency=");
-            arg.push(rust_dep);
-            p.arg("-L").arg(arg);
-        }
-
         for native_dep in compilation.native_dirs.iter() {
             p.arg("-L").arg(native_dep);
         }

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -2629,23 +2629,6 @@ fn doctest_dep_new_layout() {
 
     p.cargo("-Zbuild-dir-new-layout test")
         .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .with_status(101)
-        .with_stdout_data(str![[r#"
-...
-error[E0463]: can't find crate for `b` which `foo` depends on
-...
-
-"#]])
-        .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
-[COMPILING] b v0.0.1 ([ROOT]/foo/b)
-[COMPILING] foo v0.0.1 ([ROOT]/foo)
-[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/deps/foo-[HASH])
-[DOCTEST] foo
-[ERROR] doctest failed, to rerun pass `--doc`
-
-"#]])
         .run();
 }
 


### PR DESCRIPTION
### What does this PR try to resolve?

When compilation was updated for the new build layout, doctests were overlooked.  This extracts the search path (`-L`) creation and switches doctests to reuse it.

Part of #15010

### How to test and review this PR?
