### PR TITLE
Invalidate the whole build cache when `-Zno-embed-metadata` changes

### DIFF
--- a/src/cargo/core/compiler/fingerprint/mod.rs
+++ b/src/cargo/core/compiler/fingerprint/mod.rs
@@ -1646,6 +1646,15 @@ fn calculate_normal(
     if let Some(allow_features) = &build_runner.bcx.gctx.cli_unstable().allow_features {
         allow_features.hash(&mut config);
     }
+    // -Zno-embed-metadata changes how all units are compiled, and it also changes how we tell
+    // rustc to link to deps using `--extern`. If it changes, we should rebuild everything.
+    build_runner
+        .bcx
+        .gctx
+        .cli_unstable()
+        .no_embed_metadata
+        .hash(&mut config);
+
     let compile_kind = unit.kind.fingerprint_hash();
     let mut declared_features = unit.pkg.summary().features().keys().collect::<Vec<_>>();
     declared_features.sort(); // to avoid useless rebuild if the user orders it's features


### PR DESCRIPTION
I mixed the `-Zno-embed-metadata` value into the general config hash, because the flag does complicated stuff (pass rustc flag, but also change how dependencies are passed to rustc).

Fixes: https://github.com/rust-lang/cargo/issues/16503
