### PR TITLE
fix(timing)!: remove `--timings=<FMT>` optional format values

### DIFF
--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -44,8 +44,8 @@ pub struct BuildConfig {
     pub export_dir: Option<PathBuf>,
     /// `true` to output a future incompatibility report at the end of the build
     pub future_incompat_report: bool,
-    /// Which kinds of build timings to output (empty if none).
-    pub timing_outputs: Vec<TimingOutput>,
+    /// Output timing report at the end of the build
+    pub timing_report: bool,
     /// Output SBOM precursor files.
     pub sbom: bool,
     /// Build compile time dependencies only, e.g., build scripts and proc macros
@@ -127,7 +127,7 @@ impl BuildConfig {
             rustfix_diagnostic_server: Rc::new(RefCell::new(None)),
             export_dir: None,
             future_incompat_report: false,
-            timing_outputs: Vec::new(),
+            timing_report: false,
             sbom,
             compile_time_deps_only: false,
         })
@@ -349,13 +349,4 @@ impl UserIntent {
             UserIntent::Test | UserIntent::Bench | UserIntent::Check { test: true }
         )
     }
-}
-
-/// Kinds of build timings we can output.
-#[derive(Clone, Copy, PartialEq, Debug, Eq, Hash, PartialOrd, Ord)]
-pub enum TimingOutput {
-    /// Human-readable HTML report
-    Html,
-    /// Machine-readable JSON (unstable)
-    Json,
 }

--- a/src/cargo/core/compiler/build_runner/mod.rs
+++ b/src/cargo/core/compiler/build_runner/mod.rs
@@ -409,7 +409,7 @@ impl<'a, 'gctx> BuildRunner<'a, 'gctx> {
                 // Generally cargo check does not need to take the artifact-dir lock but there is
                 // one exception: If check has `--timings` we still need to lock artifact-dir since
                 // we will output the report files.
-                !self.bcx.build_config.timing_outputs.is_empty()
+                self.bcx.build_config.timing_report
             }
             UserIntent::Build
             | UserIntent::Test

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -71,7 +71,7 @@ use regex::Regex;
 use tracing::{debug, instrument, trace};
 
 pub use self::build_config::UserIntent;
-pub use self::build_config::{BuildConfig, CompileMode, MessageFormat, TimingOutput};
+pub use self::build_config::{BuildConfig, CompileMode, MessageFormat};
 pub use self::build_context::BuildContext;
 pub use self::build_context::FileFlavor;
 pub use self::build_context::FileType;
@@ -112,7 +112,6 @@ use cargo_util_schemas::manifest::TomlDebugInfo;
 use cargo_util_schemas::manifest::TomlTrimPaths;
 use cargo_util_schemas::manifest::TomlTrimPathsValue;
 use rustfix::diagnostics::Applicability;
-pub(crate) use timings::CompilationSection;
 
 const RUSTDOC_CRATE_VERSION_FLAG: &str = "--crate-version";
 
@@ -1131,8 +1130,7 @@ fn add_allow_features(build_runner: &BuildRunner<'_, '_>, cmd: &mut ProcessBuild
 /// [`--error-format`]: https://doc.rust-lang.org/nightly/rustc/command-line-arguments.html#--error-format-control-how-errors-are-produced
 fn add_error_format_and_color(build_runner: &BuildRunner<'_, '_>, cmd: &mut ProcessBuilder) {
     let enable_timings = build_runner.bcx.gctx.cli_unstable().section_timings
-        && (!build_runner.bcx.build_config.timing_outputs.is_empty()
-            || build_runner.bcx.logger.is_some());
+        && (build_runner.bcx.build_config.timing_report || build_runner.bcx.logger.is_some());
     if enable_timings {
         cmd.arg("-Zunstable-options");
     }

--- a/src/cargo/core/compiler/timings/mod.rs
+++ b/src/cargo/core/compiler/timings/mod.rs
@@ -7,11 +7,11 @@ pub mod report;
 
 use super::{CompileMode, Unit};
 use crate::core::PackageId;
+use crate::core::compiler::BuildContext;
+use crate::core::compiler::BuildRunner;
 use crate::core::compiler::job_queue::JobId;
-use crate::core::compiler::{BuildContext, BuildRunner, TimingOutput};
 use crate::util::cpu::State;
 use crate::util::log_message::LogMessage;
-use crate::util::machine_message::{self, Message};
 use crate::util::style;
 use crate::util::{CargoResult, GlobalContext};
 
@@ -35,8 +35,6 @@ pub struct Timings<'gctx> {
     enabled: bool,
     /// If true, saves an HTML report to disk.
     report_html: bool,
-    /// If true, emits JSON information with timing information.
-    report_json: bool,
     /// When Cargo started.
     start: Instant,
     /// A rendered string of when compilation started.
@@ -120,17 +118,14 @@ pub struct UnitData {
 impl<'gctx> Timings<'gctx> {
     pub fn new(bcx: &BuildContext<'_, 'gctx>, root_units: &[Unit]) -> Timings<'gctx> {
         let start = bcx.gctx.creation_time();
-        let has_report = |what| bcx.build_config.timing_outputs.contains(&what);
-        let report_html = has_report(TimingOutput::Html);
-        let report_json = has_report(TimingOutput::Json);
-        let enabled = report_html | report_json | bcx.logger.is_some();
+        let report_html = bcx.build_config.timing_report;
+        let enabled = report_html | bcx.logger.is_some();
 
         if !enabled {
             return Timings {
                 gctx: bcx.gctx,
                 enabled,
                 report_html,
-                report_json,
                 start,
                 start_str: String::new(),
                 root_targets: Vec::new(),
@@ -175,7 +170,6 @@ impl<'gctx> Timings<'gctx> {
             gctx: bcx.gctx,
             enabled,
             report_html,
-            report_json,
             start,
             start_str,
             root_targets,
@@ -286,18 +280,7 @@ impl<'gctx> Timings<'gctx> {
         unit_time
             .unblocked_units
             .extend(unblocked.iter().cloned().cloned());
-        if self.report_json {
-            let msg = machine_message::TimingInfo {
-                package_id: unit_time.unit.pkg.package_id().to_spec(),
-                target: &unit_time.unit.target,
-                mode: unit_time.unit.mode,
-                duration: unit_time.duration,
-                rmeta_time: unit_time.rmeta_time,
-                sections: unit_time.sections.clone().into_iter().collect(),
-            }
-            .to_json_string();
-            crate::drop_println!(self.gctx, "{}", msg);
-        }
+
         if let Some(logger) = build_runner.bcx.logger {
             let unblocked = unblocked.iter().map(|u| self.unit_to_index[u]).collect();
             logger.log(LogMessage::UnitFinished {

--- a/src/cargo/util/machine_message.rs
+++ b/src/cargo/util/machine_message.rs
@@ -6,7 +6,6 @@ use serde::ser;
 use serde_json::value::RawValue;
 
 use crate::core::Target;
-use crate::core::compiler::{CompilationSection, CompileMode};
 
 pub trait Message: ser::Serialize {
     fn reason(&self) -> &str;
@@ -91,24 +90,6 @@ pub struct BuildScript<'a> {
 impl<'a> Message for BuildScript<'a> {
     fn reason(&self) -> &str {
         "build-script-executed"
-    }
-}
-
-#[derive(Serialize)]
-pub struct TimingInfo<'a> {
-    pub package_id: PackageIdSpec,
-    pub target: &'a Target,
-    pub mode: CompileMode,
-    pub duration: f64,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub rmeta_time: Option<f64>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub sections: Vec<(String, CompilationSection)>,
-}
-
-impl<'a> Message for TimingInfo<'a> {
-    fn reason(&self) -> &str {
-        "timing-info"
     }
 }
 

--- a/src/doc/man/generated_txt/cargo-bench.txt
+++ b/src/doc/man/generated_txt/cargo-bench.txt
@@ -253,24 +253,15 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/profiles.html> for more
            details on profiles.
 
-       --timings=fmts
+       --timings
            Output information how long each compilation takes, and track
-           concurrency information over time. Accepts an optional
-           comma-separated list of output formats; --timings without an
-           argument will default to --timings=html. Specifying an output format
-           (rather than the default) is unstable and requires
-           -Zunstable-options. Valid output formats:
+           concurrency information over time.
 
-           o  html (unstable, requires -Zunstable-options): Write a
-              human-readable file cargo-timing.html to the target/cargo-timings
-              directory with a report of the compilation. Also write a report
-              to the same directory with a timestamp in the filename if you
-              want to look at older runs. HTML output is suitable for human
-              consumption only, and does not provide machine-readable timing
-              data.
-
-           o  json (unstable, requires -Zunstable-options): Emit
-              machine-readable JSON information about timing information.
+           A file cargo-timing.html will be written to the target/cargo-timings
+           directory at the end of the build. An additional report with a
+           timestamp in its filename is also written if you want to look at a
+           previous run. These reports are suitable for human consumption only,
+           and do not provide machine-readable timing data.
 
    Output Options
        --target-dir directory

--- a/src/doc/man/generated_txt/cargo-build.txt
+++ b/src/doc/man/generated_txt/cargo-build.txt
@@ -174,24 +174,15 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/profiles.html> for more
            details on profiles.
 
-       --timings=fmts
+       --timings
            Output information how long each compilation takes, and track
-           concurrency information over time. Accepts an optional
-           comma-separated list of output formats; --timings without an
-           argument will default to --timings=html. Specifying an output format
-           (rather than the default) is unstable and requires
-           -Zunstable-options. Valid output formats:
+           concurrency information over time.
 
-           o  html (unstable, requires -Zunstable-options): Write a
-              human-readable file cargo-timing.html to the target/cargo-timings
-              directory with a report of the compilation. Also write a report
-              to the same directory with a timestamp in the filename if you
-              want to look at older runs. HTML output is suitable for human
-              consumption only, and does not provide machine-readable timing
-              data.
-
-           o  json (unstable, requires -Zunstable-options): Emit
-              machine-readable JSON information about timing information.
+           A file cargo-timing.html will be written to the target/cargo-timings
+           directory at the end of the build. An additional report with a
+           timestamp in its filename is also written if you want to look at a
+           previous run. These reports are suitable for human consumption only,
+           and do not provide machine-readable timing data.
 
    Output Options
        --target-dir directory

--- a/src/doc/man/generated_txt/cargo-check.txt
+++ b/src/doc/man/generated_txt/cargo-check.txt
@@ -178,24 +178,15 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/profiles.html> for more
            details on profiles.
 
-       --timings=fmts
+       --timings
            Output information how long each compilation takes, and track
-           concurrency information over time. Accepts an optional
-           comma-separated list of output formats; --timings without an
-           argument will default to --timings=html. Specifying an output format
-           (rather than the default) is unstable and requires
-           -Zunstable-options. Valid output formats:
+           concurrency information over time.
 
-           o  html (unstable, requires -Zunstable-options): Write a
-              human-readable file cargo-timing.html to the target/cargo-timings
-              directory with a report of the compilation. Also write a report
-              to the same directory with a timestamp in the filename if you
-              want to look at older runs. HTML output is suitable for human
-              consumption only, and does not provide machine-readable timing
-              data.
-
-           o  json (unstable, requires -Zunstable-options): Emit
-              machine-readable JSON information about timing information.
+           A file cargo-timing.html will be written to the target/cargo-timings
+           directory at the end of the build. An additional report with a
+           timestamp in its filename is also written if you want to look at a
+           previous run. These reports are suitable for human consumption only,
+           and do not provide machine-readable timing data.
 
    Output Options
        --target-dir directory

--- a/src/doc/man/generated_txt/cargo-doc.txt
+++ b/src/doc/man/generated_txt/cargo-doc.txt
@@ -153,24 +153,15 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/profiles.html> for more
            details on profiles.
 
-       --timings=fmts
+       --timings
            Output information how long each compilation takes, and track
-           concurrency information over time. Accepts an optional
-           comma-separated list of output formats; --timings without an
-           argument will default to --timings=html. Specifying an output format
-           (rather than the default) is unstable and requires
-           -Zunstable-options. Valid output formats:
+           concurrency information over time.
 
-           o  html (unstable, requires -Zunstable-options): Write a
-              human-readable file cargo-timing.html to the target/cargo-timings
-              directory with a report of the compilation. Also write a report
-              to the same directory with a timestamp in the filename if you
-              want to look at older runs. HTML output is suitable for human
-              consumption only, and does not provide machine-readable timing
-              data.
-
-           o  json (unstable, requires -Zunstable-options): Emit
-              machine-readable JSON information about timing information.
+           A file cargo-timing.html will be written to the target/cargo-timings
+           directory at the end of the build. An additional report with a
+           timestamp in its filename is also written if you want to look at a
+           previous run. These reports are suitable for human consumption only,
+           and do not provide machine-readable timing data.
 
    Output Options
        --target-dir directory

--- a/src/doc/man/generated_txt/cargo-fix.txt
+++ b/src/doc/man/generated_txt/cargo-fix.txt
@@ -252,24 +252,15 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/profiles.html> for more
            details on profiles.
 
-       --timings=fmts
+       --timings
            Output information how long each compilation takes, and track
-           concurrency information over time. Accepts an optional
-           comma-separated list of output formats; --timings without an
-           argument will default to --timings=html. Specifying an output format
-           (rather than the default) is unstable and requires
-           -Zunstable-options. Valid output formats:
+           concurrency information over time.
 
-           o  html (unstable, requires -Zunstable-options): Write a
-              human-readable file cargo-timing.html to the target/cargo-timings
-              directory with a report of the compilation. Also write a report
-              to the same directory with a timestamp in the filename if you
-              want to look at older runs. HTML output is suitable for human
-              consumption only, and does not provide machine-readable timing
-              data.
-
-           o  json (unstable, requires -Zunstable-options): Emit
-              machine-readable JSON information about timing information.
+           A file cargo-timing.html will be written to the target/cargo-timings
+           directory at the end of the build. An additional report with a
+           timestamp in its filename is also written if you want to look at a
+           previous run. These reports are suitable for human consumption only,
+           and do not provide machine-readable timing data.
 
    Output Options
        --target-dir directory

--- a/src/doc/man/generated_txt/cargo-install.txt
+++ b/src/doc/man/generated_txt/cargo-install.txt
@@ -234,24 +234,15 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/profiles.html> for more
            details on profiles.
 
-       --timings=fmts
+       --timings
            Output information how long each compilation takes, and track
-           concurrency information over time. Accepts an optional
-           comma-separated list of output formats; --timings without an
-           argument will default to --timings=html. Specifying an output format
-           (rather than the default) is unstable and requires
-           -Zunstable-options. Valid output formats:
+           concurrency information over time.
 
-           o  html (unstable, requires -Zunstable-options): Write a
-              human-readable file cargo-timing.html to the target/cargo-timings
-              directory with a report of the compilation. Also write a report
-              to the same directory with a timestamp in the filename if you
-              want to look at older runs. HTML output is suitable for human
-              consumption only, and does not provide machine-readable timing
-              data.
-
-           o  json (unstable, requires -Zunstable-options): Emit
-              machine-readable JSON information about timing information.
+           A file cargo-timing.html will be written to the target/cargo-timings
+           directory at the end of the build. An additional report with a
+           timestamp in its filename is also written if you want to look at a
+           previous run. These reports are suitable for human consumption only,
+           and do not provide machine-readable timing data.
 
    Manifest Options
        --ignore-rust-version

--- a/src/doc/man/generated_txt/cargo-run.txt
+++ b/src/doc/man/generated_txt/cargo-run.txt
@@ -98,24 +98,15 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/profiles.html> for more
            details on profiles.
 
-       --timings=fmts
+       --timings
            Output information how long each compilation takes, and track
-           concurrency information over time. Accepts an optional
-           comma-separated list of output formats; --timings without an
-           argument will default to --timings=html. Specifying an output format
-           (rather than the default) is unstable and requires
-           -Zunstable-options. Valid output formats:
+           concurrency information over time.
 
-           o  html (unstable, requires -Zunstable-options): Write a
-              human-readable file cargo-timing.html to the target/cargo-timings
-              directory with a report of the compilation. Also write a report
-              to the same directory with a timestamp in the filename if you
-              want to look at older runs. HTML output is suitable for human
-              consumption only, and does not provide machine-readable timing
-              data.
-
-           o  json (unstable, requires -Zunstable-options): Emit
-              machine-readable JSON information about timing information.
+           A file cargo-timing.html will be written to the target/cargo-timings
+           directory at the end of the build. An additional report with a
+           timestamp in its filename is also written if you want to look at a
+           previous run. These reports are suitable for human consumption only,
+           and do not provide machine-readable timing data.
 
    Output Options
        --target-dir directory

--- a/src/doc/man/generated_txt/cargo-rustc.txt
+++ b/src/doc/man/generated_txt/cargo-rustc.txt
@@ -182,24 +182,15 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/profiles.html> for more
            details on profiles.
 
-       --timings=fmts
+       --timings
            Output information how long each compilation takes, and track
-           concurrency information over time. Accepts an optional
-           comma-separated list of output formats; --timings without an
-           argument will default to --timings=html. Specifying an output format
-           (rather than the default) is unstable and requires
-           -Zunstable-options. Valid output formats:
+           concurrency information over time.
 
-           o  html (unstable, requires -Zunstable-options): Write a
-              human-readable file cargo-timing.html to the target/cargo-timings
-              directory with a report of the compilation. Also write a report
-              to the same directory with a timestamp in the filename if you
-              want to look at older runs. HTML output is suitable for human
-              consumption only, and does not provide machine-readable timing
-              data.
-
-           o  json (unstable, requires -Zunstable-options): Emit
-              machine-readable JSON information about timing information.
+           A file cargo-timing.html will be written to the target/cargo-timings
+           directory at the end of the build. An additional report with a
+           timestamp in its filename is also written if you want to look at a
+           previous run. These reports are suitable for human consumption only,
+           and do not provide machine-readable timing data.
 
        --crate-type crate-type
            Build for the given crate type. This flag accepts a comma-separated

--- a/src/doc/man/generated_txt/cargo-rustdoc.txt
+++ b/src/doc/man/generated_txt/cargo-rustdoc.txt
@@ -165,24 +165,15 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/profiles.html> for more
            details on profiles.
 
-       --timings=fmts
+       --timings
            Output information how long each compilation takes, and track
-           concurrency information over time. Accepts an optional
-           comma-separated list of output formats; --timings without an
-           argument will default to --timings=html. Specifying an output format
-           (rather than the default) is unstable and requires
-           -Zunstable-options. Valid output formats:
+           concurrency information over time.
 
-           o  html (unstable, requires -Zunstable-options): Write a
-              human-readable file cargo-timing.html to the target/cargo-timings
-              directory with a report of the compilation. Also write a report
-              to the same directory with a timestamp in the filename if you
-              want to look at older runs. HTML output is suitable for human
-              consumption only, and does not provide machine-readable timing
-              data.
-
-           o  json (unstable, requires -Zunstable-options): Emit
-              machine-readable JSON information about timing information.
+           A file cargo-timing.html will be written to the target/cargo-timings
+           directory at the end of the build. An additional report with a
+           timestamp in its filename is also written if you want to look at a
+           previous run. These reports are suitable for human consumption only,
+           and do not provide machine-readable timing data.
 
    Output Options
        --target-dir directory

--- a/src/doc/man/generated_txt/cargo-test.txt
+++ b/src/doc/man/generated_txt/cargo-test.txt
@@ -279,24 +279,15 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/profiles.html> for more
            details on profiles.
 
-       --timings=fmts
+       --timings
            Output information how long each compilation takes, and track
-           concurrency information over time. Accepts an optional
-           comma-separated list of output formats; --timings without an
-           argument will default to --timings=html. Specifying an output format
-           (rather than the default) is unstable and requires
-           -Zunstable-options. Valid output formats:
+           concurrency information over time.
 
-           o  html (unstable, requires -Zunstable-options): Write a
-              human-readable file cargo-timing.html to the target/cargo-timings
-              directory with a report of the compilation. Also write a report
-              to the same directory with a timestamp in the filename if you
-              want to look at older runs. HTML output is suitable for human
-              consumption only, and does not provide machine-readable timing
-              data.
-
-           o  json (unstable, requires -Zunstable-options): Emit
-              machine-readable JSON information about timing information.
+           A file cargo-timing.html will be written to the target/cargo-timings
+           directory at the end of the build. An additional report with a
+           timestamp in its filename is also written if you want to look at a
+           previous run. These reports are suitable for human consumption only,
+           and do not provide machine-readable timing data.
 
    Output Options
        --target-dir directory

--- a/src/doc/man/includes/options-timings.md
+++ b/src/doc/man/includes/options-timings.md
@@ -1,16 +1,11 @@
-{{#option "`--timings=`_fmts_"}}
+{{#option "`--timings`"}}
 Output information how long each compilation takes, and track concurrency
-information over time. Accepts an optional comma-separated list of output
-formats; `--timings` without an argument will default to `--timings=html`.
-Specifying an output format (rather than the default) is unstable and requires
-`-Zunstable-options`. Valid output formats:
+information over time.
 
-- `html` (unstable, requires `-Zunstable-options`): Write a human-readable file `cargo-timing.html` to the
-  `target/cargo-timings` directory with a report of the compilation. Also write
-  a report to the same directory with a timestamp in the filename if you want
-  to look at older runs. HTML output is suitable for human consumption only,
-  and does not provide machine-readable timing data.
-- `json` (unstable, requires `-Zunstable-options`): Emit machine-readable JSON
-  information about timing information.
+A file `cargo-timing.html` will be written to the `target/cargo-timings`
+directory at the end of the build. An additional report with a timestamp
+in its filename is also written if you want to look at a previous run.
+These reports are suitable for human consumption only, and do not provide
+machine-readable timing data.
 {{/option}}
 

--- a/src/doc/src/commands/cargo-bench.md
+++ b/src/doc/src/commands/cargo-bench.md
@@ -296,21 +296,14 @@ See <a href="../reference/profiles.html">the reference</a> for more details on p
 </dd>
 
 
-<dt class="option-term" id="option-cargo-bench---timings=fmts"><a class="option-anchor" href="#option-cargo-bench---timings=fmts"><code>--timings=</code><em>fmts</em></a></dt>
+<dt class="option-term" id="option-cargo-bench---timings"><a class="option-anchor" href="#option-cargo-bench---timings"><code>--timings</code></a></dt>
 <dd class="option-desc"><p>Output information how long each compilation takes, and track concurrency
-information over time. Accepts an optional comma-separated list of output
-formats; <code>--timings</code> without an argument will default to <code>--timings=html</code>.
-Specifying an output format (rather than the default) is unstable and requires
-<code>-Zunstable-options</code>. Valid output formats:</p>
-<ul>
-<li><code>html</code> (unstable, requires <code>-Zunstable-options</code>): Write a human-readable file <code>cargo-timing.html</code> to the
-<code>target/cargo-timings</code> directory with a report of the compilation. Also write
-a report to the same directory with a timestamp in the filename if you want
-to look at older runs. HTML output is suitable for human consumption only,
-and does not provide machine-readable timing data.</li>
-<li><code>json</code> (unstable, requires <code>-Zunstable-options</code>): Emit machine-readable JSON
-information about timing information.</li>
-</ul>
+information over time.</p>
+<p>A file <code>cargo-timing.html</code> will be written to the <code>target/cargo-timings</code>
+directory at the end of the build. An additional report with a timestamp
+in its filename is also written if you want to look at a previous run.
+These reports are suitable for human consumption only, and do not provide
+machine-readable timing data.</p>
 </dd>
 
 

--- a/src/doc/src/commands/cargo-build.md
+++ b/src/doc/src/commands/cargo-build.md
@@ -216,21 +216,14 @@ See <a href="../reference/profiles.html">the reference</a> for more details on p
 </dd>
 
 
-<dt class="option-term" id="option-cargo-build---timings=fmts"><a class="option-anchor" href="#option-cargo-build---timings=fmts"><code>--timings=</code><em>fmts</em></a></dt>
+<dt class="option-term" id="option-cargo-build---timings"><a class="option-anchor" href="#option-cargo-build---timings"><code>--timings</code></a></dt>
 <dd class="option-desc"><p>Output information how long each compilation takes, and track concurrency
-information over time. Accepts an optional comma-separated list of output
-formats; <code>--timings</code> without an argument will default to <code>--timings=html</code>.
-Specifying an output format (rather than the default) is unstable and requires
-<code>-Zunstable-options</code>. Valid output formats:</p>
-<ul>
-<li><code>html</code> (unstable, requires <code>-Zunstable-options</code>): Write a human-readable file <code>cargo-timing.html</code> to the
-<code>target/cargo-timings</code> directory with a report of the compilation. Also write
-a report to the same directory with a timestamp in the filename if you want
-to look at older runs. HTML output is suitable for human consumption only,
-and does not provide machine-readable timing data.</li>
-<li><code>json</code> (unstable, requires <code>-Zunstable-options</code>): Emit machine-readable JSON
-information about timing information.</li>
-</ul>
+information over time.</p>
+<p>A file <code>cargo-timing.html</code> will be written to the <code>target/cargo-timings</code>
+directory at the end of the build. An additional report with a timestamp
+in its filename is also written if you want to look at a previous run.
+These reports are suitable for human consumption only, and do not provide
+machine-readable timing data.</p>
 </dd>
 
 

--- a/src/doc/src/commands/cargo-check.md
+++ b/src/doc/src/commands/cargo-check.md
@@ -216,21 +216,14 @@ detail.</p>
 </dd>
 
 
-<dt class="option-term" id="option-cargo-check---timings=fmts"><a class="option-anchor" href="#option-cargo-check---timings=fmts"><code>--timings=</code><em>fmts</em></a></dt>
+<dt class="option-term" id="option-cargo-check---timings"><a class="option-anchor" href="#option-cargo-check---timings"><code>--timings</code></a></dt>
 <dd class="option-desc"><p>Output information how long each compilation takes, and track concurrency
-information over time. Accepts an optional comma-separated list of output
-formats; <code>--timings</code> without an argument will default to <code>--timings=html</code>.
-Specifying an output format (rather than the default) is unstable and requires
-<code>-Zunstable-options</code>. Valid output formats:</p>
-<ul>
-<li><code>html</code> (unstable, requires <code>-Zunstable-options</code>): Write a human-readable file <code>cargo-timing.html</code> to the
-<code>target/cargo-timings</code> directory with a report of the compilation. Also write
-a report to the same directory with a timestamp in the filename if you want
-to look at older runs. HTML output is suitable for human consumption only,
-and does not provide machine-readable timing data.</li>
-<li><code>json</code> (unstable, requires <code>-Zunstable-options</code>): Emit machine-readable JSON
-information about timing information.</li>
-</ul>
+information over time.</p>
+<p>A file <code>cargo-timing.html</code> will be written to the <code>target/cargo-timings</code>
+directory at the end of the build. An additional report with a timestamp
+in its filename is also written if you want to look at a previous run.
+These reports are suitable for human consumption only, and do not provide
+machine-readable timing data.</p>
 </dd>
 
 

--- a/src/doc/src/commands/cargo-doc.md
+++ b/src/doc/src/commands/cargo-doc.md
@@ -191,21 +191,14 @@ See <a href="../reference/profiles.html">the reference</a> for more details on p
 </dd>
 
 
-<dt class="option-term" id="option-cargo-doc---timings=fmts"><a class="option-anchor" href="#option-cargo-doc---timings=fmts"><code>--timings=</code><em>fmts</em></a></dt>
+<dt class="option-term" id="option-cargo-doc---timings"><a class="option-anchor" href="#option-cargo-doc---timings"><code>--timings</code></a></dt>
 <dd class="option-desc"><p>Output information how long each compilation takes, and track concurrency
-information over time. Accepts an optional comma-separated list of output
-formats; <code>--timings</code> without an argument will default to <code>--timings=html</code>.
-Specifying an output format (rather than the default) is unstable and requires
-<code>-Zunstable-options</code>. Valid output formats:</p>
-<ul>
-<li><code>html</code> (unstable, requires <code>-Zunstable-options</code>): Write a human-readable file <code>cargo-timing.html</code> to the
-<code>target/cargo-timings</code> directory with a report of the compilation. Also write
-a report to the same directory with a timestamp in the filename if you want
-to look at older runs. HTML output is suitable for human consumption only,
-and does not provide machine-readable timing data.</li>
-<li><code>json</code> (unstable, requires <code>-Zunstable-options</code>): Emit machine-readable JSON
-information about timing information.</li>
-</ul>
+information over time.</p>
+<p>A file <code>cargo-timing.html</code> will be written to the <code>target/cargo-timings</code>
+directory at the end of the build. An additional report with a timestamp
+in its filename is also written if you want to look at a previous run.
+These reports are suitable for human consumption only, and do not provide
+machine-readable timing data.</p>
 </dd>
 
 

--- a/src/doc/src/commands/cargo-fix.md
+++ b/src/doc/src/commands/cargo-fix.md
@@ -302,21 +302,14 @@ detail.</p>
 </dd>
 
 
-<dt class="option-term" id="option-cargo-fix---timings=fmts"><a class="option-anchor" href="#option-cargo-fix---timings=fmts"><code>--timings=</code><em>fmts</em></a></dt>
+<dt class="option-term" id="option-cargo-fix---timings"><a class="option-anchor" href="#option-cargo-fix---timings"><code>--timings</code></a></dt>
 <dd class="option-desc"><p>Output information how long each compilation takes, and track concurrency
-information over time. Accepts an optional comma-separated list of output
-formats; <code>--timings</code> without an argument will default to <code>--timings=html</code>.
-Specifying an output format (rather than the default) is unstable and requires
-<code>-Zunstable-options</code>. Valid output formats:</p>
-<ul>
-<li><code>html</code> (unstable, requires <code>-Zunstable-options</code>): Write a human-readable file <code>cargo-timing.html</code> to the
-<code>target/cargo-timings</code> directory with a report of the compilation. Also write
-a report to the same directory with a timestamp in the filename if you want
-to look at older runs. HTML output is suitable for human consumption only,
-and does not provide machine-readable timing data.</li>
-<li><code>json</code> (unstable, requires <code>-Zunstable-options</code>): Emit machine-readable JSON
-information about timing information.</li>
-</ul>
+information over time.</p>
+<p>A file <code>cargo-timing.html</code> will be written to the <code>target/cargo-timings</code>
+directory at the end of the build. An additional report with a timestamp
+in its filename is also written if you want to look at a previous run.
+These reports are suitable for human consumption only, and do not provide
+machine-readable timing data.</p>
 </dd>
 
 

--- a/src/doc/src/commands/cargo-install.md
+++ b/src/doc/src/commands/cargo-install.md
@@ -271,21 +271,14 @@ See <a href="../reference/profiles.html">the reference</a> for more details on p
 </dd>
 
 
-<dt class="option-term" id="option-cargo-install---timings=fmts"><a class="option-anchor" href="#option-cargo-install---timings=fmts"><code>--timings=</code><em>fmts</em></a></dt>
+<dt class="option-term" id="option-cargo-install---timings"><a class="option-anchor" href="#option-cargo-install---timings"><code>--timings</code></a></dt>
 <dd class="option-desc"><p>Output information how long each compilation takes, and track concurrency
-information over time. Accepts an optional comma-separated list of output
-formats; <code>--timings</code> without an argument will default to <code>--timings=html</code>.
-Specifying an output format (rather than the default) is unstable and requires
-<code>-Zunstable-options</code>. Valid output formats:</p>
-<ul>
-<li><code>html</code> (unstable, requires <code>-Zunstable-options</code>): Write a human-readable file <code>cargo-timing.html</code> to the
-<code>target/cargo-timings</code> directory with a report of the compilation. Also write
-a report to the same directory with a timestamp in the filename if you want
-to look at older runs. HTML output is suitable for human consumption only,
-and does not provide machine-readable timing data.</li>
-<li><code>json</code> (unstable, requires <code>-Zunstable-options</code>): Emit machine-readable JSON
-information about timing information.</li>
-</ul>
+information over time.</p>
+<p>A file <code>cargo-timing.html</code> will be written to the <code>target/cargo-timings</code>
+directory at the end of the build. An additional report with a timestamp
+in its filename is also written if you want to look at a previous run.
+These reports are suitable for human consumption only, and do not provide
+machine-readable timing data.</p>
 </dd>
 
 

--- a/src/doc/src/commands/cargo-run.md
+++ b/src/doc/src/commands/cargo-run.md
@@ -122,21 +122,14 @@ See <a href="../reference/profiles.html">the reference</a> for more details on p
 </dd>
 
 
-<dt class="option-term" id="option-cargo-run---timings=fmts"><a class="option-anchor" href="#option-cargo-run---timings=fmts"><code>--timings=</code><em>fmts</em></a></dt>
+<dt class="option-term" id="option-cargo-run---timings"><a class="option-anchor" href="#option-cargo-run---timings"><code>--timings</code></a></dt>
 <dd class="option-desc"><p>Output information how long each compilation takes, and track concurrency
-information over time. Accepts an optional comma-separated list of output
-formats; <code>--timings</code> without an argument will default to <code>--timings=html</code>.
-Specifying an output format (rather than the default) is unstable and requires
-<code>-Zunstable-options</code>. Valid output formats:</p>
-<ul>
-<li><code>html</code> (unstable, requires <code>-Zunstable-options</code>): Write a human-readable file <code>cargo-timing.html</code> to the
-<code>target/cargo-timings</code> directory with a report of the compilation. Also write
-a report to the same directory with a timestamp in the filename if you want
-to look at older runs. HTML output is suitable for human consumption only,
-and does not provide machine-readable timing data.</li>
-<li><code>json</code> (unstable, requires <code>-Zunstable-options</code>): Emit machine-readable JSON
-information about timing information.</li>
-</ul>
+information over time.</p>
+<p>A file <code>cargo-timing.html</code> will be written to the <code>target/cargo-timings</code>
+directory at the end of the build. An additional report with a timestamp
+in its filename is also written if you want to look at a previous run.
+These reports are suitable for human consumption only, and do not provide
+machine-readable timing data.</p>
 </dd>
 
 

--- a/src/doc/src/commands/cargo-rustc.md
+++ b/src/doc/src/commands/cargo-rustc.md
@@ -213,21 +213,14 @@ similar to the <code>test</code> profile.</li>
 </dd>
 
 
-<dt class="option-term" id="option-cargo-rustc---timings=fmts"><a class="option-anchor" href="#option-cargo-rustc---timings=fmts"><code>--timings=</code><em>fmts</em></a></dt>
+<dt class="option-term" id="option-cargo-rustc---timings"><a class="option-anchor" href="#option-cargo-rustc---timings"><code>--timings</code></a></dt>
 <dd class="option-desc"><p>Output information how long each compilation takes, and track concurrency
-information over time. Accepts an optional comma-separated list of output
-formats; <code>--timings</code> without an argument will default to <code>--timings=html</code>.
-Specifying an output format (rather than the default) is unstable and requires
-<code>-Zunstable-options</code>. Valid output formats:</p>
-<ul>
-<li><code>html</code> (unstable, requires <code>-Zunstable-options</code>): Write a human-readable file <code>cargo-timing.html</code> to the
-<code>target/cargo-timings</code> directory with a report of the compilation. Also write
-a report to the same directory with a timestamp in the filename if you want
-to look at older runs. HTML output is suitable for human consumption only,
-and does not provide machine-readable timing data.</li>
-<li><code>json</code> (unstable, requires <code>-Zunstable-options</code>): Emit machine-readable JSON
-information about timing information.</li>
-</ul>
+information over time.</p>
+<p>A file <code>cargo-timing.html</code> will be written to the <code>target/cargo-timings</code>
+directory at the end of the build. An additional report with a timestamp
+in its filename is also written if you want to look at a previous run.
+These reports are suitable for human consumption only, and do not provide
+machine-readable timing data.</p>
 </dd>
 
 

--- a/src/doc/src/commands/cargo-rustdoc.md
+++ b/src/doc/src/commands/cargo-rustdoc.md
@@ -209,21 +209,14 @@ See <a href="../reference/profiles.html">the reference</a> for more details on p
 </dd>
 
 
-<dt class="option-term" id="option-cargo-rustdoc---timings=fmts"><a class="option-anchor" href="#option-cargo-rustdoc---timings=fmts"><code>--timings=</code><em>fmts</em></a></dt>
+<dt class="option-term" id="option-cargo-rustdoc---timings"><a class="option-anchor" href="#option-cargo-rustdoc---timings"><code>--timings</code></a></dt>
 <dd class="option-desc"><p>Output information how long each compilation takes, and track concurrency
-information over time. Accepts an optional comma-separated list of output
-formats; <code>--timings</code> without an argument will default to <code>--timings=html</code>.
-Specifying an output format (rather than the default) is unstable and requires
-<code>-Zunstable-options</code>. Valid output formats:</p>
-<ul>
-<li><code>html</code> (unstable, requires <code>-Zunstable-options</code>): Write a human-readable file <code>cargo-timing.html</code> to the
-<code>target/cargo-timings</code> directory with a report of the compilation. Also write
-a report to the same directory with a timestamp in the filename if you want
-to look at older runs. HTML output is suitable for human consumption only,
-and does not provide machine-readable timing data.</li>
-<li><code>json</code> (unstable, requires <code>-Zunstable-options</code>): Emit machine-readable JSON
-information about timing information.</li>
-</ul>
+information over time.</p>
+<p>A file <code>cargo-timing.html</code> will be written to the <code>target/cargo-timings</code>
+directory at the end of the build. An additional report with a timestamp
+in its filename is also written if you want to look at a previous run.
+These reports are suitable for human consumption only, and do not provide
+machine-readable timing data.</p>
 </dd>
 
 

--- a/src/doc/src/commands/cargo-test.md
+++ b/src/doc/src/commands/cargo-test.md
@@ -326,21 +326,14 @@ See <a href="../reference/profiles.html">the reference</a> for more details on p
 </dd>
 
 
-<dt class="option-term" id="option-cargo-test---timings=fmts"><a class="option-anchor" href="#option-cargo-test---timings=fmts"><code>--timings=</code><em>fmts</em></a></dt>
+<dt class="option-term" id="option-cargo-test---timings"><a class="option-anchor" href="#option-cargo-test---timings"><code>--timings</code></a></dt>
 <dd class="option-desc"><p>Output information how long each compilation takes, and track concurrency
-information over time. Accepts an optional comma-separated list of output
-formats; <code>--timings</code> without an argument will default to <code>--timings=html</code>.
-Specifying an output format (rather than the default) is unstable and requires
-<code>-Zunstable-options</code>. Valid output formats:</p>
-<ul>
-<li><code>html</code> (unstable, requires <code>-Zunstable-options</code>): Write a human-readable file <code>cargo-timing.html</code> to the
-<code>target/cargo-timings</code> directory with a report of the compilation. Also write
-a report to the same directory with a timestamp in the filename if you want
-to look at older runs. HTML output is suitable for human consumption only,
-and does not provide machine-readable timing data.</li>
-<li><code>json</code> (unstable, requires <code>-Zunstable-options</code>): Emit machine-readable JSON
-information about timing information.</li>
-</ul>
+information over time.</p>
+<p>A file <code>cargo-timing.html</code> will be written to the <code>target/cargo-timings</code>
+directory at the end of the build. An additional report with a timestamp
+in its filename is also written if you want to look at a previous run.
+These reports are suitable for human consumption only, and do not provide
+machine-readable timing data.</p>
 </dd>
 
 

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -2153,8 +2153,9 @@ See the [Features chapter](features.md#dependency-features) for more information
 ## timings
 
 The `-Ztimings` option has been stabilized as `--timings` in the 1.60 release.
-(`--timings=html` and the machine-readable `--timings=json` output remain
-unstable and require `-Zunstable-options`.)
+The timings output format option
+(e.g., the `--timings=html` and the machine-readable `--timings=json` output)
+has been removed in 1.94.0-nightly.
 
 ## config-cli
 

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -297,26 +297,16 @@ Benchmark with the given profile.
 See \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles.html> for more details on profiles.
 .RE
 .sp
-\fB\-\-timings=\fR\fIfmts\fR
+\fB\-\-timings\fR
 .RS 4
 Output information how long each compilation takes, and track concurrency
-information over time. Accepts an optional comma\-separated list of output
-formats; \fB\-\-timings\fR without an argument will default to \fB\-\-timings=html\fR\&.
-Specifying an output format (rather than the default) is unstable and requires
-\fB\-Zunstable\-options\fR\&. Valid output formats:
+information over time.
 .sp
-.RS 4
-\h'-04'\(bu\h'+03'\fBhtml\fR (unstable, requires \fB\-Zunstable\-options\fR): Write a human\-readable file \fBcargo\-timing.html\fR to the
-\fBtarget/cargo\-timings\fR directory with a report of the compilation. Also write
-a report to the same directory with a timestamp in the filename if you want
-to look at older runs. HTML output is suitable for human consumption only,
-and does not provide machine\-readable timing data.
-.RE
-.sp
-.RS 4
-\h'-04'\(bu\h'+03'\fBjson\fR (unstable, requires \fB\-Zunstable\-options\fR): Emit machine\-readable JSON
-information about timing information.
-.RE
+A file \fBcargo\-timing.html\fR will be written to the \fBtarget/cargo\-timings\fR
+directory at the end of the build. An additional report with a timestamp
+in its filename is also written if you want to look at a previous run.
+These reports are suitable for human consumption only, and do not provide
+machine\-readable timing data.
 .RE
 .SS "Output Options"
 .sp

--- a/src/etc/man/cargo-build.1
+++ b/src/etc/man/cargo-build.1
@@ -203,26 +203,16 @@ Build with the given profile.
 See \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles.html> for more details on profiles.
 .RE
 .sp
-\fB\-\-timings=\fR\fIfmts\fR
+\fB\-\-timings\fR
 .RS 4
 Output information how long each compilation takes, and track concurrency
-information over time. Accepts an optional comma\-separated list of output
-formats; \fB\-\-timings\fR without an argument will default to \fB\-\-timings=html\fR\&.
-Specifying an output format (rather than the default) is unstable and requires
-\fB\-Zunstable\-options\fR\&. Valid output formats:
+information over time.
 .sp
-.RS 4
-\h'-04'\(bu\h'+03'\fBhtml\fR (unstable, requires \fB\-Zunstable\-options\fR): Write a human\-readable file \fBcargo\-timing.html\fR to the
-\fBtarget/cargo\-timings\fR directory with a report of the compilation. Also write
-a report to the same directory with a timestamp in the filename if you want
-to look at older runs. HTML output is suitable for human consumption only,
-and does not provide machine\-readable timing data.
-.RE
-.sp
-.RS 4
-\h'-04'\(bu\h'+03'\fBjson\fR (unstable, requires \fB\-Zunstable\-options\fR): Emit machine\-readable JSON
-information about timing information.
-.RE
+A file \fBcargo\-timing.html\fR will be written to the \fBtarget/cargo\-timings\fR
+directory at the end of the build. An additional report with a timestamp
+in its filename is also written if you want to look at a previous run.
+These reports are suitable for human consumption only, and do not provide
+machine\-readable timing data.
 .RE
 .SS "Output Options"
 .sp

--- a/src/etc/man/cargo-check.1
+++ b/src/etc/man/cargo-check.1
@@ -205,26 +205,16 @@ detail.
 See \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles.html> for more details on profiles.
 .RE
 .sp
-\fB\-\-timings=\fR\fIfmts\fR
+\fB\-\-timings\fR
 .RS 4
 Output information how long each compilation takes, and track concurrency
-information over time. Accepts an optional comma\-separated list of output
-formats; \fB\-\-timings\fR without an argument will default to \fB\-\-timings=html\fR\&.
-Specifying an output format (rather than the default) is unstable and requires
-\fB\-Zunstable\-options\fR\&. Valid output formats:
+information over time.
 .sp
-.RS 4
-\h'-04'\(bu\h'+03'\fBhtml\fR (unstable, requires \fB\-Zunstable\-options\fR): Write a human\-readable file \fBcargo\-timing.html\fR to the
-\fBtarget/cargo\-timings\fR directory with a report of the compilation. Also write
-a report to the same directory with a timestamp in the filename if you want
-to look at older runs. HTML output is suitable for human consumption only,
-and does not provide machine\-readable timing data.
-.RE
-.sp
-.RS 4
-\h'-04'\(bu\h'+03'\fBjson\fR (unstable, requires \fB\-Zunstable\-options\fR): Emit machine\-readable JSON
-information about timing information.
-.RE
+A file \fBcargo\-timing.html\fR will be written to the \fBtarget/cargo\-timings\fR
+directory at the end of the build. An additional report with a timestamp
+in its filename is also written if you want to look at a previous run.
+These reports are suitable for human consumption only, and do not provide
+machine\-readable timing data.
 .RE
 .SS "Output Options"
 .sp

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -174,26 +174,16 @@ Document with the given profile.
 See \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles.html> for more details on profiles.
 .RE
 .sp
-\fB\-\-timings=\fR\fIfmts\fR
+\fB\-\-timings\fR
 .RS 4
 Output information how long each compilation takes, and track concurrency
-information over time. Accepts an optional comma\-separated list of output
-formats; \fB\-\-timings\fR without an argument will default to \fB\-\-timings=html\fR\&.
-Specifying an output format (rather than the default) is unstable and requires
-\fB\-Zunstable\-options\fR\&. Valid output formats:
+information over time.
 .sp
-.RS 4
-\h'-04'\(bu\h'+03'\fBhtml\fR (unstable, requires \fB\-Zunstable\-options\fR): Write a human\-readable file \fBcargo\-timing.html\fR to the
-\fBtarget/cargo\-timings\fR directory with a report of the compilation. Also write
-a report to the same directory with a timestamp in the filename if you want
-to look at older runs. HTML output is suitable for human consumption only,
-and does not provide machine\-readable timing data.
-.RE
-.sp
-.RS 4
-\h'-04'\(bu\h'+03'\fBjson\fR (unstable, requires \fB\-Zunstable\-options\fR): Emit machine\-readable JSON
-information about timing information.
-.RE
+A file \fBcargo\-timing.html\fR will be written to the \fBtarget/cargo\-timings\fR
+directory at the end of the build. An additional report with a timestamp
+in its filename is also written if you want to look at a previous run.
+These reports are suitable for human consumption only, and do not provide
+machine\-readable timing data.
 .RE
 .SS "Output Options"
 .sp

--- a/src/etc/man/cargo-fix.1
+++ b/src/etc/man/cargo-fix.1
@@ -300,26 +300,16 @@ detail.
 See \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles.html> for more details on profiles.
 .RE
 .sp
-\fB\-\-timings=\fR\fIfmts\fR
+\fB\-\-timings\fR
 .RS 4
 Output information how long each compilation takes, and track concurrency
-information over time. Accepts an optional comma\-separated list of output
-formats; \fB\-\-timings\fR without an argument will default to \fB\-\-timings=html\fR\&.
-Specifying an output format (rather than the default) is unstable and requires
-\fB\-Zunstable\-options\fR\&. Valid output formats:
+information over time.
 .sp
-.RS 4
-\h'-04'\(bu\h'+03'\fBhtml\fR (unstable, requires \fB\-Zunstable\-options\fR): Write a human\-readable file \fBcargo\-timing.html\fR to the
-\fBtarget/cargo\-timings\fR directory with a report of the compilation. Also write
-a report to the same directory with a timestamp in the filename if you want
-to look at older runs. HTML output is suitable for human consumption only,
-and does not provide machine\-readable timing data.
-.RE
-.sp
-.RS 4
-\h'-04'\(bu\h'+03'\fBjson\fR (unstable, requires \fB\-Zunstable\-options\fR): Emit machine\-readable JSON
-information about timing information.
-.RE
+A file \fBcargo\-timing.html\fR will be written to the \fBtarget/cargo\-timings\fR
+directory at the end of the build. An additional report with a timestamp
+in its filename is also written if you want to look at a previous run.
+These reports are suitable for human consumption only, and do not provide
+machine\-readable timing data.
 .RE
 .SS "Output Options"
 .sp

--- a/src/etc/man/cargo-install.1
+++ b/src/etc/man/cargo-install.1
@@ -291,26 +291,16 @@ Install with the given profile.
 See \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles.html> for more details on profiles.
 .RE
 .sp
-\fB\-\-timings=\fR\fIfmts\fR
+\fB\-\-timings\fR
 .RS 4
 Output information how long each compilation takes, and track concurrency
-information over time. Accepts an optional comma\-separated list of output
-formats; \fB\-\-timings\fR without an argument will default to \fB\-\-timings=html\fR\&.
-Specifying an output format (rather than the default) is unstable and requires
-\fB\-Zunstable\-options\fR\&. Valid output formats:
+information over time.
 .sp
-.RS 4
-\h'-04'\(bu\h'+03'\fBhtml\fR (unstable, requires \fB\-Zunstable\-options\fR): Write a human\-readable file \fBcargo\-timing.html\fR to the
-\fBtarget/cargo\-timings\fR directory with a report of the compilation. Also write
-a report to the same directory with a timestamp in the filename if you want
-to look at older runs. HTML output is suitable for human consumption only,
-and does not provide machine\-readable timing data.
-.RE
-.sp
-.RS 4
-\h'-04'\(bu\h'+03'\fBjson\fR (unstable, requires \fB\-Zunstable\-options\fR): Emit machine\-readable JSON
-information about timing information.
-.RE
+A file \fBcargo\-timing.html\fR will be written to the \fBtarget/cargo\-timings\fR
+directory at the end of the build. An additional report with a timestamp
+in its filename is also written if you want to look at a previous run.
+These reports are suitable for human consumption only, and do not provide
+machine\-readable timing data.
 .RE
 .SS "Manifest Options"
 .sp

--- a/src/etc/man/cargo-run.1
+++ b/src/etc/man/cargo-run.1
@@ -109,26 +109,16 @@ Run with the given profile.
 See \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles.html> for more details on profiles.
 .RE
 .sp
-\fB\-\-timings=\fR\fIfmts\fR
+\fB\-\-timings\fR
 .RS 4
 Output information how long each compilation takes, and track concurrency
-information over time. Accepts an optional comma\-separated list of output
-formats; \fB\-\-timings\fR without an argument will default to \fB\-\-timings=html\fR\&.
-Specifying an output format (rather than the default) is unstable and requires
-\fB\-Zunstable\-options\fR\&. Valid output formats:
+information over time.
 .sp
-.RS 4
-\h'-04'\(bu\h'+03'\fBhtml\fR (unstable, requires \fB\-Zunstable\-options\fR): Write a human\-readable file \fBcargo\-timing.html\fR to the
-\fBtarget/cargo\-timings\fR directory with a report of the compilation. Also write
-a report to the same directory with a timestamp in the filename if you want
-to look at older runs. HTML output is suitable for human consumption only,
-and does not provide machine\-readable timing data.
-.RE
-.sp
-.RS 4
-\h'-04'\(bu\h'+03'\fBjson\fR (unstable, requires \fB\-Zunstable\-options\fR): Emit machine\-readable JSON
-information about timing information.
-.RE
+A file \fBcargo\-timing.html\fR will be written to the \fBtarget/cargo\-timings\fR
+directory at the end of the build. An additional report with a timestamp
+in its filename is also written if you want to look at a previous run.
+These reports are suitable for human consumption only, and do not provide
+machine\-readable timing data.
 .RE
 .SS "Output Options"
 .sp

--- a/src/etc/man/cargo-rustc.1
+++ b/src/etc/man/cargo-rustc.1
@@ -209,26 +209,16 @@ similar to the \fBtest\fR profile.
 See \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles.html> for more details on profiles.
 .RE
 .sp
-\fB\-\-timings=\fR\fIfmts\fR
+\fB\-\-timings\fR
 .RS 4
 Output information how long each compilation takes, and track concurrency
-information over time. Accepts an optional comma\-separated list of output
-formats; \fB\-\-timings\fR without an argument will default to \fB\-\-timings=html\fR\&.
-Specifying an output format (rather than the default) is unstable and requires
-\fB\-Zunstable\-options\fR\&. Valid output formats:
+information over time.
 .sp
-.RS 4
-\h'-04'\(bu\h'+03'\fBhtml\fR (unstable, requires \fB\-Zunstable\-options\fR): Write a human\-readable file \fBcargo\-timing.html\fR to the
-\fBtarget/cargo\-timings\fR directory with a report of the compilation. Also write
-a report to the same directory with a timestamp in the filename if you want
-to look at older runs. HTML output is suitable for human consumption only,
-and does not provide machine\-readable timing data.
-.RE
-.sp
-.RS 4
-\h'-04'\(bu\h'+03'\fBjson\fR (unstable, requires \fB\-Zunstable\-options\fR): Emit machine\-readable JSON
-information about timing information.
-.RE
+A file \fBcargo\-timing.html\fR will be written to the \fBtarget/cargo\-timings\fR
+directory at the end of the build. An additional report with a timestamp
+in its filename is also written if you want to look at a previous run.
+These reports are suitable for human consumption only, and do not provide
+machine\-readable timing data.
 .RE
 .sp
 \fB\-\-crate\-type\fR \fIcrate\-type\fR

--- a/src/etc/man/cargo-rustdoc.1
+++ b/src/etc/man/cargo-rustdoc.1
@@ -191,26 +191,16 @@ Document with the given profile.
 See \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles.html> for more details on profiles.
 .RE
 .sp
-\fB\-\-timings=\fR\fIfmts\fR
+\fB\-\-timings\fR
 .RS 4
 Output information how long each compilation takes, and track concurrency
-information over time. Accepts an optional comma\-separated list of output
-formats; \fB\-\-timings\fR without an argument will default to \fB\-\-timings=html\fR\&.
-Specifying an output format (rather than the default) is unstable and requires
-\fB\-Zunstable\-options\fR\&. Valid output formats:
+information over time.
 .sp
-.RS 4
-\h'-04'\(bu\h'+03'\fBhtml\fR (unstable, requires \fB\-Zunstable\-options\fR): Write a human\-readable file \fBcargo\-timing.html\fR to the
-\fBtarget/cargo\-timings\fR directory with a report of the compilation. Also write
-a report to the same directory with a timestamp in the filename if you want
-to look at older runs. HTML output is suitable for human consumption only,
-and does not provide machine\-readable timing data.
-.RE
-.sp
-.RS 4
-\h'-04'\(bu\h'+03'\fBjson\fR (unstable, requires \fB\-Zunstable\-options\fR): Emit machine\-readable JSON
-information about timing information.
-.RE
+A file \fBcargo\-timing.html\fR will be written to the \fBtarget/cargo\-timings\fR
+directory at the end of the build. An additional report with a timestamp
+in its filename is also written if you want to look at a previous run.
+These reports are suitable for human consumption only, and do not provide
+machine\-readable timing data.
 .RE
 .SS "Output Options"
 .sp

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -324,26 +324,16 @@ Test with the given profile.
 See \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles.html> for more details on profiles.
 .RE
 .sp
-\fB\-\-timings=\fR\fIfmts\fR
+\fB\-\-timings\fR
 .RS 4
 Output information how long each compilation takes, and track concurrency
-information over time. Accepts an optional comma\-separated list of output
-formats; \fB\-\-timings\fR without an argument will default to \fB\-\-timings=html\fR\&.
-Specifying an output format (rather than the default) is unstable and requires
-\fB\-Zunstable\-options\fR\&. Valid output formats:
+information over time.
 .sp
-.RS 4
-\h'-04'\(bu\h'+03'\fBhtml\fR (unstable, requires \fB\-Zunstable\-options\fR): Write a human\-readable file \fBcargo\-timing.html\fR to the
-\fBtarget/cargo\-timings\fR directory with a report of the compilation. Also write
-a report to the same directory with a timestamp in the filename if you want
-to look at older runs. HTML output is suitable for human consumption only,
-and does not provide machine\-readable timing data.
-.RE
-.sp
-.RS 4
-\h'-04'\(bu\h'+03'\fBjson\fR (unstable, requires \fB\-Zunstable\-options\fR): Emit machine\-readable JSON
-information about timing information.
-.RE
+A file \fBcargo\-timing.html\fR will be written to the \fBtarget/cargo\-timings\fR
+directory at the end of the build. An additional report with a timestamp
+in its filename is also written if you want to look at a previous run.
+These reports are suitable for human consumption only, and do not provide
+machine\-readable timing data.
 .RE
 .SS "Output Options"
 .sp

--- a/tests/testsuite/cargo_bench/help/stdout.term.svg
+++ b/tests/testsuite/cargo_bench/help/stdout.term.svg
@@ -1,7 +1,7 @@
 <svg width="827px" height="1154px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-cyan { fill: #55FFFF }
     .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
@@ -122,7 +122,7 @@
 </tspan>
     <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--unit-graph</tspan><tspan>              Output build graph in JSON (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
+    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan>                 Output a build timing report at the end of the build</tspan>
 </tspan>
     <tspan x="10px" y="964px">
 </tspan>

--- a/tests/testsuite/cargo_build/help/stdout.term.svg
+++ b/tests/testsuite/cargo_build/help/stdout.term.svg
@@ -118,7 +118,7 @@
 </tspan>
     <tspan x="10px" y="892px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--unit-graph</tspan><tspan>              Output build graph in JSON (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="910px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
+    <tspan x="10px" y="910px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan>                 Output a build timing report at the end of the build</tspan>
 </tspan>
     <tspan x="10px" y="928px">
 </tspan>

--- a/tests/testsuite/cargo_check/help/stdout.term.svg
+++ b/tests/testsuite/cargo_check/help/stdout.term.svg
@@ -1,7 +1,7 @@
 <svg width="827px" height="1100px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-cyan { fill: #55FFFF }
     .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
@@ -116,7 +116,7 @@
 </tspan>
     <tspan x="10px" y="874px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--unit-graph</tspan><tspan>              Output build graph in JSON (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="892px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
+    <tspan x="10px" y="892px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan>                 Output a build timing report at the end of the build</tspan>
 </tspan>
     <tspan x="10px" y="910px">
 </tspan>

--- a/tests/testsuite/cargo_doc/help/stdout.term.svg
+++ b/tests/testsuite/cargo_doc/help/stdout.term.svg
@@ -1,7 +1,7 @@
 <svg width="827px" height="1046px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-cyan { fill: #55FFFF }
     .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
@@ -110,7 +110,7 @@
 </tspan>
     <tspan x="10px" y="820px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--unit-graph</tspan><tspan>              Output build graph in JSON (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="838px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
+    <tspan x="10px" y="838px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan>                 Output a build timing report at the end of the build</tspan>
 </tspan>
     <tspan x="10px" y="856px">
 </tspan>

--- a/tests/testsuite/cargo_fix/help/stdout.term.svg
+++ b/tests/testsuite/cargo_fix/help/stdout.term.svg
@@ -1,7 +1,7 @@
 <svg width="827px" height="1190px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-cyan { fill: #55FFFF }
     .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
@@ -126,7 +126,7 @@
 </tspan>
     <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
 </tspan>
-    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
+    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan>                 Output a build timing report at the end of the build</tspan>
 </tspan>
     <tspan x="10px" y="1000px">
 </tspan>

--- a/tests/testsuite/cargo_install/help/stdout.term.svg
+++ b/tests/testsuite/cargo_install/help/stdout.term.svg
@@ -1,7 +1,7 @@
 <svg width="827px" height="1136px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-cyan { fill: #55FFFF }
     .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
@@ -136,7 +136,7 @@
 </tspan>
     <tspan x="10px" y="1054px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
 </tspan>
-    <tspan x="10px" y="1072px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
+    <tspan x="10px" y="1072px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan>                 Output a build timing report at the end of the build</tspan>
 </tspan>
     <tspan x="10px" y="1090px">
 </tspan>

--- a/tests/testsuite/cargo_run/help/stdout.term.svg
+++ b/tests/testsuite/cargo_run/help/stdout.term.svg
@@ -98,7 +98,7 @@
 </tspan>
     <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--unit-graph</tspan><tspan>              Output build graph in JSON (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
+    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan>                 Output a build timing report at the end of the build</tspan>
 </tspan>
     <tspan x="10px" y="748px">
 </tspan>

--- a/tests/testsuite/cargo_rustc/help/stdout.term.svg
+++ b/tests/testsuite/cargo_rustc/help/stdout.term.svg
@@ -1,7 +1,7 @@
 <svg width="835px" height="1136px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-cyan { fill: #55FFFF }
     .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
@@ -120,7 +120,7 @@
 </tspan>
     <tspan x="10px" y="910px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--unit-graph</tspan><tspan>              Output build graph in JSON (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
+    <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan>                 Output a build timing report at the end of the build</tspan>
 </tspan>
     <tspan x="10px" y="946px">
 </tspan>

--- a/tests/testsuite/cargo_rustdoc/help/stdout.term.svg
+++ b/tests/testsuite/cargo_rustdoc/help/stdout.term.svg
@@ -1,7 +1,7 @@
 <svg width="844px" height="1118px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-cyan { fill: #55FFFF }
     .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
@@ -118,7 +118,7 @@
 </tspan>
     <tspan x="10px" y="892px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--unit-graph</tspan><tspan>              Output build graph in JSON (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="910px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
+    <tspan x="10px" y="910px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan>                 Output a build timing report at the end of the build</tspan>
 </tspan>
     <tspan x="10px" y="928px">
 </tspan>

--- a/tests/testsuite/cargo_test/help/stdout.term.svg
+++ b/tests/testsuite/cargo_test/help/stdout.term.svg
@@ -1,7 +1,7 @@
 <svg width="827px" height="1226px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-cyan { fill: #55FFFF }
     .fg-bright-green { fill: #55FF55 }
     .fg-cyan { fill: #00AAAA }
@@ -128,7 +128,7 @@
 </tspan>
     <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--unit-graph</tspan><tspan>              Output build graph in JSON (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan class="fg-cyan">[=</tspan><tspan class="fg-cyan">&lt;FMTS&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>        Timing output formats (unstable) (comma separated): html, json</tspan>
+    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan>                 Output a build timing report at the end of the build</tspan>
 </tspan>
     <tspan x="10px" y="1018px">
 </tspan>


### PR DESCRIPTION
### What does this PR try to resolve?

Arguments to remove it

* The `--timings=json` is obsolete as `-Zbuild-analysis` logging is
  a more approachable option, which doesn't need passing
  `--timings=json` ahead of time.
* There is no support infra built around `--timings=json` yet,
  while for `-Zbuild-analysis` we have `cargo report timings` already.
* `--timings=json` is a UI feature inherently unstable, and has no tests.

Counterargument:

* `--timings=json` outputs to stdout, but there is no  alternative yet
  also outputs to stdout.
  <https://github.com/rust-lang/cargo/pull/16418> was an attempt to add that back,
  but we then decide to punt until seeing requests or needs.

### How to test and review this PR?

* `cargo help build` and check the manpage
* `cargo build --help` and cehck the help text
* `cargo build --timings` and it works