### PR TITLE
feat(resolver): List features when no close match

### DIFF
--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -167,6 +167,13 @@ pub(super) fn activation_error(
                         msg.push_str("` does have feature `");
                         msg.push_str(closest);
                         msg.push_str("`\n");
+                    } else if !latest.features().is_empty() {
+                        let mut features: Vec<_> =
+                            latest.features().keys().map(|f| f.as_str()).collect();
+                        features.sort();
+                        msg.push_str(" available features: ");
+                        msg.push_str(&features.join(", "));
+                        msg.push_str("\n");
                     }
                     // p == parent so the full path is redundant.
                 }

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -330,6 +330,7 @@ fn dependency_activates_feature_with_no_close_match() {
 versions that meet the requirements `*` are: 0.0.1
 
 package `foo` depends on `bar` with feature `serde` but `bar` does not have that feature.
+ available features: cookies, json, tls
 
 
 failed to select a version for `bar` which could resolve this conflict


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes #9722

When a user requests a non-existent feature, cargo suggests a similar feature if one exists via edit distance. However, if no feature name is close enough to suggest, the error message provides no help.

This PR adds a fallback that lists all available features so the user can see their options when no close match exists.

**Before:**
```shell
package foo depends on bar with feature serde but bar does not have that feature.
```

**After:**
```shell
package foo depends on bar with feature serde but bar does not have that feature.
 available features: cookies, json, tls
```

### How to test and review this PR?

This PR follows the atomic commit pattern:
1. First commit adds a test documenting the current behavior
2. Second commit implements the fix and updates the test expectation

Run the new test:
```shell
cargo +nightly test --test testsuite -- features::dependency_activates_feature_with_no_close_match
```
