### PR TITLE
Update cargo-fetch.md to remove cargo-prefetch reference

### DIFF
--- a/doc/book/src/commands/cargo-fetch.md
+++ b/doc/book/src/commands/cargo-fetch.md
@@ -19,10 +19,6 @@ file before fetching the dependencies.
 
 If `--target` is not specified, then all target dependencies are fetched.
 
-See also the [cargo-prefetch](https://crates.io/crates/cargo-prefetch)
-plugin which adds a command to download popular crates. This may be useful if
-you plan to use Cargo without a network with the `--offline` flag.
-
 ## OPTIONS
 
 ### Fetch options

--- a/doc/man/cargo-fetch.md
+++ b/doc/man/cargo-fetch.md
@@ -24,10 +24,6 @@ file before fetching the dependencies.
 
 If `--target` is not specified, then all target dependencies are fetched.
 
-See also the [cargo-prefetch](https://crates.io/crates/cargo-prefetch)
-plugin which adds a command to download popular crates. This may be useful if
-you plan to use Cargo without a network with the `--offline` flag.
-
 ## OPTIONS
 
 ### Fetch options

--- a/doc/man/generated_txt/cargo-fetch.txt
+++ b/doc/man/generated_txt/cargo-fetch.txt
@@ -17,11 +17,6 @@ DESCRIPTION
 
        If --target is not specified, then all target dependencies are fetched.
 
-       See also the cargo-prefetch <https://crates.io/crates/cargo-prefetch>
-       plugin which adds a command to download popular crates. This may be
-       useful if you plan to use Cargo without a network with the --offline
-       flag.
-
 OPTIONS
    Fetch options
        --target triple

--- a/etc/man/cargo-fetch.1
+++ b/etc/man/cargo-fetch.1
@@ -16,10 +16,6 @@ If the lock file is not available, then this command will generate the lock
 file before fetching the dependencies.
 .sp
 If \fB\-\-target\fR is not specified, then all target dependencies are fetched.
-.sp
-See also the \fIcargo\-prefetch\fR <https://crates.io/crates/cargo\-prefetch>
-plugin which adds a command to download popular crates. This may be useful if
-you plan to use Cargo without a network with the \fB\-\-offline\fR flag.
 .SH "OPTIONS"
 .SS "Fetch options"
 .sp


### PR DESCRIPTION
Closes https://github.com/rust-lang/cargo/issues/16709

Remove the mention of the cargo-prefetch plugin, as it appears to be unmaintained.
