### PR TITLE
fix(sbom): Don't set CARGO_SBOM_PATH when empty (like stable) 

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -780,8 +780,11 @@ fn prepare_rustc(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> CargoResult
 
     if is_primary {
         base.env("CARGO_PRIMARY_PACKAGE", "1");
-        let file_list = std::env::join_paths(build_runner.sbom_output_files(unit)?)?;
-        base.env("CARGO_SBOM_PATH", file_list);
+        let file_list = build_runner.sbom_output_files(unit)?;
+        if !file_list.is_empty() {
+            let file_list = std::env::join_paths(file_list)?;
+            base.env("CARGO_SBOM_PATH", file_list);
+        }
     }
 
     if unit.target.is_test() || unit.target.is_bench() {

--- a/tests/testsuite/sbom.rs
+++ b/tests/testsuite/sbom.rs
@@ -38,7 +38,7 @@ fn warn_without_passing_unstable_flag() {
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `target/debug/foo[EXE]`
-Some("")
+None
 
 "#]])
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

Noticed `CARGO_SBOM_PATH` was being set when playing around with
artifact-deps.

I could have gated the env by whether the nightly feature was enabled
but figured it would be better to not set if it there aren't SBOMs.

### How to test and review this PR?

