### PR TITLE
test(lint): redact more due to line got omitted

### DIFF
--- a/tests/testsuite/lints/implicit_minimum_version_req.rs
+++ b/tests/testsuite/lints/implicit_minimum_version_req.rs
@@ -717,8 +717,8 @@ implicit_minimum_version_req = "warn"
 [WARNING] dependency version requirement without an explicit minimum version
  --> Cargo.toml:7:[..]
   |
-7 | bar = { git = '[ROOTURL]/bar', version = "0.1" }
-  |                                      [..]^^^^^ missing full version components
+7 | [..]/bar', version = "0.1" }
+  |                  [..]^^^^^ missing full version components
   |
 [HELP] consider specifying full `major.minor.patch` version components
   |


### PR DESCRIPTION
### What does this PR try to resolve?


```
---- expected: tests/testsuite/lints/implicit_minimum_version_req.rs:716:27
++++ actual:   stderr
   1    1 | [WARNING] dependency version requirement without an explicit minimum version
   2    2 |  --> Cargo.toml:7:[..]
   3    3 |   |
   4      - 7 | bar = { git = '[ROOTURL]/bar', version = "0.1" }
        4 + 7 | ...known-linux-gnu/tmp/cit/t2182/bar', version = "0.1" }
   5    5 |   |                                      [..]^^^^^ missing full version components
   6    6 |   |
   7    7 | [HELP] consider specifying full `major.minor.patch` version components
   8    8 |   |
   9    9 | 7 | bar = { git = '[ROOTURL]/bar', version = "0.1.0" }
  10   10 |   |                                          [..]++
  11   11 |   = [NOTE] `cargo::implicit_minimum_version_req` is set to `warn` in `[lints]`
  12   12 | [UPDATING] git repository `[ROOTURL]/bar`
  13   13 | [LOCKING] 1 package to latest compatible version
  14   14 | [CHECKING] bar v0.1.0 ([ROOTURL]/bar#[..])
  15   15 | [CHECKING] foo v0.0.0 ([ROOT]/foo)
  16   16 | [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
```

See https://github.com/rust-lang/rust/pull/149934#issuecomment-3649057452

### How to test and review this PR?

r? Muscraft 

I wonder if annotate-snippets already has a way to control not omitting for tests (or that is not worthy).