### PR TITLE
chore: Updated compiler errors for Rust 1.93

### DIFF
--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -471,7 +471,7 @@ pub struct Example {
 // Example usage that will break.
 fn main() {
     let f = updated_crate::Example { f1: 1, f2: 2 };
-    let x = &f.f2; // Error: reference to packed field is unaligned
+    let x = &f.f2; // Error: error[E0793]: reference to field of packed struct is unaligned
 }
 ```
 
@@ -656,7 +656,7 @@ use updated_crate::Packed;
 
 fn main() {
     let p = Packed { a: 1, b: 2 };
-    let x = &p.b; // Error: reference to packed field is unaligned
+    let x = &p.b; // Error: error[E0793]: reference to field of packed struct is unaligned
 }
 ```
 


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes the docs CI jobs that are currently failing since Rust 1.93 was released

Example failed job: https://github.com/rust-lang/cargo/actions/runs/21252805301/job/61158769843?pr=16542

### How to test and review this PR?

See the CI jobs status

r? @weihanglo 