### PR TITLE
Add text_direction_codepoint lint (CVE-2021-42574)

### DIFF
--- a/src/cargo/lints/rules/mod.rs
+++ b/src/cargo/lints/rules/mod.rs
@@ -1,16 +1,19 @@
 mod blanket_hint_mostly_unused;
 mod im_a_teapot;
 mod implicit_minimum_version_req;
+mod text_direction_codepoint;
 mod unknown_lints;
 
 pub use blanket_hint_mostly_unused::blanket_hint_mostly_unused;
 pub use im_a_teapot::check_im_a_teapot;
 pub use implicit_minimum_version_req::implicit_minimum_version_req;
+pub use text_direction_codepoint::text_direction_codepoint;
 pub use unknown_lints::output_unknown_lints;
 
 pub const LINTS: &[crate::lints::Lint] = &[
     blanket_hint_mostly_unused::LINT,
     implicit_minimum_version_req::LINT,
     im_a_teapot::LINT,
+    text_direction_codepoint::LINT,
     unknown_lints::LINT,
 ];

--- a/src/cargo/lints/rules/text_direction_codepoint.rs
+++ b/src/cargo/lints/rules/text_direction_codepoint.rs
@@ -1,0 +1,138 @@
+use std::path::Path;
+
+use annotate_snippets::AnnotationKind;
+use annotate_snippets::Group;
+use annotate_snippets::Level;
+use annotate_snippets::Snippet;
+use cargo_util_schemas::manifest::TomlToolLints;
+
+use crate::CargoResult;
+use crate::GlobalContext;
+use crate::lints::Lint;
+use crate::lints::LintLevel;
+use crate::lints::ManifestFor;
+use crate::lints::rel_cwd_manifest_path;
+
+/// Unicode BiDi (bidirectional) control codepoints that can be used in
+/// "Trojan Source" attacks (CVE-2021-42574).
+///
+/// These codepoints change the visual representation of text on screen
+/// in a way that does not correspond to their in-memory representation.
+const UNICODE_BIDI_CODEPOINTS: &[(char, &str)] = &[
+    ('\u{202A}', "LEFT-TO-RIGHT EMBEDDING"),
+    ('\u{202B}', "RIGHT-TO-LEFT EMBEDDING"),
+    ('\u{202C}', "POP DIRECTIONAL FORMATTING"),
+    ('\u{202D}', "LEFT-TO-RIGHT OVERRIDE"),
+    ('\u{202E}', "RIGHT-TO-LEFT OVERRIDE"),
+    ('\u{2066}', "LEFT-TO-RIGHT ISOLATE"),
+    ('\u{2067}', "RIGHT-TO-LEFT ISOLATE"),
+    ('\u{2068}', "FIRST STRONG ISOLATE"),
+    ('\u{2069}', "POP DIRECTIONAL ISOLATE"),
+];
+
+pub const LINT: Lint = Lint {
+    name: "text_direction_codepoint",
+    desc: "unicode codepoint changing visible direction of text present in manifest",
+    groups: &[],
+    default_level: LintLevel::Deny,
+    edition_lint_opts: None,
+    feature_gate: None,
+    docs: Some(
+        r#"
+### What it does
+Checks for Unicode codepoints in `Cargo.toml` that change the visual
+representation of text on screen in a way that does not correspond to
+their on memory representation.
+
+### Why it is bad
+The Unicode characters `\u{202A}`, `\u{202B}`, `\u{202C}`, `\u{202D}`,
+`\u{202E}`, `\u{2066}`, `\u{2067}`, `\u{2068}`, and `\u{2069}` make the
+flow of text on screen change its direction. This makes the text "abc"
+display as "cba" on screen. By leveraging these, people can write specially
+crafted text that makes the surrounding manifest content seem like it's
+specifying one thing, when in reality it is specifying another.
+
+This is known as a "Trojan Source" attack (CVE-2021-42574).
+
+### Example
+A malicious `Cargo.toml` could contain invisible Unicode control characters
+that reorder how text is displayed, making a malicious dependency appear
+as a comment or vice versa.
+
+See [CVE-2021-42574](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42574) for more details.
+"#,
+    ),
+};
+
+pub fn text_direction_codepoint(
+    manifest: ManifestFor<'_>,
+    manifest_path: &Path,
+    cargo_lints: &TomlToolLints,
+    error_count: &mut usize,
+    gctx: &GlobalContext,
+) -> CargoResult<()> {
+    let (lint_level, reason) = manifest.lint_level(cargo_lints, LINT);
+
+    if lint_level == LintLevel::Allow {
+        return Ok(());
+    }
+
+    let contents = manifest.contents();
+    let manifest_path_str = rel_cwd_manifest_path(manifest_path, gctx);
+
+    // Find all occurrences of BiDi codepoints
+    let mut findings: Vec<(usize, char, &str)> = Vec::new();
+
+    for (byte_idx, ch) in contents.char_indices() {
+        if let Some((_, name)) = UNICODE_BIDI_CODEPOINTS.iter().find(|(c, _)| *c == ch) {
+            findings.push((byte_idx, ch, name));
+        }
+    }
+
+    if findings.is_empty() {
+        return Ok(());
+    }
+
+    let level = lint_level.to_diagnostic_level();
+    let emitted_source = LINT.emitted_source(lint_level, reason);
+
+    for (i, (byte_idx, ch, name)) in findings.iter().enumerate() {
+        if lint_level.is_error() {
+            *error_count += 1;
+        }
+
+        let title = format!(
+            "{}: `\\u{{{:04X}}}` ({})",
+            LINT.desc,
+            *ch as u32,
+            name
+        );
+
+        // The span covers just the single character
+        let span = *byte_idx..(*byte_idx + ch.len_utf8());
+
+        let label = format!(
+            "this invisible unicode codepoint changes text flow direction"
+        );
+
+        let help = "if their presence wasn't intentional, you can remove them";
+
+        let mut group = Group::with_title(level.clone().primary_title(&title)).element(
+            Snippet::source(contents)
+                .path(&manifest_path_str)
+                .annotation(AnnotationKind::Primary.span(span).label(&label)),
+        );
+
+        // Only emit the source note on the first finding
+        if i == 0 {
+            group = group.element(Level::NOTE.message(&emitted_source));
+        }
+
+        group = group.element(Level::HELP.message(help));
+
+        gctx.shell().print_report(&[group], lint_level.force())?;
+    }
+
+    Ok(())
+}
+

--- a/tests/testsuite/lints/mod.rs
+++ b/tests/testsuite/lints/mod.rs
@@ -7,6 +7,7 @@ mod blanket_hint_mostly_unused;
 mod error;
 mod implicit_minimum_version_req;
 mod inherited;
+mod text_direction_codepoint;
 mod unknown_lints;
 mod warning;
 

--- a/tests/testsuite/lints/text_direction_codepoint.rs
+++ b/tests/testsuite/lints/text_direction_codepoint.rs
@@ -1,0 +1,244 @@
+use crate::prelude::*;
+use cargo_test_support::project;
+use cargo_test_support::str;
+
+#[cargo_test]
+fn detects_bidi_in_description() {
+    // Create a manifest with a RIGHT-TO-LEFT OVERRIDE (U+202E) in the description
+    let manifest = "
+[package]
+name = \"foo\"
+version = \"0.0.1\"
+edition = \"2015\"
+description = \"A \u{202E}test package\"
+";
+    let p = project()
+        .file("Cargo.toml", manifest)
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] unicode codepoint changing visible direction of text present in manifest: `/u{202E}` (RIGHT-TO-LEFT OVERRIDE)
+ --> Cargo.toml:6:18
+  |
+6 | description = "A �test package"
+  |                  ^ this invisible unicode codepoint changes text flow direction
+  |
+  = [NOTE] `cargo::text_direction_codepoint` is set to `deny` by default
+  = [HELP] if their presence wasn't intentional, you can remove them
+[ERROR] encountered 1 error while running lints
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn detects_multiple_bidi() {
+    // Create a manifest with multiple BiDi codepoints
+    let manifest = "
+[package]
+name = \"foo\"
+version = \"0.0.1\"
+edition = \"2015\"
+description = \"A \u{202E}test\u{202D} package\"
+";
+    let p = project()
+        .file("Cargo.toml", manifest)
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] unicode codepoint changing visible direction of text present in manifest: `/u{202E}` (RIGHT-TO-LEFT OVERRIDE)
+ --> Cargo.toml:6:18
+  |
+6 | description = "A �test� package"
+  |                  ^ this invisible unicode codepoint changes text flow direction
+  |
+  = [NOTE] `cargo::text_direction_codepoint` is set to `deny` by default
+  = [HELP] if their presence wasn't intentional, you can remove them
+[ERROR] unicode codepoint changing visible direction of text present in manifest: `/u{202D}` (LEFT-TO-RIGHT OVERRIDE)
+ --> Cargo.toml:6:23
+  |
+6 | description = "A �test� package"
+  |                       ^ this invisible unicode codepoint changes text flow direction
+  |
+  = [HELP] if their presence wasn't intentional, you can remove them
+[ERROR] encountered 2 errors while running lints
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn allow_lint() {
+    // Test that the lint can be allowed
+    let manifest = "
+[package]
+name = \"foo\"
+version = \"0.0.1\"
+edition = \"2015\"
+description = \"A \u{202E}test package\"
+
+[lints.cargo]
+text_direction_codepoint = \"allow\"
+";
+    let p = project()
+        .file("Cargo.toml", manifest)
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn warn_lint() {
+    // Test that the lint can be set to warn
+    let manifest = "
+[package]
+name = \"foo\"
+version = \"0.0.1\"
+edition = \"2015\"
+description = \"A \u{202E}test package\"
+
+[lints.cargo]
+text_direction_codepoint = \"warn\"
+";
+    let p = project()
+        .file("Cargo.toml", manifest)
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] unicode codepoint changing visible direction of text present in manifest: `/u{202E}` (RIGHT-TO-LEFT OVERRIDE)
+ --> Cargo.toml:6:18
+  |
+6 | description = "A �test package"
+  |                  ^ this invisible unicode codepoint changes text flow direction
+  |
+  = [NOTE] `cargo::text_direction_codepoint` is set to `warn` in `[lints]`
+  = [HELP] if their presence wasn't intentional, you can remove them
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn no_bidi_clean() {
+    // Test that clean manifests pass
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+[package]
+name = "foo"
+version = "0.0.1"
+edition = "2015"
+"#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn workspace_inherited_allow() {
+    // Test workspace-level lint configuration with member package
+    let manifest = "
+[workspace]
+members = [\"foo\"]
+
+[workspace.lints.cargo]
+text_direction_codepoint = \"allow\"
+";
+    let foo_manifest = "
+[package]
+name = \"foo\"
+version = \"0.0.1\"
+edition = \"2015\"
+description = \"A \u{202E}test package\"
+
+[lints]
+workspace = true
+";
+    let p = project()
+        .file("Cargo.toml", manifest)
+        .file("foo/Cargo.toml", foo_manifest)
+        .file("foo/src/lib.rs", "")
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[CHECKING] foo v0.0.1 ([ROOT]/foo/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn virtual_workspace_bidi() {
+    // Test that BiDi in virtual workspace manifest is detected
+    // Note: description isn't valid for [workspace], so we use a comment-like string in resolver
+    // Actually, virtual workspaces have limited fields, so let's put BiDi in a metadata field
+    let manifest = "
+[workspace]
+members = [\"foo\"]
+
+[workspace.metadata]
+info = \"test \u{202E}info\"
+";
+    let foo_manifest = r#"
+[package]
+name = "foo"
+version = "0.0.1"
+edition = "2015"
+"#;
+    let p = project()
+        .file("Cargo.toml", manifest)
+        .file("foo/Cargo.toml", foo_manifest)
+        .file("foo/src/lib.rs", "")
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] unicode codepoint changing visible direction of text present in manifest: `/u{202E}` (RIGHT-TO-LEFT OVERRIDE)
+ --> Cargo.toml:6:14
+  |
+6 | info = "test �info"
+  |              ^ this invisible unicode codepoint changes text flow direction
+  |
+  = [NOTE] `cargo::text_direction_codepoint` is set to `deny` by default
+  = [HELP] if their presence wasn't intentional, you can remove them
+[ERROR] encountered 1 error while running lints
+
+"#]])
+        .run();
+}


### PR DESCRIPTION
### What does this PR try to resolve?

This PR implements the **text_direction_codepoint lint** for `Cargo.toml` files:
Fixes #16373 and #16374

_lint detects Unicode BiDi (bidirectional) control codepoints that can be used in "Trojan Source" attacks. These invisible characters can alter the visual display of text without changing its underlying representation, potentially making malicious manifest content appear benign. All like descritped in rustc's text_direction_codepoint_in_comment/literal lint but for Cargo manifests._

Detected codepoints:
- `U+202A` LEFT-TO-RIGHT EMBEDDING
- `U+202B` RIGHT-TO-LEFT EMBEDDING  
- `U+202C` POP DIRECTIONAL FORMATTING
- `U+202D` LEFT-TO-RIGHT OVERRIDE
- `U+202E` RIGHT-TO-LEFT OVERRIDE
- `U+2066` LEFT-TO-RIGHT ISOLATE
- `U+2067` RIGHT-TO-LEFT ISOLATE
- `U+2068` FIRST STRONG ISOLATE
- `U+2069` POP DIRECTIONAL ISOLATE

**Default level:** `deny`

### How to test and review this PR?

`cargo test -p cargo --test testsuite -- lints::text_direction_codepoint`
Manual testing:
# Create a manifest with BiDi codepoint (U+202E)
```
printf '[package]\nname = "foo"\nversion = "0.1.0"\nedition = "2024"\ndescription = "A \xE2\x80\xAEtest"\n' > Cargo.toml
mkdir -p src && echo 'fn main(){}' > src/main.rs
cargo +nightly check -Zcargo-lints
```

The lint can be configured via `[lints.cargo]`:
```
[lints.cargo]
text_direction_codepoint = "allow"  # or "warn"
```