### PR TITLE
test(build-std): adjust snapshot

### DIFF
--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -165,9 +165,8 @@ fn basic() {
         .build_std_isolated()
         .target_host()
         .with_stderr_data(str![[r#"
-[COMPILING] [..]
-...
 [COMPILING] test v0.0.0 ([..])
+...
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] unittests src/lib.rs (target/[HOST_TARGET]/debug/deps/foo-[HASH])


### PR DESCRIPTION
### What does this PR try to resolve?

rust-lang/rust#149514 added a build.rs to libtest,
which affected how Cargo print status message
(build.rs was scheduled first because it has one dependent)


### How to test and review this PR?

See <https://github.com/rust-lang/cargo/actions/runs/21232930264/job/61094884597?pr=16506>

```
thread 'basic' (9963) panicked at tests/build-std/main.rs:179:10:

---- expected: tests/build-std/main.rs:167:27
++++ actual:   stderr
   1    1 | [COMPILING] [..]
   2      - ...
   3      - [COMPILING] test v0.0.0 ([..])
        2 + [COMPILING] rustc-std-workspace-std v1.99.0 (/home/runner/.rustup/toolchains/nightly-[HOST_TARGET]/lib/rustlib/src/rust/library/rustc-std-workspace-std)
        3 + [COMPILING] getopts v0.2.24
   4    4 | [COMPILING] foo v0.0.1 ([ROOT]/foo)
   5    5 | [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
   6    6 | [RUNNING] unittests src/lib.rs (target/[HOST_TARGET]/debug/deps/foo-[HASH])
   7    7 | [RUNNING] unittests src/main.rs (target/[HOST_TARGET]/debug/deps/foo-[HASH])
   8    8 | [RUNNING] tests/smoke.rs (target/[HOST_TARGET]/debug/deps/smoke-[HASH])
   9    9 | [DOCTEST] foo

```
