### PR TITLE
Don't check the specific build-std output

### DIFF
--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -165,7 +165,6 @@ fn basic() {
         .build_std_isolated()
         .target_host()
         .with_stderr_data(str![[r#"
-[COMPILING] test v0.0.0 ([..])
 ...
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s


### PR DESCRIPTION
This particular test was failing occasionally because the order of the output is not deterministic. Sometimes `test` would run first, and sometimes `rustc-std-workspace-std` would run first. This is because they start in parallel, and it is a race which one prints first.

The exact output here isn't particularly interesting. I would prefer to not check the particular structure of the standard library, so this just elides all the output.
