### PR TITLE
Display lockfile path in very verbose mode when blocking

### DIFF
--- a/src/cargo/util/flock.rs
+++ b/src/cargo/util/flock.rs
@@ -418,7 +418,13 @@ fn acquire(
     if try_acquire(path, lock_try)? {
         return Ok(());
     }
-    let msg = format!("waiting for file lock on {}", msg);
+
+    let msg = if gctx.extra_verbose() {
+        format!("waiting for file lock on {} ({})", msg, path.display())
+    } else {
+        format!("waiting for file lock on {}", msg)
+    };
+
     gctx.shell()
         .status_with_color("Blocking", &msg, &style::NOTE)?;
 

--- a/tests/testsuite/concurrent.rs
+++ b/tests/testsuite/concurrent.rs
@@ -575,6 +575,6 @@ fn verbose_file_lock_blocking() {
 
     assert!(a.wait().unwrap().success());
     execs()
-        .with_stderr_contains("[BLOCKING] waiting for file lock on build directory")
+        .with_stderr_contains("[BLOCKING] waiting for file lock on build directory ([ROOT]/foo/target/debug/.cargo-lock)")
         .run_output(&blocked_p_otpt);
 }


### PR DESCRIPTION
### What does this PR try to resolve?

Addresses #15094 

When waiting on a lock, the path to the lockfile is displayed when `-vv` is passed.
```console
tanmay@victus:~/foo$ cargo build -vv
    Blocking waiting for file lock on artifact directory (/home/tanmay/foo/target/debug/.cargo-lock)
```