### PR TITLE
Increase cache_lock test timeout

### DIFF
--- a/tests/testsuite/cache_lock.rs
+++ b/tests/testsuite/cache_lock.rs
@@ -12,7 +12,7 @@ use crate::config::GlobalContextBuilder;
 /// Helper to verify that it is OK to acquire the given lock (it shouldn't block).
 fn verify_lock_is_ok(mode: CacheLockMode) {
     let root = paths::root();
-    threaded_timeout(10, move || {
+    threaded_timeout(100, move || {
         let gctx = GlobalContextBuilder::new().root(root).build();
         let locker = CacheLocker::new();
         // This would block if it is held.


### PR DESCRIPTION
We've been seeing occasional failures on CI with these tests timing out. I'm guessing that the runners are too overloaded and are unable to complete the test within 1 second. This bumps up the timeout to 10s to see if that will resolve the problem.
