### PR TITLE
fix(package): detect dirty files when run from workspace member

### DIFF
--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1357,19 +1357,18 @@ to proceed despite this and include the uncommitted changes, pass the `--allow-d
 "#]])
         .run();
 
+    // Running from workspace member directory should also detect the untracked file.
     p.cargo("package --list --no-metadata")
         .cwd("inner")
-        .with_status(0)
-        .with_stdout_data(str![[r#"
-.cargo_vcs_info.json
-Cargo.lock
-Cargo.toml
-Cargo.toml.orig
-src/lib.rs
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] 1 files in the working directory contain changes that were not yet committed into git:
+
 untracked
 
+to proceed despite this and include the uncommitted changes, pass the `--allow-dirty` flag
+
 "#]])
-        .with_stderr_data(str![""])
         .run();
 }
 


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes https://github.com/rust-lang/cargo/issues/16478

When running `cargo package` from a workspace member directory,
the VCS dirty check fails to detect untracked files due to the
pathspec being interpreted relative to the current working directory
instead of the repository root.

Use `:(top)` magic signature to make the pathspec relative to the repo root,
not the current working directory.

See also https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec

### How to test and review this PR?
