### PR TITLE
fix(lints): Pluralize non_kebab_case_bins

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -25,7 +25,7 @@ use crate::lints::analyze_cargo_lints_table;
 use crate::lints::rules::blanket_hint_mostly_unused;
 use crate::lints::rules::check_im_a_teapot;
 use crate::lints::rules::implicit_minimum_version_req;
-use crate::lints::rules::non_kebab_case_bin;
+use crate::lints::rules::non_kebab_case_bins;
 use crate::lints::rules::redundant_readme;
 use crate::ops;
 use crate::ops::lockfile::LOCKFILE_NAME;
@@ -1356,7 +1356,7 @@ impl<'gctx> Workspace<'gctx> {
                 &mut run_error_count,
                 self.gctx,
             )?;
-            non_kebab_case_bin(
+            non_kebab_case_bins(
                 self,
                 pkg.into(),
                 &path,

--- a/src/cargo/lints/rules/mod.rs
+++ b/src/cargo/lints/rules/mod.rs
@@ -1,14 +1,14 @@
 mod blanket_hint_mostly_unused;
 mod im_a_teapot;
 mod implicit_minimum_version_req;
-mod non_kebab_case_bin;
+mod non_kebab_case_bins;
 mod redundant_readme;
 mod unknown_lints;
 
 pub use blanket_hint_mostly_unused::blanket_hint_mostly_unused;
 pub use im_a_teapot::check_im_a_teapot;
 pub use implicit_minimum_version_req::implicit_minimum_version_req;
-pub use non_kebab_case_bin::non_kebab_case_bin;
+pub use non_kebab_case_bins::non_kebab_case_bins;
 pub use redundant_readme::redundant_readme;
 pub use unknown_lints::output_unknown_lints;
 
@@ -16,7 +16,7 @@ pub const LINTS: &[crate::lints::Lint] = &[
     blanket_hint_mostly_unused::LINT,
     implicit_minimum_version_req::LINT,
     im_a_teapot::LINT,
-    non_kebab_case_bin::LINT,
+    non_kebab_case_bins::LINT,
     redundant_readme::LINT,
     unknown_lints::LINT,
 ];

--- a/src/cargo/lints/rules/non_kebab_case_bins.rs
+++ b/src/cargo/lints/rules/non_kebab_case_bins.rs
@@ -21,7 +21,7 @@ use crate::lints::get_key_value_span;
 use crate::lints::rel_cwd_manifest_path;
 
 pub const LINT: Lint = Lint {
-    name: "non_kebab_case_bin",
+    name: "non_kebab_case_bins",
     desc: "binaries should have a kebab-case name",
     primary_group: &STYLE,
     edition_lint_opts: None,
@@ -61,7 +61,7 @@ name = "foo-bar"
     ),
 };
 
-pub fn non_kebab_case_bin(
+pub fn non_kebab_case_bins(
     ws: &Workspace<'_>,
     pkg: &Package,
     manifest_path: &Path,

--- a/src/doc/src/reference/lints.md
+++ b/src/doc/src/reference/lints.md
@@ -25,7 +25,7 @@ These lints are all set to the 'allow' level by default.
 
 These lints are all set to the 'warn' level by default.
 - [`blanket_hint_mostly_unused`](#blanket_hint_mostly_unused)
-- [`non_kebab_case_bin`](#non_kebab_case_bin)
+- [`non_kebab_case_bins`](#non_kebab_case_bins)
 - [`redundant_readme`](#redundant_readme)
 - [`unknown_lints`](#unknown_lints)
 
@@ -110,7 +110,7 @@ serde = "1.0.219"
 ```
 
 
-## `non_kebab_case_bin`
+## `non_kebab_case_bins`
 Group: `style`
 
 Level: `warn`

--- a/tests/testsuite/lints/mod.rs
+++ b/tests/testsuite/lints/mod.rs
@@ -7,7 +7,7 @@ mod blanket_hint_mostly_unused;
 mod error;
 mod implicit_minimum_version_req;
 mod inherited;
-mod non_kebab_case_bin;
+mod non_kebab_case_bins;
 mod redundant_readme;
 mod unknown_lints;
 mod warning;

--- a/tests/testsuite/lints/non_kebab_case_bins.rs
+++ b/tests/testsuite/lints/non_kebab_case_bins.rs
@@ -19,7 +19,7 @@ name = "foo_bar"
 path = "src/main.rs"
 
 [lints.cargo]
-non_kebab_case_bin = "warn"
+non_kebab_case_bins = "warn"
 "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -33,7 +33,7 @@ non_kebab_case_bin = "warn"
 1 | [ROOT]/foo/target/.../foo_bar[EXE]
   |                   [..]^^^^^^^
   |
-  = [NOTE] `cargo::non_kebab_case_bin` is set to `warn` in `[lints]`
+  = [NOTE] `cargo::non_kebab_case_bins` is set to `warn` in `[lints]`
 [HELP] to change the binary name to kebab case, convert `bin.name`
  --> Cargo.toml:9:8
   |
@@ -60,7 +60,7 @@ edition = "2015"
 authors = []
 
 [lints.cargo]
-non_kebab_case_bin = "warn"
+non_kebab_case_bins = "warn"
 "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -74,7 +74,7 @@ non_kebab_case_bin = "warn"
  1 | [ROOT]/foo/target/.../foo_bar[EXE]
    |                   [..]^^^^^^^
    |
-   = [NOTE] `cargo::non_kebab_case_bin` is set to `warn` in `[lints]`
+   = [NOTE] `cargo::non_kebab_case_bins` is set to `warn` in `[lints]`
 [HELP] to change the binary name to kebab case, convert `package.name`
   --> Cargo.toml:3:8
    |
@@ -82,9 +82,9 @@ non_kebab_case_bin = "warn"
  3 + name = "foo-bar"
    |
 [HELP] to change the binary name to kebab case, specify `bin.name`
-  --> Cargo.toml:9:29
+  --> Cargo.toml:9:30
    |
- 9 ~ non_kebab_case_bin = "warn"
+ 9 ~ non_kebab_case_bins = "warn"
 10 + [[bin]]
 11 + name = "foo-bar"
 12 + path = "src/main.rs"
@@ -109,7 +109,7 @@ edition = "2015"
 authors = []
 
 [lints.cargo]
-non_kebab_case_bin = "warn"
+non_kebab_case_bins = "warn"
 "#,
         )
         .file("src/bin/foo_bar.rs", "fn main() {}")
@@ -123,7 +123,7 @@ non_kebab_case_bin = "warn"
 1 | [ROOT]/foo/target/.../foo_bar[EXE]
   |                   [..]^^^^^^^
   |
-  = [NOTE] `cargo::non_kebab_case_bin` is set to `warn` in `[lints]`
+  = [NOTE] `cargo::non_kebab_case_bins` is set to `warn` in `[lints]`
 [HELP] to change the binary name to kebab case, convert the file stem
   |
 1 - src/bin/foo_bar.rs
@@ -144,7 +144,7 @@ fn bin_name_from_script_name() {
             r#"
 ---
 [lints.cargo]
-non_kebab_case_bin = "warn"
+non_kebab_case_bins = "warn"
 ---
 fn main() {}"#,
         )
@@ -159,7 +159,7 @@ fn main() {}"#,
 1 | [ROOT]/home/.cargo/build/[HASH]/target/.../foo_bar[EXE]
   |                                        [..]^^^^^^^
   |
-  = [NOTE] `cargo::non_kebab_case_bin` is set to `warn` in `[lints]`
+  = [NOTE] `cargo::non_kebab_case_bins` is set to `warn` in `[lints]`
 [HELP] to change the binary name to kebab case, convert the file stem
   |
 1 - foo_bar


### PR DESCRIPTION
### What does this PR try to resolve?

From https://rustc-dev-guide.rust-lang.org/diagnostics.html?#lint-naming

> If a lint applies to a specific grammatical class, mention that class
> and use the plural form: use `unused_variables` rather than
> `unused_variable`. This makes `#[allow(unused_variables)]` read correctly.


### How to test and review this PR?

Noticed while doing similar elsewhere