### PR TITLE
Avoid console output for cargo script with unchanged builds

### DIFF
--- a/crates/xtask-bump-check/src/xtask.rs
+++ b/crates/xtask-bump-check/src/xtask.rs
@@ -82,6 +82,7 @@ fn global_context_configure(gctx: &mut GlobalContext, args: &ArgMatches) -> CliR
     // quiet is unusual because it is redefined in some subcommands in order
     // to provide custom help text.
     let quiet = args.flag("quiet");
+    let is_manifest = false; // TODO
     let color = args.get_one::<String>("color").map(String::as_str);
     let frozen = args.flag("frozen");
     let locked = args.flag("locked");
@@ -97,6 +98,7 @@ fn global_context_configure(gctx: &mut GlobalContext, args: &ArgMatches) -> CliR
     gctx.configure(
         verbose,
         quiet,
+        is_manifest,
         color,
         frozen,
         locked,

--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -417,7 +417,10 @@ fn configure_gctx(
     let mut quiet = args.flag("quiet")
         || subcommand_args.map(|a| a.flag("quiet")).unwrap_or_default()
         || global_args.quiet;
-    if matches!(exec, Some(Exec::Manifest(_))) && !quiet {
+
+    let is_manifest = matches!(exec, Some(Exec::Manifest(_)));
+
+    if is_manifest && !quiet {
         // Verbosity is shifted quieter for `Exec::Manifest` as it is can be used as if you ran
         // `cargo install` and we especially shouldn't pollute programmatic output.
         //
@@ -449,6 +452,7 @@ fn configure_gctx(
     gctx.configure(
         verbose,
         quiet,
+        is_manifest,
         color,
         frozen,
         locked,

--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -131,6 +131,12 @@ pub struct Compilation<'gctx> {
 
     /// The total number of lint warnings emitted by the compilation.
     pub lint_warning_count: usize,
+
+    /// Were all compiled units up to date? This is initialised to true
+    /// and then set to false if we have to actually compile anything, instead
+    /// of using cached artifacts. This is used by `cargo script` to suppress
+    /// cargo messages when the script is already built.
+    pub unchanged: bool,
 }
 
 impl<'gctx> Compilation<'gctx> {
@@ -170,6 +176,7 @@ impl<'gctx> Compilation<'gctx> {
                 .map(|kind| Ok((*kind, target_linker(bcx, *kind)?)))
                 .collect::<CargoResult<HashMap<_, _>>>()?,
             lint_warning_count: 0,
+            unchanged: true,
         })
     }
 

--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -848,7 +848,13 @@ impl<'gctx> DrainState<'gctx> {
                 "{profile_link}`{profile_name}` profile [{opt_type}]{profile_link:#} target(s) in {time_elapsed}",
             );
             // It doesn't really matter if this fails.
-            let _ = build_runner.bcx.gctx.shell().status("Finished", message);
+            let _ = build_runner
+                .bcx
+                .gctx
+                .shell()
+                .if_unchanged(build_runner.compilation.unchanged, move |shell| {
+                    shell.status("Finished", &message)
+                });
             future_incompat::save_and_display_report(
                 build_runner.bcx,
                 &self.per_package_future_incompat_reports,

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -202,6 +202,9 @@ fn compile<'gctx>(
             let force = exec.force_rebuild(unit) || force_rebuild;
             let mut job = fingerprint::prepare_target(build_runner, unit, force)?;
             job.before(if job.freshness().is_dirty() {
+                // Mark the compilation as having done some work.
+                build_runner.compilation.unchanged = false;
+
                 let work = if unit.mode.is_doc() || unit.mode.is_doc_scrape() {
                     rustdoc(build_runner, unit)?
                 } else {

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -213,6 +213,18 @@ impl Shell {
         }
     }
 
+    // Runs the callback if unless the verbosity is `QuietIfUnchanged` and
+    // `unchanged` is true.
+    pub fn if_unchanged<F>(&mut self, unchanged: bool, mut callback: F) -> CargoResult<()>
+    where
+        F: FnMut(&mut Shell) -> CargoResult<()>,
+    {
+        match (self.verbosity, unchanged) {
+            (Verbosity::QuietIfUnchanged, true) => Ok(()),
+            _ => callback(self),
+        }
+    }
+
     /// Prints a red 'error' message.
     pub fn error<T: fmt::Display>(&mut self, message: T) -> CargoResult<()> {
         if self.needs_clear {
@@ -558,6 +570,8 @@ impl TtyWidth {
 pub enum Verbosity {
     Verbose,
     Normal,
+    /// No output if it's a no-change build with no warnings.
+    QuietIfUnchanged,
     Quiet,
 }
 

--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -122,7 +122,11 @@ pub fn run(
         process.display_env_vars();
     }
 
-    gctx.shell().status("Running", process.to_string())?;
+    let process_string = process.to_string();
+
+    gctx.shell().if_unchanged(compile.unchanged, move |shell| {
+        shell.status("Running", &process_string)
+    })?;
 
     process.exec_replace()
 }

--- a/src/cargo/ops/registry/info/view.rs
+++ b/src/cargo/ops/registry/info/view.rs
@@ -181,7 +181,7 @@ fn pretty_deps(
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     match verbosity {
-        Verbosity::Quiet | Verbosity::Normal => {
+        Verbosity::Quiet | Verbosity::Normal | Verbosity::QuietIfUnchanged => {
             return Ok(());
         }
         Verbosity::Verbose => {}
@@ -345,7 +345,7 @@ fn pretty_features(
         .filter(|(_, s)| s.is_disabled())
         .count();
     let show_all = match verbosity {
-        Verbosity::Quiet | Verbosity::Normal => false,
+        Verbosity::Quiet | Verbosity::Normal | Verbosity::QuietIfUnchanged => false,
         Verbosity::Verbose => true,
     };
     let show_activated = total_activated <= MAX_FEATURE_PRINTS || show_all;

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -1095,7 +1095,7 @@ fn fetch_with_cli(
         cmd.arg(format!("--depth={depth}"));
     }
     match gctx.shell().verbosity() {
-        Verbosity::Normal => {}
+        Verbosity::Normal | Verbosity::QuietIfUnchanged => {}
         Verbosity::Verbose => {
             cmd.arg("--verbose");
         }

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -1559,6 +1559,7 @@ pub fn new_gctx_for_completions() -> CargoResult<GlobalContext> {
 
     let verbose = 0;
     let quiet = true;
+    let is_manifest = false;
     let color = None;
     let frozen = false;
     let locked = true;
@@ -1570,6 +1571,7 @@ pub fn new_gctx_for_completions() -> CargoResult<GlobalContext> {
     gctx.configure(
         verbose,
         quiet,
+        is_manifest,
         color,
         frozen,
         locked,

--- a/src/cargo/util/dependency_queue.rs
+++ b/src/cargo/util/dependency_queue.rs
@@ -170,6 +170,11 @@ impl<N: Hash + Eq + Clone, E: Eq + Hash + Clone, V> DependencyQueue<N, E, V> {
         self.dep_map.len()
     }
 
+    /// Return an iterator over the values in the queue.
+    pub fn values(&self) -> impl Iterator<Item = &V> {
+        self.dep_map.values().map(|(_, v)| v)
+    }
+
     /// Indicate that something has finished.
     ///
     /// Calling this function indicates that the `node` has produced `edge`. All


### PR DESCRIPTION
This adds a flag that records whether any work was actually done during a build (i.e. it is false for no-change builds). Then for 'manifest' commands, it suppresses some console output if the build was unchanged.

This means that after the first time you run a `cargo script` and it's all cached, you only see output from the actual command; nothing from cargo (assuming your code has no warnings).

Fixes #16388

### Testing

1. Create this script (if I add any dependencies it gives me grief about mismatched rustc versions or something but we don't need any to test this fortunately):

```
#!/usr/bin/env -S /path/to/cargo/target/debug/cargo -Zscript
---
[package]
edition = "2024"
[dependencies]
---

fn main() {
    println!("Hello");
}
```

2. Build cargo with nightly:

```
cargo +nightly build
```

3. Run the script once. You should see some compilation output messages from Cargo.
4. Run it again. This time you should *only* see `Hello`.