### PR TITLE
fix(layout): Remove hashes from bins in new layout 

### DIFF
--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -336,10 +336,10 @@ fn cargo_tmpdir_should_output_to_build_dir() {
 [ROOT]/foo/build-dir/CACHEDIR.TAG
 [ROOT]/foo/build-dir/debug/.cargo-lock
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/deps/foo-[HASH].d
-[ROOT]/foo/build-dir/debug/build/foo/[HASH]/deps/foo-[HASH].d
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/deps/foo.d
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/deps/foo[..].d
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/deps/foo-[HASH][EXE]
-[ROOT]/foo/build-dir/debug/build/foo/[HASH]/deps/foo-[HASH][EXE]
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/deps/foo[EXE]
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/deps/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-test-bin-foo

--- a/tests/testsuite/clean_new_layout.rs
+++ b/tests/testsuite/clean_new_layout.rs
@@ -126,7 +126,7 @@ fn clean_multiple_packages_in_glob_char_path() {
     let foo_path = &p.build_dir().join("debug").join("build");
 
     #[cfg(not(target_env = "msvc"))]
-    let file_glob = "foo/*/deps/foo-*";
+    let file_glob = "foo/*/deps/foo*";
 
     #[cfg(target_env = "msvc")]
     let file_glob = "foo/*/deps/foo.pdb";


### PR DESCRIPTION
### What does this PR try to resolve?

There is a desire in #8332 to make our use of `-Cextra-file-name` in `deps/` more
consistent across platforms.
Having it present gets in the way of finding PDBs.
With #15010, we no longer need `-Cextra-file-name` to avoid collisions.
It might still be used by rustc for faster lookups though.
So we can at least adjust all other platforms to be like Windows,
making things consistent

Addresses #8332 if #15010 is stabilized

Part of #15010

### How to test and review this PR?

