### PR TITLE
Fixed incorrect locking logic when artifact-dir == build-dir

### DIFF
--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -1710,13 +1710,13 @@ fn check_build_should_not_output_files_to_artifact_dir() {
 }
 
 #[cargo_test]
-fn check_build_should_not_lock_artifact_dir() {
+fn check_build_should_lock_target_dir_when_artifact_dir_is_same_as_build_dir() {
     let p = project()
         .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
         .build();
 
     p.cargo("check").enable_mac_dsym().run();
-    assert!(!p.root().join("target/debug/.cargo-lock").exists());
+    assert!(p.root().join("target/debug/.cargo-lock").exists());
 }
 
 #[cargo_test]


### PR DESCRIPTION
### What does this PR try to resolve?

This PR fixes incorrect locking behavior in `layout.rs` that forgets to lock the `build-dir` when `build-dir == artifact-dir`.
This is problematic is the default for both are `$WORKSPACE/target`  and I overlooked this :( 

Issue reported in #16384

### How to test and review this PR?

See the tests. You can also run `cargo check` and check for the presence of `.cargo-lock`

r? @weihanglo 


