### PR TITLE
fix(vendor): recursively filter git files in subdirectories

### DIFF
--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -2151,7 +2151,7 @@ fn deterministic_mtime() {
     assert_deterministic_mtime(p.root().join("vendor/foo/Cargo.lock"));
     assert_deterministic_mtime(p.root().join("vendor/foo/Cargo.toml"));
     assert_deterministic_mtime(p.root().join("vendor/foo/.cargo_vcs_info.json"));
-} // <- ADD THIS CLOSING BRACE!
+}
 
 #[cargo_test]
 fn vendor_filters_git_files_recursively() {
@@ -2181,11 +2181,11 @@ fn vendor_filters_git_files_recursively() {
 
     p.cargo("vendor --respect-source-config").run();
 
-// Currently these files are NOT filtered (buggy behavior)
-    assert!(p.root().join("vendor/bar/subdir/.gitattributes").exists());
-    assert!(p.root().join("vendor/bar/subdir/.gitignore").exists());
-    assert!(p.root().join("vendor/bar/deep/nested/.git").exists());
-    assert!(p.root().join("vendor/bar/tests/.gitattributes").exists());
+    // After fix, these should be filtered
+    assert!(!p.root().join("vendor/bar/subdir/.gitattributes").exists());
+    assert!(!p.root().join("vendor/bar/subdir/.gitignore").exists());
+    assert!(!p.root().join("vendor/bar/deep/nested/.git").exists());
+    assert!(!p.root().join("vendor/bar/tests/.gitattributes").exists());
     assert!(!p.root().join("vendor/bar/.gitattributes").exists());
     assert!(p.root().join("vendor/bar/src/lib.rs").exists());
 }


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes #16148
Fixes #13607

Right now cargo vendor only filters .gitattributes, .gitignore, and .git at the top level of each package. If these files exist in subdirectories, they don't get filtered. This causes problems when the vendored code gets checked into a git repo - git processes those files and modifies them, which breaks checksums.

I ran into this when trying to vendor libssh2-sys. The .gitattributes file in libgit2/src/util/ was getting its line endings changed by git, causing checksum failures.

### How should we test and review this PR?

This follows the atomic commit pattern:
- First commit adds a test showing the current buggy behavior (test passes)
- Second commit implements the fix and updates test assertions (test still passes)

The fix uses components() to recursively check for .git directories (since they can appear at any path level like deep/nested/.git/config), while using file_name() for .gitattributes and .gitignore files.

### Additional context

This should also help with #13607 since it filters .gitignore and .git recursively too.

If people actually need git functionality in their vendored deps, they can add rules to their own .gitattributes at the root level.