### PR TITLE
fix: show implicit_minimum_version_req emitted source once per package

### DIFF
--- a/src/cargo/lints/rules/implicit_minimum_version_req.rs
+++ b/src/cargo/lints/rules/implicit_minimum_version_req.rs
@@ -126,6 +126,7 @@ pub fn lint_package(
     let contents = manifest.contents();
     let target_key_for_platform = target_key_for_platform(&manifest);
 
+    let mut emit_source = true;
     for dep in manifest.dependencies().iter() {
         let version_req = dep.version_req();
         let Some(suggested_req) = get_suggested_version_req(&version_req) else {
@@ -148,9 +149,14 @@ pub fn lint_package(
             key_path,
             &manifest_path,
             &suggested_req,
+            emit_source,
         ) else {
             continue;
         };
+
+        if emit_source {
+            emit_source = false;
+        }
 
         if lint_level.is_error() {
             *error_count += 1;
@@ -198,6 +204,7 @@ pub fn lint_workspace(
             (name, req)
         });
 
+    let mut emit_source = true;
     for (name_in_toml, version_req) in dep_iter {
         let Some(suggested_req) = get_suggested_version_req(&version_req) else {
             continue;
@@ -213,9 +220,14 @@ pub fn lint_workspace(
             &key_path,
             &manifest_path,
             &suggested_req,
+            emit_source,
         ) else {
             continue;
         };
+
+        if emit_source {
+            emit_source = false;
+        }
 
         if lint_level.is_error() {
             *error_count += 1;
@@ -256,6 +268,7 @@ fn report<'a>(
     key_path: &[&str],
     manifest_path: &str,
     suggested_req: &str,
+    emit_source: bool,
 ) -> Option<[Group<'a>; 2]> {
     let level = lint_level.to_diagnostic_level();
     let emitted_source = LINT.emitted_source(lint_level, reason);
@@ -272,18 +285,19 @@ fn report<'a>(
         let Some(span) = span_of_version_req(document, key_path) else {
             return None;
         };
-        desc = desc
-            .element(
-                Snippet::source(contents)
-                    .path(manifest_path.to_owned())
-                    .annotation(AnnotationKind::Primary.span(span.clone()).label(label)),
-            )
-            .element(Level::NOTE.message(emitted_source));
+        desc = desc.element(
+            Snippet::source(contents)
+                .path(manifest_path.to_owned())
+                .annotation(AnnotationKind::Primary.span(span.clone()).label(label)),
+        );
+
         help = help.element(Snippet::source(contents).patch(Patch::new(span.clone(), replacement)));
     } else {
-        desc = desc
-            .element(Origin::path(manifest_path.to_owned()))
-            .element(Level::NOTE.message(emitted_source));
+        desc = desc.element(Origin::path(manifest_path.to_owned()));
+    }
+
+    if emit_source {
+        desc = desc.element(Level::NOTE.message(emitted_source));
     }
 
     Some([desc, help])

--- a/tests/testsuite/lints/implicit_minimum_version_req.rs
+++ b/tests/testsuite/lints/implicit_minimum_version_req.rs
@@ -968,7 +968,6 @@ implicit_minimum_version_req = "warn"
 8 | regex = "1.0"
   |         ^^^^^ missing full version components
   |
-  = [NOTE] `cargo::implicit_minimum_version_req` is set to `warn` in `[lints]`
 [HELP] consider specifying full `major.minor.patch` version components
   |
 8 | regex = "1.0.0"


### PR DESCRIPTION
## What does this PR try to resolve?

This follows the diagnostic style of other lints.
For example, this one:

https://github.com/rust-lang/cargo/blob/441c07d/src/cargo/lints/rules/non_kebab_case_bin.rs#L135-L137