### PR TITLE
fix(lints): handle lints separately at ws pkg level 

### DIFF
--- a/tests/testsuite/lints/inherited/mod.rs
+++ b/tests/testsuite/lints/inherited/mod.rs
@@ -37,7 +37,7 @@ workspace = true
         .arg("check")
         .arg("-Zcargo-lints")
         .assert()
-        .success()
+        .code(101)
         .stdout_eq(str![""])
         .stderr_eq(file!["stderr.term.svg"]);
 }

--- a/tests/testsuite/lints/inherited/stderr.term.svg
+++ b/tests/testsuite/lints/inherited/stderr.term.svg
@@ -1,8 +1,9 @@
-<svg width="740px" height="74px" xmlns="http://www.w3.org/2000/svg">
+<svg width="818px" height="182px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
-    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +19,23 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Checking</tspan><tspan> foo v0.0.1 ([ROOT]/foo/foo)</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan class="bold">: use of unstable lint `im_a_teapot`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">    Finished</tspan><tspan> </tspan><tspan><a href="https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles">`dev` profile [unoptimized + debuginfo]</a></tspan><tspan> target(s) in [ELAPSED]s</tspan>
+    <tspan x="10px" y="46px"><tspan> </tspan><tspan class="fg-bright-blue bold">--&gt; </tspan><tspan>Cargo.toml:6:1</tspan>
 </tspan>
-    <tspan x="10px" y="64px">
+    <tspan x="10px" y="64px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">6</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> im_a_teapot = { level = "warn", priority = 10 }</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan><tspan> </tspan><tspan class="fg-bright-red bold">^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-bright-red bold">this is behind `test-dummy-unstable`, which is not enabled</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-blue bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-blue bold">= </tspan><tspan class="bold">help</tspan><tspan>: consider adding `cargo-features = ["test-dummy-unstable"]` to the top of the manifest</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-red bold">error</tspan><tspan>: encountered 1 error while verifying lints</tspan>
+</tspan>
+    <tspan x="10px" y="172px">
 </tspan>
   </text>
 

--- a/tests/testsuite/lints/mod.rs
+++ b/tests/testsuite/lints/mod.rs
@@ -139,6 +139,8 @@ fn dont_always_inherit_workspace_lints() {
         .file(
             "Cargo.toml",
             r#"
+cargo-features = ["test-dummy-unstable"]
+
 [workspace]
 members = ["foo"]
 
@@ -295,9 +297,23 @@ workspace = true
 
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_status(101)
         .with_stderr_data(str![[r#"
-[CHECKING] foo v0.0.1 ([ROOT]/foo/foo)
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[ERROR] use of unstable lint `im_a_teapot`
+ --> Cargo.toml:6:1
+  |
+6 | im_a_teapot = { level = "warn", priority = 10 }
+  | ^^^^^^^^^^^ this is behind `test-dummy-unstable`, which is not enabled
+  |
+  = [HELP] consider adding `cargo-features = ["test-dummy-unstable"]` to the top of the manifest
+[ERROR] use of unstable lint `test_dummy_unstable`
+ --> Cargo.toml:7:1
+  |
+7 | test_dummy_unstable = { level = "forbid", priority = -1 }
+  | ^^^^^^^^^^^^^^^^^^^ this is behind `test-dummy-unstable`, which is not enabled
+  |
+  = [HELP] consider adding `cargo-features = ["test-dummy-unstable"]` to the top of the manifest
+[ERROR] encountered 2 errors while verifying lints
 
 "#]])
         .run();
@@ -332,9 +348,23 @@ authors = []
 
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_status(101)
         .with_stderr_data(str![[r#"
-[CHECKING] foo v0.0.1 ([ROOT]/foo/foo)
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[ERROR] use of unstable lint `im_a_teapot`
+ --> Cargo.toml:6:1
+  |
+6 | im_a_teapot = { level = "warn", priority = 10 }
+  | ^^^^^^^^^^^ this is behind `test-dummy-unstable`, which is not enabled
+  |
+  = [HELP] consider adding `cargo-features = ["test-dummy-unstable"]` to the top of the manifest
+[ERROR] use of unstable lint `test_dummy_unstable`
+ --> Cargo.toml:7:1
+  |
+7 | test_dummy_unstable = { level = "forbid", priority = -1 }
+  | ^^^^^^^^^^^^^^^^^^^ this is behind `test-dummy-unstable`, which is not enabled
+  |
+  = [HELP] consider adding `cargo-features = ["test-dummy-unstable"]` to the top of the manifest
+[ERROR] encountered 2 errors while verifying lints
 
 "#]])
         .run();

--- a/tests/testsuite/lints/unknown_lints.rs
+++ b/tests/testsuite/lints/unknown_lints.rs
@@ -70,6 +70,13 @@ workspace = true
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
+[WARNING] unknown lint: `this-lint-does-not-exist`
+ --> Cargo.toml:6:1
+  |
+6 | this-lint-does-not-exist = "warn"
+  | ^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [CHECKING] foo v0.0.1 ([ROOT]/foo/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -106,6 +113,13 @@ authors = []
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
+[WARNING] unknown lint: `this-lint-does-not-exist`
+ --> Cargo.toml:6:1
+  |
+6 | this-lint-does-not-exist = "warn"
+  | ^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [CHECKING] foo v0.0.1 ([ROOT]/foo/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 


### PR DESCRIPTION
### What does this PR try to resolve?

`unknown_lints` is special that it analyzes only at package level,
and warn if your lint is inherited from workspace.

According to the discussion in <https://github.com/rust-lang/cargo/pull/16321#discussion_r2586539709>,
we should lint against workspace always plus selected packages.

This additionally handles unstable lint gating.

### How to test and review this PR?

Two new tests are added to reflect that workspace lints were not analyzed if not inheriting.
