### PR TITLE
Re-downgrade curl-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,9 +873,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.84+curl-8.17.0"
+version = "0.4.83+curl-8.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abc4294dc41b882eaff37973c2ec3ae203d0091341ee68fbadd1d06e0c18a73b"
+checksum = "5830daf304027db10c82632a464879d46a3f7c4ba17a31592657ad16c719b483"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ criterion = { version = "0.8.1", features = ["html_reports"] }
 curl = "0.4.49"
 # Do not upgrade curl-sys past 0.4.83
 # https://github.com/rust-lang/cargo/issues/16357
-curl-sys = "0.4.84"
+curl-sys = "=0.4.83"
 filetime = "0.2.26"
 flate2 = { version = "1.1.5", default-features = false, features = ["zlib-rs"] }
 git2 = "0.20.3"


### PR DESCRIPTION
Works around issue #16357

### What does this PR try to resolve?

Fixes fetch crates from crates.io on FreeBSD 13 and 14.

### How to test and review this PR?

Run `cargo build` on practically any repository on FreeBSD 14.3, in a clean install with nothing else installed.  In particular, do not install the ca_root_nss package.