### PR TITLE
Update handlebars to 6.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2232,9 +2232,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "6.3.1"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d752747ddabc4c1a70dd28e72f2e3c218a816773e0d7faf67433f1acfa6cba7c"
+checksum = "9b3f9296c208515b87bd915a2f5d1163d4b3f863ba83337d7713cf478055948e"
 dependencies = [
  "derive_builder",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,7 @@ git2-curl = "0.21.0"
 # When updating this, also see if `gix-transport` further down needs updating or some auth-related tests will fail.
 gix = { version = "0.74.1", default-features = false, features = ["progress-tree", "parallel", "dirwalk", "status"] }
 glob = "0.3.3"
-# Pinned due to https://github.com/sunng87/handlebars-rust/issues/711
-handlebars = { version = "=6.3.1", features = ["dir_source"] }
+handlebars = { version = "6.4.0", features = ["dir_source"] }
 hex = "0.4.3"
 hmac = "0.12.1"
 home = "0.5.12"


### PR DESCRIPTION
A new release has been made which fixes the issue we were having with a previous release.

Release notes: https://github.com/sunng87/handlebars-rust/releases/tag/v6.4.0
