### PR TITLE
fix(timings): forgot to negate filter

### DIFF
--- a/src/cargo/core/compiler/timings/report.rs
+++ b/src/cargo/core/compiler/timings/report.rs
@@ -283,7 +283,7 @@ fn write_unit_table(ctx: &RenderContext<'_>, f: &mut impl Write) -> CargoResult<
                 .iter()
                 // We don't want to show the "Other" section in the table,
                 // as it is usually a tiny portion out of the entire unit.
-                .filter(|(name, _)| matches!(name, SectionName::Other))
+                .filter(|(name, _)| !matches!(name, SectionName::Other))
                 .map(|s| s.0.clone())
                 .collect()
         })


### PR DESCRIPTION
Wanted to filter out "Other" but missed the `!`

Regressed since https://github.com/rust-lang/cargo/commit/1bd6113f5e270b90e3b9ee5c2ed4e5117cce1fa7