### PR TITLE
fix(vendor): unpack from local-registry cache path

### DIFF
--- a/src/cargo/sources/registry/http_remote.rs
+++ b/src/cargo/sources/registry/http_remote.rs
@@ -472,6 +472,10 @@ impl<'gctx> RegistryData for HttpRegistry<'gctx> {
         &self.index_path
     }
 
+    fn cache_path(&self) -> &Filesystem {
+        &self.cache_path
+    }
+
     fn assert_index_locked<'a>(&self, path: &'a Filesystem) -> &'a Path {
         self.gctx
             .assert_package_cache_locked(CacheLockMode::DownloadExclusive, path)

--- a/src/cargo/sources/registry/local.rs
+++ b/src/cargo/sources/registry/local.rs
@@ -95,6 +95,10 @@ impl<'gctx> RegistryData for LocalRegistry<'gctx> {
         &self.index_path
     }
 
+    fn cache_path(&self) -> &Filesystem {
+        &self.root
+    }
+
     fn assert_index_locked<'a>(&self, path: &'a Filesystem) -> &'a Path {
         // Note that the `*_unlocked` variant is used here since we're not
         // modifying the index and it's required to be externally synchronized.

--- a/src/cargo/sources/registry/remote.rs
+++ b/src/cargo/sources/registry/remote.rs
@@ -233,6 +233,10 @@ impl<'gctx> RegistryData for RemoteRegistry<'gctx> {
         &self.index_path
     }
 
+    fn cache_path(&self) -> &Filesystem {
+        &self.cache_path
+    }
+
     fn assert_index_locked<'a>(&self, path: &'a Filesystem) -> &'a Path {
         self.gctx
             .assert_package_cache_locked(CacheLockMode::DownloadExclusive, path)

--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -2160,21 +2160,32 @@ fn vendor_local_registry() {
         .build();
 
     p.cargo("vendor --respect-source-config")
-        .with_status(101)
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to latest compatible version
 [UNPACKING] bar v0.0.0 (registry `[ROOT]/registry`)
    Vendoring bar v0.0.0 ([ROOT]/home/.cargo/registry/src/-[HASH]/bar-0.0.0) to vendor/bar
-[ERROR] failed to sync
+To use vendored sources, add this to your .cargo/config.toml for this project:
 
-Caused by:
-  failed to open [ROOT]/home/.cargo/registry/cache/-[HASH]/bar-0.0.0.crate
-
-Caused by:
-  [NOT_FOUND]
 
 "#]])
         .run();
+
+    assert_e2e().eq(
+        p.read_file("vendor/bar/Cargo.toml"),
+        str![[r#"
+
+            [package]
+            name = "bar"
+            version = "0.0.0"
+            authors = []
+        
+"#]],
+    );
+
+    assert_e2e().eq(
+        p.read_file("vendor/bar/src/lib.rs"),
+        str!["pub fn bar() {}"],
+    );
 }
 
 #[cargo_test]


### PR DESCRIPTION
### What does this PR try to resolve?

In https://github.com/rust-lang/cargo/pull/15514, Cargo starts direct-extraction from `.crate`
tarball in `$CARGO_HOME/registry/cache` when vendoring. This is fine with
remote registrires but not for local registries, as local registries'
tarball are stored along with index.

This fix abstracts `cache_path` to `RegistryData` trait, so every
registry source type can define its own locationa of tarball cache.

Note that for local-registry when accessing either index or cache, the
assumption is that file lock of the index and cache directory need to
be externally synchronized. Cargo doesn't take care of it.

Fixes https://github.com/rust-lang/cargo/issues/16412

### How to test and review this PR?