### PR TITLE
Improve error message for missing dependencies

### DIFF
--- a/src/cargo/util/toml_mut/manifest.rs
+++ b/src/cargo/util/toml_mut/manifest.rs
@@ -681,9 +681,13 @@ fn non_existent_dependency_err(
 ) -> anyhow::Error {
     let mut msg = format!("the dependency `{name}` could not be found in `{search_table}`");
     if let Some(found_table) = found_table {
-        msg.push_str(&format!("; it is present in `{found_table}`",));
+        msg.push_str(&format!(
+            "\n\nhelp: a dependency with the same name exists in `{found_table}`"
+        ));
     } else if let Some(alt_name) = alt_name {
-        msg.push_str(&format!("; dependency `{alt_name}` exists",));
+        msg.push_str(&format!(
+            "\n\nhelp: a dependency with a similar name exists: `{alt_name}`"
+        ));
     }
     anyhow::format_err!(msg)
 }

--- a/tests/testsuite/cargo_remove/invalid_dep/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/invalid_dep/stderr.term.svg
@@ -1,7 +1,7 @@
-<svg width="1104px" height="74px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-green { fill: #55FF55 }
     .fg-bright-red { fill: #FF5555 }
     .container {
@@ -21,9 +21,13 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> invalid_dependency_name from dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: the dependency `invalid_dependency_name` could not be found in `dependencies`; dependency `invalid-dependency-name` exists</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: the dependency `invalid_dependency_name` could not be found in `dependencies`</tspan>
 </tspan>
     <tspan x="10px" y="64px">
+</tspan>
+    <tspan x="10px" y="82px"><tspan>help: a dependency with a similar name exists: `invalid-dependency-name`</tspan>
+</tspan>
+    <tspan x="10px" y="100px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_remove/invalid_section/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/invalid_section/stderr.term.svg
@@ -1,7 +1,7 @@
-<svg width="911px" height="74px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-green { fill: #55FF55 }
     .fg-bright-red { fill: #FF5555 }
     .container {
@@ -21,9 +21,13 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> docopt from build-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: the dependency `docopt` could not be found in `build-dependencies`; it is present in `dependencies`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: the dependency `docopt` could not be found in `build-dependencies`</tspan>
 </tspan>
     <tspan x="10px" y="64px">
+</tspan>
+    <tspan x="10px" y="82px"><tspan>help: a dependency with the same name exists in `dependencies`</tspan>
+</tspan>
+    <tspan x="10px" y="100px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_remove/invalid_section_dep/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/invalid_section_dep/stderr.term.svg
@@ -1,7 +1,7 @@
-<svg width="894px" height="74px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-green { fill: #55FF55 }
     .fg-bright-red { fill: #FF5555 }
     .container {
@@ -21,9 +21,13 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> semver from dev-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: the dependency `semver` could not be found in `dev-dependencies`; it is present in `dependencies`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: the dependency `semver` could not be found in `dev-dependencies`</tspan>
 </tspan>
     <tspan x="10px" y="64px">
+</tspan>
+    <tspan x="10px" y="82px"><tspan>help: a dependency with the same name exists in `dependencies`</tspan>
+</tspan>
+    <tspan x="10px" y="100px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_remove/invalid_target/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/invalid_target/stderr.term.svg
@@ -1,7 +1,7 @@
-<svg width="1373px" height="74px" xmlns="http://www.w3.org/2000/svg">
+<svg width="844px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-green { fill: #55FF55 }
     .fg-bright-red { fill: #FF5555 }
     .container {
@@ -21,9 +21,13 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> dbus from dependencies for target `powerpc-unknown-linux-gnu`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: the dependency `dbus` could not be found in `target.powerpc-unknown-linux-gnu.dependencies`; it is present in `target.wasm32-unknown-unknown.dependencies`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: the dependency `dbus` could not be found in `target.powerpc-unknown-linux-gnu.dependencies`</tspan>
 </tspan>
     <tspan x="10px" y="64px">
+</tspan>
+    <tspan x="10px" y="82px"><tspan>help: a dependency with the same name exists in `target.wasm32-unknown-unknown.dependencies`</tspan>
+</tspan>
+    <tspan x="10px" y="100px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_remove/invalid_target_dep/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/invalid_target_dep/stderr.term.svg
@@ -1,7 +1,7 @@
-<svg width="1096px" height="74px" xmlns="http://www.w3.org/2000/svg">
+<svg width="818px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-green { fill: #55FF55 }
     .fg-bright-red { fill: #FF5555 }
     .container {
@@ -21,9 +21,13 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> toml from dependencies for target `wasm32-unknown-unknown`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: the dependency `toml` could not be found in `target.wasm32-unknown-unknown.dependencies`; it is present in `dependencies`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: the dependency `toml` could not be found in `target.wasm32-unknown-unknown.dependencies`</tspan>
 </tspan>
     <tspan x="10px" y="64px">
+</tspan>
+    <tspan x="10px" y="82px"><tspan>help: a dependency with the same name exists in `dependencies`</tspan>
+</tspan>
+    <tspan x="10px" y="100px">
 </tspan>
   </text>
 


### PR DESCRIPTION
Resolves #16499

This diff uses rustc-style diagnostics with `help:` lines instead of inline semicolon-separated messages when a dependency cannot be found.

Before:
```
  error: the dependency `fo` could not be found in `dependencies`; dependency `foo` exists
```

After:
```
  error: the dependency `fo` could not be found in `dependencies`

  help: a dependency with a similar name exists: `foo`
```

r? @weihanglo