### PR TITLE
test: Use a larger default term width

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1423,7 +1423,7 @@ pub trait TestEnvCommandExt: Sized {
             .env("__CARGO_TEST_DISABLE_GLOBAL_KNOWN_HOST", "1")
             // Set retry sleep to 1 millisecond.
             .env("__CARGO_TEST_FIXED_RETRY_SLEEP_MS", "1")
-            .env("__CARGO_TEST_TTY_WIDTH_DO_NOT_USE_THIS", "140")
+            .env("__CARGO_TEST_TTY_WIDTH_DO_NOT_USE_THIS", "200")
             // Incremental generates a huge amount of data per test, which we
             // don't particularly need. Tests that specifically need to check
             // the incremental behavior should turn this back on.

--- a/tests/testsuite/lints/implicit_minimum_version_req.rs
+++ b/tests/testsuite/lints/implicit_minimum_version_req.rs
@@ -717,8 +717,8 @@ implicit_minimum_version_req = "warn"
 [WARNING] dependency version requirement without an explicit minimum version
  --> Cargo.toml:7:[..]
   |
-7 | [..]/bar', version = "0.1" }
-  |                  [..]^^^^^ missing full version components
+7 | bar = { git = '[ROOTURL]/bar', version = "0.1" }
+  |                                      [..]^^^^^ missing full version components
   |
 [HELP] consider specifying full `major.minor.patch` version components
   |


### PR DESCRIPTION
@ehuss [made a comment](https://github.com/rust-lang/cargo/pull/16391#issuecomment-3649925243) saying that `cargo` should set `__CARGO_TEST_TTY_WIDTH_DO_NOT_USE_THIS` to a very large value to avoid problems with long paths in tests. This PR does that by setting it to `200` (the previous default was `140`). 


Note: `200` is a start, and we can always go up if needed 