### PR TITLE
Implictly enable -Zbuild-dir-new-layout when -Zrustdoc-mergeable-info

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -1531,6 +1531,10 @@ impl CliUnstable {
             debug!("-Zbuild-dir-new-layout implicitly enabled by -Zfine-grain-locking");
             self.build_dir_new_layout = true;
         }
+        if self.rustdoc_mergeable_info && !self.build_dir_new_layout {
+            debug!("-Zrustdoc-mergeable-info implicitly enabled by -Zfine-grain-locking");
+            self.build_dir_new_layout = true;
+        }
     }
 }
 

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -3249,13 +3249,13 @@ fn mergeable_info_with_deps() {
 [LOCKING] 1 package to latest compatible version
 [DOCUMENTING] dep v0.0.0 ([ROOT]/foo/dep)
 [CHECKING] dep v0.0.0 ([ROOT]/foo/dep)
-[RUNNING] `rustdoc [..]--crate-name dep [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/deps [..]`
+[RUNNING] `rustdoc [..]--crate-name dep [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/deps [..]`
 [RUNNING] `rustc --crate-name dep [..]`
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/deps[..]`
+[RUNNING] `rustdoc [..]--crate-name foo [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/deps[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 2 docs for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/deps --include-parts-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/deps`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/deps --include-parts-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/deps`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 
@@ -3265,16 +3265,16 @@ fn mergeable_info_with_deps() {
 
     assert!(p.root().join("target/doc/foo/index.html").is_file());
     assert!(p.root().join("target/doc/dep/index.html").is_file());
-    assert_eq!(p.glob("target/debug/build/foo-*/deps/foo.json").count(), 1);
-    assert_eq!(p.glob("target/debug/build/dep-*/deps/dep.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/foo/*/deps/foo.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/dep/*/deps/dep.json").count(), 1);
 
     assert_e2e().eq(
         fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/dep-[HASH]/deps/dep.json",
-    "debug/build/foo-[HASH]/deps/foo.json"
+    "debug/build/dep/[HASH]/deps/dep.json",
+    "debug/build/foo/[HASH]/deps/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3310,10 +3310,10 @@ fn mergeable_info_no_deps() {
 [CHECKING] dep v0.0.0 ([ROOT]/foo/dep)
 [RUNNING] `rustc --crate-name dep --edition=2015 [..]`
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/deps [..]`
+[RUNNING] `rustdoc [..]--crate-name foo [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/deps [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/deps`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/deps`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 
@@ -3323,15 +3323,15 @@ fn mergeable_info_no_deps() {
 
     assert!(p.root().join("target/doc/foo/index.html").is_file());
     assert!(!p.root().join("target/doc/dep/index.html").is_file());
-    assert_eq!(p.glob("target/debug/build/foo-*/deps/foo.json").count(), 1);
-    assert_eq!(p.glob("target/debug/build/dep-*/deps/dep.json").count(), 0);
+    assert_eq!(p.glob("target/debug/build/foo/*/deps/foo.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/dep/*/deps/dep.json").count(), 0);
 
     assert_e2e().eq(
         fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/foo-[HASH]/deps/foo.json"
+    "debug/build/foo/[HASH]/deps/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3376,14 +3376,14 @@ fn mergeable_info_workspace() {
 [DOCUMENTING] dep v0.0.0 ([ROOT]/foo/dep)
 [CHECKING] dep v0.0.0 ([ROOT]/foo/dep)
 [DOCUMENTING] bar v0.0.0 ([ROOT]/foo/bar)
-[RUNNING] `rustdoc [..]--crate-name dep [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/deps [..]`
-[RUNNING] `rustdoc [..]--crate-name bar [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/bar-[HASH]/deps [..]`
+[RUNNING] `rustdoc [..]--crate-name dep [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/deps [..]`
+[RUNNING] `rustdoc [..]--crate-name bar [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/bar/[HASH]/deps [..]`
 [RUNNING] `rustc --crate-name dep [..]`
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/deps [..]`
+[RUNNING] `rustdoc [..]--crate-name foo [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/deps [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 3 docs for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/bar-[HASH]/deps --include-parts-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/deps --include-parts-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/deps`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/bar/[HASH]/deps --include-parts-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/deps --include-parts-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/deps`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/bar/index.html
 [GENERATED] [ROOT]/foo/target/doc/dep/index.html
@@ -3396,18 +3396,18 @@ fn mergeable_info_workspace() {
     assert!(p.root().join("target/doc/foo/index.html").is_file());
     assert!(p.root().join("target/doc/bar/index.html").is_file());
     assert!(p.root().join("target/doc/dep/index.html").is_file());
-    assert_eq!(p.glob("target/debug/build/foo-*/deps/foo.json").count(), 1);
-    assert_eq!(p.glob("target/debug/build/bar-*/deps/bar.json").count(), 1);
-    assert_eq!(p.glob("target/debug/build/dep-*/deps/dep.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/foo/*/deps/foo.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/bar/*/deps/bar.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/dep/*/deps/dep.json").count(), 1);
 
     assert_e2e().eq(
         fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/bar-[HASH]/deps/bar.json",
-    "debug/build/dep-[HASH]/deps/dep.json",
-    "debug/build/foo-[HASH]/deps/foo.json"
+    "debug/build/bar/[HASH]/deps/bar.json",
+    "debug/build/dep/[HASH]/deps/dep.json",
+    "debug/build/foo/[HASH]/deps/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3443,13 +3443,13 @@ fn mergeable_info_multi_targets() {
         .with_stderr_data(
             str![[r#"
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo src/lib.rs --target [HOST_TARGET] [..]--merge=none --parts-out-dir=[ROOT]/foo/target/[HOST_TARGET]/debug/build/foo-[HASH]/deps [..]`
-[RUNNING] `rustdoc [..]--crate-name foo src/lib.rs --target [ALT_TARGET] [..]--merge=none --parts-out-dir=[ROOT]/foo/target/[ALT_TARGET]/debug/build/foo-[HASH]/deps [..]`
+[RUNNING] `rustdoc [..]--crate-name foo src/lib.rs --target [HOST_TARGET] [..]--merge=none --parts-out-dir=[ROOT]/foo/target/[HOST_TARGET]/debug/build/foo/[HASH]/deps [..]`
+[RUNNING] `rustdoc [..]--crate-name foo src/lib.rs --target [ALT_TARGET] [..]--merge=none --parts-out-dir=[ROOT]/foo/target/[ALT_TARGET]/debug/build/foo/[HASH]/deps [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for [ALT_TARGET]
-[RUNNING] `rustdoc -o [ROOT]/foo/target/[ALT_TARGET]/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/[ALT_TARGET]/debug/build/foo-[HASH]/deps`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/[ALT_TARGET]/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/[ALT_TARGET]/debug/build/foo/[HASH]/deps`
 [MERGING] 1 doc for [HOST_TARGET]
-[RUNNING] `rustdoc -o [ROOT]/foo/target/[HOST_TARGET]/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/[HOST_TARGET]/debug/build/foo-[HASH]/deps`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/[HOST_TARGET]/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/[HOST_TARGET]/debug/build/foo/[HASH]/deps`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/[HOST_TARGET]/doc/foo/index.html
 [GENERATED] [ROOT]/foo/target/[ALT_TARGET]/doc/foo/index.html
@@ -3464,9 +3464,9 @@ fn mergeable_info_multi_targets() {
     assert!(p.root().join(path).is_file());
     let path = format!("target/{target}/doc/foo/index.html");
     assert!(p.root().join(path).is_file());
-    let path = format!("target/{host}/debug/build/foo-*/deps/foo.json");
+    let path = format!("target/{host}/debug/build/foo/*/deps/foo.json");
     assert_eq!(p.glob(path).count(), 1);
-    let path = format!("target/{target}/debug/build/foo-*/deps/foo.json");
+    let path = format!("target/{target}/debug/build/foo/*/deps/foo.json");
     assert_eq!(p.glob(path).count(), 1);
 
     assert_e2e().eq(
@@ -3474,7 +3474,7 @@ fn mergeable_info_multi_targets() {
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/foo-[HASH]/deps/foo.json"
+    "debug/build/foo/[HASH]/deps/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3487,7 +3487,7 @@ fn mergeable_info_multi_targets() {
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/foo-[HASH]/deps/foo.json"
+    "debug/build/foo/[HASH]/deps/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3515,10 +3515,10 @@ fn mergeable_info_rebuild_detection() {
         .with_stderr_data(
             str![[r#"
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/deps [..]`
+[RUNNING] `rustdoc [..]--crate-name foo [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/deps [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/deps`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/deps`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 
@@ -3527,14 +3527,14 @@ fn mergeable_info_rebuild_detection() {
         .run();
 
     assert!(p.root().join("target/doc/foo/index.html").is_file());
-    assert_eq!(p.glob("target/debug/build/foo-*/deps/foo.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/foo/*/deps/foo.json").count(), 1);
 
     assert_e2e().eq(
         fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/foo-[HASH]/deps/foo.json"
+    "debug/build/foo/[HASH]/deps/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3561,7 +3561,7 @@ fn mergeable_info_rebuild_detection() {
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/foo-[HASH]/deps/foo.json"
+    "debug/build/foo/[HASH]/deps/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3579,10 +3579,10 @@ fn mergeable_info_rebuild_detection() {
             str![[r#"
 [DIRTY] foo v0.0.0 ([ROOT]/foo): the precalculated components changed
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/deps [..]`
+[RUNNING] `rustdoc [..]--crate-name foo [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/deps [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/deps`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/deps`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 
@@ -3622,7 +3622,7 @@ fn mergeable_info_rebuild_detection() {
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/foo-[HASH]/deps/foo.json"
+    "debug/build/foo/[HASH]/deps/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3653,10 +3653,10 @@ fn mergeable_info_rebuild_with_depinfo() {
         .with_stderr_data(
             str![[r#"
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--emit=invocation-specific,dep-info=[..] --merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/deps [..]`
+[RUNNING] `rustdoc [..]--crate-name foo [..]--emit=invocation-specific,dep-info=[..] --merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/deps [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/deps`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/deps`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 
@@ -3665,14 +3665,14 @@ fn mergeable_info_rebuild_with_depinfo() {
         .run();
 
     assert!(p.root().join("target/doc/foo/index.html").is_file());
-    assert_eq!(p.glob("target/debug/build/foo-*/deps/foo.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/foo/*/deps/foo.json").count(), 1);
 
     assert_e2e().eq(
         fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/foo-[HASH]/deps/foo.json"
+    "debug/build/foo/[HASH]/deps/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3699,7 +3699,7 @@ fn mergeable_info_rebuild_with_depinfo() {
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/foo-[HASH]/deps/foo.json"
+    "debug/build/foo/[HASH]/deps/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3717,10 +3717,10 @@ fn mergeable_info_rebuild_with_depinfo() {
             str![[r#"
 [DIRTY] foo v0.0.0 ([ROOT]/foo): the file `src/lib.rs` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--emit=invocation-specific,dep-info=[..] --merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/deps [..]`
+[RUNNING] `rustdoc [..]--crate-name foo [..]--emit=invocation-specific,dep-info=[..] --merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/deps [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/deps`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/deps`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 
@@ -3760,7 +3760,7 @@ fn mergeable_info_rebuild_with_depinfo() {
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/foo-[HASH]/deps/foo.json"
+    "debug/build/foo/[HASH]/deps/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3805,10 +3805,10 @@ fn mergeable_info_additive() {
 [CHECKING] dep v0.0.0 ([ROOT]/foo/dep)
 [RUNNING] `rustc --crate-name dep [..]`
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/deps [..]`
+[RUNNING] `rustdoc [..]--crate-name foo [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/deps [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/deps`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/deps`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 
@@ -3819,16 +3819,16 @@ fn mergeable_info_additive() {
     assert!(p.root().join("target/doc/foo/index.html").is_file());
     assert!(!p.root().join("target/doc/bar/index.html").is_file());
     assert!(!p.root().join("target/doc/dep/index.html").is_file());
-    assert_eq!(p.glob("target/debug/build/foo-*/deps/foo.json").count(), 1);
-    assert_eq!(p.glob("target/debug/build/bar-*/deps/bar.json").count(), 0);
-    assert_eq!(p.glob("target/debug/build/dep-*/deps/dep.json").count(), 0);
+    assert_eq!(p.glob("target/debug/build/foo/*/deps/foo.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/bar/*/deps/bar.json").count(), 0);
+    assert_eq!(p.glob("target/debug/build/dep/*/deps/dep.json").count(), 0);
 
     assert_e2e().eq(
         fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/foo-[HASH]/deps/foo.json"
+    "debug/build/foo/[HASH]/deps/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3841,10 +3841,10 @@ fn mergeable_info_additive() {
         .with_stderr_data(
             str![[r#"
 [DOCUMENTING] dep v0.0.0 ([ROOT]/foo/dep)
-[RUNNING] `rustdoc [..]--crate-name dep [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/deps [..]`
+[RUNNING] `rustdoc [..]--crate-name dep [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/deps [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 2 docs for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/deps --include-parts-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/deps`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/deps --include-parts-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/deps`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/dep/index.html
 
@@ -3855,17 +3855,17 @@ fn mergeable_info_additive() {
     assert!(p.root().join("target/doc/foo/index.html").is_file());
     assert!(!p.root().join("target/doc/bar/index.html").is_file());
     assert!(p.root().join("target/doc/dep/index.html").is_file());
-    assert_eq!(p.glob("target/debug/build/foo-*/deps/foo.json").count(), 1);
-    assert_eq!(p.glob("target/debug/build/bar-*/deps/bar.json").count(), 0);
-    assert_eq!(p.glob("target/debug/build/dep-*/deps/dep.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/foo/*/deps/foo.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/bar/*/deps/bar.json").count(), 0);
+    assert_eq!(p.glob("target/debug/build/dep/*/deps/dep.json").count(), 1);
 
     assert_e2e().eq(
         fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/dep-[HASH]/deps/dep.json",
-    "debug/build/foo-[HASH]/deps/foo.json"
+    "debug/build/dep/[HASH]/deps/dep.json",
+    "debug/build/foo/[HASH]/deps/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3878,10 +3878,10 @@ fn mergeable_info_additive() {
         .with_stderr_data(
             str![[r#"
 [DOCUMENTING] bar v0.0.0 ([ROOT]/foo/bar)
-[RUNNING] `rustdoc [..]--crate-name bar [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/bar-[HASH]/deps [..]`
+[RUNNING] `rustdoc [..]--crate-name bar [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/bar/[HASH]/deps [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 3 docs for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/bar-[HASH]/deps --include-parts-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/deps --include-parts-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/deps`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/bar/[HASH]/deps --include-parts-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/deps --include-parts-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/deps`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/bar/index.html
 
@@ -3892,18 +3892,18 @@ fn mergeable_info_additive() {
     assert!(p.root().join("target/doc/foo/index.html").is_file());
     assert!(p.root().join("target/doc/bar/index.html").is_file());
     assert!(p.root().join("target/doc/dep/index.html").is_file());
-    assert_eq!(p.glob("target/debug/build/foo-*/deps/foo.json").count(), 1);
-    assert_eq!(p.glob("target/debug/build/bar-*/deps/bar.json").count(), 1);
-    assert_eq!(p.glob("target/debug/build/dep-*/deps/dep.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/foo/*/deps/foo.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/bar/*/deps/bar.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/dep/*/deps/dep.json").count(), 1);
 
     assert_e2e().eq(
         fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/bar-[HASH]/deps/bar.json",
-    "debug/build/dep-[HASH]/deps/dep.json",
-    "debug/build/foo-[HASH]/deps/foo.json"
+    "debug/build/bar/[HASH]/deps/bar.json",
+    "debug/build/dep/[HASH]/deps/dep.json",
+    "debug/build/foo/[HASH]/deps/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3954,10 +3954,10 @@ fn mergeable_info_dep_collision() {
 [DOWNLOADED] dep v0.2.0 (registry `dummy-registry`)
 [DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)
 [DOCUMENTING] dep v0.1.0
-[RUNNING] `rustdoc [..]--crate-name dep [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/deps [..]--crate-version 0.1.0`
+[RUNNING] `rustdoc [..]--crate-name dep [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/deps [..]--crate-version 0.1.0`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/deps`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/deps`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/dep/index.html
 
@@ -3966,7 +3966,7 @@ fn mergeable_info_dep_collision() {
         .run();
 
     assert!(p.root().join("target/doc/dep/index.html").is_file());
-    assert_eq!(p.glob("target/debug/build/dep-*/deps/dep.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/dep/*/deps/dep.json").count(), 1);
 
     // See `fn dep010()`
     assert!(p.build_dir().join("doc/dep/fn.dep010.html").exists());
@@ -3979,7 +3979,7 @@ fn mergeable_info_dep_collision() {
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/dep-[HASH]/deps/dep.json"
+    "debug/build/dep/[HASH]/deps/dep.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3993,10 +3993,10 @@ fn mergeable_info_dep_collision() {
         .with_stderr_data(
             str![[r#"
 [DOCUMENTING] dep v0.2.0
-[RUNNING] `rustdoc [..]--crate-name dep [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/deps [..]--crate-version 0.2.0`
+[RUNNING] `rustdoc [..]--crate-name dep [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/deps [..]--crate-version 0.2.0`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/deps`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/deps`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/dep/index.html
 
@@ -4006,7 +4006,7 @@ fn mergeable_info_dep_collision() {
 
     assert!(p.root().join("target/doc/dep/index.html").is_file());
     // We'll have two dep.json
-    assert_eq!(p.glob("target/debug/build/dep-*/deps/dep.json").count(), 2);
+    assert_eq!(p.glob("target/debug/build/dep/*/deps/dep.json").count(), 2);
 
     // ...but only the selected dep@0.2.0 would be merged
     assert!(!p.build_dir().join("doc/dep/fn.dep010.html").exists());
@@ -4019,7 +4019,7 @@ fn mergeable_info_dep_collision() {
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/dep-[HASH]/deps/dep.json"
+    "debug/build/dep/[HASH]/deps/dep.json"
   ],
   "rustc_vv": "{...}"
 }


### PR DESCRIPTION
### What does this PR try to resolve?

Originally reported in: https://github.com/rust-lang/cargo/issues/16306#issuecomment-3764979388

`-Zrustdoc-mergeable-info` only supports the new build-dir layout. Currently just passing `-Zrustdoc-mergeable-info` alone will use the new layout while the rest of the build uses the old layout.

This commit changes the the behavior to implictly enable `-Zbuild-dir-new-layout` when `-Zrustdoc-mergable-info` is enabled.

Note that paths in the tests have also changed from `foo-[HASH]` to `foo/[HASH]`. 
The previous behavior of `<build-dir>/<profile>/build/foo-[HASH]/deps` was incorrect and not valid for both new and old layouts.

tracking issue: https://github.com/rust-lang/cargo/issues/16306

### How to test and review this PR?

See the updated tests

r? @weihanglo 

