### PR TITLE
refactor(timings): reuse timing metric collection logic between `--timings` and `-Zbuild-analysis`

### DIFF
--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -391,7 +391,7 @@ impl<'gctx> JobQueue<'gctx> {
         JobQueue {
             queue: DependencyQueue::new(),
             counts: HashMap::new(),
-            timings: Timings::new(bcx, &bcx.roots),
+            timings: Timings::new(bcx),
         }
     }
 
@@ -974,13 +974,11 @@ impl<'gctx> DrainState<'gctx> {
 
         match is_fresh {
             true => {
-                self.timings.add_fresh();
                 // Running a fresh job on the same thread is often much faster than spawning a new
                 // thread to run the job.
                 doit(Some(&self.diag_dedupe));
             }
             false => {
-                self.timings.add_dirty();
                 scope.spawn(move || doit(None));
             }
         }

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1173,8 +1173,8 @@ fn add_allow_features(build_runner: &BuildRunner<'_, '_>, cmd: &mut ProcessBuild
 ///
 /// [`--error-format`]: https://doc.rust-lang.org/nightly/rustc/command-line-arguments.html#--error-format-control-how-errors-are-produced
 fn add_error_format_and_color(build_runner: &BuildRunner<'_, '_>, cmd: &mut ProcessBuilder) {
-    let enable_timings = build_runner.bcx.gctx.cli_unstable().section_timings
-        && (build_runner.bcx.build_config.timing_report || build_runner.bcx.logger.is_some());
+    let enable_timings =
+        build_runner.bcx.gctx.cli_unstable().section_timings && build_runner.bcx.logger.is_some();
     if enable_timings {
         cmd.arg("-Zunstable-options");
     }

--- a/src/cargo/core/compiler/timings/mod.rs
+++ b/src/cargo/core/compiler/timings/mod.rs
@@ -8,21 +8,19 @@ pub mod report;
 use super::CompileMode;
 use super::Unit;
 use super::UnitIndex;
-use crate::core::PackageId;
 use crate::core::compiler::BuildContext;
 use crate::core::compiler::BuildRunner;
 use crate::core::compiler::job_queue::JobId;
+use crate::ops::cargo_report::timings::prepare_context;
 use crate::util::cpu::State;
 use crate::util::log_message::LogMessage;
 use crate::util::style;
 use crate::util::{CargoResult, GlobalContext};
 
 use cargo_util::paths;
-use indexmap::IndexMap;
 use std::collections::HashMap;
 use std::io::BufWriter;
 use std::time::{Duration, Instant};
-use tracing::warn;
 
 /// Tracking information for the entire build.
 ///
@@ -35,29 +33,15 @@ pub struct Timings<'gctx> {
     gctx: &'gctx GlobalContext,
     /// Whether or not timings should be captured.
     enabled: bool,
-    /// If true, saves an HTML report to disk.
-    report_html: bool,
     /// When Cargo started.
     start: Instant,
-    /// A rendered string of when compilation started.
-    start_str: String,
     /// A summary of the root units.
     ///
-    /// Tuples of `(package_description, target_descriptions)`.
-    root_targets: Vec<(String, Vec<String>)>,
-    /// The build profile.
-    profile: String,
-    /// Total number of fresh units.
-    total_fresh: u32,
-    /// Total number of dirty units.
-    total_dirty: u32,
     /// A map from unit to index.
     unit_to_index: HashMap<Unit, UnitIndex>,
-    /// Time tracking for each individual unit.
-    unit_times: Vec<UnitTime>,
     /// Units that are in the process of being built.
     /// When they finished, they are moved to `unit_times`.
-    active: HashMap<JobId, UnitTime>,
+    active: HashMap<JobId, Unit>,
     /// Last recorded state of the system's CPUs and when it happened
     last_cpu_state: Option<State>,
     last_cpu_recording: Instant,
@@ -74,29 +58,6 @@ pub struct CompilationSection {
     pub start: f64,
     /// End of the section, as an offset in seconds from `UnitTime::start`.
     pub end: Option<f64>,
-}
-
-/// Tracking information for an individual unit.
-struct UnitTime {
-    unit: Unit,
-    /// A string describing the cargo target.
-    target: String,
-    /// The time when this unit started as an offset in seconds from `Timings::start`.
-    start: f64,
-    /// Total time to build this unit in seconds.
-    duration: f64,
-    /// The time when the `.rmeta` file was generated, an offset in seconds
-    /// from `start`.
-    rmeta_time: Option<f64>,
-    /// Reverse deps that are unblocked and ready to run after this unit finishes.
-    unblocked_units: Vec<Unit>,
-    /// Same as `unblocked_units`, but unblocked by rmeta.
-    unblocked_rmeta_units: Vec<Unit>,
-    /// Individual compilation section durations, gathered from `--json=timings`.
-    ///
-    /// IndexMap is used to keep original insertion order, we want to be able to tell which
-    /// sections were started in which order.
-    sections: IndexMap<String, CompilationSection>,
 }
 
 /// Data for a single compilation unit, prepared for serialization to JSON.
@@ -118,24 +79,16 @@ pub struct UnitData {
 }
 
 impl<'gctx> Timings<'gctx> {
-    pub fn new(bcx: &BuildContext<'_, 'gctx>, root_units: &[Unit]) -> Timings<'gctx> {
+    pub fn new(bcx: &BuildContext<'_, 'gctx>) -> Timings<'gctx> {
         let start = bcx.gctx.creation_time();
-        let report_html = bcx.build_config.timing_report;
-        let enabled = report_html | bcx.logger.is_some();
+        let enabled = bcx.logger.is_some();
 
         if !enabled {
             return Timings {
                 gctx: bcx.gctx,
                 enabled,
-                report_html,
                 start,
-                start_str: String::new(),
-                root_targets: Vec::new(),
-                profile: String::new(),
-                total_fresh: 0,
-                total_dirty: 0,
                 unit_to_index: HashMap::new(),
-                unit_times: Vec::new(),
                 active: HashMap::new(),
                 last_cpu_state: None,
                 last_cpu_recording: Instant::now(),
@@ -143,23 +96,6 @@ impl<'gctx> Timings<'gctx> {
             };
         }
 
-        let mut root_map: HashMap<PackageId, Vec<String>> = HashMap::new();
-        for unit in root_units {
-            let target_desc = unit.target.description_named();
-            root_map
-                .entry(unit.pkg.package_id())
-                .or_default()
-                .push(target_desc);
-        }
-        let root_targets = root_map
-            .into_iter()
-            .map(|(pkg_id, targets)| {
-                let pkg_desc = format!("{} {}", pkg_id.name(), pkg_id.version());
-                (pkg_desc, targets)
-            })
-            .collect();
-        let start_str = jiff::Timestamp::now().to_string();
-        let profile = bcx.build_config.requested_profile.to_string();
         let last_cpu_state = match State::current() {
             Ok(state) => Some(state),
             Err(e) => {
@@ -171,15 +107,8 @@ impl<'gctx> Timings<'gctx> {
         Timings {
             gctx: bcx.gctx,
             enabled,
-            report_html,
             start,
-            start_str,
-            root_targets,
-            profile,
-            total_fresh: 0,
-            total_dirty: 0,
             unit_to_index: bcx.unit_to_index.clone(),
-            unit_times: Vec::new(),
             active: HashMap::new(),
             last_cpu_state,
             last_cpu_recording: Instant::now(),
@@ -189,9 +118,9 @@ impl<'gctx> Timings<'gctx> {
 
     /// Mark that a unit has started running.
     pub fn unit_start(&mut self, build_runner: &BuildRunner<'_, '_>, id: JobId, unit: Unit) {
-        if !self.enabled {
+        let Some(logger) = build_runner.bcx.logger else {
             return;
-        }
+        };
         let mut target = if unit.target.is_lib()
             && matches!(unit.mode, CompileMode::Build | CompileMode::Check { .. })
         {
@@ -211,23 +140,12 @@ impl<'gctx> Timings<'gctx> {
             CompileMode::RunCustomBuild => target.push_str(" (run)"),
         }
         let start = self.start.elapsed().as_secs_f64();
-        let unit_time = UnitTime {
-            unit,
-            target,
-            start,
-            duration: 0.0,
-            rmeta_time: None,
-            unblocked_units: Vec::new(),
-            unblocked_rmeta_units: Vec::new(),
-            sections: Default::default(),
-        };
-        if let Some(logger) = build_runner.bcx.logger {
-            logger.log(LogMessage::UnitStarted {
-                index: self.unit_to_index[&unit_time.unit],
-                elapsed: start,
-            });
-        }
-        assert!(self.active.insert(id, unit_time).is_none());
+        logger.log(LogMessage::UnitStarted {
+            index: self.unit_to_index[&unit],
+            elapsed: start,
+        });
+
+        assert!(self.active.insert(id, unit).is_none());
     }
 
     /// Mark that the `.rmeta` file as generated.
@@ -237,30 +155,23 @@ impl<'gctx> Timings<'gctx> {
         id: JobId,
         unblocked: Vec<&Unit>,
     ) {
-        if !self.enabled {
+        let Some(logger) = build_runner.bcx.logger else {
             return;
-        }
+        };
         // `id` may not always be active. "fresh" units unconditionally
         // generate `Message::Finish`, but this active map only tracks dirty
         // units.
-        let Some(unit_time) = self.active.get_mut(&id) else {
+        let Some(unit) = self.active.get(&id) else {
             return;
         };
         let elapsed = self.start.elapsed().as_secs_f64();
-        unit_time.rmeta_time = Some(elapsed - unit_time.start);
-        assert!(unit_time.unblocked_rmeta_units.is_empty());
-        unit_time
-            .unblocked_rmeta_units
-            .extend(unblocked.iter().cloned().cloned());
 
-        if let Some(logger) = build_runner.bcx.logger {
-            let unblocked = unblocked.iter().map(|u| self.unit_to_index[u]).collect();
-            logger.log(LogMessage::UnitRmetaFinished {
-                index: self.unit_to_index[&unit_time.unit],
-                elapsed,
-                unblocked,
-            });
-        }
+        let unblocked = unblocked.iter().map(|u| self.unit_to_index[u]).collect();
+        logger.log(LogMessage::UnitRmetaFinished {
+            index: self.unit_to_index[unit],
+            elapsed,
+            unblocked,
+        });
     }
 
     /// Mark that a unit has finished running.
@@ -270,29 +181,21 @@ impl<'gctx> Timings<'gctx> {
         id: JobId,
         unblocked: Vec<&Unit>,
     ) {
-        if !self.enabled {
+        let Some(logger) = build_runner.bcx.logger else {
             return;
-        }
+        };
         // See note above in `unit_rmeta_finished`, this may not always be active.
-        let Some(mut unit_time) = self.active.remove(&id) else {
+        let Some(unit) = self.active.remove(&id) else {
             return;
         };
         let elapsed = self.start.elapsed().as_secs_f64();
-        unit_time.duration = elapsed - unit_time.start;
-        assert!(unit_time.unblocked_units.is_empty());
-        unit_time
-            .unblocked_units
-            .extend(unblocked.iter().cloned().cloned());
 
-        if let Some(logger) = build_runner.bcx.logger {
-            let unblocked = unblocked.iter().map(|u| self.unit_to_index[u]).collect();
-            logger.log(LogMessage::UnitFinished {
-                index: self.unit_to_index[&unit_time.unit],
-                elapsed,
-                unblocked,
-            });
-        }
-        self.unit_times.push(unit_time);
+        let unblocked = unblocked.iter().map(|u| self.unit_to_index[u]).collect();
+        logger.log(LogMessage::UnitFinished {
+            index: self.unit_to_index[&unit],
+            elapsed,
+            unblocked,
+        });
     }
 
     /// Handle the start/end of a compilation section.
@@ -302,49 +205,28 @@ impl<'gctx> Timings<'gctx> {
         id: JobId,
         section_timing: &SectionTiming,
     ) {
-        if !self.enabled {
+        let Some(logger) = build_runner.bcx.logger else {
             return;
-        }
-        let Some(unit_time) = self.active.get_mut(&id) else {
+        };
+        let Some(unit) = self.active.get(&id) else {
             return;
         };
         let elapsed = self.start.elapsed().as_secs_f64();
 
-        match section_timing.event {
-            SectionTimingEvent::Start => {
-                unit_time.start_section(&section_timing.name, elapsed);
-            }
-            SectionTimingEvent::End => {
-                unit_time.end_section(&section_timing.name, elapsed);
-            }
-        }
-
-        if let Some(logger) = build_runner.bcx.logger {
-            let index = self.unit_to_index[&unit_time.unit];
-            let section = section_timing.name.clone();
-            logger.log(match section_timing.event {
-                SectionTimingEvent::Start => LogMessage::UnitSectionStarted {
-                    index,
-                    elapsed,
-                    section,
-                },
-                SectionTimingEvent::End => LogMessage::UnitSectionFinished {
-                    index,
-                    elapsed,
-                    section,
-                },
-            })
-        }
-    }
-
-    /// Mark that a fresh unit was encountered. (No re-compile needed)
-    pub fn add_fresh(&mut self) {
-        self.total_fresh += 1;
-    }
-
-    /// Mark that a dirty unit was encountered. (Re-compile needed)
-    pub fn add_dirty(&mut self) {
-        self.total_dirty += 1;
+        let index = self.unit_to_index[&unit];
+        let section = section_timing.name.clone();
+        logger.log(match section_timing.event {
+            SectionTimingEvent::Start => LogMessage::UnitSectionStarted {
+                index,
+                elapsed,
+                section,
+            },
+            SectionTimingEvent::End => LogMessage::UnitSectionFinished {
+                index,
+                elapsed,
+                section,
+            },
+        })
     }
 
     /// Take a sample of CPU usage
@@ -380,58 +262,21 @@ impl<'gctx> Timings<'gctx> {
         build_runner: &BuildRunner<'_, '_>,
         error: &Option<anyhow::Error>,
     ) -> CargoResult<()> {
-        if !self.enabled {
-            return Ok(());
-        }
-        self.unit_times
-            .sort_unstable_by(|a, b| a.start.partial_cmp(&b.start).unwrap());
-        if self.report_html {
-            let timestamp = self.start_str.replace(&['-', ':'][..], "");
+        if let Some(logger) = build_runner.bcx.logger
+            && let Some(logs) = logger.get_logs()
+        {
             let timings_path = build_runner
                 .files()
                 .timings_dir()
                 .expect("artifact-dir was not locked");
             paths::create_dir_all(&timings_path)?;
-            let filename = timings_path.join(format!("cargo-timing-{}.html", timestamp));
+            let run_id = logger.run_id();
+            let filename = timings_path.join(format!("cargo-timing-{run_id}.html"));
             let mut f = BufWriter::new(paths::create(&filename)?);
 
-            let rustc_version = build_runner
-                .bcx
-                .rustc()
-                .verbose_version
-                .lines()
-                .next()
-                .expect("rustc version");
-            let requested_targets = build_runner
-                .bcx
-                .build_config
-                .requested_kinds
-                .iter()
-                .map(|kind| build_runner.bcx.target_data.short_name(kind).to_owned())
-                .collect::<Vec<_>>();
-            let num_cpus = std::thread::available_parallelism()
-                .ok()
-                .map(|x| x.get() as u64);
-
-            let unit_data = report::to_unit_data(&self.unit_times, &self.unit_to_index);
-            let concurrency = report::compute_concurrency(&unit_data);
-
-            let ctx = report::RenderContext {
-                start_str: self.start_str.clone(),
-                root_units: self.root_targets.clone(),
-                profile: self.profile.clone(),
-                total_fresh: self.total_fresh,
-                total_dirty: self.total_dirty,
-                unit_data,
-                concurrency,
-                cpu_usage: &self.cpu_usage,
-                rustc_version: rustc_version.into(),
-                host: build_runner.bcx.rustc().host.to_string(),
-                requested_targets,
-                jobs: build_runner.bcx.jobs(),
-                num_cpus,
-                error,
-            };
+            let mut ctx = prepare_context(logs.into_iter(), run_id)?;
+            ctx.error = error;
+            ctx.cpu_usage = &self.cpu_usage;
             report::write_html(ctx, &mut f)?;
 
             let unstamped_filename = timings_path.join("cargo-timing.html");
@@ -444,32 +289,6 @@ impl<'gctx> Timings<'gctx> {
             shell.status_with_color("Timing", msg, &style::NOTE)?;
         }
         Ok(())
-    }
-}
-
-impl UnitTime {
-    fn start_section(&mut self, name: &str, now: f64) {
-        if self
-            .sections
-            .insert(
-                name.to_string(),
-                CompilationSection {
-                    start: now - self.start,
-                    end: None,
-                },
-            )
-            .is_some()
-        {
-            warn!("compilation section {name} started more than once");
-        }
-    }
-
-    fn end_section(&mut self, name: &str, now: f64) {
-        let Some(section) = self.sections.get_mut(name) else {
-            warn!("compilation section {name} ended, but it has no start recorded");
-            return;
-        };
-        section.end = Some(now - self.start);
     }
 }
 

--- a/src/cargo/ops/cargo_compile/mod.rs
+++ b/src/cargo/ops/cargo_compile/mod.rs
@@ -160,7 +160,7 @@ pub fn compile_ws<'a>(
     exec: &Arc<dyn Executor>,
 ) -> CargoResult<Compilation<'a>> {
     let interner = UnitInterner::new();
-    let logger = BuildLogger::maybe_new(ws)?;
+    let logger = BuildLogger::maybe_new(ws, &options.build_config)?;
 
     if let Some(ref logger) = logger {
         let rustc = ws.gctx().load_global_rustc(Some(ws))?;
@@ -311,6 +311,7 @@ pub fn create_bcx<'a, 'gctx>(
         let elapsed = ws.gctx().creation_time().elapsed().as_secs_f64();
         logger.log(LogMessage::ResolutionStarted { elapsed });
     }
+
     let resolve = ops::resolve_ws_with_opts(
         ws,
         &mut target_data,
@@ -530,6 +531,7 @@ pub fn create_bcx<'a, 'gctx>(
         .enumerate()
         .map(|(i, &unit)| (unit.clone(), UnitIndex(i as u64)))
         .collect();
+
     if let Some(logger) = logger {
         let root_unit_indexes: HashSet<_> =
             root_units.iter().map(|unit| unit_to_index[&unit]).collect();

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -67,7 +67,7 @@ mod cargo_package;
 mod cargo_pkgid;
 mod cargo_read_manifest;
 pub mod cargo_remove;
-mod cargo_report;
+pub(crate) mod cargo_report;
 mod cargo_run;
 mod cargo_test;
 mod cargo_uninstall;

--- a/src/cargo/util/log_message.rs
+++ b/src/cargo/util/log_message.rs
@@ -16,7 +16,7 @@ use crate::core::compiler::fingerprint::DirtyReason;
 /// A log message.
 ///
 /// Each variant represents a different type of event.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 #[serde(tag = "reason", rename_all = "kebab-case")]
 pub enum LogMessage {
     /// Emitted when a build starts.
@@ -153,7 +153,7 @@ pub enum LogMessage {
 }
 
 /// Cargo target information.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct Target {
     /// Target name.
     pub name: String,
@@ -162,7 +162,7 @@ pub struct Target {
 }
 
 /// Status of the rebuild detection fingerprint.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub enum FingerprintStatus {
     /// There is no previous fingerprints for this unit.


### PR DESCRIPTION
Close #16474.

## What this PR addresses

As described in the issue above, `cargo build --timings` and `cargo report timings` each had its own metric collection logic. Because `cargo report timings` will supersede `cargo build --timings`, this PR try to remove redundant logics from `core/compiler/timings/mod.rs`.

## Review points

- I'm not sure if it's appropriate to modify logger for refactoring. However, logs emitted inside `core/compiler/timings/mod.rs` alone is not enough for `prepare_context_from_iter()` to properly replay the build so I think this is an appropriate way.
