### PR TITLE
fix: preserve `dep_name` for build script metadata 

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -469,20 +469,10 @@ fn build_work(build_runner: &mut BuildRunner<'_, '_>, unit: &Unit) -> CargoResul
             if dep.unit.mode.is_run_custom_build() {
                 let dep_metadata = build_runner.get_run_build_script_metadata(&dep.unit);
 
-                let Some(dependency) = unit.pkg.dependencies().iter().find(|d| {
-                    d.package_name() == dep.unit.pkg.name()
-                        && d.source_id() == dep.unit.pkg.package_id().source_id()
-                        && d.version_req().matches(dep.unit.pkg.version())
-                }) else {
-                    panic!(
-                        "Dependency `{}` not found in `{}`s dependencies",
-                        dep.unit.pkg.name(),
-                        unit.pkg.name()
-                    )
-                };
+                let dep_name = dep.dep_name.unwrap_or(dep.unit.pkg.name());
 
                 Some((
-                    dependency.name_in_toml(),
+                    dep_name,
                     dep.unit
                         .pkg
                         .manifest()

--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -1005,7 +1005,16 @@ fn connect_run_custom_build_deps(state: &mut State<'_, '_>) {
                     state.unit_dependencies[&other.unit]
                         .iter()
                         .find(|other_dep| other_dep.unit.mode == CompileMode::RunCustomBuild)
-                        .cloned()
+                        .map(|other_dep| {
+                            let mut dep = other_dep.clone();
+                            let dep_name = other.dep_name.unwrap_or(other.unit.pkg.name());
+                            // Propagate the manifest dep name from the sibling edge.
+                            // The RunCustomBuild-RustCustomBuild edge is synthetic
+                            // and doesn't carry a usable dep name, but build script
+                            // metadata needs one for `CARGO_DEP_<dep_name>_*` env var
+                            dep.dep_name = Some(dep_name);
+                            dep
+                        })
                 })
                 .collect::<HashSet<_>>();
 

--- a/src/cargo/core/compiler/unit_graph.rs
+++ b/src/cargo/core/compiler/unit_graph.rs
@@ -26,11 +26,15 @@ pub struct UnitDep {
     pub unit_for: UnitFor,
     /// The name the parent uses to refer to this dependency.
     pub extern_crate_name: InternedString,
-    /// If `Some`, the name of the dependency if renamed in toml.
-    /// It's particularly interesting to artifact dependencies which rely on it
-    /// for naming their environment variables. Note that the `extern_crate_name`
-    /// cannot be used for this as it also may be the build target itself,
-    /// which isn't always the renamed dependency name.
+    /// The dependency name as written in the manifest (including a rename).
+    ///
+    /// `None` means this edge does not carry a manifest dep name. For example,
+    /// std edges in build-std or synthetic edges for build script executions.
+    /// When `None`, the package name is typically used by callers as a fallback.
+    ///
+    /// This is mainly for Cargo-synthesized outputs
+    /// (artifact env vars and `CARGO_DEP_*` metadata env)
+    /// and is distinct from `extern_crate_name`.
     pub dep_name: Option<InternedString>,
     /// Whether or not this is a public dependency.
     pub public: bool,

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -1759,14 +1759,12 @@ fn with_patch() {
         .build();
 
     p.cargo("check")
-        .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
-
-thread 'main' ([..]) panicked at src/cargo/core/compiler/custom_build.rs:[..]
-Dependency `cxx` not found in `foo`s dependencies
-[NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+[COMPILING] cxx v1.0.0 ([ROOT]/foo/cxx)
+[COMPILING] foo v0.0.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

rust-lang/cargo#16493 regressed because we looked up the manifest dependency name by matching SourceId, which fails when `[patch]` changes the source.

This fix ensures the synthetic RunCustomBuild-RunCustomBuild edges carry the manifest dep name, so `CARGO_DEP_*` environment variable uses the correct prefix even with patched sources and renamed dependencies.

### How to test and review this PR?

Run repro in rust-lang/cargo#16493.

Fixes rust-lang/cargo#16493



