### PR TITLE
Stabilize cargo script

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -337,9 +337,7 @@ To pass the arguments to the subcommand, remove `--`",
                     }
                 }
                 if commands::run::is_manifest_command(cmd) {
-                    {
-                        return Ok((args, GlobalArgs::default()));
-                    }
+                    return Ok((args, GlobalArgs::default()));
                 }
 
                 let mut alias = alias
@@ -476,15 +474,12 @@ impl Exec {
         match self {
             Self::Builtin(exec) => exec(gctx, subcommand_args),
             Self::Manifest(cmd) => {
-                // Placeholder
-                {
-                    let ext_args: Vec<OsString> = subcommand_args
-                        .get_many::<OsString>("")
-                        .unwrap_or_default()
-                        .cloned()
-                        .collect();
-                    commands::run::exec_manifest_command(gctx, &cmd, &ext_args)
-                }
+                let ext_args: Vec<OsString> = subcommand_args
+                    .get_many::<OsString>("")
+                    .unwrap_or_default()
+                    .cloned()
+                    .collect();
+                commands::run::exec_manifest_command(gctx, &cmd, &ext_args)
             }
             Self::External(cmd) => {
                 let mut ext_args = vec![OsStr::new(&cmd)];

--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -337,22 +337,8 @@ To pass the arguments to the subcommand, remove `--`",
                     }
                 }
                 if commands::run::is_manifest_command(cmd) {
-                    if gctx.cli_unstable().script {
+                    {
                         return Ok((args, GlobalArgs::default()));
-                    } else {
-                        gctx.shell().print_report(
-                            &[
-                                Level::WARNING.secondary_title(
-                                    format!("user-defined alias `{cmd}` has the appearance of a manifest-command")
-                                ).element(
-                                    Level::NOTE.message(
-                                        "this was previously accepted but will be phased out when `-Zscript` is stabilized; \
-                                        see <https://github.com/rust-lang/cargo/issues/12207>"
-                                    )
-                                )
-                            ],
-                            false
-                        )?;
                     }
                 }
 
@@ -490,24 +476,8 @@ impl Exec {
         match self {
             Self::Builtin(exec) => exec(gctx, subcommand_args),
             Self::Manifest(cmd) => {
-                let ext_path = super::find_external_subcommand(gctx, &cmd);
-                if !gctx.cli_unstable().script && ext_path.is_some() {
-                    gctx.shell().print_report(
-                        &[
-                            Level::WARNING.secondary_title(
-                                format!("external subcommand `{cmd}` has the appearance of a manifest-command")
-                            ).element(
-                                Level::NOTE.message(
-                                    "this was previously accepted but will be phased out when `-Zscript` is stabilized; \
-                                    see <https://github.com/rust-lang/cargo/issues/12207>"
-                                )
-                            )
-                        ],
-                        false
-                    )?;
-
-                    Self::External(cmd).exec(gctx, subcommand_args)
-                } else {
+                // Placeholder
+                {
                     let ext_args: Vec<OsString> = subcommand_args
                         .get_many::<OsString>("")
                         .unwrap_or_default()
@@ -581,11 +551,11 @@ pub fn cli(gctx: &GlobalContext) -> Command {
 
     let usage = if is_rustup() {
         color_print::cstr!(
-            "<bright-cyan,bold>cargo</> <cyan>[+toolchain] [OPTIONS] [COMMAND]</>\n       <bright-cyan,bold>cargo</> <cyan>[+toolchain] [OPTIONS]</> <bright-cyan,bold>-Zscript</> <cyan><<MANIFEST_RS>> [ARGS]...</>"
+            "<bright-cyan,bold>cargo</> <cyan>[+toolchain] [OPTIONS] [COMMAND]</>\n       <bright-cyan,bold>cargo</> <cyan>[+toolchain] [OPTIONS]</> <cyan><<MANIFEST_RS>> [ARGS]...</>"
         )
     } else {
         color_print::cstr!(
-            "<bright-cyan,bold>cargo</> <cyan>[OPTIONS] [COMMAND]</>\n       <bright-cyan,bold>cargo</> <cyan>[OPTIONS]</> <bright-cyan,bold>-Zscript</> <cyan><<MANIFEST_RS>> [ARGS]...</>"
+            "<bright-cyan,bold>cargo</> <cyan>[OPTIONS] [COMMAND]</>\n       <bright-cyan,bold>cargo</> <cyan>[OPTIONS]</> <cyan><<MANIFEST_RS>> [ARGS]...</>"
         )
     };
 

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -276,9 +276,7 @@ fn execute_external_subcommand(gctx: &GlobalContext, cmd: &str, args: &[&OsStr])
     let command = match path {
         Some(command) => command,
         None => {
-            let script_suggestion = if gctx.cli_unstable().script
-                && std::path::Path::new(cmd).is_file()
-            {
+            let script_suggestion = if std::path::Path::new(cmd).is_file() {
                 let sep = std::path::MAIN_SEPARATOR;
                 format!(
                     "\nhelp: to run the file `{cmd}`, provide a relative path like `.{sep}{cmd}`"

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -791,13 +791,8 @@ fn prepare_rustc(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> CargoResult
         .compilation
         .rustc_process(unit, is_primary, is_workspace)?;
     build_base_args(build_runner, &mut base, unit)?;
+    // TODO: remove once frontmatter hits nightly
     if unit.pkg.manifest().is_embedded() {
-        if !gctx.cli_unstable().script {
-            anyhow::bail!(
-                "parsing `{}` requires `-Zscript`",
-                unit.pkg.manifest_path().display()
-            );
-        }
         base.arg("-Z").arg("crate-attr=feature(frontmatter)");
         base.arg("-Z").arg("crate-attr=allow(unused_features)");
     }
@@ -853,13 +848,8 @@ fn prepare_rustdoc(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> CargoResu
     let bcx = build_runner.bcx;
     // script_metadata is not needed here, it is only for tests.
     let mut rustdoc = build_runner.compilation.rustdoc_process(unit, None)?;
+    // TODO: remove once frontmatter hits nightly
     if unit.pkg.manifest().is_embedded() {
-        if !bcx.gctx.cli_unstable().script {
-            anyhow::bail!(
-                "parsing `{}` requires `-Zscript`",
-                unit.pkg.manifest_path().display()
-            );
-        }
         rustdoc.arg("-Z").arg("crate-attr=feature(frontmatter)");
         rustdoc.arg("-Z").arg("crate-attr=allow(unused_features)");
     }

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -907,7 +907,6 @@ unstable_cli_options!(
     rustdoc_mergeable_info: bool = ("Use rustdoc mergeable cross-crate-info files"),
     rustdoc_scrape_examples: bool = ("Allows Rustdoc to scrape code examples from reverse-dependencies"),
     sbom: bool = ("Enable the `sbom` option in build config in .cargo/config.toml file"),
-    script: bool = ("Enable support for single-file, `.rs` packages"),
     section_timings: bool = ("Enable support for extended compilation sections in --timings output"),
     separate_nightlies: bool,
     skip_rustdoc_fingerprint: bool,
@@ -1000,6 +999,8 @@ const STABILIZED_PACKAGE_WORKSPACE: &str =
 const STABILIZED_BUILD_DIR: &str = "build.build-dir is now always enabled.";
 
 const STABILIZED_CONFIG_INCLUDE: &str = "The `include` config key is now always available";
+
+const STABILIZED_SCRIPT: &str = "Cargo scripts are now always available";
 
 fn deserialize_comma_separated_list<'de, D>(
     deserializer: D,
@@ -1389,6 +1390,7 @@ impl CliUnstable {
             "package-workspace" => stabilized_warn(k, "1.89", STABILIZED_PACKAGE_WORKSPACE),
             "build-dir" => stabilized_warn(k, "1.91", STABILIZED_BUILD_DIR),
             "config-include" => stabilized_warn(k, "1.93", STABILIZED_CONFIG_INCLUDE),
+            "script" => stabilized_warn(k, "1.95", STABILIZED_SCRIPT),
 
             // Unstable features
             // Sorted alphabetically:
@@ -1452,7 +1454,6 @@ impl CliUnstable {
             "separate-nightlies" => self.separate_nightlies = parse_empty(k, v)?,
             "checksum-freshness" => self.checksum_freshness = parse_empty(k, v)?,
             "skip-rustdoc-fingerprint" => self.skip_rustdoc_fingerprint = parse_empty(k, v)?,
-            "script" => self.script = parse_empty(k, v)?,
             "target-applies-to-host" => self.target_applies_to_host = parse_empty(k, v)?,
             "panic-immediate-abort" => self.panic_immediate_abort = parse_empty(k, v)?,
             "unstable-options" => self.unstable_options = parse_empty(k, v)?,

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -1064,20 +1064,13 @@ pub fn root_manifest(manifest_path: Option<&Path>, gctx: &GlobalContext) -> Carg
                 manifest_path.display()
             )
         } else if !path.ends_with("Cargo.toml") && !crate::util::toml::is_embedded(&path) {
-            if gctx.cli_unstable().script {
+            // Placeholder
+            {
                 anyhow::bail!(
                     "the manifest-path must be a path to a Cargo.toml or script file: `{}`",
                     path.display()
                 )
-            } else {
-                anyhow::bail!(
-                    "the manifest-path must be a path to a Cargo.toml file: `{}`",
-                    path.display()
-                )
             }
-        }
-        if crate::util::toml::is_embedded(&path) && !gctx.cli_unstable().script {
-            anyhow::bail!("embedded manifest `{}` requires `-Zscript`", path.display())
         }
         Ok(path)
     } else {

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -1064,13 +1064,10 @@ pub fn root_manifest(manifest_path: Option<&Path>, gctx: &GlobalContext) -> Carg
                 manifest_path.display()
             )
         } else if !path.ends_with("Cargo.toml") && !crate::util::toml::is_embedded(&path) {
-            // Placeholder
-            {
-                anyhow::bail!(
-                    "the manifest-path must be a path to a Cargo.toml or script file: `{}`",
-                    path.display()
-                )
-            }
+            anyhow::bail!(
+                "the manifest-path must be a path to a Cargo.toml or script file: `{}`",
+                path.display()
+            )
         }
         Ok(path)
     } else {

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -155,9 +155,6 @@ pub fn read_manifest(
 fn read_toml_string(path: &Path, is_embedded: bool, gctx: &GlobalContext) -> CargoResult<String> {
     let mut contents = paths::read(path).map_err(|err| ManifestError::new(err, path.into()))?;
     if is_embedded {
-        if !gctx.cli_unstable().script {
-            anyhow::bail!("parsing `{}` requires `-Zscript`", path.display());
-        }
         contents = embedded::expand_manifest(&contents)
             .map_err(|e| emit_frontmatter_diagnostic(e, &contents, path, gctx))?;
     }

--- a/src/doc/man/cargo-run.md
+++ b/src/doc/man/cargo-run.md
@@ -22,6 +22,9 @@ Unlike {{man "cargo-test" 1}} and {{man "cargo-bench" 1}}, `cargo run` sets the
 working directory of the binary executed to the current working directory, same 
 as if it was executed in the shell directly.
 
+When running scripts, the process' [arg0](../../std/env/fn.args.html) will be set to the
+script's path on a best-effort basis.
+
 ## OPTIONS
 
 {{> section-options-package }}

--- a/src/doc/man/cargo.md
+++ b/src/doc/man/cargo.md
@@ -7,6 +7,7 @@ cargo --- The Rust package manager
 ## SYNOPSIS
 
 `cargo` [_options_] _command_ [_args_]\
+`cargo` [_options_] _script_ [_args_]\
 `cargo` [_options_] `--version`\
 `cargo` [_options_] `--list`\
 `cargo` [_options_] `--help`\
@@ -19,11 +20,25 @@ available at <https://rust-lang.org>.
 
 _command_ may be one of:
 - built-in commands, see below
+- [script](#scripts)
 - [aliases]
 - [external tools]
 
 [aliases]: ../reference/config.html#alias
 [external tools]: ../reference/external-tools.html#custom-subcommands
+
+## SCRIPTS
+
+A _script_ is distinguished from a _command_ or _alias_ by having path separators present or a `.rs` extension.
+These are Rust source files with an optional [manifest] embedded in the frontmatter.
+
+For configuration discovery,
+`cargo` _script_ operates on the script level and not in the context of it's invocation.
+This means that the local [configuration discovery] is done in the directory of the _script_
+rather than the current working directory of `cargo`.
+
+[manifest]: ../reference/manifest.html
+[configuration discovery]: ../reference/config.html#hierarchical-structure
 
 ## COMMANDS
 
@@ -248,7 +263,11 @@ stable yet and may be subject to change.
        mkdir foo && cd foo
        cargo init .
 
-6. Learn about a command's options and usage:
+6. Run a script
+
+       cargo task.rs --action
+
+7. Learn about a command's options and usage:
 
        cargo help clean
 

--- a/src/doc/man/generated_txt/cargo-add.txt
+++ b/src/doc/man/generated_txt/cargo-add.txt
@@ -164,8 +164,9 @@ OPTIONS
 
    Manifest Options
        --manifest-path path
-           Path to the Cargo.toml file. By default, Cargo searches for the
-           Cargo.toml file in the current directory or any parent directory.
+           Path to the Cargo.toml or cargo script file. By default, Cargo
+           searches for the Cargo.toml file in the current directory or any
+           parent directory.
 
        -p spec, --package spec
            Add dependencies to only the specified package.

--- a/src/doc/man/generated_txt/cargo-bench.txt
+++ b/src/doc/man/generated_txt/cargo-bench.txt
@@ -335,8 +335,9 @@ OPTIONS
 
    Manifest Options
        --manifest-path path
-           Path to the Cargo.toml file. By default, Cargo searches for the
-           Cargo.toml file in the current directory or any parent directory.
+           Path to the Cargo.toml or cargo script file. By default, Cargo
+           searches for the Cargo.toml file in the current directory or any
+           parent directory.
 
        --ignore-rust-version
            Ignore rust-version specification in packages.

--- a/src/doc/man/generated_txt/cargo-build.txt
+++ b/src/doc/man/generated_txt/cargo-build.txt
@@ -259,8 +259,9 @@ OPTIONS
 
    Manifest Options
        --manifest-path path
-           Path to the Cargo.toml file. By default, Cargo searches for the
-           Cargo.toml file in the current directory or any parent directory.
+           Path to the Cargo.toml or cargo script file. By default, Cargo
+           searches for the Cargo.toml file in the current directory or any
+           parent directory.
 
        --ignore-rust-version
            Ignore rust-version specification in packages.

--- a/src/doc/man/generated_txt/cargo-check.txt
+++ b/src/doc/man/generated_txt/cargo-check.txt
@@ -253,8 +253,9 @@ OPTIONS
 
    Manifest Options
        --manifest-path path
-           Path to the Cargo.toml file. By default, Cargo searches for the
-           Cargo.toml file in the current directory or any parent directory.
+           Path to the Cargo.toml or cargo script file. By default, Cargo
+           searches for the Cargo.toml file in the current directory or any
+           parent directory.
 
        --ignore-rust-version
            Ignore rust-version specification in packages.

--- a/src/doc/man/generated_txt/cargo-clean.txt
+++ b/src/doc/man/generated_txt/cargo-clean.txt
@@ -104,8 +104,9 @@ OPTIONS
 
    Manifest Options
        --manifest-path path
-           Path to the Cargo.toml file. By default, Cargo searches for the
-           Cargo.toml file in the current directory or any parent directory.
+           Path to the Cargo.toml or cargo script file. By default, Cargo
+           searches for the Cargo.toml file in the current directory or any
+           parent directory.
 
        --locked
            Asserts that the exact same dependencies and versions are used as

--- a/src/doc/man/generated_txt/cargo-doc.txt
+++ b/src/doc/man/generated_txt/cargo-doc.txt
@@ -228,8 +228,9 @@ OPTIONS
 
    Manifest Options
        --manifest-path path
-           Path to the Cargo.toml file. By default, Cargo searches for the
-           Cargo.toml file in the current directory or any parent directory.
+           Path to the Cargo.toml or cargo script file. By default, Cargo
+           searches for the Cargo.toml file in the current directory or any
+           parent directory.
 
        --ignore-rust-version
            Ignore rust-version specification in packages.

--- a/src/doc/man/generated_txt/cargo-fetch.txt
+++ b/src/doc/man/generated_txt/cargo-fetch.txt
@@ -81,8 +81,9 @@ OPTIONS
 
    Manifest Options
        --manifest-path path
-           Path to the Cargo.toml file. By default, Cargo searches for the
-           Cargo.toml file in the current directory or any parent directory.
+           Path to the Cargo.toml or cargo script file. By default, Cargo
+           searches for the Cargo.toml file in the current directory or any
+           parent directory.
 
        --locked
            Asserts that the exact same dependencies and versions are used as

--- a/src/doc/man/generated_txt/cargo-fix.txt
+++ b/src/doc/man/generated_txt/cargo-fix.txt
@@ -327,8 +327,9 @@ OPTIONS
 
    Manifest Options
        --manifest-path path
-           Path to the Cargo.toml file. By default, Cargo searches for the
-           Cargo.toml file in the current directory or any parent directory.
+           Path to the Cargo.toml or cargo script file. By default, Cargo
+           searches for the Cargo.toml file in the current directory or any
+           parent directory.
 
        --ignore-rust-version
            Ignore rust-version specification in packages.

--- a/src/doc/man/generated_txt/cargo-generate-lockfile.txt
+++ b/src/doc/man/generated_txt/cargo-generate-lockfile.txt
@@ -43,8 +43,9 @@ OPTIONS
 
    Manifest Options
        --manifest-path path
-           Path to the Cargo.toml file. By default, Cargo searches for the
-           Cargo.toml file in the current directory or any parent directory.
+           Path to the Cargo.toml or cargo script file. By default, Cargo
+           searches for the Cargo.toml file in the current directory or any
+           parent directory.
 
        --ignore-rust-version
            Ignore rust-version specification in packages.

--- a/src/doc/man/generated_txt/cargo-locate-project.txt
+++ b/src/doc/man/generated_txt/cargo-locate-project.txt
@@ -60,8 +60,9 @@ OPTIONS
 
    Manifest Options
        --manifest-path path
-           Path to the Cargo.toml file. By default, Cargo searches for the
-           Cargo.toml file in the current directory or any parent directory.
+           Path to the Cargo.toml or cargo script file. By default, Cargo
+           searches for the Cargo.toml file in the current directory or any
+           parent directory.
 
    Common Options
        +toolchain

--- a/src/doc/man/generated_txt/cargo-metadata.txt
+++ b/src/doc/man/generated_txt/cargo-metadata.txt
@@ -412,8 +412,9 @@ OPTIONS
 
    Manifest Options
        --manifest-path path
-           Path to the Cargo.toml file. By default, Cargo searches for the
-           Cargo.toml file in the current directory or any parent directory.
+           Path to the Cargo.toml or cargo script file. By default, Cargo
+           searches for the Cargo.toml file in the current directory or any
+           parent directory.
 
        --locked
            Asserts that the exact same dependencies and versions are used as

--- a/src/doc/man/generated_txt/cargo-package.txt
+++ b/src/doc/man/generated_txt/cargo-package.txt
@@ -246,8 +246,9 @@ OPTIONS
 
    Manifest Options
        --manifest-path path
-           Path to the Cargo.toml file. By default, Cargo searches for the
-           Cargo.toml file in the current directory or any parent directory.
+           Path to the Cargo.toml or cargo script file. By default, Cargo
+           searches for the Cargo.toml file in the current directory or any
+           parent directory.
 
        --locked
            Asserts that the exact same dependencies and versions are used as

--- a/src/doc/man/generated_txt/cargo-pkgid.txt
+++ b/src/doc/man/generated_txt/cargo-pkgid.txt
@@ -81,8 +81,9 @@ OPTIONS
 
    Manifest Options
        --manifest-path path
-           Path to the Cargo.toml file. By default, Cargo searches for the
-           Cargo.toml file in the current directory or any parent directory.
+           Path to the Cargo.toml or cargo script file. By default, Cargo
+           searches for the Cargo.toml file in the current directory or any
+           parent directory.
 
        --locked
            Asserts that the exact same dependencies and versions are used as

--- a/src/doc/man/generated_txt/cargo-publish.txt
+++ b/src/doc/man/generated_txt/cargo-publish.txt
@@ -159,8 +159,9 @@ OPTIONS
 
    Manifest Options
        --manifest-path path
-           Path to the Cargo.toml file. By default, Cargo searches for the
-           Cargo.toml file in the current directory or any parent directory.
+           Path to the Cargo.toml or cargo script file. By default, Cargo
+           searches for the Cargo.toml file in the current directory or any
+           parent directory.
 
        --locked
            Asserts that the exact same dependencies and versions are used as

--- a/src/doc/man/generated_txt/cargo-remove.txt
+++ b/src/doc/man/generated_txt/cargo-remove.txt
@@ -58,8 +58,9 @@ OPTIONS
 
    Manifest Options
        --manifest-path path
-           Path to the Cargo.toml file. By default, Cargo searches for the
-           Cargo.toml file in the current directory or any parent directory.
+           Path to the Cargo.toml or cargo script file. By default, Cargo
+           searches for the Cargo.toml file in the current directory or any
+           parent directory.
 
        --locked
            Asserts that the exact same dependencies and versions are used as

--- a/src/doc/man/generated_txt/cargo-run.txt
+++ b/src/doc/man/generated_txt/cargo-run.txt
@@ -17,6 +17,10 @@ DESCRIPTION
        directory of the binary executed to the current working directory, same
        as if it was executed in the shell directly.
 
+       When running scripts, the process’ arg0
+       <https://doc.rust-lang.org/std/env/fn.args.html> will be set to the
+       script’s path on a best-effort basis.
+
 OPTIONS
    Package Selection
        By default, the package in the current working directory is selected.
@@ -173,8 +177,9 @@ OPTIONS
 
    Manifest Options
        --manifest-path path
-           Path to the Cargo.toml file. By default, Cargo searches for the
-           Cargo.toml file in the current directory or any parent directory.
+           Path to the Cargo.toml or cargo script file. By default, Cargo
+           searches for the Cargo.toml file in the current directory or any
+           parent directory.
 
        --ignore-rust-version
            Ignore rust-version specification in packages.

--- a/src/doc/man/generated_txt/cargo-rustc.txt
+++ b/src/doc/man/generated_txt/cargo-rustc.txt
@@ -271,8 +271,9 @@ OPTIONS
 
    Manifest Options
        --manifest-path path
-           Path to the Cargo.toml file. By default, Cargo searches for the
-           Cargo.toml file in the current directory or any parent directory.
+           Path to the Cargo.toml or cargo script file. By default, Cargo
+           searches for the Cargo.toml file in the current directory or any
+           parent directory.
 
        --ignore-rust-version
            Ignore rust-version specification in packages.

--- a/src/doc/man/generated_txt/cargo-rustdoc.txt
+++ b/src/doc/man/generated_txt/cargo-rustdoc.txt
@@ -240,8 +240,9 @@ OPTIONS
 
    Manifest Options
        --manifest-path path
-           Path to the Cargo.toml file. By default, Cargo searches for the
-           Cargo.toml file in the current directory or any parent directory.
+           Path to the Cargo.toml or cargo script file. By default, Cargo
+           searches for the Cargo.toml file in the current directory or any
+           parent directory.
 
        --ignore-rust-version
            Ignore rust-version specification in packages.

--- a/src/doc/man/generated_txt/cargo-test.txt
+++ b/src/doc/man/generated_txt/cargo-test.txt
@@ -361,8 +361,9 @@ OPTIONS
 
    Manifest Options
        --manifest-path path
-           Path to the Cargo.toml file. By default, Cargo searches for the
-           Cargo.toml file in the current directory or any parent directory.
+           Path to the Cargo.toml or cargo script file. By default, Cargo
+           searches for the Cargo.toml file in the current directory or any
+           parent directory.
 
        --ignore-rust-version
            Ignore rust-version specification in packages.

--- a/src/doc/man/generated_txt/cargo-tree.txt
+++ b/src/doc/man/generated_txt/cargo-tree.txt
@@ -211,8 +211,9 @@ OPTIONS
 
    Manifest Options
        --manifest-path path
-           Path to the Cargo.toml file. By default, Cargo searches for the
-           Cargo.toml file in the current directory or any parent directory.
+           Path to the Cargo.toml or cargo script file. By default, Cargo
+           searches for the Cargo.toml file in the current directory or any
+           parent directory.
 
        --locked
            Asserts that the exact same dependencies and versions are used as

--- a/src/doc/man/generated_txt/cargo-update.txt
+++ b/src/doc/man/generated_txt/cargo-update.txt
@@ -102,8 +102,9 @@ OPTIONS
 
    Manifest Options
        --manifest-path path
-           Path to the Cargo.toml file. By default, Cargo searches for the
-           Cargo.toml file in the current directory or any parent directory.
+           Path to the Cargo.toml or cargo script file. By default, Cargo
+           searches for the Cargo.toml file in the current directory or any
+           parent directory.
 
        --ignore-rust-version
            Ignore rust-version specification in packages.

--- a/src/doc/man/generated_txt/cargo-vendor.txt
+++ b/src/doc/man/generated_txt/cargo-vendor.txt
@@ -50,8 +50,9 @@ OPTIONS
 
    Manifest Options
        --manifest-path path
-           Path to the Cargo.toml file. By default, Cargo searches for the
-           Cargo.toml file in the current directory or any parent directory.
+           Path to the Cargo.toml or cargo script file. By default, Cargo
+           searches for the Cargo.toml file in the current directory or any
+           parent directory.
 
        --locked
            Asserts that the exact same dependencies and versions are used as

--- a/src/doc/man/generated_txt/cargo.txt
+++ b/src/doc/man/generated_txt/cargo.txt
@@ -5,6 +5,7 @@ NAME
 
 SYNOPSIS
        cargo [options] command [args]
+       cargo [options] script [args]
        cargo [options] --version
        cargo [options] --list
        cargo [options] --help
@@ -18,10 +19,26 @@ DESCRIPTION
 
        o  built-in commands, see below
 
+       o  script
+
        o  aliases <https://doc.rust-lang.org/cargo/reference/config.html#alias>
 
        o  external tools
           <https://doc.rust-lang.org/cargo/reference/external-tools.html#custom-subcommands>
+
+SCRIPTS
+       A script is distinguished from a command or alias by having path
+       separators present or a .rs extension. These are Rust source files with
+       an optional manifest
+       <https://doc.rust-lang.org/cargo/reference/manifest.html> embedded in
+       the frontmatter.
+
+       For configuration discovery, cargo script operates on the script level
+       and not in the context of it’s invocation. This means that the local
+       configuration discovery
+       <https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure>
+       is done in the directory of the script rather than the current working
+       directory of cargo.
 
 COMMANDS
    Build Commands
@@ -315,7 +332,11 @@ EXAMPLES
               mkdir foo && cd foo
               cargo init .
 
-       6. Learn about a command’s options and usage:
+       6. Run a script
+
+              cargo task.rs --action
+
+       7. Learn about a command’s options and usage:
 
               cargo help clean
 

--- a/src/doc/man/includes/options-manifest-path.md
+++ b/src/doc/man/includes/options-manifest-path.md
@@ -1,4 +1,4 @@
 {{#option "`--manifest-path` _path_" }}
-Path to the `Cargo.toml` file. By default, Cargo searches for the
+Path to the `Cargo.toml` or cargo script file. By default, Cargo searches for the
 `Cargo.toml` file in the current directory or any parent directory.
 {{/option}}

--- a/src/doc/src/commands/cargo-add.md
+++ b/src/doc/src/commands/cargo-add.md
@@ -201,7 +201,7 @@ terminal.</li>
 
 <dl>
 <dt class="option-term" id="option-cargo-add---manifest-path"><a class="option-anchor" href="#option-cargo-add---manifest-path"><code>--manifest-path</code> <em>path</em></a></dt>
-<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> file. By default, Cargo searches for the
+<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> or cargo script file. By default, Cargo searches for the
 <code>Cargo.toml</code> file in the current directory or any parent directory.</p>
 </dd>
 

--- a/src/doc/src/commands/cargo-bench.md
+++ b/src/doc/src/commands/cargo-bench.md
@@ -393,7 +393,7 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 
 <dl>
 <dt class="option-term" id="option-cargo-bench---manifest-path"><a class="option-anchor" href="#option-cargo-bench---manifest-path"><code>--manifest-path</code> <em>path</em></a></dt>
-<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> file. By default, Cargo searches for the
+<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> or cargo script file. By default, Cargo searches for the
 <code>Cargo.toml</code> file in the current directory or any parent directory.</p>
 </dd>
 

--- a/src/doc/src/commands/cargo-build.md
+++ b/src/doc/src/commands/cargo-build.md
@@ -316,7 +316,7 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 
 <dl>
 <dt class="option-term" id="option-cargo-build---manifest-path"><a class="option-anchor" href="#option-cargo-build---manifest-path"><code>--manifest-path</code> <em>path</em></a></dt>
-<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> file. By default, Cargo searches for the
+<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> or cargo script file. By default, Cargo searches for the
 <code>Cargo.toml</code> file in the current directory or any parent directory.</p>
 </dd>
 

--- a/src/doc/src/commands/cargo-check.md
+++ b/src/doc/src/commands/cargo-check.md
@@ -304,7 +304,7 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 
 <dl>
 <dt class="option-term" id="option-cargo-check---manifest-path"><a class="option-anchor" href="#option-cargo-check---manifest-path"><code>--manifest-path</code> <em>path</em></a></dt>
-<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> file. By default, Cargo searches for the
+<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> or cargo script file. By default, Cargo searches for the
 <code>Cargo.toml</code> file in the current directory or any parent directory.</p>
 </dd>
 

--- a/src/doc/src/commands/cargo-clean.md
+++ b/src/doc/src/commands/cargo-clean.md
@@ -127,7 +127,7 @@ terminal.</li>
 
 <dl>
 <dt class="option-term" id="option-cargo-clean---manifest-path"><a class="option-anchor" href="#option-cargo-clean---manifest-path"><code>--manifest-path</code> <em>path</em></a></dt>
-<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> file. By default, Cargo searches for the
+<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> or cargo script file. By default, Cargo searches for the
 <code>Cargo.toml</code> file in the current directory or any parent directory.</p>
 </dd>
 

--- a/src/doc/src/commands/cargo-doc.md
+++ b/src/doc/src/commands/cargo-doc.md
@@ -279,7 +279,7 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 
 <dl>
 <dt class="option-term" id="option-cargo-doc---manifest-path"><a class="option-anchor" href="#option-cargo-doc---manifest-path"><code>--manifest-path</code> <em>path</em></a></dt>
-<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> file. By default, Cargo searches for the
+<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> or cargo script file. By default, Cargo searches for the
 <code>Cargo.toml</code> file in the current directory or any parent directory.</p>
 </dd>
 

--- a/src/doc/src/commands/cargo-fetch.md
+++ b/src/doc/src/commands/cargo-fetch.md
@@ -83,7 +83,7 @@ terminal.</li>
 
 <dl>
 <dt class="option-term" id="option-cargo-fetch---manifest-path"><a class="option-anchor" href="#option-cargo-fetch---manifest-path"><code>--manifest-path</code> <em>path</em></a></dt>
-<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> file. By default, Cargo searches for the
+<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> or cargo script file. By default, Cargo searches for the
 <code>Cargo.toml</code> file in the current directory or any parent directory.</p>
 </dd>
 

--- a/src/doc/src/commands/cargo-fix.md
+++ b/src/doc/src/commands/cargo-fix.md
@@ -390,7 +390,7 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 
 <dl>
 <dt class="option-term" id="option-cargo-fix---manifest-path"><a class="option-anchor" href="#option-cargo-fix---manifest-path"><code>--manifest-path</code> <em>path</em></a></dt>
-<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> file. By default, Cargo searches for the
+<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> or cargo script file. By default, Cargo searches for the
 <code>Cargo.toml</code> file in the current directory or any parent directory.</p>
 </dd>
 

--- a/src/doc/src/commands/cargo-generate-lockfile.md
+++ b/src/doc/src/commands/cargo-generate-lockfile.md
@@ -57,7 +57,7 @@ terminal.</li>
 
 <dl>
 <dt class="option-term" id="option-cargo-generate-lockfile---manifest-path"><a class="option-anchor" href="#option-cargo-generate-lockfile---manifest-path"><code>--manifest-path</code> <em>path</em></a></dt>
-<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> file. By default, Cargo searches for the
+<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> or cargo script file. By default, Cargo searches for the
 <code>Cargo.toml</code> file in the current directory or any parent directory.</p>
 </dd>
 

--- a/src/doc/src/commands/cargo-locate-project.md
+++ b/src/doc/src/commands/cargo-locate-project.md
@@ -79,7 +79,7 @@ terminal.</li>
 
 <dl>
 <dt class="option-term" id="option-cargo-locate-project---manifest-path"><a class="option-anchor" href="#option-cargo-locate-project---manifest-path"><code>--manifest-path</code> <em>path</em></a></dt>
-<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> file. By default, Cargo searches for the
+<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> or cargo script file. By default, Cargo searches for the
 <code>Cargo.toml</code> file in the current directory or any parent directory.</p>
 </dd>
 

--- a/src/doc/src/commands/cargo-metadata.md
+++ b/src/doc/src/commands/cargo-metadata.md
@@ -443,7 +443,7 @@ terminal.</li>
 
 <dl>
 <dt class="option-term" id="option-cargo-metadata---manifest-path"><a class="option-anchor" href="#option-cargo-metadata---manifest-path"><code>--manifest-path</code> <em>path</em></a></dt>
-<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> file. By default, Cargo searches for the
+<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> or cargo script file. By default, Cargo searches for the
 <code>Cargo.toml</code> file in the current directory or any parent directory.</p>
 </dd>
 

--- a/src/doc/src/commands/cargo-package.md
+++ b/src/doc/src/commands/cargo-package.md
@@ -274,7 +274,7 @@ be specified multiple times, which enables all specified features.</p>
 <dl>
 
 <dt class="option-term" id="option-cargo-package---manifest-path"><a class="option-anchor" href="#option-cargo-package---manifest-path"><code>--manifest-path</code> <em>path</em></a></dt>
-<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> file. By default, Cargo searches for the
+<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> or cargo script file. By default, Cargo searches for the
 <code>Cargo.toml</code> file in the current directory or any parent directory.</p>
 </dd>
 

--- a/src/doc/src/commands/cargo-pkgid.md
+++ b/src/doc/src/commands/cargo-pkgid.md
@@ -90,7 +90,7 @@ terminal.</li>
 <dl>
 
 <dt class="option-term" id="option-cargo-pkgid---manifest-path"><a class="option-anchor" href="#option-cargo-pkgid---manifest-path"><code>--manifest-path</code> <em>path</em></a></dt>
-<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> file. By default, Cargo searches for the
+<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> or cargo script file. By default, Cargo searches for the
 <code>Cargo.toml</code> file in the current directory or any parent directory.</p>
 </dd>
 

--- a/src/doc/src/commands/cargo-publish.md
+++ b/src/doc/src/commands/cargo-publish.md
@@ -182,7 +182,7 @@ be specified multiple times, which enables all specified features.</p>
 <dl>
 
 <dt class="option-term" id="option-cargo-publish---manifest-path"><a class="option-anchor" href="#option-cargo-publish---manifest-path"><code>--manifest-path</code> <em>path</em></a></dt>
-<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> file. By default, Cargo searches for the
+<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> or cargo script file. By default, Cargo searches for the
 <code>Cargo.toml</code> file in the current directory or any parent directory.</p>
 </dd>
 

--- a/src/doc/src/commands/cargo-remove.md
+++ b/src/doc/src/commands/cargo-remove.md
@@ -84,7 +84,7 @@ terminal.</li>
 
 <dl>
 <dt class="option-term" id="option-cargo-remove---manifest-path"><a class="option-anchor" href="#option-cargo-remove---manifest-path"><code>--manifest-path</code> <em>path</em></a></dt>
-<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> file. By default, Cargo searches for the
+<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> or cargo script file. By default, Cargo searches for the
 <code>Cargo.toml</code> file in the current directory or any parent directory.</p>
 </dd>
 

--- a/src/doc/src/commands/cargo-run.md
+++ b/src/doc/src/commands/cargo-run.md
@@ -19,6 +19,9 @@ Unlike [cargo-test(1)](cargo-test.html) and [cargo-bench(1)](cargo-bench.html), 
 working directory of the binary executed to the current working directory, same 
 as if it was executed in the shell directly.
 
+When running scripts, the process' [arg0](../../std/env/fn.args.html) will be set to the
+script's path on a best-effort basis.
+
 ## OPTIONS
 
 ### Package Selection
@@ -213,7 +216,7 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 <dl>
 
 <dt class="option-term" id="option-cargo-run---manifest-path"><a class="option-anchor" href="#option-cargo-run---manifest-path"><code>--manifest-path</code> <em>path</em></a></dt>
-<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> file. By default, Cargo searches for the
+<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> or cargo script file. By default, Cargo searches for the
 <code>Cargo.toml</code> file in the current directory or any parent directory.</p>
 </dd>
 

--- a/src/doc/src/commands/cargo-rustc.md
+++ b/src/doc/src/commands/cargo-rustc.md
@@ -317,7 +317,7 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 <dl>
 
 <dt class="option-term" id="option-cargo-rustc---manifest-path"><a class="option-anchor" href="#option-cargo-rustc---manifest-path"><code>--manifest-path</code> <em>path</em></a></dt>
-<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> file. By default, Cargo searches for the
+<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> or cargo script file. By default, Cargo searches for the
 <code>Cargo.toml</code> file in the current directory or any parent directory.</p>
 </dd>
 

--- a/src/doc/src/commands/cargo-rustdoc.md
+++ b/src/doc/src/commands/cargo-rustdoc.md
@@ -297,7 +297,7 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 
 <dl>
 <dt class="option-term" id="option-cargo-rustdoc---manifest-path"><a class="option-anchor" href="#option-cargo-rustdoc---manifest-path"><code>--manifest-path</code> <em>path</em></a></dt>
-<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> file. By default, Cargo searches for the
+<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> or cargo script file. By default, Cargo searches for the
 <code>Cargo.toml</code> file in the current directory or any parent directory.</p>
 </dd>
 

--- a/src/doc/src/commands/cargo-test.md
+++ b/src/doc/src/commands/cargo-test.md
@@ -424,7 +424,7 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 <dl>
 
 <dt class="option-term" id="option-cargo-test---manifest-path"><a class="option-anchor" href="#option-cargo-test---manifest-path"><code>--manifest-path</code> <em>path</em></a></dt>
-<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> file. By default, Cargo searches for the
+<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> or cargo script file. By default, Cargo searches for the
 <code>Cargo.toml</code> file in the current directory or any parent directory.</p>
 </dd>
 

--- a/src/doc/src/commands/cargo-tree.md
+++ b/src/doc/src/commands/cargo-tree.md
@@ -233,7 +233,7 @@ single quotes or double quotes around each pattern.</p>
 <dl>
 
 <dt class="option-term" id="option-cargo-tree---manifest-path"><a class="option-anchor" href="#option-cargo-tree---manifest-path"><code>--manifest-path</code> <em>path</em></a></dt>
-<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> file. By default, Cargo searches for the
+<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> or cargo script file. By default, Cargo searches for the
 <code>Cargo.toml</code> file in the current directory or any parent directory.</p>
 </dd>
 

--- a/src/doc/src/commands/cargo-update.md
+++ b/src/doc/src/commands/cargo-update.md
@@ -122,7 +122,7 @@ terminal.</li>
 <dl>
 
 <dt class="option-term" id="option-cargo-update---manifest-path"><a class="option-anchor" href="#option-cargo-update---manifest-path"><code>--manifest-path</code> <em>path</em></a></dt>
-<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> file. By default, Cargo searches for the
+<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> or cargo script file. By default, Cargo searches for the
 <code>Cargo.toml</code> file in the current directory or any parent directory.</p>
 </dd>
 

--- a/src/doc/src/commands/cargo-vendor.md
+++ b/src/doc/src/commands/cargo-vendor.md
@@ -68,7 +68,7 @@ only a subset of the packages have changed.</p>
 <dl>
 
 <dt class="option-term" id="option-cargo-vendor---manifest-path"><a class="option-anchor" href="#option-cargo-vendor---manifest-path"><code>--manifest-path</code> <em>path</em></a></dt>
-<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> file. By default, Cargo searches for the
+<dd class="option-desc"><p>Path to the <code>Cargo.toml</code> or cargo script file. By default, Cargo searches for the
 <code>Cargo.toml</code> file in the current directory or any parent directory.</p>
 </dd>
 

--- a/src/doc/src/commands/cargo.md
+++ b/src/doc/src/commands/cargo.md
@@ -7,6 +7,7 @@ cargo --- The Rust package manager
 ## SYNOPSIS
 
 `cargo` [_options_] _command_ [_args_]\
+`cargo` [_options_] _script_ [_args_]\
 `cargo` [_options_] `--version`\
 `cargo` [_options_] `--list`\
 `cargo` [_options_] `--help`\
@@ -19,11 +20,25 @@ available at <https://rust-lang.org>.
 
 _command_ may be one of:
 - built-in commands, see below
+- [script](#scripts)
 - [aliases]
 - [external tools]
 
 [aliases]: ../reference/config.html#alias
 [external tools]: ../reference/external-tools.html#custom-subcommands
+
+## SCRIPTS
+
+A _script_ is distinguished from a _command_ or _alias_ by having path separators present or a `.rs` extension.
+These are Rust source files with an optional [manifest] embedded in the frontmatter.
+
+For configuration discovery,
+`cargo` _script_ operates on the script level and not in the context of it's invocation.
+This means that the local [configuration discovery] is done in the directory of the _script_
+rather than the current working directory of `cargo`.
+
+[manifest]: ../reference/manifest.html
+[configuration discovery]: ../reference/config.html#hierarchical-structure
 
 ## COMMANDS
 
@@ -359,7 +374,11 @@ stable yet and may be subject to change.
        mkdir foo && cd foo
        cargo init .
 
-6. Learn about a command's options and usage:
+6. Run a script
+
+       cargo task.rs --action
+
+7. Learn about a command's options and usage:
 
        cargo help clean
 

--- a/src/doc/src/reference/cargo-targets.md
+++ b/src/doc/src/reference/cargo-targets.md
@@ -363,6 +363,9 @@ autobins = false
 > is `false` if at least one target is manually defined in `Cargo.toml`.
 > Beginning with the 2018 edition, the default is always `true`.
 
+> **Note:** Scripts are self-contained and do not support additional targets
+> nor controlling target discovery.
+
 > **MSRV:** Respected as of 1.27 for `autobins`, `autoexamples`, `autotests`, and `autobenches`
 
 > **MSRV:** Respected as of 1.83 for `autolib`

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -531,7 +531,8 @@ target = ["x86_64-unknown-linux-gnu", "i686-unknown-linux-gnu"]
 * Environment: `CARGO_BUILD_TARGET_DIR` or `CARGO_TARGET_DIR`
 
 The path to where all compiler output is placed. The default if not specified
-is a directory named `target` located at the root of the workspace.
+is a directory named `target` located at the root of the workspace for `Cargo.toml` files.
+The default for scripts is in an unspecified cache directory, away from the script's location.
 
 Can be overridden with the `--target-dir` CLI option.
 

--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -4,6 +4,22 @@ The `Cargo.toml` file for each package is called its *manifest*. It is written
 in the [TOML] format. It contains metadata that is needed to compile the package. Checkout
 the `cargo locate-project` section for more detail on how cargo finds the manifest file.
 
+The content of the manifest can also be embedded inside of the frontmatter inside of a Rust source file:
+```rust
+#!/usr/bin/env cargo
+---
+[package]
+edition = "2024"
+
+[dependencies]
+regex = "1"
+---
+
+fn main() {
+    // ...
+}
+```
+
 Every manifest file consists of the following sections:
 
 * [`cargo-features`](unstable.md) --- Unstable, nightly-only features.
@@ -66,10 +82,11 @@ name = "hello_world" # the name of the package
 version = "0.1.0"    # the current version, obeying semver
 ```
 
-The only field required by Cargo is [`name`](#the-name-field). If publishing to
-a registry, the registry may require additional fields. See the notes below and
-[the publishing chapter][publishing] for requirements for publishing to
-[crates.io].
+The only field required by Cargo for `Cargo.toml` files is [`name`](#the-name-field).
+There are no required fields for cargo scripts.
+If publishing to a registry, the registry may require additional fields. See
+the notes below and [the publishing chapter][publishing] for requirements for
+publishing to [crates.io].
 
 ### The `name` field
 
@@ -87,6 +104,9 @@ a keyword. [crates.io] imposes even more restrictions, such as:
 - Do not use reserved names.
 - Do not use special Windows names such as "nul".
 - Use a maximum of 64 characters of length.
+
+This field is optional for scripts and defaults to the file stem.
+The field is required for `Cargo.toml` manifests.
 
 [alphanumeric]: ../../std/primitive.char.html#method.is_alphanumeric
 
@@ -154,7 +174,9 @@ with the latest stable edition. By default `cargo new` creates a manifest with
 the 2024 edition currently.
 
 If the `edition` field is not present in `Cargo.toml`, then the 2015 edition is
-assumed for backwards compatibility. Note that all manifests
+assumed for backwards compatibility.
+In scripts, the current edition is assumed.
+Note that all manifests
 created with [`cargo new`] will not use this historical fallback because they
 will have `edition` explicitly specified to a newer value.
 
@@ -328,6 +350,8 @@ table defined. That is, a crate cannot both be a root crate in a workspace
 
 For more information, see the [workspaces chapter](workspaces.md).
 
+This field is disallowed in scripts.
+
 ### The `build` field
 
 The `build` field specifies a file in the package root which is a [build
@@ -347,6 +371,8 @@ The default is `"build.rs"`, which loads the script from a file named
 specify a path to a different file or `build = false` to disable automatic
 detection of the build script.
 
+This field is disallowed in scripts.
+
 ### The `links` field
 
 The `links` field specifies the name of a native library that is being linked
@@ -363,6 +389,8 @@ on Linux) may specify:
 # ...
 links = "git2"
 ```
+
+This field is disallowed in scripts.
 
 ### The `exclude` and `include` fields
 
@@ -518,6 +546,8 @@ both `src/bin/a.rs` and `src/bin/b.rs`:
 [package]
 default-run = "a"
 ```
+
+This field is disallowed in scripts.
 
 ## The `[lints]` section
 

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -129,7 +129,6 @@ Each new feature described below should explain how to use it.
     * [asymmetric-token](#asymmetric-token) --- Adds support for authentication tokens using asymmetric cryptography (`cargo:paseto` provider).
 * Other
     * [gitoxide](#gitoxide) --- Use `gitoxide` instead of `git2` for a set of operations.
-    * [script](#script) --- Enable support for single-file `.rs` packages.
     * [lockfile-path](#lockfile-path) --- Allows to specify a path to lockfile other than the default path `<workspace_root>/Cargo.lock`.
     * [native-completions](#native-completions) --- Move cargo shell completions to native completions.
     * [warnings](#warnings) --- controls warning behavior; options for allowing or denying warnings.
@@ -1386,99 +1385,6 @@ Valid operations are the following:
 * When the unstable feature is on, fetching/cloning a git repository is always a shallow fetch. This roughly equals to `git fetch --depth 1` everywhere.
 * Even with the presence of `Cargo.lock` or specifying a commit `{ rev = "…" }`, gitoxide and libgit2 are still smart enough to shallow fetch without unshallowing the existing repository.
 
-## script
-
-* Tracking Issue: [#12207](https://github.com/rust-lang/cargo/issues/12207)
-
-Cargo can directly run `.rs` files as:
-```console
-$ cargo +nightly -Zscript file.rs
-```
-where `file.rs` can be as simple as:
-```rust
-fn main() {}
-```
-
-A user may optionally specify a manifest in a `cargo` code fence in a module-level comment, like:
-````rust
-#!/usr/bin/env -S cargo +nightly -Zscript
----cargo
-[dependencies]
-clap = { version = "4.2", features = ["derive"] }
----
-
-use clap::Parser;
-
-#[derive(Parser, Debug)]
-#[clap(version)]
-struct Args {
-    #[clap(short, long, help = "Path to config")]
-    config: Option<std::path::PathBuf>,
-}
-
-fn main() {
-    let args = Args::parse();
-    println!("{:?}", args);
-}
-````
-
-### Single-file packages
-
-In addition to today's multi-file packages (`Cargo.toml` file with other `.rs`
-files), we are adding the concept of single-file packages which may contain an
-embedded manifest.  There is no required distinguishment for a single-file
-`.rs` package from any other `.rs` file.
-
-Single-file packages may be selected via `--manifest-path`, like
-`cargo test --manifest-path foo.rs`. Unlike `Cargo.toml`, these files cannot be auto-discovered.
-
-A single-file package may contain an embedded manifest.  An embedded manifest
-is stored using `TOML` in rust "frontmatter", a markdown code-fence with `cargo`
-at the start of the infostring at the top of the file.
-
-Inferred / defaulted manifest fields:
-- `package.name = <slugified file stem>`
-- `package.edition = <current>` to avoid always having to add an embedded
-  manifest at the cost of potentially breaking scripts on rust upgrades
-  - Warn when `edition` is unspecified to raise awareness of this
-
-Disallowed manifest fields:
-- `[workspace]`, `[lib]`, `[[bin]]`, `[[example]]`, `[[test]]`, `[[bench]]`
-- `package.workspace`, `package.build`, `package.links`, `package.autolib`, `package.autobins`, `package.autoexamples`, `package.autotests`, `package.autobenches`
-
-The default `CARGO_TARGET_DIR` for single-file packages is at `$CARGO_HOME/target/<hash>`:
-- Avoid conflicts from multiple single-file packages being in the same directory
-- Avoid problems with the single-file package's parent directory being read-only
-- Avoid cluttering the user's directory
-
-The lockfile for single-file packages will be placed in `CARGO_TARGET_DIR`.  In
-the future, when workspaces are supported, that will allow a user to have a
-persistent lockfile.
-
-### Manifest-commands
-
-You may pass a manifest directly to the `cargo` command, without a subcommand,
-like `foo/Cargo.toml` or a single-file package like `foo.rs`.  This is mostly
-intended for being put in `#!` lines.
-
-The precedence for how to interpret `cargo <subcommand>` is
-1. Built-in xor single-file packages
-2. Aliases
-3. External subcommands
-
-A parameter is identified as a manifest-command if it has one of:
-- Path separators
-- A `.rs` extension
-- The file name is `Cargo.toml`
-
-Differences between `cargo run --manifest-path <path>` and `cargo <path>`
-- `cargo <path>` runs with the config for `<path>` and not the current dir, more like `cargo install --path <path>`
-- `cargo <path>` is at a verbosity level below the normal default.  Pass `-v` to get normal output.
-
-When running a package with an embedded manifest,
-[`arg0`](https://doc.rust-lang.org/std/os/unix/process/trait.CommandExt.html#tymethod.arg0) will be the scripts path.
-To get the executable's path, see [`current_exe`](https://doc.rust-lang.org/std/env/fn.current_exe.html).
-
 ### Documentation Updates
 
 ## Profile `trim-paths` option
@@ -2353,3 +2259,7 @@ See the [`include` config documentation](config.md#include) for more.
 ## pubtime
 
 The `pubtime` index field  has been stabilized in Rust 1.94.0.
+
+## Cargo script
+
+Support for `-Zscript` has been stabilized in 1.95.0.

--- a/src/etc/man/cargo-add.1
+++ b/src/etc/man/cargo-add.1
@@ -208,7 +208,7 @@ May also be specified with the \fBterm.color\fR
 .sp
 \fB\-\-manifest\-path\fR \fIpath\fR
 .RS 4
-Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
+Path to the \fBCargo.toml\fR or cargo script file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -410,7 +410,7 @@ coming from rustc are still emitted. Cannot be used with \fBhuman\fR or \fBshort
 .sp
 \fB\-\-manifest\-path\fR \fIpath\fR
 .RS 4
-Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
+Path to the \fBCargo.toml\fR or cargo script file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp

--- a/src/etc/man/cargo-build.1
+++ b/src/etc/man/cargo-build.1
@@ -317,7 +317,7 @@ coming from rustc are still emitted. Cannot be used with \fBhuman\fR or \fBshort
 .sp
 \fB\-\-manifest\-path\fR \fIpath\fR
 .RS 4
-Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
+Path to the \fBCargo.toml\fR or cargo script file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp

--- a/src/etc/man/cargo-check.1
+++ b/src/etc/man/cargo-check.1
@@ -308,7 +308,7 @@ coming from rustc are still emitted. Cannot be used with \fBhuman\fR or \fBshort
 .sp
 \fB\-\-manifest\-path\fR \fIpath\fR
 .RS 4
-Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
+Path to the \fBCargo.toml\fR or cargo script file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp

--- a/src/etc/man/cargo-clean.1
+++ b/src/etc/man/cargo-clean.1
@@ -128,7 +128,7 @@ May also be specified with the \fBterm.color\fR
 .sp
 \fB\-\-manifest\-path\fR \fIpath\fR
 .RS 4
-Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
+Path to the \fBCargo.toml\fR or cargo script file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -277,7 +277,7 @@ coming from rustc are still emitted. Cannot be used with \fBhuman\fR or \fBshort
 .sp
 \fB\-\-manifest\-path\fR \fIpath\fR
 .RS 4
-Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
+Path to the \fBCargo.toml\fR or cargo script file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp

--- a/src/etc/man/cargo-fetch.1
+++ b/src/etc/man/cargo-fetch.1
@@ -91,7 +91,7 @@ May also be specified with the \fBterm.color\fR
 .sp
 \fB\-\-manifest\-path\fR \fIpath\fR
 .RS 4
-Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
+Path to the \fBCargo.toml\fR or cargo script file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp

--- a/src/etc/man/cargo-fix.1
+++ b/src/etc/man/cargo-fix.1
@@ -403,7 +403,7 @@ coming from rustc are still emitted. Cannot be used with \fBhuman\fR or \fBshort
 .sp
 \fB\-\-manifest\-path\fR \fIpath\fR
 .RS 4
-Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
+Path to the \fBCargo.toml\fR or cargo script file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp

--- a/src/etc/man/cargo-generate-lockfile.1
+++ b/src/etc/man/cargo-generate-lockfile.1
@@ -58,7 +58,7 @@ May also be specified with the \fBterm.color\fR
 .sp
 \fB\-\-manifest\-path\fR \fIpath\fR
 .RS 4
-Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
+Path to the \fBCargo.toml\fR or cargo script file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp

--- a/src/etc/man/cargo-locate-project.1
+++ b/src/etc/man/cargo-locate-project.1
@@ -79,7 +79,7 @@ May also be specified with the \fBterm.color\fR
 .sp
 \fB\-\-manifest\-path\fR \fIpath\fR
 .RS 4
-Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
+Path to the \fBCargo.toml\fR or cargo script file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .SS "Common Options"

--- a/src/etc/man/cargo-metadata.1
+++ b/src/etc/man/cargo-metadata.1
@@ -442,7 +442,7 @@ May also be specified with the \fBterm.color\fR
 .sp
 \fB\-\-manifest\-path\fR \fIpath\fR
 .RS 4
-Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
+Path to the \fBCargo.toml\fR or cargo script file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp

--- a/src/etc/man/cargo-package.1
+++ b/src/etc/man/cargo-package.1
@@ -299,7 +299,7 @@ Do not activate the \fBdefault\fR feature of the selected packages.
 .sp
 \fB\-\-manifest\-path\fR \fIpath\fR
 .RS 4
-Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
+Path to the \fBCargo.toml\fR or cargo script file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp

--- a/src/etc/man/cargo-pkgid.1
+++ b/src/etc/man/cargo-pkgid.1
@@ -117,7 +117,7 @@ May also be specified with the \fBterm.color\fR
 .sp
 \fB\-\-manifest\-path\fR \fIpath\fR
 .RS 4
-Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
+Path to the \fBCargo.toml\fR or cargo script file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp

--- a/src/etc/man/cargo-publish.1
+++ b/src/etc/man/cargo-publish.1
@@ -180,7 +180,7 @@ Do not activate the \fBdefault\fR feature of the selected packages.
 .sp
 \fB\-\-manifest\-path\fR \fIpath\fR
 .RS 4
-Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
+Path to the \fBCargo.toml\fR or cargo script file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp

--- a/src/etc/man/cargo-remove.1
+++ b/src/etc/man/cargo-remove.1
@@ -77,7 +77,7 @@ May also be specified with the \fBterm.color\fR
 .sp
 \fB\-\-manifest\-path\fR \fIpath\fR
 .RS 4
-Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
+Path to the \fBCargo.toml\fR or cargo script file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp

--- a/src/etc/man/cargo-run.1
+++ b/src/etc/man/cargo-run.1
@@ -17,6 +17,9 @@ run. If you\[cq]re passing arguments to both Cargo and the binary, the ones afte
 Unlike \fBcargo\-test\fR(1) and \fBcargo\-bench\fR(1), \fBcargo run\fR sets the
 working directory of the binary executed to the current working directory, same
 as if it was executed in the shell directly.
+.sp
+When running scripts, the process\[cq] \fIarg0\fR <https://doc.rust\-lang.org/std/env/fn.args.html> will be set to the
+script\[cq]s path on a best\-effort basis.
 .SH "OPTIONS"
 .SS "Package Selection"
 By default, the package in the current working directory is selected. The \fB\-p\fR
@@ -212,7 +215,7 @@ coming from rustc are still emitted. Cannot be used with \fBhuman\fR or \fBshort
 .sp
 \fB\-\-manifest\-path\fR \fIpath\fR
 .RS 4
-Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
+Path to the \fBCargo.toml\fR or cargo script file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp

--- a/src/etc/man/cargo-rustc.1
+++ b/src/etc/man/cargo-rustc.1
@@ -327,7 +327,7 @@ coming from rustc are still emitted. Cannot be used with \fBhuman\fR or \fBshort
 .sp
 \fB\-\-manifest\-path\fR \fIpath\fR
 .RS 4
-Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
+Path to the \fBCargo.toml\fR or cargo script file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp

--- a/src/etc/man/cargo-rustdoc.1
+++ b/src/etc/man/cargo-rustdoc.1
@@ -294,7 +294,7 @@ coming from rustc are still emitted. Cannot be used with \fBhuman\fR or \fBshort
 .sp
 \fB\-\-manifest\-path\fR \fIpath\fR
 .RS 4
-Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
+Path to the \fBCargo.toml\fR or cargo script file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -437,7 +437,7 @@ coming from rustc are still emitted. Cannot be used with \fBhuman\fR or \fBshort
 .sp
 \fB\-\-manifest\-path\fR \fIpath\fR
 .RS 4
-Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
+Path to the \fBCargo.toml\fR or cargo script file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp

--- a/src/etc/man/cargo-tree.1
+++ b/src/etc/man/cargo-tree.1
@@ -265,7 +265,7 @@ single quotes or double quotes around each pattern.
 .sp
 \fB\-\-manifest\-path\fR \fIpath\fR
 .RS 4
-Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
+Path to the \fBCargo.toml\fR or cargo script file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp

--- a/src/etc/man/cargo-update.1
+++ b/src/etc/man/cargo-update.1
@@ -134,7 +134,7 @@ May also be specified with the \fBterm.color\fR
 .sp
 \fB\-\-manifest\-path\fR \fIpath\fR
 .RS 4
-Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
+Path to the \fBCargo.toml\fR or cargo script file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp

--- a/src/etc/man/cargo-vendor.1
+++ b/src/etc/man/cargo-vendor.1
@@ -58,7 +58,7 @@ only a subset of the packages have changed.
 .sp
 \fB\-\-manifest\-path\fR \fIpath\fR
 .RS 4
-Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
+Path to the \fBCargo.toml\fR or cargo script file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp

--- a/src/etc/man/cargo.1
+++ b/src/etc/man/cargo.1
@@ -8,6 +8,8 @@ cargo \[em] The Rust package manager
 .SH "SYNOPSIS"
 \fBcargo\fR [\fIoptions\fR] \fIcommand\fR [\fIargs\fR]
 .br
+\fBcargo\fR [\fIoptions\fR] \fIscript\fR [\fIargs\fR]
+.br
 \fBcargo\fR [\fIoptions\fR] \fB\-\-version\fR
 .br
 \fBcargo\fR [\fIoptions\fR] \fB\-\-list\fR
@@ -26,12 +28,24 @@ available at <https://rust\-lang.org>\&.
 .RE
 .sp
 .RS 4
+\h'-04'\(bu\h'+03'script
+.RE
+.sp
+.RS 4
 \h'-04'\(bu\h'+03'\fIaliases\fR <https://doc.rust\-lang.org/cargo/reference/config.html#alias>
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+03'\fIexternal tools\fR <https://doc.rust\-lang.org/cargo/reference/external\-tools.html#custom\-subcommands>
 .RE
+.SH "SCRIPTS"
+A \fIscript\fR is distinguished from a \fIcommand\fR or \fIalias\fR by having path separators present or a \fB\&.rs\fR extension.
+These are Rust source files with an optional \fImanifest\fR <https://doc.rust\-lang.org/cargo/reference/manifest.html> embedded in the frontmatter.
+.sp
+For configuration discovery,
+\fBcargo\fR \fIscript\fR operates on the script level and not in the context of it\[cq]s invocation.
+This means that the local \fIconfiguration discovery\fR <https://doc.rust\-lang.org/cargo/reference/config.html#hierarchical\-structure> is done in the directory of the \fIscript\fR
+rather than the current working directory of \fBcargo\fR\&.
 .SH "COMMANDS"
 .SS "Build Commands"
 \fBcargo\-bench\fR(1)
@@ -422,7 +436,17 @@ cargo init .
 .RE
 .sp
 .RS 4
-\h'-04' 6.\h'+01'Learn about a command\[cq]s options and usage:
+\h'-04' 6.\h'+01'Run a script
+.sp
+.RS 4
+.nf
+cargo task.rs \-\-action
+.fi
+.RE
+.RE
+.sp
+.RS 4
+\h'-04' 7.\h'+01'Learn about a command\[cq]s options and usage:
 .sp
 .RS 4
 .nf

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -349,7 +349,7 @@ fn cargo_compile_with_unsupported_short_unstable_feature_flag() {
   tip: a similar argument exists: '-Z'
 
 Usage: cargo [..][OPTIONS] [COMMAND]
-       cargo [..][OPTIONS] -Zscript <MANIFEST_RS> [ARGS]...
+       cargo [..][OPTIONS] <MANIFEST_RS> [ARGS]...
 
 For more information, try '--help'.
 

--- a/tests/testsuite/cargo/help/stdout.term.svg
+++ b/tests/testsuite/cargo/help/stdout.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">cargo</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS] [COMMAND]</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>       </tspan><tspan class="fg-bright-cyan bold">cargo</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">-Zscript</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;MANIFEST_RS&gt; [ARGS]...</tspan>
+    <tspan x="10px" y="82px"><tspan>       </tspan><tspan class="fg-bright-cyan bold">cargo</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;MANIFEST_RS&gt; [ARGS]...</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo/z_help/stdout.term.svg
+++ b/tests/testsuite/cargo/z_help/stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="1255px" height="1010px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1255px" height="992px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -104,27 +104,25 @@
 </tspan>
     <tspan x="10px" y="802px"><tspan>    -Z sbom                        Enable the `sbom` option in build config in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="820px"><tspan>    -Z script                      Enable support for single-file, `.rs` packages</tspan>
+    <tspan x="10px" y="820px"><tspan>    -Z section-timings             Enable support for extended compilation sections in --timings output</tspan>
 </tspan>
-    <tspan x="10px" y="838px"><tspan>    -Z section-timings             Enable support for extended compilation sections in --timings output</tspan>
+    <tspan x="10px" y="838px"><tspan>    -Z target-applies-to-host      Enable the `target-applies-to-host` key in the .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="856px"><tspan>    -Z target-applies-to-host      Enable the `target-applies-to-host` key in the .cargo/config.toml file</tspan>
+    <tspan x="10px" y="856px"><tspan>    -Z trim-paths                  Enable the `trim-paths` option in profiles</tspan>
 </tspan>
-    <tspan x="10px" y="874px"><tspan>    -Z trim-paths                  Enable the `trim-paths` option in profiles</tspan>
+    <tspan x="10px" y="874px"><tspan>    -Z unstable-options            Allow the usage of unstable options</tspan>
 </tspan>
-    <tspan x="10px" y="892px"><tspan>    -Z unstable-options            Allow the usage of unstable options</tspan>
+    <tspan x="10px" y="892px"><tspan>    -Z warnings                    Allow use of the build.warnings config key</tspan>
 </tspan>
-    <tspan x="10px" y="910px"><tspan>    -Z warnings                    Allow use of the build.warnings config key</tspan>
+    <tspan x="10px" y="910px">
 </tspan>
-    <tspan x="10px" y="928px">
+    <tspan x="10px" y="928px"><tspan>Run with `cargo -Z [FLAG] [COMMAND]`</tspan>
 </tspan>
-    <tspan x="10px" y="946px"><tspan>Run with `cargo -Z [FLAG] [COMMAND]`</tspan>
+    <tspan x="10px" y="946px">
 </tspan>
-    <tspan x="10px" y="964px">
+    <tspan x="10px" y="964px"><tspan>See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html for more information about these flags.</tspan>
 </tspan>
-    <tspan x="10px" y="982px"><tspan>See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html for more information about these flags.</tspan>
-</tspan>
-    <tspan x="10px" y="1000px">
+    <tspan x="10px" y="982px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_add/script_bare/mod.rs
+++ b/tests/testsuite/cargo_add/script_bare/mod.rs
@@ -25,8 +25,6 @@ fn case() {
     let cwd = &project_root;
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo(&["script"])
-        .arg("-Zscript")
         .arg("add")
         .arg_line("--manifest-path cargo-test-fixture.rs my-package")
         .current_dir(cwd)

--- a/tests/testsuite/cargo_add/script_escape/mod.rs
+++ b/tests/testsuite/cargo_add/script_escape/mod.rs
@@ -25,8 +25,6 @@ fn case() {
     let cwd = &project_root;
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo(&["script"])
-        .arg("-Zscript")
         .arg("add")
         .arg_line("--manifest-path cargo-test-fixture.rs my-package")
         .current_dir(cwd)

--- a/tests/testsuite/cargo_add/script_frontmatter/mod.rs
+++ b/tests/testsuite/cargo_add/script_frontmatter/mod.rs
@@ -25,8 +25,6 @@ fn case() {
     let cwd = &project_root;
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo(&["script"])
-        .arg("-Zscript")
         .arg("add")
         .arg_line("--manifest-path cargo-test-fixture.rs my-package")
         .current_dir(cwd)

--- a/tests/testsuite/cargo_add/script_frontmatter_empty/mod.rs
+++ b/tests/testsuite/cargo_add/script_frontmatter_empty/mod.rs
@@ -25,8 +25,6 @@ fn case() {
     let cwd = &project_root;
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo(&["script"])
-        .arg("-Zscript")
         .arg("add")
         .arg_line("--manifest-path cargo-test-fixture.rs my-package")
         .current_dir(cwd)

--- a/tests/testsuite/cargo_add/script_shebang/mod.rs
+++ b/tests/testsuite/cargo_add/script_shebang/mod.rs
@@ -25,8 +25,6 @@ fn case() {
     let cwd = &project_root;
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo(&["script"])
-        .arg("-Zscript")
         .arg("add")
         .arg_line("--manifest-path cargo-test-fixture.rs my-package")
         .current_dir(cwd)

--- a/tests/testsuite/cargo_help/single_alias/stdout.term.txt
+++ b/tests/testsuite/cargo_help/single_alias/stdout.term.txt
@@ -58,8 +58,9 @@ OPTIONS
 
    Manifest Options
        --manifest-path path
-           Path to the Cargo.toml file. By default, Cargo searches for the
-           Cargo.toml file in the current directory or any parent directory.
+           Path to the Cargo.toml or cargo script file. By default, Cargo
+           searches for the Cargo.toml file in the current directory or any
+           parent directory.
 
        --locked
            Asserts that the exact same dependencies and versions are used as

--- a/tests/testsuite/cargo_help/single_cmd/stdout.term.txt
+++ b/tests/testsuite/cargo_help/single_cmd/stdout.term.txt
@@ -259,8 +259,9 @@ OPTIONS
 
    Manifest Options
        --manifest-path path
-           Path to the Cargo.toml file. By default, Cargo searches for the
-           Cargo.toml file in the current directory or any parent directory.
+           Path to the Cargo.toml or cargo script file. By default, Cargo
+           searches for the Cargo.toml file in the current directory or any
+           parent directory.
 
        --ignore-rust-version
            Ignore rust-version specification in packages.

--- a/tests/testsuite/cargo_remove/script/mod.rs
+++ b/tests/testsuite/cargo_remove/script/mod.rs
@@ -25,8 +25,6 @@ fn case() {
     let cwd = &project_root;
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo(&["script"])
-        .arg("-Zscript")
         .arg("remove")
         .arg_line("--manifest-path cargo-remove-test-fixture.rs docopt")
         .current_dir(cwd)

--- a/tests/testsuite/cargo_remove/script_last/mod.rs
+++ b/tests/testsuite/cargo_remove/script_last/mod.rs
@@ -15,8 +15,6 @@ fn case() {
     let cwd = &project_root;
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo(&["script"])
-        .arg("-Zscript")
         .arg("remove")
         .arg_line("--manifest-path cargo-remove-test-fixture.rs docopt")
         .current_dir(cwd)

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -2558,7 +2558,7 @@ edition = "2021"
     );
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn migrate_removes_project_for_script() {
     let p = project()
         .file(
@@ -2586,8 +2586,7 @@ fn main() {
         )
         .build();
 
-    p.cargo("-Zscript fix --edition --allow-no-vcs --manifest-path foo.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("fix --edition --allow-no-vcs --manifest-path foo.rs")
         .with_stderr_data(str![[r#"
 [MIGRATING] foo.rs from 2021 edition to 2024
 [FIXED] foo.rs (1 fix)
@@ -3090,7 +3089,10 @@ fn script_without_frontmatter() {
         .masquerade_as_nightly_cargo(&["script"])
         .with_stdout_data(str![""])
         .with_stderr_data(str![[r#"
-[WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[WARNING] flag `-Z script` has been stabilized in the 1.95 release, and is no longer necessary
+  Cargo scripts are now always available
+
+[WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `2024`)
 [FIXED] echo.rs (1 fix)
 [CHECKING] echo v0.0.0 ([ROOT]/foo/echo.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -3128,7 +3130,10 @@ fn main() {}",
         .masquerade_as_nightly_cargo(&["script"])
         .with_stdout_data(str![""])
         .with_stderr_data(str![[r#"
-[WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[WARNING] flag `-Z script` has been stabilized in the 1.95 release, and is no longer necessary
+  Cargo scripts are now always available
+
+[WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `2024`)
 [FIXED] echo.rs (1 fix)
 [CHECKING] echo v0.0.0 ([ROOT]/foo/echo.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -3168,7 +3173,10 @@ fn main() {}"#,
         .masquerade_as_nightly_cargo(&["script"])
         .with_stdout_data(str![""])
         .with_stderr_data(str![[r#"
-[WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[WARNING] flag `-Z script` has been stabilized in the 1.95 release, and is no longer necessary
+  Cargo scripts are now always available
+
+[WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `2024`)
 [FIXED] echo.rs (1 fix)
 [CHECKING] foo v0.0.0 ([ROOT]/foo/echo.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -3207,7 +3215,10 @@ fn main() {}"#,
         .masquerade_as_nightly_cargo(&["script"])
         .with_stdout_data(str![""])
         .with_stderr_data(str![[r#"
-[WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[WARNING] flag `-Z script` has been stabilized in the 1.95 release, and is no longer necessary
+  Cargo scripts are now always available
+
+[WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `2024`)
 [FIXED] echo.rs (1 fix)
 [CHECKING] foo v0.0.0 ([ROOT]/foo/echo.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -3245,6 +3256,9 @@ fn main() {}"#,
         .masquerade_as_nightly_cargo(&["script"])
         .with_stdout_data(str![""])
         .with_stderr_data(str![[r#"
+[WARNING] flag `-Z script` has been stabilized in the 1.95 release, and is no longer necessary
+  Cargo scripts are now always available
+
 [CHECKING] echo v0.0.0 ([ROOT]/foo/echo.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/lints/non_kebab_case_bins.rs
+++ b/tests/testsuite/lints/non_kebab_case_bins.rs
@@ -136,7 +136,7 @@ non_kebab_case_bins = "warn"
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn bin_name_from_script_name() {
     let p = cargo_test_support::project()
         .file(
@@ -150,8 +150,8 @@ fn main() {}"#,
         )
         .build();
 
-    p.cargo("check -Zcargo-lints -Zscript --manifest-path foo_bar")
-        .masquerade_as_nightly_cargo(&["cargo-lints", "script"])
+    p.cargo("check -Zcargo-lints --manifest-path foo_bar")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
 [WARNING] binaries should have a kebab-case name

--- a/tests/testsuite/lints/non_kebab_case_packages.rs
+++ b/tests/testsuite/lints/non_kebab_case_packages.rs
@@ -43,7 +43,7 @@ non_kebab_case_packages = "warn"
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn package_name_from_script_name() {
     let p = cargo_test_support::project()
         .file(
@@ -57,8 +57,8 @@ fn main() {}"#,
         )
         .build();
 
-    p.cargo("check -Zcargo-lints -Zscript --manifest-path foo_bar")
-        .masquerade_as_nightly_cargo(&["cargo-lints", "script"])
+    p.cargo("check -Zcargo-lints --manifest-path foo_bar")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
 [WARNING] packages should have a kebab-case name

--- a/tests/testsuite/lints/non_snake_case_packages.rs
+++ b/tests/testsuite/lints/non_snake_case_packages.rs
@@ -43,7 +43,7 @@ non_snake_case_packages = "warn"
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn package_name_from_script_name() {
     let p = cargo_test_support::project()
         .file(
@@ -57,8 +57,8 @@ fn main() {}"#,
         )
         .build();
 
-    p.cargo("check -Zcargo-lints -Zscript --manifest-path foo-bar")
-        .masquerade_as_nightly_cargo(&["cargo-lints", "script"])
+    p.cargo("check -Zcargo-lints --manifest-path foo-bar")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
 [WARNING] packages should have a snake-case name

--- a/tests/testsuite/lockfile_path.rs
+++ b/tests/testsuite/lockfile_path.rs
@@ -416,7 +416,7 @@ dependencies = [
     assert_has_installed_exe(paths::cargo_home(), "foo");
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn config_run_embed() {
     let lockfile_path = "mylockfile/Cargo.lock";
     let invalid_lockfile = "Cargo.lock";
@@ -427,7 +427,6 @@ fn config_run_embed() {
 
     p.cargo("run -Zlockfile-path")
         .masquerade_as_nightly_cargo(&["lockfile-path"])
-        .arg("-Zscript")
         .arg("--config")
         .arg(&format!("resolver.lockfile-path='{lockfile_path}'"))
         .arg("--manifest-path")
@@ -439,7 +438,6 @@ fn config_run_embed() {
     p.cargo("run -Zlockfile-path")
         .masquerade_as_nightly_cargo(&["lockfile-path"])
         .arg("-Zunstable-options")
-        .arg("-Zscript")
         .arg("--config")
         .arg(&format!("resolver.lockfile-path='{invalid_lockfile}'"))
         .arg("--manifest-path")

--- a/tests/testsuite/open_namespaces.rs
+++ b/tests/testsuite/open_namespaces.rs
@@ -259,7 +259,7 @@ fn explicit_bin_within_namespace() {
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[cfg(unix)]
 fn namespaced_script_name() {
     let p = cargo_test_support::project()
@@ -275,8 +275,8 @@ fn main() {}
         )
         .build();
 
-    p.cargo("read-manifest -Zscript --manifest-path foo::bar.rs")
-        .masquerade_as_nightly_cargo(&["script", "open-namespaces"])
+    p.cargo("read-manifest --manifest-path foo::bar.rs")
+        .masquerade_as_nightly_cargo(&["open-namespaces"])
         .with_stdout_data(
             str![[r#"
 {

--- a/tests/testsuite/script/cargo.rs
+++ b/tests/testsuite/script/cargo.rs
@@ -24,14 +24,13 @@ fn path() -> Vec<std::path::PathBuf> {
     std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default()).collect()
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn basic_rs() {
     let p = cargo_test_support::project()
         .file("echo.rs", ECHO_SCRIPT)
         .build();
 
-    p.cargo("-Zscript -v echo.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v echo.rs")
         .with_stdout_data(str![[r#"
 current_exe: [ROOT]/home/.cargo/build/[HASH]/target/debug/echo[EXE]
 arg0: [..]
@@ -49,14 +48,13 @@ args: []
 }
 
 #[cfg(unix)]
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn arg0() {
     let p = cargo_test_support::project()
         .file("echo.rs", ECHO_SCRIPT)
         .build();
 
-    p.cargo("-Zscript -v echo.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v echo.rs")
         .with_stdout_data(str![[r#"
 current_exe: [ROOT]/home/.cargo/build/[HASH]/target/debug/echo[EXE]
 arg0: [ROOT]/foo/echo.rs
@@ -74,14 +72,13 @@ args: []
 }
 
 #[cfg(windows)]
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn arg0() {
     let p = cargo_test_support::project()
         .file("echo.rs", ECHO_SCRIPT)
         .build();
 
-    p.cargo("-Zscript -v echo.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v echo.rs")
         .with_stdout_data(str![[r#"
 current_exe: [ROOT]/home/.cargo/build/[HASH]/target/debug/echo[EXE]
 arg0: [ROOT]/home/.cargo/build/[HASH]/target/debug/echo[EXE]
@@ -98,14 +95,13 @@ args: []
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn basic_path() {
     let p = cargo_test_support::project()
         .file("echo", ECHO_SCRIPT)
         .build();
 
-    p.cargo("-Zscript -v ./echo")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v ./echo")
         .with_stdout_data(str![[r#"
 current_exe: [ROOT]/home/.cargo/build/[HASH]/target/debug/echo[EXE]
 arg0: [..]
@@ -122,14 +118,13 @@ args: []
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn path_required() {
     let p = cargo_test_support::project()
         .file("echo", ECHO_SCRIPT)
         .build();
 
-    p.cargo("-Zscript -v echo")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v echo")
         .with_status(101)
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
@@ -146,7 +141,7 @@ fn path_required() {
 }
 
 #[cfg(unix)]
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn manifest_precedence_over_plugins() {
     let p = cargo_test_support::project()
         .file("echo.rs", ECHO_SCRIPT)
@@ -158,9 +153,8 @@ fn manifest_precedence_over_plugins() {
     path.push(p.root().join("path-test"));
     let path = std::env::join_paths(path.iter()).unwrap();
 
-    p.cargo("-Zscript -v echo.rs")
+    p.cargo("-v echo.rs")
         .env("PATH", &path)
-        .masquerade_as_nightly_cargo(&["script"])
         .with_stdout_data(str![[r#"
 current_exe: [ROOT]/home/.cargo/build/[HASH]/target/debug/echo[EXE]
 arg0: [..]
@@ -177,64 +171,7 @@ args: []
         .run();
 }
 
-#[cfg(unix)]
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
-fn warn_when_plugin_masks_manifest_on_stable() {
-    let p = cargo_test_support::project()
-        .file("echo.rs", ECHO_SCRIPT)
-        .executable(std::path::Path::new("path-test").join("cargo-echo.rs"), "")
-        .build();
-
-    let mut path = path();
-    path.push(p.root().join("path-test"));
-    let path = std::env::join_paths(path.iter()).unwrap();
-
-    p.cargo("-v echo.rs")
-        .env("PATH", &path)
-        .with_stdout_data("")
-        .with_stderr_data(str![[r#"
-[WARNING] external subcommand `echo.rs` has the appearance of a manifest-command
-  |
-  = [NOTE] this was previously accepted but will be phased out when `-Zscript` is stabilized; see <https://github.com/rust-lang/cargo/issues/12207>
-
-"#]])
-        .run();
-}
-
-#[cargo_test]
-fn requires_nightly() {
-    let p = cargo_test_support::project()
-        .file("echo.rs", ECHO_SCRIPT)
-        .build();
-
-    p.cargo("-v echo.rs")
-        .with_status(101)
-        .with_stdout_data("")
-        .with_stderr_data(str![[r#"
-[ERROR] running the file `echo.rs` requires `-Zscript`
-
-"#]])
-        .run();
-}
-
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
-fn requires_z_flag() {
-    let p = cargo_test_support::project()
-        .file("echo.rs", ECHO_SCRIPT)
-        .build();
-
-    p.cargo("-v echo.rs")
-        .masquerade_as_nightly_cargo(&["script"])
-        .with_status(101)
-        .with_stdout_data("")
-        .with_stderr_data(str![[r#"
-[ERROR] running the file `echo.rs` requires `-Zscript`
-
-"#]])
-        .run();
-}
-
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn manifest_parse_error() {
     // Exaggerate the newlines to make it more obvious if the error's line number is off
     let script = r#"#!/usr/bin/env cargo
@@ -255,8 +192,7 @@ fn main() {
         .file("script.rs", script)
         .build();
 
-    p.cargo("-Zscript -v script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v script.rs")
         .with_status(101)
         .with_stdout_data(str![""])
         .with_stderr_data(str![[r#"
@@ -270,7 +206,7 @@ fn main() {
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn clean_output_with_edition() {
     let script = r#"#!/usr/bin/env cargo
 ---
@@ -285,8 +221,7 @@ fn main() {
         .file("script.rs", script)
         .build();
 
-    p.cargo("-Zscript -v script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v script.rs")
         .with_stdout_data(str![[r#"
 Hello world!
 
@@ -300,7 +235,7 @@ Hello world!
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn warning_without_edition() {
     let script = r#"#!/usr/bin/env cargo
 ---
@@ -314,8 +249,7 @@ fn main() {
         .file("script.rs", script)
         .build();
 
-    p.cargo("-Zscript -v script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v script.rs")
         .with_stdout_data(str![[r#"
 Hello world!
 
@@ -330,7 +264,7 @@ Hello world!
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn rebuild() {
     let script = r#"#!/usr/bin/env cargo-eval
 
@@ -342,8 +276,7 @@ fn main() {
         .file("script.rs", script)
         .build();
 
-    p.cargo("-Zscript -v script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v script.rs")
         .with_stdout_data(str![[r#"
 msg = undefined
 
@@ -358,8 +291,7 @@ msg = undefined
         .run();
 
     // Verify we don't rebuild
-    p.cargo("-Zscript -v script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v script.rs")
         .with_stdout_data(str![[r#"
 msg = undefined
 
@@ -373,9 +305,8 @@ msg = undefined
         .run();
 
     // Verify we do rebuild
-    p.cargo("-Zscript -v script.rs")
+    p.cargo("-v script.rs")
         .env("_MESSAGE", "hello")
-        .masquerade_as_nightly_cargo(&["script"])
         .with_stdout_data(str![[r#"
 msg = hello
 
@@ -390,7 +321,7 @@ msg = hello
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn use_script_config() {
     let script = ECHO_SCRIPT;
     let _ = cargo_test_support::project()
@@ -410,8 +341,7 @@ rustc = "non-existent-rustc"
         .build();
 
     // Verify the config is bad
-    p.cargo("-Zscript script.rs -NotAnArg")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("script.rs -NotAnArg")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `2024`)
@@ -424,8 +354,7 @@ Caused by:
         .run();
 
     // Verify that the config isn't used
-    p.cargo("-Zscript ../script/script.rs -NotAnArg")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("../script/script.rs -NotAnArg")
         .with_stdout_data(str![[r#"
 current_exe: [ROOT]/home/.cargo/build/[HASH]/target/debug/script[EXE]
 arg0: [..]
@@ -435,15 +364,14 @@ args: ["-NotAnArg"]
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn default_programmatic_verbosity() {
     let script = ECHO_SCRIPT;
     let p = cargo_test_support::project()
         .file("script.rs", script)
         .build();
 
-    p.cargo("-Zscript script.rs -NotAnArg")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("script.rs -NotAnArg")
         .with_stdout_data(str![[r#"
 current_exe: [ROOT]/home/.cargo/build/[HASH]/target/debug/script[EXE]
 arg0: [..]
@@ -457,15 +385,14 @@ args: ["-NotAnArg"]
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn quiet() {
     let script = ECHO_SCRIPT;
     let p = cargo_test_support::project()
         .file("script.rs", script)
         .build();
 
-    p.cargo("-Zscript -q script.rs -NotAnArg")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-q script.rs -NotAnArg")
         .with_stdout_data(str![[r#"
 current_exe: [ROOT]/home/.cargo/build/[HASH]/target/debug/script[EXE]
 arg0: [..]
@@ -479,7 +406,7 @@ args: ["-NotAnArg"]
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn test_line_numbering_preserved() {
     let script = r#"#!/usr/bin/env cargo
 
@@ -491,8 +418,7 @@ fn main() {
         .file("script.rs", script)
         .build();
 
-    p.cargo("-Zscript -v script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v script.rs")
         .with_stdout_data(str![[r#"
 line: 4
 
@@ -507,15 +433,14 @@ line: 4
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn test_escaped_hyphen_arg() {
     let script = ECHO_SCRIPT;
     let p = cargo_test_support::project()
         .file("script.rs", script)
         .build();
 
-    p.cargo("-Zscript -v -- script.rs -NotAnArg")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v -- script.rs -NotAnArg")
         .with_stdout_data(str![[r#"
 current_exe: [ROOT]/home/.cargo/build/[HASH]/target/debug/script[EXE]
 arg0: [..]
@@ -532,15 +457,14 @@ args: ["-NotAnArg"]
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn test_unescaped_hyphen_arg() {
     let script = ECHO_SCRIPT;
     let p = cargo_test_support::project()
         .file("script.rs", script)
         .build();
 
-    p.cargo("-Zscript -v script.rs -NotAnArg")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v script.rs -NotAnArg")
         .with_stdout_data(str![[r#"
 current_exe: [ROOT]/home/.cargo/build/[HASH]/target/debug/script[EXE]
 arg0: [..]
@@ -557,15 +481,14 @@ args: ["-NotAnArg"]
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn test_same_flags() {
     let script = ECHO_SCRIPT;
     let p = cargo_test_support::project()
         .file("script.rs", script)
         .build();
 
-    p.cargo("-Zscript -v script.rs --help")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v script.rs --help")
         .with_stdout_data(str![[r#"
 current_exe: [ROOT]/home/.cargo/build/[HASH]/target/debug/script[EXE]
 arg0: [..]
@@ -582,15 +505,14 @@ args: ["--help"]
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn test_name_has_weird_chars() {
     let script = ECHO_SCRIPT;
     let p = cargo_test_support::project()
         .file("s-h.w§c!.rs", script)
         .build();
 
-    p.cargo("-Zscript -v s-h.w§c!.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v s-h.w§c!.rs")
         .with_stdout_data(str![[r#"
 current_exe: [ROOT]/home/.cargo/build/[HASH]/target/debug/s-h-w-c-[EXE]
 arg0: [..]
@@ -607,15 +529,14 @@ args: []
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn test_name_has_leading_number() {
     let script = ECHO_SCRIPT;
     let p = cargo_test_support::project()
         .file("42answer.rs", script)
         .build();
 
-    p.cargo("-Zscript -v 42answer.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v 42answer.rs")
         .with_stdout_data(str![[r#"
 current_exe: [ROOT]/home/.cargo/build/[HASH]/target/debug/answer[EXE]
 arg0: [..]
@@ -632,13 +553,12 @@ args: []
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn test_name_is_number() {
     let script = ECHO_SCRIPT;
     let p = cargo_test_support::project().file("42.rs", script).build();
 
-    p.cargo("-Zscript -v 42.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v 42.rs")
         .with_stdout_data(str![[r#"
 current_exe: [ROOT]/home/.cargo/build/[HASH]/target/debug/package[EXE]
 arg0: [..]
@@ -655,14 +575,13 @@ args: []
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[cfg(not(windows))]
 fn test_name_is_windows_reserved_name() {
     let script = ECHO_SCRIPT;
     let p = cargo_test_support::project().file("con", script).build();
 
-    p.cargo("-Zscript -v ./con")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v ./con")
         .with_stdout_data(str![[r#"
 current_exe: [ROOT]/home/.cargo/build/[HASH]/target/debug/con[EXE]
 arg0: [..]
@@ -679,13 +598,12 @@ args: []
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn test_name_is_sysroot_package_name() {
     let script = ECHO_SCRIPT;
     let p = cargo_test_support::project().file("test", script).build();
 
-    p.cargo("-Zscript -v ./test")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v ./test")
         .with_stdout_data(str![[r#"
 current_exe: [ROOT]/home/.cargo/build/[HASH]/target/debug/test[EXE]
 arg0: [..]
@@ -702,13 +620,12 @@ args: []
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn test_name_is_keyword() {
     let script = ECHO_SCRIPT;
     let p = cargo_test_support::project().file("self", script).build();
 
-    p.cargo("-Zscript -v ./self")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v ./self")
         .with_stdout_data(str![[r#"
 current_exe: [ROOT]/home/.cargo/build/[HASH]/target/debug/self[EXE]
 arg0: [..]
@@ -725,15 +642,14 @@ args: []
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn test_name_is_deps_dir_implicit() {
     let script = ECHO_SCRIPT;
     let p = cargo_test_support::project()
         .file("deps.rs", script)
         .build();
 
-    p.cargo("-Zscript -v deps.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v deps.rs")
         .with_status(101)
         .with_stdout_data(str![""])
         .with_stderr_data(str![[r#"
@@ -747,7 +663,7 @@ Caused by:
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn test_name_is_deps_dir_explicit() {
     let script = r#"#!/usr/bin/env cargo
 ---
@@ -771,8 +687,7 @@ fn test () {}
         .file("deps.rs", script)
         .build();
 
-    p.cargo("-Zscript -v deps.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v deps.rs")
         .with_status(101)
         .with_stdout_data(str![""])
         .with_stderr_data(str![[r#"
@@ -786,14 +701,13 @@ Caused by:
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn script_like_dir() {
     let p = cargo_test_support::project()
         .file("foo.rs/foo", "something")
         .build();
 
-    p.cargo("-Zscript -v foo.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v foo.rs")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] no such file or subcommand `foo.rs`: `foo.rs` is a directory
@@ -802,12 +716,11 @@ fn script_like_dir() {
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn non_existent_rs() {
     let p = cargo_test_support::project().build();
 
-    p.cargo("-Zscript -v foo.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v foo.rs")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] no such file or subcommand `foo.rs`
@@ -816,29 +729,27 @@ fn non_existent_rs() {
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn non_existent_rs_stable() {
     let p = cargo_test_support::project().build();
 
     p.cargo("-v foo.rs")
-        .masquerade_as_nightly_cargo(&["script"])
         .with_status(101)
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
-[ERROR] no such subcommand `foo.rs`
+[ERROR] no such file or subcommand `foo.rs`
 
 "#]])
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn did_you_mean_file() {
     let p = cargo_test_support::project()
         .file("food.rs", ECHO_SCRIPT)
         .build();
 
-    p.cargo("-Zscript -v foo.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v foo.rs")
         .with_status(101)
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
@@ -849,30 +760,28 @@ fn did_you_mean_file() {
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn did_you_mean_file_stable() {
     let p = cargo_test_support::project()
         .file("food.rs", ECHO_SCRIPT)
         .build();
 
     p.cargo("-v foo.rs")
-        .masquerade_as_nightly_cargo(&["script"])
         .with_status(101)
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
-[ERROR] no such subcommand `foo.rs`
-[HELP] there is a script with a similar name: `./food.rs` (requires `-Zscript`)
+[ERROR] no such file or subcommand `foo.rs`
+[HELP] there is a script with a similar name: `./food.rs`
 
 "#]])
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn did_you_mean_command() {
     let p = cargo_test_support::project().build();
 
-    p.cargo("-Zscript -v build--manifest-path=./Cargo.toml")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v build--manifest-path=./Cargo.toml")
         .with_status(101)
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
@@ -883,23 +792,22 @@ fn did_you_mean_command() {
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn did_you_mean_command_stable() {
     let p = cargo_test_support::project().build();
 
     p.cargo("-v build--manifest-path=./Cargo.toml")
-        .masquerade_as_nightly_cargo(&["script"])
         .with_status(101)
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
-[ERROR] no such subcommand `build--manifest-path=./Cargo.toml`
+[ERROR] no such file or subcommand `build--manifest-path=./Cargo.toml`
 [HELP] there is a command with a similar name: `build --manifest-path=./Cargo.toml`
 
 "#]])
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn test_name_same_as_dependency() {
     Package::new("script", "1.0.0").publish();
     let script = r#"#!/usr/bin/env cargo
@@ -915,8 +823,7 @@ fn main() {
         .file("script.rs", script)
         .build();
 
-    p.cargo("-Zscript -v script.rs --help")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v script.rs --help")
         .with_stdout_data(str![[r#"
 Hello world!
 
@@ -936,7 +843,7 @@ Hello world!
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn test_path_dep() {
     let script = r#"#!/usr/bin/env cargo
 ---
@@ -954,8 +861,7 @@ fn main() {
         .file("bar/src/lib.rs", "pub fn bar() {}")
         .build();
 
-    p.cargo("-Zscript -v script.rs --help")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v script.rs --help")
         .with_stdout_data(str![[r#"
 Hello world!
 
@@ -972,7 +878,7 @@ Hello world!
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn test_no_build_rs() {
     let script = r#"#!/usr/bin/env cargo
 
@@ -984,8 +890,7 @@ fn main() {
         .file("build.rs", "broken")
         .build();
 
-    p.cargo("-Zscript -v script.rs --help")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v script.rs --help")
         .with_stdout_data(str![[r#"
 Hello world!
 
@@ -1000,7 +905,7 @@ Hello world!
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn test_no_autobins() {
     let script = r#"#!/usr/bin/env cargo
 
@@ -1012,8 +917,7 @@ fn main() {
         .file("src/bin/not-script/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("-Zscript -v script.rs --help")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v script.rs --help")
         .with_stdout_data(str![[r#"
 Hello world!
 
@@ -1028,7 +932,7 @@ Hello world!
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn test_no_autolib() {
     let script = r#"#!/usr/bin/env cargo
 
@@ -1040,8 +944,7 @@ fn main() {
         .file("src/lib.rs", r#"compile_error!{"must not be built"}"#)
         .build();
 
-    p.cargo("-Zscript -v script.rs --help")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v script.rs --help")
         .with_stdout_data(str![[r#"
 Hello world!
 
@@ -1056,7 +959,7 @@ Hello world!
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn disallow_explicit_workspace() {
     let p = cargo_test_support::project()
         .file(
@@ -1073,8 +976,7 @@ fn main() {}
         )
         .build();
 
-    p.cargo("-Zscript -v script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v script.rs")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] failed to parse manifest at `[ROOT]/foo/script.rs`
@@ -1086,7 +988,7 @@ Caused by:
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn workspace_members_mentions_script() {
     let p = cargo_test_support::project()
         .file(
@@ -1108,8 +1010,7 @@ fn main() {}
         )
         .build();
 
-    p.cargo("-Zscript check")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("check")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] manifest path `[ROOT]/foo` contains no package: The manifest is virtual, and the workspace has no members.
@@ -1118,7 +1019,7 @@ fn main() {}
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn workspace_members_glob_matches_script() {
     let p = cargo_test_support::project()
         .file(
@@ -1140,8 +1041,7 @@ fn main() {}
         )
         .build();
 
-    p.cargo("-Zscript check")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("check")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] manifest path `[ROOT]/foo` contains no package: The manifest is virtual, and the workspace has no members.
@@ -1150,7 +1050,7 @@ fn main() {}
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn package_workspace() {
     let p = cargo_test_support::project()
         .file(
@@ -1176,8 +1076,7 @@ fn main() {}
         )
         .build();
 
-    p.cargo("-Zscript ./scripts/nop.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("./scripts/nop.rs")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] failed to parse manifest at `[ROOT]/foo/scripts/nop.rs`
@@ -1189,7 +1088,7 @@ Caused by:
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn disallow_explicit_lib() {
     let p = cargo_test_support::project()
         .file(
@@ -1208,8 +1107,7 @@ fn main() {}
         )
         .build();
 
-    p.cargo("-Zscript -v script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v script.rs")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] failed to parse manifest at `[ROOT]/foo/script.rs`
@@ -1221,7 +1119,7 @@ Caused by:
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn disallow_explicit_bin() {
     let p = cargo_test_support::project()
         .file(
@@ -1240,8 +1138,7 @@ fn main() {}
         )
         .build();
 
-    p.cargo("-Zscript -v script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v script.rs")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] failed to parse manifest at `[ROOT]/foo/script.rs`
@@ -1253,7 +1150,7 @@ Caused by:
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn disallow_explicit_example() {
     let p = cargo_test_support::project()
         .file(
@@ -1272,8 +1169,7 @@ fn main() {}
         )
         .build();
 
-    p.cargo("-Zscript -v script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v script.rs")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] failed to parse manifest at `[ROOT]/foo/script.rs`
@@ -1285,7 +1181,7 @@ Caused by:
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn disallow_explicit_test() {
     let p = cargo_test_support::project()
         .file(
@@ -1304,8 +1200,7 @@ fn main() {}
         )
         .build();
 
-    p.cargo("-Zscript -v script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v script.rs")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] failed to parse manifest at `[ROOT]/foo/script.rs`
@@ -1317,7 +1212,7 @@ Caused by:
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn disallow_explicit_bench() {
     let p = cargo_test_support::project()
         .file(
@@ -1336,8 +1231,7 @@ fn main() {}
         )
         .build();
 
-    p.cargo("-Zscript -v script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v script.rs")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] failed to parse manifest at `[ROOT]/foo/script.rs`
@@ -1349,7 +1243,7 @@ Caused by:
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn disallow_explicit_package_build() {
     let p = cargo_test_support::project()
         .file(
@@ -1366,8 +1260,7 @@ fn main() {}
         )
         .build();
 
-    p.cargo("-Zscript -v script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v script.rs")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] failed to parse manifest at `[ROOT]/foo/script.rs`
@@ -1379,7 +1272,7 @@ Caused by:
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn disallow_explicit_package_links() {
     let p = cargo_test_support::project()
         .file(
@@ -1396,8 +1289,7 @@ fn main() {}
         )
         .build();
 
-    p.cargo("-Zscript -v script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v script.rs")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] failed to parse manifest at `[ROOT]/foo/script.rs`
@@ -1409,7 +1301,7 @@ Caused by:
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn disallow_explicit_package_autolib() {
     let p = cargo_test_support::project()
         .file(
@@ -1426,8 +1318,7 @@ fn main() {}
         )
         .build();
 
-    p.cargo("-Zscript -v script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v script.rs")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] failed to parse manifest at `[ROOT]/foo/script.rs`
@@ -1439,7 +1330,7 @@ Caused by:
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn disallow_explicit_package_autobins() {
     let p = cargo_test_support::project()
         .file(
@@ -1456,8 +1347,7 @@ fn main() {}
         )
         .build();
 
-    p.cargo("-Zscript -v script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v script.rs")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] failed to parse manifest at `[ROOT]/foo/script.rs`
@@ -1469,7 +1359,7 @@ Caused by:
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn disallow_explicit_package_autoexamples() {
     let p = cargo_test_support::project()
         .file(
@@ -1486,8 +1376,7 @@ fn main() {}
         )
         .build();
 
-    p.cargo("-Zscript -v script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v script.rs")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] failed to parse manifest at `[ROOT]/foo/script.rs`
@@ -1499,7 +1388,7 @@ Caused by:
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn disallow_explicit_package_autotests() {
     let p = cargo_test_support::project()
         .file(
@@ -1516,8 +1405,7 @@ fn main() {}
         )
         .build();
 
-    p.cargo("-Zscript -v script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v script.rs")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] failed to parse manifest at `[ROOT]/foo/script.rs`
@@ -1529,7 +1417,7 @@ Caused by:
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn disallow_explicit_package_autobenches() {
     let p = cargo_test_support::project()
         .file(
@@ -1546,8 +1434,7 @@ fn main() {}
         )
         .build();
 
-    p.cargo("-Zscript -v script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v script.rs")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] failed to parse manifest at `[ROOT]/foo/script.rs`
@@ -1559,15 +1446,14 @@ Caused by:
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn implicit_target_dir() {
     let script = ECHO_SCRIPT;
     let p = cargo_test_support::project()
         .file("script.rs", script)
         .build();
 
-    p.cargo("-Zscript -v script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v script.rs")
         .with_stdout_data(str![[r#"
 current_exe: [ROOT]/home/.cargo/build/[HASH]/target/debug/script[EXE]
 arg0: [..]
@@ -1584,7 +1470,7 @@ args: []
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn no_local_lockfile() {
     let script = ECHO_SCRIPT;
     let p = cargo_test_support::project()
@@ -1594,8 +1480,7 @@ fn no_local_lockfile() {
 
     assert!(!local_lockfile_path.exists());
 
-    p.cargo("-Zscript -v script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v script.rs")
         .with_stdout_data(str![[r#"
 current_exe: [ROOT]/home/.cargo/build/[HASH]/target/debug/script[EXE]
 arg0: [..]
@@ -1614,50 +1499,14 @@ args: []
     assert!(!local_lockfile_path.exists());
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
-fn cmd_check_requires_nightly() {
-    let script = ECHO_SCRIPT;
-    let p = cargo_test_support::project()
-        .file("script.rs", script)
-        .build();
-
-    p.cargo("check --manifest-path script.rs")
-        .with_status(101)
-        .with_stdout_data("")
-        .with_stderr_data(str![[r#"
-[ERROR] embedded manifest `[ROOT]/foo/script.rs` requires `-Zscript`
-
-"#]])
-        .run();
-}
-
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
-fn cmd_check_requires_z_flag() {
-    let script = ECHO_SCRIPT;
-    let p = cargo_test_support::project()
-        .file("script.rs", script)
-        .build();
-
-    p.cargo("check --manifest-path script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
-        .with_status(101)
-        .with_stdout_data("")
-        .with_stderr_data(str![[r#"
-[ERROR] embedded manifest `[ROOT]/foo/script.rs` requires `-Zscript`
-
-"#]])
-        .run();
-}
-
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn cmd_check_with_embedded() {
     let script = ECHO_SCRIPT;
     let p = cargo_test_support::project()
         .file("script.rs", script)
         .build();
 
-    p.cargo("-Zscript check --manifest-path script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("check --manifest-path script.rs")
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
@@ -1668,12 +1517,11 @@ fn cmd_check_with_embedded() {
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn cmd_check_with_missing_script_rs() {
     let p = cargo_test_support::project().build();
 
-    p.cargo("-Zscript check --manifest-path script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("check --manifest-path script.rs")
         .with_status(101)
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
@@ -1683,12 +1531,11 @@ fn cmd_check_with_missing_script_rs() {
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn cmd_check_with_missing_script() {
     let p = cargo_test_support::project().build();
 
-    p.cargo("-Zscript check --manifest-path script")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("check --manifest-path script")
         .with_status(101)
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
@@ -1698,15 +1545,14 @@ fn cmd_check_with_missing_script() {
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn cmd_build_with_embedded() {
     let script = ECHO_SCRIPT;
     let p = cargo_test_support::project()
         .file("script.rs", script)
         .build();
 
-    p.cargo("-Zscript build --manifest-path script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("build --manifest-path script.rs")
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
@@ -1717,15 +1563,14 @@ fn cmd_build_with_embedded() {
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn cmd_test_with_embedded() {
     let script = ECHO_SCRIPT;
     let p = cargo_test_support::project()
         .file("script.rs", script)
         .build();
 
-    p.cargo("-Zscript test --manifest-path script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("test --manifest-path script.rs")
         .with_stdout_data(str![[r#"
 
 running 1 test
@@ -1745,7 +1590,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn cmd_clean_with_embedded() {
     let script = ECHO_SCRIPT;
     let p = cargo_test_support::project()
@@ -1753,12 +1598,9 @@ fn cmd_clean_with_embedded() {
         .build();
 
     // Ensure there is something to clean
-    p.cargo("-Zscript script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
-        .run();
+    p.cargo("script.rs").run();
 
-    p.cargo("-Zscript clean --manifest-path script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("clean --manifest-path script.rs")
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
@@ -1768,15 +1610,14 @@ fn cmd_clean_with_embedded() {
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn cmd_generate_lockfile_with_embedded() {
     let script = ECHO_SCRIPT;
     let p = cargo_test_support::project()
         .file("script.rs", script)
         .build();
 
-    p.cargo("-Zscript generate-lockfile --manifest-path script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("generate-lockfile --manifest-path script.rs")
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
@@ -1785,15 +1626,14 @@ fn cmd_generate_lockfile_with_embedded() {
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn cmd_metadata_with_embedded() {
     let script = ECHO_SCRIPT;
     let p = cargo_test_support::project()
         .file("script.rs", script)
         .build();
 
-    p.cargo("-Zscript metadata --manifest-path script.rs --format-version=1")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("metadata --manifest-path script.rs --format-version=1")
         .with_stdout_data(
             str![[r#"
 {
@@ -1873,15 +1713,14 @@ fn cmd_metadata_with_embedded() {
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn cmd_read_manifest_with_embedded() {
     let script = ECHO_SCRIPT;
     let p = cargo_test_support::project()
         .file("script.rs", script)
         .build();
 
-    p.cargo("-Zscript read-manifest --manifest-path script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("read-manifest --manifest-path script.rs")
         .with_stdout_data(
             str![[r#"
 {
@@ -1935,14 +1774,13 @@ fn cmd_read_manifest_with_embedded() {
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn cmd_run_with_embedded() {
     let p = cargo_test_support::project()
         .file("script.rs", ECHO_SCRIPT)
         .build();
 
-    p.cargo("-Zscript run --manifest-path script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("run --manifest-path script.rs")
         .with_stdout_data(str![[r#"
 current_exe: [ROOT]/home/.cargo/build/[HASH]/target/debug/script[EXE]
 arg0: [..]
@@ -1959,14 +1797,13 @@ args: []
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn cmd_tree_with_embedded() {
     let p = cargo_test_support::project()
         .file("script.rs", ECHO_SCRIPT)
         .build();
 
-    p.cargo("-Zscript tree --manifest-path script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("tree --manifest-path script.rs")
         .with_stdout_data(str![[r#"
 script v0.0.0 ([ROOT]/foo/script.rs)
 
@@ -1978,14 +1815,13 @@ script v0.0.0 ([ROOT]/foo/script.rs)
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn cmd_update_with_embedded() {
     let p = cargo_test_support::project()
         .file("script.rs", ECHO_SCRIPT)
         .build();
 
-    p.cargo("-Zscript update --manifest-path script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("update --manifest-path script.rs")
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
@@ -1994,14 +1830,13 @@ fn cmd_update_with_embedded() {
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn cmd_verify_project_with_embedded() {
     let p = cargo_test_support::project()
         .file("script.rs", ECHO_SCRIPT)
         .build();
 
-    p.cargo("-Zscript verify-project --manifest-path script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("verify-project --manifest-path script.rs")
         .with_stdout_data(
             str![[r#"
 {
@@ -2017,18 +1852,15 @@ fn cmd_verify_project_with_embedded() {
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn cmd_pkgid_with_embedded() {
     let p = cargo_test_support::project()
         .file("script.rs", ECHO_SCRIPT)
         .build();
 
-    p.cargo("-Zscript script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
-        .run();
+    p.cargo("script.rs").run();
 
-    p.cargo("-Zscript pkgid --manifest-path script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("pkgid --manifest-path script.rs")
         .with_stdout_data(str![[r#"
 path+[ROOTURL]/foo/script.rs#script@0.0.0
 
@@ -2040,14 +1872,13 @@ path+[ROOTURL]/foo/script.rs#script@0.0.0
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn cmd_pkgid_with_embedded_no_lock_file() {
     let p = cargo_test_support::project()
         .file("script.rs", ECHO_SCRIPT)
         .build();
 
-    p.cargo("-Zscript pkgid --manifest-path script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("pkgid --manifest-path script.rs")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
@@ -2057,7 +1888,7 @@ fn cmd_pkgid_with_embedded_no_lock_file() {
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn cmd_pkgid_with_embedded_dep() {
     Package::new("dep", "1.0.0").publish();
     let script = r#"#!/usr/bin/env cargo
@@ -2073,12 +1904,9 @@ fn main() {
         .file("script.rs", script)
         .build();
 
-    p.cargo("-Zscript script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
-        .run();
+    p.cargo("script.rs").run();
 
-    p.cargo("-Zscript pkgid --manifest-path script.rs -p dep")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("pkgid --manifest-path script.rs -p dep")
         .with_stdout_data(str![[r#"
 registry+https://github.com/rust-lang/crates.io-index#dep@1.0.0
 
@@ -2090,7 +1918,7 @@ registry+https://github.com/rust-lang/crates.io-index#dep@1.0.0
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn script_as_dep() {
     let p = cargo_test_support::project()
         .file("script.rs", ECHO_SCRIPT)
@@ -2109,7 +1937,6 @@ script.path = "script.rs"
         .build();
 
     p.cargo("build")
-        .masquerade_as_nightly_cargo(&["script"])
         .with_status(101)
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to `2015` while the latest is `[..]`
@@ -2128,14 +1955,13 @@ Caused by:
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn cmd_install_with_embedded() {
     let p = cargo_test_support::project()
         .file("script.rs", ECHO_SCRIPT)
         .build();
 
-    p.cargo("-Zscript install --path script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("install --path script.rs")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] `[ROOT]/foo/script.rs` is not a directory. --path must point to a directory containing a Cargo.toml file.
@@ -2144,14 +1970,13 @@ fn cmd_install_with_embedded() {
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn cmd_package_with_embedded() {
     let p = cargo_test_support::project()
         .file("script.rs", ECHO_SCRIPT)
         .build();
 
-    p.cargo("-Zscript package --manifest-path script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("package --manifest-path script.rs")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
@@ -2161,14 +1986,13 @@ fn cmd_package_with_embedded() {
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn cmd_publish_with_embedded() {
     let p = cargo_test_support::project()
         .file("script.rs", ECHO_SCRIPT)
         .build();
 
-    p.cargo("-Zscript publish --manifest-path script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("publish --manifest-path script.rs")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
@@ -2178,7 +2002,7 @@ fn cmd_publish_with_embedded() {
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn manifest_path_env() {
     let p = cargo_test_support::project()
         .file(
@@ -2192,8 +2016,7 @@ fn main() {
 "#,
         )
         .build();
-    p.cargo("-Zscript -v script.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v script.rs")
         .with_stdout_data(str![[r#"
 CARGO_MANIFEST_PATH: [ROOT]/foo/script.rs
 
@@ -2208,7 +2031,7 @@ CARGO_MANIFEST_PATH: [ROOT]/foo/script.rs
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 fn ignore_surrounding_workspace() {
     let p = cargo_test_support::project()
         .file(
@@ -2242,8 +2065,7 @@ members = [
         )
         .build();
 
-    p.cargo("-Zscript -v script/echo.rs")
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo("-v script/echo.rs")
         .with_stdout_data(str![[r#"
 current_exe: [ROOT]/home/.cargo/build/[HASH]/target/debug/echo[EXE]
 arg0: [..]
@@ -2260,7 +2082,7 @@ args: []
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[cfg(target_os = "linux")]
 fn memfd_script() {
     use std::io::Write;
@@ -2280,8 +2102,7 @@ fn memfd_script() {
         .file("echo.rs", ECHO_SCRIPT)
         .build();
 
-    p.cargo(&format!("-Zscript -v /proc/self/fd/{raw_fd}"))
-        .masquerade_as_nightly_cargo(&["script"])
+    p.cargo(&format!("-v /proc/self/fd/{raw_fd}"))
         .with_stdout_data(str![[r#"
 current_exe: [ROOT]/home/.cargo/build/[HASH]/target/debug/package
 arg0: /proc/self/fd/[..]

--- a/tests/testsuite/script/rustc.rs
+++ b/tests/testsuite/script/rustc.rs
@@ -110,7 +110,7 @@ impl std::fmt::Display for Fixture {
                 write!(
                     fmt,
                     r#"
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn {fn_name}() {{
     let fixture_path = {fixture_path:?};
@@ -127,7 +127,7 @@ fn {fn_name}() {{
                 write!(
                     fmt,
                     r#"
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn {fn_name}() {{
     let fixture_path = {fixture_path:?};
@@ -154,7 +154,7 @@ fn assert_success(fixture_path: &str, assertion_path: &str) {
         .build();
 
     // `read-manifest` to validate frontmatter content without processing deps, compiling
-    p.cargo("-Zscript read-manifest --manifest-path script")
+    p.cargo("read-manifest --manifest-path script")
         .masquerade_as_nightly_cargo(&["script"])
         .with_stdout_data(snapbox::Data::read_from(
             std::path::Path::new(assertion_path),
@@ -170,7 +170,7 @@ fn assert_failure(fixture_path: &str, assertion_path: &str) {
         .build();
 
     // `read-manifest` to validate frontmatter content without processing deps, compiling
-    p.cargo("-Zscript read-manifest --manifest-path script")
+    p.cargo("read-manifest --manifest-path script")
         .masquerade_as_nightly_cargo(&["script"])
         .with_status(101)
         .with_stderr_data(snapbox::Data::read_from(
@@ -182,7 +182,7 @@ fn assert_failure(fixture_path: &str, assertion_path: &str) {
 
 // START CODE GENERATION
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn content_contains_whitespace() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/content-contains-whitespace.rs";
@@ -190,7 +190,7 @@ fn content_contains_whitespace() {
     assert_failure(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn content_non_lexible_tokens() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/content-non-lexible-tokens.rs";
@@ -198,7 +198,7 @@ fn content_non_lexible_tokens() {
     assert_success(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn escape_hyphens_leading() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/escape-hyphens-leading.rs";
@@ -206,7 +206,7 @@ fn escape_hyphens_leading() {
     assert_success(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn escape_hyphens_nonleading_1() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/escape-hyphens-nonleading-1.rs";
@@ -214,7 +214,7 @@ fn escape_hyphens_nonleading_1() {
     assert_success(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn escape_hyphens_nonleading_2() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/escape-hyphens-nonleading-2.rs";
@@ -222,7 +222,7 @@ fn escape_hyphens_nonleading_2() {
     assert_success(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn escape_hyphens_nonleading_3() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/escape-hyphens-nonleading-3.rs";
@@ -230,7 +230,7 @@ fn escape_hyphens_nonleading_3() {
     assert_success(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn fence_close_extra_after() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/fence-close-extra-after.rs";
@@ -238,7 +238,7 @@ fn fence_close_extra_after() {
     assert_failure(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn fence_indented() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/fence-indented.rs";
@@ -246,7 +246,7 @@ fn fence_indented() {
     assert_success(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn fence_indented_mismatch() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/fence-indented-mismatch.rs";
@@ -254,7 +254,7 @@ fn fence_indented_mismatch() {
     assert_failure(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn fence_mismatch_1() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/fence-mismatch-1.rs";
@@ -262,7 +262,7 @@ fn fence_mismatch_1() {
     assert_failure(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn fence_mismatch_2() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/fence-mismatch-2.rs";
@@ -270,7 +270,7 @@ fn fence_mismatch_2() {
     assert_failure(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn fence_too_many_dashes() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/fence-too-many-dashes.rs";
@@ -278,7 +278,7 @@ fn fence_too_many_dashes() {
     assert_failure(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn fence_unclosed_1() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/fence-unclosed-1.rs";
@@ -286,7 +286,7 @@ fn fence_unclosed_1() {
     assert_failure(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn fence_unclosed_2() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/fence-unclosed-2.rs";
@@ -294,7 +294,7 @@ fn fence_unclosed_2() {
     assert_failure(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn fence_unclosed_3() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/fence-unclosed-3.rs";
@@ -302,7 +302,7 @@ fn fence_unclosed_3() {
     assert_failure(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn fence_unclosed_4() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/fence-unclosed-4.rs";
@@ -310,7 +310,7 @@ fn fence_unclosed_4() {
     assert_failure(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn fence_unclosed_5() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/fence-unclosed-5.rs";
@@ -318,7 +318,7 @@ fn fence_unclosed_5() {
     assert_failure(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn fence_unclosed_6() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/fence-unclosed-6.rs";
@@ -326,7 +326,7 @@ fn fence_unclosed_6() {
     assert_failure(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn fence_whitespace_trailing_1() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/fence-whitespace-trailing-1.rs";
@@ -334,7 +334,7 @@ fn fence_whitespace_trailing_1() {
     assert_success(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn fence_whitespace_trailing_2() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/fence-whitespace-trailing-2.rs";
@@ -342,7 +342,7 @@ fn fence_whitespace_trailing_2() {
     assert_success(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn frontmatter_crlf() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/frontmatter-crlf.rs";
@@ -350,7 +350,7 @@ fn frontmatter_crlf() {
     assert_success(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn infostring_comma() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/infostring-comma.rs";
@@ -358,7 +358,7 @@ fn infostring_comma() {
     assert_failure(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn infostring_dot_leading() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/infostring-dot-leading.rs";
@@ -366,7 +366,7 @@ fn infostring_dot_leading() {
     assert_failure(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn infostring_dot_nonleading() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/infostring-dot-nonleading.rs";
@@ -374,7 +374,7 @@ fn infostring_dot_nonleading() {
     assert_failure(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn infostring_hyphen_leading() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/infostring-hyphen-leading.rs";
@@ -382,7 +382,7 @@ fn infostring_hyphen_leading() {
     assert_failure(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn infostring_hyphen_nonleading() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/infostring-hyphen-nonleading.rs";
@@ -390,7 +390,7 @@ fn infostring_hyphen_nonleading() {
     assert_failure(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn infostring_space() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/infostring-space.rs";
@@ -398,7 +398,7 @@ fn infostring_space() {
     assert_failure(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn location_after_shebang() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/location-after-shebang.rs";
@@ -406,7 +406,7 @@ fn location_after_shebang() {
     assert_success(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn location_after_tokens() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/location-after-tokens.rs";
@@ -414,7 +414,7 @@ fn location_after_tokens() {
     assert_success(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn location_include_in_expr_ctxt() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/location-include-in-expr-ctxt.rs";
@@ -422,7 +422,7 @@ fn location_include_in_expr_ctxt() {
     assert_success(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn location_include_in_item_ctxt() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/location-include-in-item-ctxt.rs";
@@ -430,7 +430,7 @@ fn location_include_in_item_ctxt() {
     assert_success(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn location_proc_macro_observer() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/location-proc-macro-observer.rs";
@@ -438,7 +438,7 @@ fn location_proc_macro_observer() {
     assert_success(fixture_path, assertion_path);
 }
 
-#[cargo_test(nightly, reason = "-Zscript is unstable")]
+#[cargo_test(nightly, reason = "`#[feature(frontmatter]` hasn't hit stable yet")]
 #[rustfmt::skip]  // code-generated
 fn multifrontmatter() {
     let fixture_path = "tests/testsuite/script/rustc_fixtures/multifrontmatter.rs";


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/cargo/pull/16569)*

Fixes #12207

RFC: https://rust-lang.github.io/rfcs/3502-cargo-script.html
Tracking issue: https://github.com/rust-lang/cargo/issues/12207
Frontmatter stabilization: https://github.com/rust-lang/rust/pull/148051

This stabilizes an MVP of Cargo script
- Cargo scripts are Rust source files without an extension or with a `.rs` extension
- They may have a frontmatter block with manifest content
- Changes from `Cargo.toml`
  - `package.name` is optional, defaults to the file stem
  - `package.edition` defaults to current edition, not 2015 edition, with a warning
  - `package.build`, `package.links`, `package.default-run`, `package.workspace`, `package.auto-*` are disallowed
  - `workspace`, `build-dependencies`, and any build-target tables are disallowed
  - Workspace auto-discovery does **not** run
- `package.name` defaulting logic
  - strips leading numbers
    - If nothing left after this, calls it `package`
  - replaces non-`UnicodeXID` characters with `-` or `_`
  - commonly reserved names are allowed:
    - windows names, like `con`
    - sysroot names, like `test`
    - keywords, like `self`
  - disallowed names on a short-term basis:
    - build-dir directories like `deps`
- `cargo foo` precedence:
  1. built-in command
  2. script *if* there is a `.rs` extension or a path component is present (e.g. `./foo` )
  3. aliases
  4. plugins
- Command support:
  - `cargo install` **errors** on publishing a script
  - `cargo package` **errors** on publishing a script
  - `cargo publish` **errors** on publishing a script
- Script metadata
  - `arg0` is set on a best-effort basis to the script's path
  - `CARGO_MANIFEST_PATH` was previously stabilized in addition to the existing `CARGO_MANIFEST_DIR`
- `cargo foo.rs` loads config relative to `foo`
  - Like `cargo install --path bar/` and unlike the rest of the Cargo commands
  - Regular `cargo run --manifest-path foo.rs` loads from current dir
  - See also #16620
- Pseudo-config defaults
  ```toml
  [build]
  build-dir = "{cargo-cache-home}/build/{workspace-path-hash}"
  target-dir = "{build-dir}/target"
  [resolver]
  lockfile-path = "{build-dir}/{workspace-path-hash}/Cargo.lock"
  ```

Whats missing:
- rustfmt styling frontmatter according to the Style Guide
- rust-analyzer handling manifest in frontmatter
- playground support

Known issues:
- `cargo remove` prints the "unset edition" warning twice
- Some users are asking for reduced noise (#16388)
- Shebang stripping isn't as complete as rustc in that it only considers whitespace between `#!` and `[]` and not comments
- Users write throwaway scripts or move their scripts and they then leak the entire `build-dir`.  #13136 will resolve this.

Risks
- ~~If people share their `build-dir` across projects, then multiple scripts will point to the same `Cargo.lock`, fighting over what is locked in it~~ (#16619)
- ~~Not allowing local config for scripts could become a problem as we get into workspace support as people would expect their repo's config to be respected when it won't be~~ (#16620)
- Changing package name rules impacts programmatic output
- Precedence rules for `cargo foo`
  - In particularly, requiring an extension or path element should be safe, especially for most uses of shebang but you can intentionally contrive a shebang and `PATH` that makes this not work

Future possibilities
- Membership in workspaces including opt-in discovery (#16563)
  - #8511 makes this more difficult
- Publish support
- Lib support
  - main question is how to denote it is a lib
- Build script delegation support (#14903)
- Use as artifact dependencies
- GC build-dirs (#13136)
- Reduce special casing in manifests with #12689
- `cargo Cargo.toml` support