### PR TITLE
Fix `cargo tree -p` output with `feature-unification=workspace`

### DIFF
--- a/src/cargo/ops/tree/mod.rs
+++ b/src/cargo/ops/tree/mod.rs
@@ -182,7 +182,7 @@ pub fn build_and_print(ws: &Workspace<'_>, opts: &TreeOptions) -> CargoResult<()
         .collect();
 
     for SpecsAndResolvedFeatures {
-        specs,
+        specs: entry_specs,
         resolved_features,
     } in ws_resolve.specs_and_features
     {
@@ -190,7 +190,7 @@ pub fn build_and_print(ws: &Workspace<'_>, opts: &TreeOptions) -> CargoResult<()
             ws,
             &ws_resolve.targeted_resolve,
             &resolved_features,
-            &specs,
+            &entry_specs,
             &opts.cli_features,
             &target_data,
             &requested_kinds,
@@ -199,7 +199,7 @@ pub fn build_and_print(ws: &Workspace<'_>, opts: &TreeOptions) -> CargoResult<()
         )?;
 
         let root_specs = if opts.invert.is_empty() {
-            specs
+            entry_specs
         } else {
             opts.invert
                 .iter()

--- a/src/cargo/ops/tree/mod.rs
+++ b/src/cargo/ops/tree/mod.rs
@@ -206,6 +206,9 @@ pub fn build_and_print(ws: &Workspace<'_>, opts: &TreeOptions) -> CargoResult<()
                 .into_iter()
                 .collect::<HashSet<_>>();
 
+            // `entry_specs` can be broader than the CLI request (for example,
+            // all workspace members when `feature-unification=workspace`).
+            // Keep only the packages explicitly requested by `-p`.
             entry_ids
                 .into_iter()
                 .filter(|id| requested_ids.contains(id))

--- a/tests/testsuite/feature_unification.rs
+++ b/tests/testsuite/feature_unification.rs
@@ -837,6 +837,24 @@ b v0.1.0 ([ROOT]/foo/b)
 
 "#]])
         .run();
+
+    p.cargo("tree -p a")
+        .arg("-Zfeature-unification")
+        .masquerade_as_nightly_cargo(&["feature-unification"])
+        .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "workspace")
+        .with_stdout_data(str![[r#"
+a v0.1.0 ([ROOT]/foo/a)
+├── common v0.1.0 ([ROOT]/foo/common)
+└── outside v0.1.0
+
+b v0.1.0 ([ROOT]/foo/b)
+├── common v0.1.0 ([ROOT]/foo/common)
+└── outside v0.1.0
+
+common v0.1.0 ([ROOT]/foo/common)
+
+"#]])
+        .run();
 }
 
 #[cargo_test]

--- a/tests/testsuite/feature_unification.rs
+++ b/tests/testsuite/feature_unification.rs
@@ -847,12 +847,6 @@ a v0.1.0 ([ROOT]/foo/a)
 ├── common v0.1.0 ([ROOT]/foo/common)
 └── outside v0.1.0
 
-b v0.1.0 ([ROOT]/foo/b)
-├── common v0.1.0 ([ROOT]/foo/common)
-└── outside v0.1.0
-
-common v0.1.0 ([ROOT]/foo/common)
-
 "#]])
         .run();
 }


### PR DESCRIPTION
Resolves https://github.com/rust-lang/cargo/issues/16583

When using `feature-unification=workspace`, running `cargo tree -p <package>` incorrectly displayed trees for all workspace members instead of just the requested package.