### PR TITLE
fix(git): avoid partial oid got zero padded

### DIFF
--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -1007,7 +1007,7 @@ pub fn fetch(
                 fast_path_rev = true;
                 refspecs.push(format!("+{0}:refs/commit/{0}", oid_to_fetch));
             } else if !matches!(shallow, gix::remote::fetch::Shallow::NoChange)
-                && rev.parse::<Oid>().is_ok()
+                && rev_to_oid(rev).is_some()
             {
                 // There is a specific commit to fetch and we will do so in shallow-mode only
                 // to not disturb the previous logic.

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -1569,8 +1569,10 @@ fn github_fast_path(
     if response_code == 304 {
         debug!("github fast path up-to-date");
         Ok(FastPathRev::UpToDate)
-    } else if response_code == 200 {
-        let oid_to_fetch = str::from_utf8(&response_body)?.parse::<Oid>()?;
+    } else if response_code == 200
+        && let Some(oid_to_fetch) = rev_to_oid(str::from_utf8(&response_body)?)
+    {
+        // response expected to be a full hash hexstring (40 or 64 chars)
         debug!("github fast path fetch {oid_to_fetch}");
         Ok(FastPathRev::NeedsFetch(oid_to_fetch))
     } else {


### PR DESCRIPTION
### What does this PR try to resolve?

There is no actual regression regarding these.
I found them when working SHA256 support and got paranoid on them.
They at least makes future integration easier (`Oid::from_str` might be removed).

### How to test and review this PR?