### PR TITLE
Downgrade curl-sys to 0.4.83

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,6 +8,9 @@
   ignorePaths: [
     '**/tests/**',
   ],
+  // Ignore curl-sys, for now
+  // https://github.com/rust-lang/cargo/issues/16357
+  ignoreDeps: ['curl-sys'],
   customManagers: [
     {
       customType: 'regex',

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,9 +871,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.84+curl-8.17.0"
+version = "0.4.83+curl-8.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abc4294dc41b882eaff37973c2ec3ae203d0091341ee68fbadd1d06e0c18a73b"
+checksum = "5830daf304027db10c82632a464879d46a3f7c4ba17a31592657ad16c719b483"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,9 @@ core-foundation = { version = "0.10.1", features = ["mac_os_10_7_support"] }
 crates-io = { version = "0.40.16", path = "crates/crates-io" }
 criterion = { version = "0.7.0", features = ["html_reports"] }
 curl = "0.4.49"
-curl-sys = "0.4.84"
+# Do not upgrade curl-sys past 0.4.83
+# https://github.com/rust-lang/cargo/issues/16357
+curl-sys = "0.4.83"
 filetime = "0.2.26"
 flate2 = { version = "1.1.5", default-features = false, features = ["zlib-rs"] }
 git2 = "0.20.2"


### PR DESCRIPTION
With version 0.4.84, cargo was failing on FreeBSD 13.5 and 14.3 every time, with errors like this:

```
    Updating crates.io index
error: failed to get `futures` as a dependency of package `tokio-file v0.11.0 (/tmp/cirrus-ci-build)`
Caused by:
  download of config.json failed
Caused by:
  failed to download from `https://index.crates.io/config.json`
Caused by:
  [60] SSL peer certificate or SSH remote key was not OK (SSL certificate OpenSSL verify result: unable to get local issuer certificate (20))
```

Fixes #16357

_Thanks for the pull request 🎉!_
_Please read the contribution guide: <https://doc.crates.io/contrib/>._

### What does this PR try to resolve?

_Explain the motivation behind this change._
_A clear overview along with an in-depth explanation are helpful._

### How to test and review this PR?

_Demonstrate how you test this change and guide reviewers through your PR._
_With a smooth review process, a pull request usually gets reviewed quicker._
