### PR TITLE
Add command field to BuildStarted in build-analysis

### DIFF
--- a/src/cargo/ops/cargo_compile/mod.rs
+++ b/src/cargo/ops/cargo_compile/mod.rs
@@ -168,6 +168,9 @@ pub fn compile_ws<'a>(
             .ok()
             .map(|x| x.get() as u64);
         logger.log(LogMessage::BuildStarted {
+            command: std::env::args_os()
+                .map(|arg| arg.to_string_lossy().into_owned())
+                .collect(),
             cwd: ws.gctx().cwd().to_path_buf(),
             host: rustc.host.to_string(),
             jobs: options.build_config.jobs,

--- a/src/cargo/ops/cargo_report/timings.rs
+++ b/src/cargo/ops/cargo_report/timings.rs
@@ -159,6 +159,7 @@ where
     for msg in log {
         match msg {
             LogMessage::BuildStarted {
+                command: _,
                 cwd: _,
                 host,
                 jobs,

--- a/src/cargo/util/log_message.rs
+++ b/src/cargo/util/log_message.rs
@@ -21,6 +21,8 @@ use crate::core::compiler::fingerprint::DirtyReason;
 pub enum LogMessage {
     /// Emitted when a build starts.
     BuildStarted {
+        /// The command-line arguments Cargo was invoked with.
+        command: Vec<String>,
         /// Current working directory.
         cwd: PathBuf,
         /// Host triple.

--- a/tests/testsuite/build_analysis.rs
+++ b/tests/testsuite/build_analysis.rs
@@ -77,6 +77,7 @@ fn log_msg_build_started() {
         str![[r#"
 [
   {
+    "command": "{...}",
     "cwd": "[ROOT]/foo",
     "host": "[HOST_TARGET]",
     "jobs": "{...}",


### PR DESCRIPTION
### What does this PR try to resolve?

This PR adds a command field to `LogMessage::BuildStarted` that records the CLI arguments Cargo was invoked with.    Currently, when reviewing build-analysis logs in ~/.cargo/log/, there's no way to tell which command triggered a particular build session. 
Added `capture std::env::args()` and included it in the BuildStarted message.

Example Output:                           
```json5
  {
    "reason": "build-started",
    "command": ["cargo", "build", "--release", "-p", "foo"],
    "cwd": "/home/user/project",
    ...
  } 
```

### How to test and review this PR?

Run the build-analysis tests using `cargo test --test testsuite build_analysis`                                                                          
All 10 tests pass, including `log_msg_build_started` which verifies the new field is present.                            
                                                                                                                         
To manually test:
                                                                                                      
	export CARGO_BUILD_ANALYSIS_ENABLED=true
	cargo +nightly build -Zbuild-analysis
	cat ~/.cargo/log/*.jsonl | head -1 | jq .command
