### PR TITLE
Remove `[no-mentions]` handler in our triagebot config

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -30,9 +30,6 @@ label = "O-windows"
 # Documentation at: https://forge.rust-lang.org/triagebot/transfer.html
 [transfer]
 
-# Prevents mentions in commits to avoid users being spammed
-[no-mentions]
-
 # Enable `@rustbot note` functionality
 # Documentation at: https://forge.rust-lang.org/triagebot/note.html
 [note]


### PR DESCRIPTION
This PR removes the `[no-mentions]` handler in our triagebot config as [GitHub is removing notifications for @-mentions in commit messages on December 8th 2025.](https://github.blog/changelog/2025-11-07-removing-notifications-for-mentions-in-commit-messages/)

cf. https://github.com/rust-lang/triagebot/issues/2225