### PR TITLE
iTerm now supports OSC 9;4 (terminal window progress bar)

### DIFF
--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -640,8 +640,9 @@ fn supports_term_integration(stream: &dyn IsTerminal) -> bool {
     let conemu = std::env::var("ConEmuANSI").ok() == Some("ON".into());
     let wezterm = std::env::var("TERM_PROGRAM").ok() == Some("WezTerm".into());
     let ghostty = std::env::var("TERM_PROGRAM").ok() == Some("ghostty".into());
+    let iterm = std::env::var("TERM_PROGRAM").ok() == Some("iTerm.app".into());
 
-    (windows_terminal || conemu || wezterm || ghostty) && stream.is_terminal()
+    (windows_terminal || conemu || wezterm || ghostty || iterm) && stream.is_terminal()
 }
 
 pub struct Hyperlink<D: fmt::Display> {

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -640,9 +640,59 @@ fn supports_term_integration(stream: &dyn IsTerminal) -> bool {
     let conemu = std::env::var("ConEmuANSI").ok() == Some("ON".into());
     let wezterm = std::env::var("TERM_PROGRAM").ok() == Some("WezTerm".into());
     let ghostty = std::env::var("TERM_PROGRAM").ok() == Some("ghostty".into());
-    let iterm = std::env::var("TERM_PROGRAM").ok() == Some("iTerm.app".into());
+    // iTerm added OSC 9;4 support in v3.6.6, which we can check for.
+    // See https://github.com/rust-lang/cargo/pull/16506#discussion_r2706584034 for reference.
+    let iterm = term_features_has_progress();
 
     (windows_terminal || conemu || wezterm || ghostty || iterm) && stream.is_terminal()
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "reading the state of the system, not config"
+)]
+// For iTerm, the TERM_FEATURES value "P" indicates OSC 9;4 support.
+// See https://iterm2.com/feature-reporting/ for reference.
+fn term_features_has_progress() -> bool {
+    let Ok(value) = std::env::var("TERM_FEATURES") else {
+        return false;
+    };
+
+    let mut current = String::new();
+
+    for ch in value.chars() {
+        if !ch.is_ascii_alphanumeric() {
+            break;
+        }
+        if ch.is_ascii_uppercase() {
+            if current == "P" {
+                return true;
+            }
+            current.clear();
+            current.push(ch);
+        } else {
+            current.push(ch);
+        }
+    }
+    current == "P"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::term_features_has_progress;
+
+    #[test]
+    fn term_features_progress_detection() {
+        // With PROGRESS feature ("P")
+        unsafe { std::env::set_var("TERM_FEATURES", "MBT2ScP") };
+        assert!(term_features_has_progress());
+
+        // Without PROGRESS feature
+        unsafe { std::env::set_var("TERM_FEATURES", "MBT2Sc") };
+        assert!(!term_features_has_progress());
+
+        unsafe { std::env::remove_var("TERM_FEATURES") };
+    }
 }
 
 pub struct Hyperlink<D: fmt::Display> {


### PR DESCRIPTION
### What does this PR try to resolve?

Per the iTerm [version 3.6.6 release](https://iterm2.com/downloads.html) - "Add support for OSC 9;4 progress bars"

I added iTerm to `nextest` [here](https://github.com/nextest-rs/nextest/pull/2927) and they suggested I add it to Cargo as well. 

### How to test and review this PR?

I've test this locally, but it isn't really a unit test or integration test candidate.

Here's the output from my local iTerm console:

```shell
$ echo $TERM_PROGRAM
iTerm.app
```
