### PR TITLE
tests: add regression test for --artifact-dir on stable

### DIFF
--- a/tests/testsuite/artifact_dir.rs
+++ b/tests/testsuite/artifact_dir.rs
@@ -384,9 +384,7 @@ fn cargo_build_deprecated_out_dir() {
 
 #[cargo_test]
 fn artifact_dir_rejected_on_stable() {
-    let p = project()
-        .file("src/main.rs", "fn main() {}")
-        .build();
+    let p = project().file("src/main.rs", "fn main() {}").build();
 
     p.cargo("build --artifact-dir out")
         .with_status(101)
@@ -397,7 +395,6 @@ See https://github.com/rust-lang/cargo/issues/6790 for more information about th
 "#]])
         .run();
 }
-
 
 fn check_dir_contents(
     artifact_dir: &Path,


### PR DESCRIPTION
### What does this PR try to resolve?

This PR adds a regression test to ensure that `cargo build --artifact-dir` is rejected on the stable channel unless `-Z unstable-options` is used.

The behavior is already correct, but this test ensures it does not regress in the future.

### How to test and review this PR?

Run the Cargo test suite:

```bash
cargo test --test testsuite artifact_dir::artifact_dir_rejected_on_stable
