### PR TITLE
Set `TMPDIR` / `TMP`+`TEMP` environment variables

### DIFF
--- a/src/cargo/core/compiler/build_runner/compilation_files.rs
+++ b/src/cargo/core/compiler/build_runner/compilation_files.rs
@@ -389,6 +389,20 @@ impl<'a, 'gctx: 'a> CompilationFiles<'a, 'gctx> {
         self.build_script_run_dir(unit).join("out")
     }
 
+    /// Returns the directory which build scripts should use for temporary
+    /// files.
+    /// `/path/to/target/{debug,release}/build/PKG-HASH/tmp`
+    pub fn build_script_tmp_dir(&self, unit: &Unit) -> PathBuf {
+        self.build_script_run_dir(unit).join("tmp")
+    }
+
+    /// Returns the directory which `rustc` invocations should use for
+    /// temporary files, and which `CARGO_CFG_TMPDIR` should be set to.
+    /// `/path/to/target/tmp`
+    pub fn rustc_tmp_dir(&self, unit: &Unit) -> &Path {
+        self.layout(unit.kind).build_dir().tmp()
+    }
+
     /// Returns the path to the executable binary for the given bin target.
     ///
     /// This should only to be used when a `Unit` is not available.

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -325,6 +325,7 @@ fn emit_build_output(
 ///
 /// * Set environment variables for the build script run.
 /// * Create the output dir (`OUT_DIR`) for the build script output.
+/// * Create the temporary dir (`TMPDIR`/`TMP`/`TEMP`) that will be set.
 /// * Determine if the build script needs a re-run.
 /// * Run the build script and store its output.
 fn build_work(build_runner: &mut BuildRunner<'_, '_>, unit: &Unit) -> CargoResult<Job> {
@@ -339,6 +340,7 @@ fn build_work(build_runner: &mut BuildRunner<'_, '_>, unit: &Unit) -> CargoResul
     let script_dir = build_runner.files().build_script_dir(build_script_unit);
     let script_out_dir = build_runner.files().build_script_out_dir(unit);
     let script_run_dir = build_runner.files().build_script_run_dir(unit);
+    let script_tmp_dir = build_runner.files().build_script_tmp_dir(unit);
 
     if let Some(deps) = unit.pkg.manifest().metabuild() {
         prepare_metabuild(build_runner, build_script_unit, deps)?;
@@ -375,6 +377,12 @@ fn build_work(build_runner: &mut BuildRunner<'_, '_>, unit: &Unit) -> CargoResul
         .env("RUSTC", &bcx.rustc().path)
         .env("RUSTDOC", &*bcx.gctx.rustdoc()?)
         .inherit_jobserver(&build_runner.jobserver);
+
+    // Make build scripts output temporary files to `script_tmp_dir` instead
+    // of the path returned by `std::env::temp_dir()`.
+    for key in paths::tmpdir_envvars() {
+        cmd.env(key, &script_tmp_dir);
+    }
 
     // Find all artifact dependencies and make their file and containing directory discoverable using environment variables.
     for (var, value) in artifact::get_env(build_runner, dependencies)? {
@@ -495,6 +503,7 @@ fn build_work(build_runner: &mut BuildRunner<'_, '_>, unit: &Unit) -> CargoResul
 
     paths::create_dir_all(&script_dir)?;
     paths::create_dir_all(&script_out_dir)?;
+    paths::create_dir_all(&script_tmp_dir)?;
 
     let nightly_features_allowed = build_runner.bcx.gctx.nightly_features_allowed;
     let targets: Vec<Target> = unit.pkg.targets().to_vec();

--- a/src/cargo/core/compiler/layout.rs
+++ b/src/cargo/core/compiler/layout.rs
@@ -380,9 +380,8 @@ impl BuildDirLayout {
     pub fn build_unit(&self, pkg_dir: &str) -> PathBuf {
         self.build().join(pkg_dir)
     }
-    /// Create and return the tmp path.
-    pub fn prepare_tmp(&self) -> CargoResult<&Path> {
-        paths::create_dir_all(&self.tmp)?;
-        Ok(&self.tmp)
+    /// Return the tmp path.
+    pub fn tmp(&self) -> &Path {
+        &self.tmp
     }
 }

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -787,13 +787,17 @@ fn prepare_rustc(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> CargoResult
         }
     }
 
+    let tmpdir = build_runner.files().rustc_tmp_dir(unit);
+    paths::create_dir_all(tmpdir)?;
+
+    // Make `rustc`, proc-macros and the linker output temporary files to
+    // `tmpdir` instead of the path returned by `std::env::temp_dir()`.
+    for key in paths::tmpdir_envvars() {
+        base.env(key, tmpdir);
+    }
+
     if unit.target.is_test() || unit.target.is_bench() {
-        let tmp = build_runner
-            .files()
-            .layout(unit.kind)
-            .build_dir()
-            .prepare_tmp()?;
-        base.env("CARGO_TARGET_TMPDIR", tmp.display().to_string());
+        base.env("CARGO_TARGET_TMPDIR", tmpdir.display().to_string());
     }
 
     Ok(base)
@@ -921,6 +925,15 @@ fn prepare_rustdoc(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> CargoResu
 
     if !crate_version_flag_already_present(&rustdoc) {
         append_crate_version_flag(unit, &mut rustdoc);
+    }
+
+    let tmpdir = build_runner.files().rustc_tmp_dir(unit);
+    paths::create_dir_all(tmpdir)?;
+
+    // Make `rustdoc` and proc-macros output temporary files to `tmpdir`
+    // instead of the path returned by `std::env::temp_dir()`.
+    for key in paths::tmpdir_envvars() {
+        rustdoc.env(key, tmpdir);
     }
 
     Ok(rustdoc)


### PR DESCRIPTION
Fixes https://github.com/rust-lang/cargo/issues/16427.

### What does this PR try to resolve?

Build scripts, procedural macros, the linker and even the compiler itself[^1] may output temporary files to `std::env::temp_dir()` during compilation. It is possible to request that programs use a different temporary directory by setting the `TMPDIR` (Unix) or `TMP` and `TEMP` (Windows) environment variables.

[^1]: Cargo has a pretty good understanding of which files the compiler outputs, though it is incomplete in certain areas, especially areas that the compiler doesn't (yet) want to make public, such as the `symbols.o` trick. Such files are placed in the temporary directory.

This PR makes Cargo set these environment variables to a temporary directory within the `target` directory.

This is useful when debugging, as it allows more easily inspecting the state the compiler was working with when something went wrong, especially if using [`-Csave-temps=yes`](https://doc.rust-lang.org/rustc/codegen-options/index.html#save-temps), as relevant files can more easily be found in the project directory instead of being bundled in `/tmp` with everything else. It also makes it easier to clean up after compilation is finished (`cargo clean` would remove temporary files as well, instead of the user having to reboot for `/tmp` to be cleared).

Additionally, this is useful for preventing information leakage: `/tmp` is global and world readable[^2], and this means that a different user on the same machine could figure out possibly sensitive details about the project you were building. This is even an issue on macOS where the temporary directory is scoped to the current user (`getconf DARWIN_USER_TEMP_DIR`), since you'd still be susceptible to Man-in-the-middle attacks by less privileged processes by the same user.

[^2]: Though often only writable by the same user that created the file.

Finally, this makes build scripts and proc-macros more self-contained, which is useful when sandboxing them, such as that which I'm working on in [`cargo-sandbox`](https://github.com/madsmtm/cargo-sandbox).

### Implementation notes

When running build scripts, the temporary directory we request is `/path/to/target/{debug,release}/build/PKG-HASH/tmp` (same as `$OUT_DIR/../tmp`). For `rustc`/`rustdoc` invocations, the directory we request is `/path/to/target/tmp` (same as `$CARGO_TARGET_TMPDIR`), see https://github.com/rust-lang/cargo/pull/9814 for breakage introduced in the past by trying to make it `/path/to/target/{debug,release}/tmp`.

I had a look at the standard library's implementation of `std::env::temp_dir`, it seems that only [Hermit](https://hermit-os.org/) and [Motor OS](https://motor-os.org/) don't respect any environment variable when considering the temporary directory, so the test that I've added should work on all host platforms but those (I'd argue the onus is on those niche platforms to figure out a standard environment variable that they want to use for this, but I can submit bugs upstream if you want me to?)

### How to test and review this PR?

1. Run a build script like:
    ```rust
    fn main() {
        fs::write(std::env::temp_dir().join("foo.txt"), b"Lorem ipsum").unwrap();
    }
    ```
    And verify that the file shows up in the project-local folder.
2. Do something similar in a proc-macro.
3. Run `cargo rustc -- -Csave-temps=yes`, and verify that the `symbols.o` file shows up in the project-local temporary directory.
