### PR TITLE
Do not create examples dir in build dir with new layout

### DIFF
--- a/src/cargo/core/compiler/layout.rs
+++ b/src/cargo/core/compiler/layout.rs
@@ -314,9 +314,9 @@ impl BuildDirLayout {
         if !self.is_new_layout {
             paths::create_dir_all(&self.deps)?;
             paths::create_dir_all(&self.fingerprint)?;
+            paths::create_dir_all(&self.examples)?;
         }
         paths::create_dir_all(&self.incremental)?;
-        paths::create_dir_all(&self.examples)?;
         paths::create_dir_all(&self.build)?;
 
         Ok(())

--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -412,7 +412,7 @@ fn examples_should_output_to_build_dir_and_uplift_to_target_dir() {
 
 "#]]);
 
-    assert!(p.root().join("build-dir/debug/examples").exists());
+    assert!(!p.root().join("build-dir/debug/examples").exists());
 
     p.root()
         .join("target-dir")


### PR DESCRIPTION
### What does this PR try to resolve?

While documenting the `build-dir` layout changes in https://github.com/rust-lang/cargo/pull/16502 I noticed that we are still creating the `<build-dir>/<profile>/examples` directory when `-Zbuild-dir-new-layout` is passed even though its no longer used.
This PR fixes it

cc tracking issue: #15010


### How to test and review this PR?

Updating the existing examples test to catch this particular case

r? @epage 
