### PR TITLE
Let git decide when to run gc

### DIFF
--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -1313,47 +1313,30 @@ fn fetch_with_libgit2(
 /// descriptors, getting us dangerously close to blowing out the OS limits of
 /// how many fds we can have open. This is detailed in [#4403].
 ///
-/// To try to combat this problem we attempt a `git gc` here. Note, though, that
-/// we may not even have `git` installed on the system! As a result we
-/// opportunistically try a `git gc` when the pack directory looks too big, and
-/// failing that we just blow away the repository and start over.
-///
-/// In theory this shouldn't be too expensive compared to the network request
-/// we're about to issue.
+/// Instead of trying to be clever about when gc is needed, we just run
+/// `git gc --auto` and let git figure it out. It checks its own thresholds
+/// (gc.auto, gc.autoPackLimit) and either does the work or exits quickly.
+/// If git isn't installed, no worries - we skip it.
 ///
 /// [#4403]: https://github.com/rust-lang/cargo/issues/4403
 fn maybe_gc_repo(repo: &mut git2::Repository, gctx: &GlobalContext) -> CargoResult<()> {
-    // Here we arbitrarily declare that if you have more than 100 files in your
-    // `pack` folder that we need to do a gc.
-    let entries = match repo.path().join("objects/pack").read_dir() {
-        Ok(e) => e.count(),
-        Err(_) => {
-            debug!("skipping gc as pack dir appears gone");
-            return Ok(());
-        }
-    };
-    let max = gctx
-        .get_env("__CARGO_PACKFILE_LIMIT")
-        .ok()
-        .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or(100);
-    if entries < max {
-        debug!("skipping gc as there's only {} pack files", entries);
-        return Ok(());
+    // Let git decide whether gc is actually needed based on its own thresholds
+    // (gc.auto, gc.autoPackLimit). This avoids duplicating git's internal logic
+    // for deciding when housekeeping is needed.
+    //
+    // For testing purposes, __CARGO_PACKFILE_LIMIT can be set to override
+    // gc.autoPackLimit, which has the same meaning. This lets tests force gc
+    // to run by setting a low threshold without depending on git's defaults.
+    let mut cmd = Command::new("git");
+    if let Ok(limit) = gctx.get_env("__CARGO_PACKFILE_LIMIT") {
+        cmd.arg(format!("-c gc.autoPackLimit={}", limit));
     }
+    cmd.arg("gc").arg("--auto").current_dir(repo.path());
 
-    // First up, try a literal `git gc` by shelling out to git. This is pretty
-    // likely to fail though as we may not have `git` installed. Note that
-    // libgit2 doesn't currently implement the gc operation, so there's no
-    // equivalent there.
-    match Command::new("git")
-        .arg("gc")
-        .current_dir(repo.path())
-        .output()
-    {
+    match cmd.output() {
         Ok(out) => {
             debug!(
-                "git-gc status: {}\n\nstdout ---\n{}\nstderr ---\n{}",
+                "git-gc --auto status: {}\n\nstdout ---\n{}\nstderr ---\n{}",
                 out.status,
                 String::from_utf8_lossy(&out.stdout),
                 String::from_utf8_lossy(&out.stderr)
@@ -1364,7 +1347,7 @@ fn maybe_gc_repo(repo: &mut git2::Repository, gctx: &GlobalContext) -> CargoResu
                 return Ok(());
             }
         }
-        Err(e) => debug!("git-gc failed to spawn: {}", e),
+        Err(e) => debug!("git-gc --auto failed to spawn: {}", e),
     }
 
     // Alright all else failed, let's start over.

--- a/tests/testsuite/git_gc.rs
+++ b/tests/testsuite/git_gc.rs
@@ -62,6 +62,8 @@ fn run_test(path_env: Option<&OsStr>) {
     drop((repo, index));
     Package::new("bar", "0.1.1").publish();
 
+    // Each fetch above creates a new pack file in the index. Count them before
+    // running cargo update so we can verify gc actually consolidates them.
     let before = find_index()
         .join(".git/objects/pack")
         .read_dir()
@@ -69,6 +71,9 @@ fn run_test(path_env: Option<&OsStr>) {
         .count();
     assert!(before > N);
 
+    // Set __CARGO_PACKFILE_LIMIT=10 so gc.autoPackLimit=10 is passed to
+    // `git gc --auto`. This forces consolidation at a low threshold rather
+    // than relying on git's default (which is much higher).
     let mut cmd = foo.cargo("update");
     cmd.env("__CARGO_PACKFILE_LIMIT", "10");
     if let Some(path) = path_env {
@@ -76,6 +81,7 @@ fn run_test(path_env: Option<&OsStr>) {
     }
     cmd.env("CARGO_LOG", "trace");
     cmd.run();
+
     let after = find_index()
         .join(".git/objects/pack")
         .read_dir()


### PR DESCRIPTION




### What does this PR try to resolve?
Let git handle gc timing

Fixes #4495

We were counting packfiles ourselves, but git already does this
with gc --auto. No need to duplicate that logic.

