### PR TITLE
test: add `-Zunstable-options` with custom targets

### DIFF
--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -821,7 +821,7 @@ windows
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "custom targets are unstable in rustc")]
 fn rustc_with_print_cfg_config_toml_env() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -841,6 +841,7 @@ RUST_TARGET_PATH = { value = "./targets", relative = true }
     p.cargo("rustc -Z unstable-options --print cfg")
         .masquerade_as_nightly_cargo(&["print"])
         .with_stdout_data(str!["..."].unordered())
+        .env("RUSTFLAGS", "-Z unstable-options")
         .run();
 }
 


### PR DESCRIPTION
rustc is destabilising custom targets (rust-lang/rust#150151) by requiring that `-Zunstable-options` is passed when custom targets are used. This patch is the minimum change required so that the rustc patch can be merged without failing the Cargo tests run in rustc's CI.
