### PR TITLE
Fixed incorrect version comparision during build script dependency selection

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -467,7 +467,7 @@ fn build_work(build_runner: &mut BuildRunner<'_, '_>, unit: &Unit) -> CargoResul
                 let Some(dependency) = unit.pkg.dependencies().iter().find(|d| {
                     d.package_name() == dep.unit.pkg.name()
                         && d.source_id() == dep.unit.pkg.package_id().source_id()
-                        && d.version_req().matches(unit.pkg.version())
+                        && d.version_req().matches(dep.unit.pkg.version())
                 }) else {
                     panic!(
                         "Dependency `{}` not found in `{}`s dependencies",


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes a bug in the logic during (unit) dependency selection for build scripts introduced in #16436

This was discovered while updating the submodule in rust-lang/rust https://github.com/rust-lang/rust/pull/150739

### How to test and review this PR?

```sh
cargo new foo
cd foo
cargo add cortex-m-semihosting
cargo build
```

I plan to add test case for this in a follow up PR, but raising the fix PR to unblock the submodule update for now.

r? @weihanglo 