### PR TITLE
Isolate build script metadata progation between std and non-std crates

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -460,6 +460,11 @@ fn build_work(build_runner: &mut BuildRunner<'_, '_>, unit: &Unit) -> CargoResul
     // sorts of variables need to be discovered at that time.
     let lib_deps = dependencies
         .iter()
+        // We allow std dependencies to propagate metadata between other std dependencies but
+        // not to non-std crates. Non-std crates can propagate metadata to other non-std crates.
+        // We enforce a boundary between std and non-std crates. This may be lifted in the
+        // future but for now we are being conservative.
+        .filter(|dep| dep.unit.is_std == unit.is_std)
         .filter_map(|dep| {
             if dep.unit.mode.is_run_custom_build() {
                 let dep_metadata = build_runner.get_run_build_script_metadata(&dep.unit);


### PR DESCRIPTION
### What does this PR try to resolve?

This PR fixes a regression found in https://github.com/rust-lang/rust/pull/150739 that was introduced in https://github.com/rust-lang/cargo/pull/16436.

For `-Zbuild-std` std dependencies, we would panic due to the dependency not being present in `Cargo.toml`.
~~This PR adds handling fallback to the `unit.pkg.name()` if the unit both not present in `Cargo.toml` and `is_std`.~~ (see https://github.com/rust-lang/cargo/pull/16489#discussion_r2674615151)

This PR ensures that metadata propagation is only allowed between `std->std` crates and `non-std->non-std` crates.

### How to test and review this PR?

```
cargo new foo
cd foo
cargo add cortex-m
cargo -Zbuild-std build
```

Previously we panic with
```
thread 'main' (4072127) panicked at src/cargo/core/compiler/custom_build.rs:472:21:
Dependency `compiler_builtins` not found in `foo`s dependencies
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

with this change we not compile successfully

r? @weihanglo 

