### PR TITLE
Update build_std::basic test to ensure index doesn't update

### DIFF
--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -165,8 +165,8 @@ fn basic() {
         .build_std_isolated()
         .target_host()
         .with_stderr_data(str![[r#"
+[COMPILING] [..]
 ...
-[COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] unittests src/lib.rs (target/[HOST_TARGET]/debug/deps/foo-[HASH])
 [RUNNING] unittests src/main.rs (target/[HOST_TARGET]/debug/deps/foo-[HASH])


### PR DESCRIPTION
This makes sure that cargo doesn't try to update the index or do anything else before compiling.

Requested in https://github.com/rust-lang/cargo/pull/16551#discussion_r2722625871