### PR TITLE
Add host.runner for wrapping host build target executions

### DIFF
--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -708,12 +708,17 @@ false` is set in the Cargo configuration file.
 # config.toml
 [host]
 linker = "/path/to/host/linker"
+runner = "host-runner"
 [host.x86_64-unknown-linux-gnu]
 linker = "/path/to/host/arch/linker"
+runner = "host-arch-runner"
 rustflags = ["-Clink-arg=--verbose"]
 [target.x86_64-unknown-linux-gnu]
 linker = "/path/to/target/linker"
 ```
+
+The `host.runner` setting wraps execution of host build targets such as build
+scripts, similar to how `target.<triple>.runner` wraps `cargo run`/`test`/`bench`.
 
 The generic `host` table above will be entirely ignored when building on an
 `x86_64-unknown-linux-gnu` host as the `host.x86_64-unknown-linux-gnu` table


### PR DESCRIPTION
### What does this PR try to resolve?

This PR resolves #16591 by adding support for `host.runner` config under the existing `-Zhost-config` unstable feature. Cargo already has `target.<triple>.runner` to wrap execution of target binaries (`cargo run`/`test`/`bench`), but no equivalent for host build targets like build scripts.

### How to test and review this PR?

The implementation is two small changes in `compilation.rs`:

1. `target_runner()` now uses `bcx.target_data.target_config(kind).runner` instead of manually constructing a `target.{triple}.runner` key, mirroring how `target_linker()` already works. This routes through `host_config` for `CompileKind::Host` when `-Zhost-config` is enabled.
2. `host_process()` now prepends the runner, mirroring the existing logic in `target_process()`.

I added four new tests to cover the feature.