### PR TITLE
chore(ci): report-timings to upload HTML report

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,7 @@ jobs:
       - lint-docs
       - lockfile
       - resolver
+      - report-timings
       - rustfmt
       - schema
       - spellcheck
@@ -327,3 +328,20 @@ jobs:
       uses: actions/checkout@v5
     - name: Spell Check Repo
       uses: crate-ci/typos@v1.40.0
+
+  report-timings:
+    name: Timing HTML report
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+    - run: rustup update nightly && rustup default nightly
+    - run: cargo build
+    - name: Generate timing report for rustfix
+      run: |
+        cargo run -- build -p rustfix -Zbuild-analysis -Zsection-timings --config build.analysis.enabled=true --config 'build.build-dir="tmp"'
+        cargo run -- report timings -Zbuild-analysis
+    - uses: actions/upload-artifact@v6
+      with:
+        name: timing-report
+        path: target/cargo-timings/*.html
+        if-no-files-found: error


### PR DESCRIPTION
### What does this PR try to resolve?

This could help review the HTML report by download the artifacts.


### How to test and review this PR?

To review the HTML report changed in this PR

1. Go the the summary page of the associated GitHub Action run (e.g., <https://github.com/rust-lang/cargo/actions/runs/20354778718>)
2. Scroll to "Artifacts" section and download the `timing-report` artifact
4. Unzip the `timing-report.zip` file, and open the `cargo-timing-*.html` in your browser