### PR TITLE
[beta-1.93] Downgrade curl-sys to 0.4.83

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,6 +8,9 @@
   ignorePaths: [
     '**/tests/**',
   ],
+  // Ignore curl-sys, for now
+  // https://github.com/rust-lang/cargo/issues/16357
+  ignoreDeps: ['curl-sys'],
   customManagers: [
     {
       customType: 'regex',

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,9 +870,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.84+curl-8.17.0"
+version = "0.4.83+curl-8.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abc4294dc41b882eaff37973c2ec3ae203d0091341ee68fbadd1d06e0c18a73b"
+checksum = "5830daf304027db10c82632a464879d46a3f7c4ba17a31592657ad16c719b483"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,9 @@ core-foundation = { version = "0.10.1", features = ["mac_os_10_7_support"] }
 crates-io = { version = "0.40.16", path = "crates/crates-io" }
 criterion = { version = "0.7.0", features = ["html_reports"] }
 curl = "0.4.49"
-curl-sys = "0.4.84"
+# Do not upgrade curl-sys past 0.4.83
+# https://github.com/rust-lang/cargo/issues/16357
+curl-sys = "0.4.83"
 filetime = "0.2.26"
 flate2 = { version = "1.1.5", default-features = false, features = ["zlib-rs"] }
 git2 = "0.20.2"


### PR DESCRIPTION
Beta backports
- rust-lang/cargo@389962f7104077ffe99903f5017208c80af6bf9b

In order to make CI pass, the following PRs are also cherry-picked:

- 

See also

* [#t-cargo > &#91;beta-1.93&#93; nominate backport curl downgrade](https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/.5Bbeta-1.2E93.5D.20nominate.20backport.20curl.20downgrade/with/563873939)
* https://github.com/rust-lang/cargo/issues/16357#issuecomment-3646675377