### PR TITLE
Clear `RUSTUP_*` environment variables in `test_env`

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1383,6 +1383,11 @@ pub trait TestEnvCommandExt: Sized {
                 self = self.env_remove(&k);
             }
         }
+        for (k, _v) in env::vars() {
+            if k.starts_with("RUSTUP_") {
+                self = self.env_remove(&k);
+            }
+        }
         if env::var_os("RUSTUP_TOOLCHAIN").is_some() {
             // Override the PATH to avoid executing the rustup wrapper thousands
             // of times. This makes the testsuite run substantially faster.

--- a/tests/testsuite/cargo_alias_config.rs
+++ b/tests/testsuite/cargo_alias_config.rs
@@ -151,15 +151,17 @@ fn builtin_alias_shadowing_external_subcommand() {
     paths.push(p.root());
     let path = env::join_paths(paths).unwrap();
 
-    p.cargo("t")
-        .env("PATH", &path)
-        .with_stderr_data(str![[r#"
+    let mut process = p.cargo("t");
+    process.env("PATH", &path).with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] unittests src/main.rs (target/debug/deps/foo-[HASH][EXE])
 
-"#]])
-        .run();
+"#]]);
+    if let Some(val) = env::var_os("RUSTUP_HOME") {
+        process.env("RUSTUP_HOME", val);
+    }
+    process.run();
 }
 
 #[cargo_test]
@@ -181,7 +183,8 @@ fn alias_shadowing_external_subcommand() {
     paths.push(echo.target_debug_dir());
     let path = env::join_paths(paths).unwrap();
 
-    p.cargo("echo")
+    let mut process = p.cargo("echo");
+    process
         .env("PATH", &path)
         .with_stderr_data(str![[r#"
 [WARNING] user-defined alias `echo` is shadowing an external subcommand found at `[ROOT]/cargo-echo/target/debug/cargo-echo[EXE]`
@@ -190,8 +193,11 @@ fn alias_shadowing_external_subcommand() {
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
-"#]])
-        .run();
+"#]]);
+    if let Some(val) = env::var_os("RUSTUP_HOME") {
+        process.env("RUSTUP_HOME", val);
+    }
+    process.run();
 }
 
 #[cargo_test]

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -280,7 +280,8 @@ fn multiple_pkgs_path_set() {
     let mut path = path();
     path.push(paths::cargo_home().join("bin"));
     let new_path = env::join_paths(path).unwrap();
-    cargo_process("install foo bar baz")
+    let mut process = cargo_process("install foo bar baz");
+    process
         .env("PATH", new_path)
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -303,8 +304,11 @@ fn multiple_pkgs_path_set() {
 [SUMMARY] Successfully installed foo, bar! Failed to install baz (see error(s) above).
 [ERROR] some crates failed to install
 
-"#]])
-        .run();
+"#]]);
+    if let Some(val) = env::var_os("RUSTUP_HOME") {
+        process.env("RUSTUP_HOME", val);
+    }
+    process.run();
     assert_has_installed_exe(paths::cargo_home(), "foo");
     assert_has_installed_exe(paths::cargo_home(), "bar");
 
@@ -645,8 +649,11 @@ fn relative_install_location_with_path_set() {
 [INSTALLING] [ROOT]/foo/t1/bin/foo[EXE]
 [INSTALLED] package `foo v0.0.1 ([ROOT]/foo)` (executable `foo[EXE]`)
 
-"#]])
-        .run();
+"#]]);
+    if let Some(val) = env::var_os("RUSTUP_HOME") {
+        cmd.env("RUSTUP_HOME", val);
+    }
+    cmd.run();
 
     assert_has_installed_exe(&project_t1, "foo");
 }

--- a/tests/testsuite/jobserver.rs
+++ b/tests/testsuite/jobserver.rs
@@ -196,7 +196,8 @@ test-runner:
         .arg("run")
         .arg("-j2")
         .run();
-    p.process(make)
+    let mut process = p.process(make);
+    process
         .env("PATH", path)
         .env("CARGO", cargo_exe())
         .arg("run-runner")
@@ -206,14 +207,18 @@ test-runner:
 [RUNNING] `runner target/debug/cargo-jobserver-check[EXE]`
 this is a runner
 
-"#]])
-        .run();
+"#]]);
+    if let Some(val) = env::var_os("RUSTUP_HOME") {
+        process.env("RUSTUP_HOME", val);
+    }
+    process.run();
     p.process(make)
         .env("CARGO", cargo_exe())
         .arg("test")
         .arg("-j2")
         .run();
-    p.process(make)
+    let mut process = p.process(make);
+    process
         .env("PATH", path)
         .env("CARGO", cargo_exe())
         .arg("test-runner")
@@ -223,8 +228,11 @@ this is a runner
 [RUNNING] unittests src/lib.rs (target/debug/deps/cargo_jobserver_check-[HASH][EXE])
 this is a runner
 
-"#]])
-        .run();
+"#]]);
+    if let Some(val) = env::var_os("RUSTUP_HOME") {
+        process.env("RUSTUP_HOME", val);
+    }
+    process.run();
 
     // but not from `-j` flag
     p.cargo("run -j2")
@@ -238,7 +246,8 @@ this is a runner
 
 "#]])
         .run();
-    p.cargo("run -j2")
+    let mut process = p.cargo("run -j2");
+    process
         .env("PATH", path)
         .arg("--config")
         .arg(config_value)
@@ -251,13 +260,17 @@ this is a runner
 [..]no jobserver from env[..]
 ...
 
-"#]])
-        .run();
+"#]]);
+    if let Some(val) = env::var_os("RUSTUP_HOME") {
+        process.env("RUSTUP_HOME", val);
+    }
+    process.run();
     p.cargo("test -j2")
         .with_status(101)
         .with_stdout_data("...\n[..]no jobserver from env[..]\n...")
         .run();
-    p.cargo("test -j2")
+    let mut process = p.cargo("test -j2");
+    process
         .env("PATH", path)
         .arg("--config")
         .arg(config_value)
@@ -269,8 +282,11 @@ this is a runner
 ...
 
 "#]])
-        .with_stdout_data("...\n[..]no jobserver from env[..]\n...")
-        .run();
+        .with_stdout_data("...\n[..]no jobserver from env[..]\n...");
+    if let Some(val) = env::var_os("RUSTUP_HOME") {
+        process.env("RUSTUP_HOME", val);
+    }
+    process.run();
 }
 
 #[cargo_test]

--- a/tests/testsuite/script/cargo.rs
+++ b/tests/testsuite/script/cargo.rs
@@ -161,7 +161,8 @@ fn manifest_precedence_over_plugins() {
     path.push(p.root().join("path-test"));
     let path = std::env::join_paths(path.iter()).unwrap();
 
-    p.cargo("-Zscript -v echo.rs")
+    let mut process = p.cargo("-Zscript -v echo.rs");
+    process
         .env("PATH", &path)
         .masquerade_as_nightly_cargo(&["script"])
         .with_stdout_data(str![[r#"
@@ -176,8 +177,11 @@ args: []
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/echo[EXE]`
 
-"#]])
-        .run();
+"#]]);
+    if let Some(val) = std::env::var_os("RUSTUP_HOME") {
+        process.env("RUSTUP_HOME", val);
+    }
+    process.run();
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
This PR clears all `RUSTUP_*` environment variables in effort to create a "clean" environment.

However, some tests fail when `RUSTUP_HOME` is cleared. This PR sets `RUSTUP_HOME` for those tests, so that they might be further investigated.

This PR came out of https://github.com/rust-lang/cargo/pull/16131#discussion_r2661917692 and https://github.com/rust-lang/cargo/pull/16131#discussion_r2661884630.