### PR TITLE
Helpful error when the [package] table is missing

### DIFF
--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -2296,7 +2296,6 @@ fn ws_err_unused() {
         "[badges]",
         "[lints]",
     ] {
-        let key = table.trim_start_matches('[').trim_end_matches(']');
         let p = project()
             .file(
                 "Cargo.toml",
@@ -2319,7 +2318,7 @@ fn ws_err_unused() {
 [ERROR] failed to parse manifest at `[..]/foo/Cargo.toml`
 
 Caused by:
-  this virtual manifest specifies a `{key}` section, which is not allowed
+  this virtual manifest does not have a `[package]` section, which is required when specifying the `{table}` section
 ",
             ))
             .run();


### PR DESCRIPTION
### What does this PR try to resolve?

Makes an error message more helpful to novice users who may encounter it when writing `Cargo.toml` for the first time. The previous wording expected users to know what a "virtual manifest" and did not provide any further hints.

### How to test and review this PR?

Updated unit tests demonstrate it.