### PR TITLE
fix(log): add `dependencies` field to `UnitRegistered`

### DIFF
--- a/src/cargo/ops/cargo_compile/mod.rs
+++ b/src/cargo/ops/cargo_compile/mod.rs
@@ -535,6 +535,14 @@ pub fn create_bcx<'a, 'gctx>(
 
         for (index, unit) in units.into_iter().enumerate() {
             let index = index as u64;
+            let dependencies = unit_graph
+                .get(unit)
+                .map(|deps| {
+                    deps.iter()
+                        .filter_map(|dep| unit_to_index.get(&dep.unit).copied())
+                        .collect()
+                })
+                .unwrap_or_default();
             logger.log(LogMessage::UnitRegistered {
                 package_id: unit.pkg.package_id().to_spec(),
                 target: (&unit.target).into(),
@@ -547,6 +555,7 @@ pub fn create_bcx<'a, 'gctx>(
                     .map(|s| s.as_str().to_owned())
                     .collect(),
                 requested: root_unit_indexes.contains(&index),
+                dependencies,
             });
         }
         let elapsed = ws.gctx().creation_time().elapsed().as_secs_f64();

--- a/src/cargo/ops/cargo_report/timings.rs
+++ b/src/cargo/ops/cargo_report/timings.rs
@@ -177,6 +177,7 @@ fn prepare_context(log: &Path, run_id: &RunId) -> CargoResult<RenderContext<'sta
                 index,
                 features,
                 requested,
+                dependencies: _,
             } => {
                 if requested {
                     requested_units.insert(index);

--- a/src/cargo/util/log_message.rs
+++ b/src/cargo/util/log_message.rs
@@ -86,6 +86,9 @@ pub enum LogMessage {
         /// like via the `-p` flag or the default workspace members.
         #[serde(default, skip_serializing_if = "std::ops::Not::not")]
         requested: bool,
+        /// Unit indices that this unit depends on.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        dependencies: Vec<u64>,
     },
     /// Emitted when a compilation unit starts.
     UnitStarted {

--- a/tests/testsuite/build_analysis.rs
+++ b/tests/testsuite/build_analysis.rs
@@ -606,6 +606,11 @@ fn log_msg_unit_graph() {
     "timestamp": "[..]T[..]Z"
   },
   {
+    "dependencies": [
+      0,
+      1,
+      4
+    ],
     "index": 2,
     "mode": "doc",
     "package_id": "path+[ROOTURL]/foo#0.0.0",
@@ -633,6 +638,9 @@ fn log_msg_unit_graph() {
     "timestamp": "[..]T[..]Z"
   },
   {
+    "dependencies": [
+      3
+    ],
     "index": 4,
     "mode": "run-custom-build",
     "package_id": "path+[ROOTURL]/foo#0.0.0",


### PR DESCRIPTION

### What does this PR try to resolve?

Track unit dependency graph in `LogMessage::UnitRegistered`.

This gives the unit-graph information before running the build, which will help enable root cause analysis for cascading rebuilds.

Part of <https://github.com/rust-lang/cargo/issues/15844>

### How to test and review this PR?
