### PR TITLE
fix: handled the case of help and list flags combination to show list

### DIFF
--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -654,3 +654,44 @@ fn overwrite_cargo_environment_variable() {
         .with_stderr_contains(stderr_other_cargo)
         .run();
 }
+
+#[cargo_test]
+fn help_list_combination() {
+    // Test that `--help --list` is treated as `--list`.
+    // When the help output says "See all commands with --list", users may
+    // naturally try `cargo --help --list`. This should show the list.
+    cargo_process("--help --list")
+        .with_stdout_data(str![[r#"
+Installed Commands:
+...
+    build                Compile a local package and all of its dependencies
+...
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn help_list_reverse_order() {
+    // Test that `--list --help` is treated as `--list` (order shouldn't matter).
+    cargo_process("--list --help")
+        .with_stdout_data(str![[r#"
+Installed Commands:
+...
+    build                Compile a local package and all of its dependencies
+...
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn help_short_flag_with_list() {
+    // Test that `-h --list` is treated as `--list`.
+    cargo_process("-h --list")
+        .with_stdout_data(str![[r#"
+Installed Commands:
+...
+    build                Compile a local package and all of its dependencies
+...
+"#]])
+        .run();
+}


### PR DESCRIPTION
### What does this PR try to resolve?

 Fixes #15648

  When running `cargo --help`, users are told to "See all commands with --list". A natural interpretation is that `cargo --help --list` should show the full list of commands. However, clap's automatic `--help` handling exits early, so `--list` was being ignored.

  This PR makes `--help --list` (or `-h --list`, or `--list --help`) behave as `--list`, showing the full list of installed commands.

### How to test and review this PR?

 #### Before this change:
 ```bash
  cargo --help --list
  # Shows only the help output, --list is ignored
```

 #### After this change:
  ```bash
  cargo --help --list
  Installed Commands:
      add                  Add dependencies to a Cargo.toml manifest file
      bench                Execute all benchmarks of a local package
      build                Compile a local package and all of its dependencies
      ...
 ```
