### PR TITLE
feat(lints): Emit unused_dependencies lint

### DIFF
--- a/src/cargo/core/compiler/build_context/mod.rs
+++ b/src/cargo/core/compiler/build_context/mod.rs
@@ -64,6 +64,9 @@ pub struct BuildContext<'a, 'gctx> {
     /// Configuration information for a rustc build.
     pub build_config: &'a BuildConfig,
 
+    /// Associated [`DepKind`][crate::core::dependency::DepKind]s for root targets
+    pub selected_dep_kinds: DepKindSet,
+
     /// Extra compiler args for either `rustc` or `rustdoc`.
     pub extra_compiler_args: HashMap<Unit, Vec<String>>,
 
@@ -97,6 +100,7 @@ impl<'a, 'gctx> BuildContext<'a, 'gctx> {
         logger: Option<&'a BuildLogger>,
         packages: PackageSet<'gctx>,
         build_config: &'a BuildConfig,
+        selected_dep_kinds: DepKindSet,
         profiles: Profiles,
         extra_compiler_args: HashMap<Unit, Vec<String>>,
         target_data: RustcTargetData<'gctx>,
@@ -118,6 +122,7 @@ impl<'a, 'gctx> BuildContext<'a, 'gctx> {
             logger,
             packages,
             build_config,
+            selected_dep_kinds,
             profiles,
             extra_compiler_args,
             target_data,
@@ -156,4 +161,11 @@ impl<'a, 'gctx> BuildContext<'a, 'gctx> {
     pub fn extra_args_for(&self, unit: &Unit) -> Option<&Vec<String>> {
         self.extra_compiler_args.get(unit)
     }
+}
+
+#[derive(Copy, Clone, Default, Debug)]
+pub struct DepKindSet {
+    pub build: bool,
+    pub normal: bool,
+    pub dev: bool,
 }

--- a/src/cargo/core/compiler/build_context/mod.rs
+++ b/src/cargo/core/compiler/build_context/mod.rs
@@ -7,6 +7,7 @@ use crate::core::compiler::CompileKind;
 use crate::core::compiler::Unit;
 use crate::core::compiler::UnitIndex;
 use crate::core::compiler::unit_graph::UnitGraph;
+use crate::core::dependency::DepKind;
 use crate::core::profiles::Profiles;
 use crate::util::Rustc;
 use crate::util::context::GlobalContext;
@@ -64,7 +65,7 @@ pub struct BuildContext<'a, 'gctx> {
     /// Configuration information for a rustc build.
     pub build_config: &'a BuildConfig,
 
-    /// Associated [`DepKind`][crate::core::dependency::DepKind]s for root targets
+    /// Associated [`DepKind`]s for root targets
     pub selected_dep_kinds: DepKindSet,
 
     /// Extra compiler args for either `rustc` or `rustdoc`.
@@ -168,4 +169,14 @@ pub struct DepKindSet {
     pub build: bool,
     pub normal: bool,
     pub dev: bool,
+}
+
+impl DepKindSet {
+    pub fn contains(&self, kind: DepKind) -> bool {
+        match kind {
+            DepKind::Build => self.build,
+            DepKind::Normal => self.normal,
+            DepKind::Development => self.dev,
+        }
+    }
 }

--- a/src/cargo/core/compiler/job_queue/job_state.rs
+++ b/src/cargo/core/compiler/job_queue/job_state.rs
@@ -219,4 +219,13 @@ impl<'a, 'gctx> JobState<'a, 'gctx> {
         self.messages
             .push(Message::FutureIncompatReport(self.id, report));
     }
+
+    /// The rustc emitted the list of unused `--extern` args.
+    ///
+    /// This is useful for checking unused dependencies.
+    /// Should only be called once, as the compiler only emits it once per compilation.
+    pub fn unused_externs(&self, unused_externs: Vec<String>) {
+        self.messages
+            .push(Message::UnusedExterns(self.id, unused_externs));
+    }
 }

--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -138,6 +138,7 @@ use super::UnitIndex;
 use super::custom_build::Severity;
 use super::timings::SectionTiming;
 use super::timings::Timings;
+use super::unused_deps::UnusedDepState;
 use crate::core::compiler::descriptive_pkg_name;
 use crate::core::compiler::future_incompat::{
     self, FutureBreakageItem, FutureIncompatReportPackage,
@@ -187,6 +188,7 @@ struct DrainState<'gctx> {
     progress: Progress<'gctx>,
     next_id: u32,
     timings: Timings<'gctx>,
+    unused_dep_state: UnusedDepState,
 
     /// Map from unit index to unit, for looking up dependency information.
     index_to_unit: HashMap<UnitIndex, Unit>,
@@ -505,6 +507,7 @@ impl<'gctx> JobQueue<'gctx> {
             progress,
             next_id: 0,
             timings: self.timings,
+            unused_dep_state: UnusedDepState::new(build_runner),
             index_to_unit: build_runner
                 .bcx
                 .unit_to_index
@@ -742,8 +745,10 @@ impl<'gctx> DrainState<'gctx> {
                         items,
                     });
             }
-            Message::UnusedExterns(id, _unused_externs) => {
-                let _unit = &self.active[&id];
+            Message::UnusedExterns(id, unused_externs) => {
+                let unit = &self.active[&id];
+                self.unused_dep_state
+                    .record_unused_externs_for_unit(unit, unused_externs);
             }
             Message::Token(acquired_token) => {
                 let token = acquired_token.context("failed to acquire jobserver token")?;
@@ -836,6 +841,18 @@ impl<'gctx> DrainState<'gctx> {
             }
         }
         self.progress.clear();
+
+        if build_runner.bcx.gctx.cli_unstable().cargo_lints {
+            let mut warn_count = 0;
+            let mut error_count = 0;
+            drop(self.unused_dep_state.emit_unused_warnings(
+                &mut warn_count,
+                &mut error_count,
+                build_runner,
+            ));
+            errors.count += error_count;
+            build_runner.compilation.lint_warning_count += warn_count;
+        }
 
         let profile_name = build_runner.bcx.build_config.requested_profile;
         // NOTE: this may be a bit inaccurate, since this may not display the

--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -385,6 +385,7 @@ enum Message {
     Finish(JobId, Artifact, CargoResult<()>),
     FutureIncompatReport(JobId, Vec<FutureBreakageItem>),
     SectionTiming(JobId, SectionTiming),
+    UnusedExterns(JobId, Vec<String>),
 }
 
 impl<'gctx> JobQueue<'gctx> {
@@ -740,6 +741,9 @@ impl<'gctx> DrainState<'gctx> {
                         is_local,
                         items,
                     });
+            }
+            Message::UnusedExterns(id, _unused_externs) => {
+                let _unit = &self.active[&id];
             }
             Message::Token(acquired_token) => {
                 let token = acquired_token.context("failed to acquire jobserver token")?;

--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -544,12 +544,10 @@ impl<'gctx> JobQueue<'gctx> {
             .take()
             .map(move |srv| srv.start(move |msg| messages.push(Message::FixDiagnostic(msg))));
 
-        thread::scope(
-            move |scope| match state.drain_the_queue(build_runner, scope, &helper) {
-                Some(err) => Err(err),
-                None => Ok(()),
-            },
-        )
+        thread::scope(move |scope| {
+            let (result,) = state.drain_the_queue(build_runner, scope, &helper);
+            result
+        })
     }
 }
 
@@ -783,14 +781,15 @@ impl<'gctx> DrainState<'gctx> {
     /// This is the "main" loop, where Cargo does all work to run the
     /// compiler.
     ///
-    /// This returns an Option to prevent the use of `?` on `Result` types
-    /// because it is important for the loop to carefully handle errors.
+    /// This returns a tuple of `Result` to prevent the use of `?` on
+    /// `Result` types because it is important for the loop to
+    /// carefully handle errors.
     fn drain_the_queue<'s>(
         mut self,
         build_runner: &mut BuildRunner<'_, '_>,
         scope: &'s Scope<'s, '_>,
         jobserver_helper: &HelperThread,
-    ) -> Option<anyhow::Error> {
+    ) -> (Result<(), anyhow::Error>,) {
         trace!("queue: {:#?}", self.queue);
 
         // Iteratively execute the entire dependency graph. Each turn of the
@@ -874,7 +873,7 @@ impl<'gctx> DrainState<'gctx> {
         if let Some(error) = errors.to_error() {
             // Any errors up to this point have already been printed via the
             // `display_error` inside `handle_error`.
-            Some(anyhow::Error::new(AlreadyPrintedError::new(error)))
+            (Err(anyhow::Error::new(AlreadyPrintedError::new(error))),)
         } else if self.queue.is_empty() && self.pending_queue.is_empty() {
             let profile_link = build_runner.bcx.gctx.shell().err_hyperlink(
                 "https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles",
@@ -889,10 +888,10 @@ impl<'gctx> DrainState<'gctx> {
                 &self.per_package_future_incompat_reports,
             );
 
-            None
+            (Ok(()),)
         } else {
             debug!("queue: {:#?}", self.queue);
-            Some(internal("finished with jobs still left in the queue"))
+            (Err(internal("finished with jobs still left in the queue")),)
         }
     }
 

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -74,6 +74,7 @@ use tracing::{debug, instrument, trace};
 pub use self::build_config::UserIntent;
 pub use self::build_config::{BuildConfig, CompileMode, MessageFormat};
 pub use self::build_context::BuildContext;
+pub use self::build_context::DepKindSet;
 pub use self::build_context::FileFlavor;
 pub use self::build_context::FileType;
 pub use self::build_context::RustcTargetData;

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -51,6 +51,7 @@ pub mod timings;
 mod unit;
 pub mod unit_dependencies;
 pub mod unit_graph;
+mod unused_deps;
 
 use std::borrow::Cow;
 use std::cell::OnceCell;

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -833,6 +833,12 @@ fn prepare_rustc(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> CargoResult
         base.env("CARGO_TARGET_TMPDIR", tmp.display().to_string());
     }
 
+    if build_runner.bcx.gctx.cli_unstable().cargo_lints {
+        // Added last to reduce the risk of RUSTFLAGS or `[lints]` from interfering with
+        // `unused_dependencies` tracking
+        base.arg("-Wunused_crate_dependencies");
+    }
+
     Ok(base)
 }
 
@@ -1178,6 +1184,9 @@ fn add_error_format_and_color(build_runner: &BuildRunner<'_, '_>, cmd: &mut Proc
     cmd.arg("--error-format=json");
 
     let mut json = String::from("--json=diagnostic-rendered-ansi,artifacts,future-incompat");
+    if build_runner.bcx.gctx.cli_unstable().cargo_lints {
+        json.push_str(",unused-externs-silent");
+    }
     if let MessageFormat::Short | MessageFormat::Json { short: true, .. } =
         build_runner.bcx.build_config.message_format
     {
@@ -2364,6 +2373,19 @@ fn on_stderr_line_inner(
             state.rmeta_produced();
         }
         return Ok(false);
+    }
+
+    #[derive(serde::Deserialize)]
+    struct UnusedExterns {
+        unused_extern_names: Vec<String>,
+    }
+    if let Ok(uext) = serde_json::from_str::<UnusedExterns>(compiler_message.get()) {
+        trace!(
+            "obtained unused externs list from rustc: `{:?}`",
+            uext.unused_extern_names
+        );
+        state.unused_externs(uext.unused_extern_names);
+        return Ok(true);
     }
 
     // And failing all that above we should have a legitimate JSON diagnostic

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1175,8 +1175,8 @@ fn add_error_format_and_color(build_runner: &BuildRunner<'_, '_>, cmd: &mut Proc
     }
 
     cmd.arg("--error-format=json");
-    let mut json = String::from("--json=diagnostic-rendered-ansi,artifacts,future-incompat");
 
+    let mut json = String::from("--json=diagnostic-rendered-ansi,artifacts,future-incompat");
     if let MessageFormat::Short | MessageFormat::Json { short: true, .. } =
         build_runner.bcx.build_config.message_format
     {
@@ -1186,11 +1186,9 @@ fn add_error_format_and_color(build_runner: &BuildRunner<'_, '_>, cmd: &mut Proc
     {
         json.push_str(",diagnostic-unicode");
     }
-
     if enable_timings {
         json.push_str(",timings");
     }
-
     cmd.arg(json);
 
     let gctx = build_runner.bcx.gctx;

--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -35,6 +35,7 @@ use crate::core::{
 };
 use crate::ops::resolve_all_features;
 use crate::util::GlobalContext;
+use crate::util::Unhashed;
 use crate::util::interning::InternedString;
 
 const IS_NO_ARTIFACT_DEP: Option<&'static Artifact> = None;
@@ -207,6 +208,8 @@ fn attach_std_deps(
                 public: true,
                 noprelude: true,
                 nounused: true,
+                // Artificial dependency
+                manifest_deps: Unhashed(None),
             }));
             found = true;
         }
@@ -306,6 +309,8 @@ fn compute_deps(
         let mode = check_or_build_mode(unit.mode, dep_lib);
         let dep_unit_for = unit_for.with_dependency(unit, dep_lib, unit_for.root_compile_kind());
 
+        let manifest_deps = deps.iter().map(|d| (*d).clone()).collect::<Vec<_>>();
+
         let start = ret.len();
         if state.gctx.cli_unstable().dual_proc_macros
             && dep_lib.proc_macro()
@@ -316,6 +321,7 @@ fn compute_deps(
                 unit,
                 dep_pkg,
                 dep_lib,
+                Some(manifest_deps.clone()),
                 dep_unit_for,
                 unit.kind,
                 mode,
@@ -327,6 +333,7 @@ fn compute_deps(
                 unit,
                 dep_pkg,
                 dep_lib,
+                Some(manifest_deps),
                 dep_unit_for,
                 CompileKind::Host,
                 mode,
@@ -339,6 +346,7 @@ fn compute_deps(
                 unit,
                 dep_pkg,
                 dep_lib,
+                Some(manifest_deps),
                 dep_unit_for,
                 unit.kind.for_target(dep_lib),
                 mode,
@@ -417,6 +425,7 @@ fn compute_deps(
                         unit,
                         &unit.pkg,
                         t,
+                        None, // artificial
                         UnitFor::new_normal(unit_for.root_compile_kind()),
                         unit.kind.for_target(t),
                         CompileMode::Build,
@@ -512,6 +521,7 @@ fn compute_deps_custom_build(
         unit,
         &unit.pkg,
         &unit.target,
+        None, // artificial
         script_unit_for,
         // Build scripts always compiled for the host.
         CompileKind::Host,
@@ -605,6 +615,7 @@ fn artifact_targets_to_unit_deps(
                                     target
                                         .clone()
                                         .set_kind(TargetKind::Lib(vec![target_kind.clone()])),
+                                    None, // TBD
                                     parent_unit_for,
                                     compile_kind,
                                     CompileMode::Build,
@@ -617,6 +628,7 @@ fn artifact_targets_to_unit_deps(
                         parent,
                         artifact_pkg,
                         target,
+                        None, // TBD
                         parent_unit_for,
                         compile_kind,
                         CompileMode::Build,
@@ -652,6 +664,7 @@ fn compute_deps_doc(
             unit,
             dep_pkg,
             dep_lib,
+            None, // not checking unused deps
             dep_unit_for,
             unit.kind.for_target(dep_lib),
             mode,
@@ -665,6 +678,7 @@ fn compute_deps_doc(
                 unit,
                 dep_pkg,
                 dep_lib,
+                None, // not checking unused deps
                 dep_unit_for,
                 unit.kind.for_target(dep_lib),
                 unit.mode,
@@ -698,6 +712,7 @@ fn compute_deps_doc(
                 unit,
                 &unit.pkg,
                 lib,
+                None, // not checking unused deps
                 dep_unit_for,
                 unit.kind.for_target(lib),
                 unit.mode,
@@ -717,6 +732,7 @@ fn compute_deps_doc(
                 scrape_unit,
                 &scrape_unit.pkg,
                 &scrape_unit.target,
+                None, // not checking unused deps
                 scrape_unit_for,
                 scrape_unit.kind,
                 scrape_unit.mode,
@@ -745,6 +761,7 @@ fn maybe_lib(
                 unit,
                 &unit.pkg,
                 t,
+                None,
                 dep_unit_for,
                 unit.kind.for_target(t),
                 mode,
@@ -806,6 +823,7 @@ fn dep_build_script(
                     unit,
                     &unit.pkg,
                     t,
+                    None, // artificial
                     script_unit_for,
                     unit.kind,
                     CompileMode::RunCustomBuild,
@@ -842,6 +860,7 @@ fn new_unit_dep(
     parent: &Unit,
     pkg: &Package,
     target: &Target,
+    manifest_deps: Option<Vec<Dependency>>,
     unit_for: UnitFor,
     kind: CompileKind,
     mode: CompileMode,
@@ -856,7 +875,16 @@ fn new_unit_dep(
         kind,
     );
     new_unit_dep_with_profile(
-        state, parent, pkg, target, unit_for, kind, mode, profile, artifact,
+        state,
+        parent,
+        pkg,
+        target,
+        manifest_deps,
+        unit_for,
+        kind,
+        mode,
+        profile,
+        artifact,
     )
 }
 
@@ -865,6 +893,7 @@ fn new_unit_dep_with_profile(
     parent: &Unit,
     pkg: &Package,
     target: &Target,
+    manifest_deps: Option<Vec<Dependency>>,
     unit_for: UnitFor,
     kind: CompileKind,
     mode: CompileMode,
@@ -913,6 +942,7 @@ fn new_unit_dep_with_profile(
         public,
         noprelude: false,
         nounused: false,
+        manifest_deps: Unhashed(manifest_deps),
     })
 }
 

--- a/src/cargo/core/compiler/unit_graph.rs
+++ b/src/cargo/core/compiler/unit_graph.rs
@@ -8,8 +8,10 @@ use crate::GlobalContext;
 use crate::core::Target;
 use crate::core::compiler::Unit;
 use crate::core::compiler::{CompileKind, CompileMode};
+use crate::core::dependency::Dependency;
 use crate::core::profiles::{Profile, UnitFor};
 use crate::util::CargoResult;
+use crate::util::Unhashed;
 use crate::util::interning::InternedString;
 use std::collections::HashMap;
 
@@ -42,6 +44,10 @@ pub struct UnitDep {
     pub noprelude: bool,
     /// If `true`, the dependency will not trigger Rust lint.
     pub nounused: bool,
+    /// The manifest dependency that gave rise to this dependency
+    ///
+    /// Skip hashing as this is redundant and for book keekping purposes only
+    pub manifest_deps: Unhashed<Option<Vec<Dependency>>>,
 }
 
 const VERSION: u32 = 1;

--- a/src/cargo/core/compiler/unused_deps.rs
+++ b/src/cargo/core/compiler/unused_deps.rs
@@ -149,6 +149,23 @@ impl UnusedDepState {
                 continue;
             }
 
+            let mut ignore = Vec::new();
+            if let Some(unused_dependencies) = cargo_lints.get("unused_dependencies") {
+                if let Some(config) = unused_dependencies.config() {
+                    if let Some(config_ignore) = config.get("ignore") {
+                        if let Ok(config_ignore) =
+                            toml::Value::try_into::<Vec<InternedString>>(config_ignore.clone())
+                        {
+                            ignore = config_ignore
+                        } else {
+                            anyhow::bail!(
+                                "`lints.cargo.unused_dependencies.ignore` must be a list of string"
+                            );
+                        }
+                    }
+                }
+            }
+
             let manifest_path = rel_cwd_manifest_path(pkg.manifest_path(), build_runner.bcx.gctx);
             let mut lint_count = 0;
             for (dep_kind, state) in states.iter() {
@@ -187,6 +204,16 @@ impl UnusedDepState {
                         continue;
                     };
                     for dependency in dependency {
+                        if ignore.contains(&dependency.name_in_toml()) {
+                            trace!(
+                                "pkg {} v{} ({dep_kind:?}): extern {} is ignored",
+                                pkg_id.name(),
+                                pkg_id.version(),
+                                ext
+                            );
+                            continue;
+                        }
+
                         let manifest = pkg.manifest();
                         let document = manifest.document();
                         let contents = manifest.contents();

--- a/src/cargo/core/compiler/unused_deps.rs
+++ b/src/cargo/core/compiler/unused_deps.rs
@@ -1,0 +1,297 @@
+use cargo_util_schemas::manifest;
+use cargo_util_terminal::report::AnnotationKind;
+use cargo_util_terminal::report::Group;
+use cargo_util_terminal::report::Level;
+use cargo_util_terminal::report::Origin;
+use cargo_util_terminal::report::Patch;
+use cargo_util_terminal::report::Snippet;
+use indexmap::IndexMap;
+use indexmap::IndexSet;
+use tracing::trace;
+
+use super::BuildRunner;
+use super::unit::Unit;
+use crate::core::Dependency;
+use crate::core::Package;
+use crate::core::PackageId;
+use crate::core::compiler::build_config::CompileMode;
+use crate::core::dependency::DepKind;
+use crate::core::manifest::TargetKind;
+use crate::lints::LintLevel;
+use crate::lints::get_key_value_span;
+use crate::lints::rel_cwd_manifest_path;
+use crate::lints::rules::unused_dependencies::LINT;
+use crate::util::errors::CargoResult;
+use crate::util::interning::InternedString;
+
+/// Track and translate `unused_externs` to `unused_dependencies`
+pub struct UnusedDepState {
+    states: IndexMap<PackageId, IndexMap<DepKind, DependenciesState>>,
+}
+
+impl UnusedDepState {
+    pub fn new(build_runner: &mut BuildRunner<'_, '_>) -> Self {
+        let mut states = IndexMap::<_, IndexMap<_, DependenciesState>>::new();
+
+        let roots = &build_runner.bcx.roots;
+
+        // Find all units for a package that can report unused externs
+        let mut root_build_script_builds = IndexSet::new();
+        for root in roots.iter() {
+            for build_script_run in build_runner.unit_deps(root).iter() {
+                if !build_script_run.unit.target.is_custom_build()
+                    && build_script_run.unit.pkg.package_id() != root.pkg.package_id()
+                {
+                    continue;
+                }
+                for build_script_build in build_runner.unit_deps(&build_script_run.unit).iter() {
+                    if !build_script_build.unit.target.is_custom_build()
+                        && build_script_build.unit.pkg.package_id() != root.pkg.package_id()
+                    {
+                        continue;
+                    }
+                    if build_script_build.unit.mode != CompileMode::Build {
+                        continue;
+                    }
+                    root_build_script_builds.insert(build_script_build.unit.clone());
+                }
+            }
+        }
+
+        trace!(
+            "selected dep kinds: {:?}",
+            build_runner.bcx.selected_dep_kinds
+        );
+        for root in roots.iter().chain(root_build_script_builds.iter()) {
+            let pkg_id = root.pkg.package_id();
+            let dep_kind = dep_kind_of(root);
+            if !build_runner.bcx.selected_dep_kinds.contains(dep_kind) {
+                trace!(
+                    "pkg {} v{} ({dep_kind:?}): ignoring unused deps due to non-exhaustive units",
+                    pkg_id.name(),
+                    pkg_id.version(),
+                );
+                continue;
+            }
+            trace!(
+                "tracking root {} {} ({:?})",
+                root.pkg.name(),
+                unit_desc(root),
+                dep_kind
+            );
+
+            let state = states
+                .entry(pkg_id)
+                .or_default()
+                .entry(dep_kind)
+                .or_default();
+            state.needed_units += 1;
+            for dep in build_runner.unit_deps(root).iter() {
+                trace!(
+                    "    => {} (deps={})",
+                    dep.unit.pkg.name(),
+                    dep.manifest_deps.0.is_some()
+                );
+                let manifest_deps = if let Some(manifest_deps) = &dep.manifest_deps.0 {
+                    Some(manifest_deps.clone())
+                } else if dep.unit.pkg.package_id() == root.pkg.package_id() {
+                    None
+                } else {
+                    continue;
+                };
+                state.externs.insert(dep.extern_crate_name, manifest_deps);
+            }
+        }
+
+        Self { states }
+    }
+
+    pub fn record_unused_externs_for_unit(&mut self, unit: &Unit, unused_externs: Vec<String>) {
+        let pkg_id = unit.pkg.package_id();
+        let kind = dep_kind_of(unit);
+        if let Some(state) = self.states.get_mut(&pkg_id).and_then(|s| s.get_mut(&kind)) {
+            state
+                .unused_externs
+                .entry(unit.clone())
+                .or_default()
+                .extend(unused_externs.into_iter().map(|s| InternedString::new(&s)));
+        }
+    }
+
+    pub fn emit_unused_warnings(
+        &self,
+        warn_count: &mut usize,
+        error_count: &mut usize,
+        build_runner: &mut BuildRunner<'_, '_>,
+    ) -> CargoResult<()> {
+        for (pkg_id, states) in &self.states {
+            let Some(pkg) = self.get_package(pkg_id) else {
+                continue;
+            };
+            let toml_lints = pkg
+                .manifest()
+                .normalized_toml()
+                .lints
+                .clone()
+                .map(|lints| lints.lints)
+                .unwrap_or(manifest::TomlLints::default());
+            let cargo_lints = toml_lints
+                .get("cargo")
+                .cloned()
+                .unwrap_or(manifest::TomlToolLints::default());
+            let (lint_level, reason) = LINT.level(
+                &cargo_lints,
+                pkg.rust_version(),
+                pkg.manifest().unstable_features(),
+            );
+
+            if lint_level == LintLevel::Allow {
+                continue;
+            }
+
+            let manifest_path = rel_cwd_manifest_path(pkg.manifest_path(), build_runner.bcx.gctx);
+            let mut lint_count = 0;
+            for (dep_kind, state) in states.iter() {
+                if state.unused_externs.len() != state.needed_units {
+                    // Some compilations errored without printing the unused externs.
+                    // Don't print the warning in order to reduce false positive
+                    // spam during errors.
+                    trace!(
+                        "pkg {} v{} ({dep_kind:?}): ignoring unused deps due to {} outstanding units",
+                        pkg_id.name(),
+                        pkg_id.version(),
+                        state.needed_units
+                    );
+                    continue;
+                }
+
+                for (ext, dependency) in &state.externs {
+                    if state
+                        .unused_externs
+                        .values()
+                        .any(|unused| !unused.contains(ext))
+                    {
+                        trace!(
+                            "pkg {} v{} ({dep_kind:?}): extern {} is used",
+                            pkg_id.name(),
+                            pkg_id.version(),
+                            ext
+                        );
+                        continue;
+                    }
+
+                    // Implicitly added dependencies (in the same crate) aren't interesting
+                    let dependency = if let Some(dependency) = dependency {
+                        dependency
+                    } else {
+                        continue;
+                    };
+                    for dependency in dependency {
+                        let manifest = pkg.manifest();
+                        let document = manifest.document();
+                        let contents = manifest.contents();
+                        let level = lint_level.to_diagnostic_level();
+                        let emitted_source = LINT.emitted_source(lint_level, reason);
+                        let toml_path = dependency.toml_path();
+
+                        let mut primary = Group::with_title(level.primary_title(LINT.desc));
+                        if let Some(document) = document
+                            && let Some(contents) = contents
+                            && let Some(span) = get_key_value_span(document, &toml_path)
+                        {
+                            let span = span.key.start..span.value.end;
+                            primary = primary.element(
+                                Snippet::source(contents)
+                                    .path(&manifest_path)
+                                    .annotation(AnnotationKind::Primary.span(span)),
+                            );
+                        } else {
+                            primary = primary.element(Origin::path(&manifest_path));
+                        }
+                        if lint_count == 0 {
+                            primary = primary.element(Level::NOTE.message(emitted_source));
+                        }
+                        lint_count += 1;
+                        let mut report = vec![primary];
+                        if let Some(document) = document
+                            && let Some(contents) = contents
+                            && let Some(span) = get_key_value_span(document, &toml_path)
+                        {
+                            let span = span.key.start..span.value.end;
+                            let mut help = Group::with_title(
+                                Level::HELP.secondary_title("remove the dependency"),
+                            );
+                            help = help.element(
+                                Snippet::source(contents)
+                                    .path(&manifest_path)
+                                    .patch(Patch::new(span, "")),
+                            );
+                            report.push(help);
+                        }
+
+                        if lint_level.is_warn() {
+                            *warn_count += 1;
+                        }
+                        if lint_level.is_error() {
+                            *error_count += 1;
+                        }
+                        build_runner
+                            .bcx
+                            .gctx
+                            .shell()
+                            .print_report(&report, lint_level.force())?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn get_package(&self, pkg_id: &PackageId) -> Option<&Package> {
+        let state = self.states.get(pkg_id)?;
+        let mut iter = state.values();
+        let state = iter.next()?;
+        let mut iter = state.unused_externs.keys();
+        let unit = iter.next()?;
+        Some(&unit.pkg)
+    }
+}
+
+/// Track a package's [`DepKind`]
+#[derive(Default)]
+struct DependenciesState {
+    /// All declared dependencies
+    externs: IndexMap<InternedString, Option<Vec<Dependency>>>,
+    /// Expected [`Self::unused_externs`] entries to know we've received them all
+    ///
+    /// To avoid warning in cases where we didn't,
+    /// e.g. if a [`Unit`] errored and didn't report unused externs.
+    needed_units: usize,
+    /// As reported by rustc
+    unused_externs: IndexMap<Unit, Vec<InternedString>>,
+}
+
+fn dep_kind_of(unit: &Unit) -> DepKind {
+    match unit.target.kind() {
+        TargetKind::Lib(_) => match unit.mode {
+            // To support lib.rs with #[cfg(test)] use foo_crate as _;
+            CompileMode::Test => DepKind::Development,
+            _ => DepKind::Normal,
+        },
+        TargetKind::Bin => DepKind::Normal,
+        TargetKind::Test => DepKind::Development,
+        TargetKind::Bench => DepKind::Development,
+        TargetKind::ExampleLib(_) => DepKind::Development,
+        TargetKind::ExampleBin => DepKind::Development,
+        TargetKind::CustomBuild => DepKind::Build,
+    }
+}
+
+fn unit_desc(unit: &Unit) -> String {
+    format!(
+        "{}/{}+{:?}",
+        unit.target.name(),
+        unit.target.kind().description(),
+        unit.mode,
+    )
+}

--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -293,6 +293,18 @@ impl Dependency {
         self.inner.explicit_name_in_toml
     }
 
+    /// The keys to this entry in a `Cargo.toml` file
+    pub fn toml_path(&self) -> Vec<String> {
+        let mut path = Vec::new();
+        if let Some(platform) = self.platform() {
+            path.push("target".to_owned());
+            path.push(platform.to_string());
+        }
+        path.push(self.kind().kind_table().to_owned());
+        path.push((&*self.name_in_toml()).to_owned());
+        path
+    }
+
     pub fn set_kind(&mut self, kind: DepKind) -> &mut Dependency {
         if self.is_public() {
             // Setting 'public' only makes sense for normal dependencies

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -34,6 +34,7 @@ use crate::lints::rules::non_snake_case_features;
 use crate::lints::rules::non_snake_case_packages;
 use crate::lints::rules::redundant_homepage;
 use crate::lints::rules::redundant_readme;
+use crate::lints::rules::unused_build_dependencies_no_build_rs;
 use crate::lints::rules::unused_workspace_dependencies;
 use crate::lints::rules::unused_workspace_package_fields;
 use crate::ops;
@@ -1389,6 +1390,13 @@ impl<'gctx> Workspace<'gctx> {
             )?;
             non_kebab_case_features(pkg, &path, &cargo_lints, &mut run_error_count, self.gctx)?;
             non_snake_case_features(pkg, &path, &cargo_lints, &mut run_error_count, self.gctx)?;
+            unused_build_dependencies_no_build_rs(
+                pkg,
+                &path,
+                &cargo_lints,
+                &mut run_error_count,
+                self.gctx,
+            )?;
             redundant_readme(pkg, &path, &cargo_lints, &mut run_error_count, self.gctx)?;
             redundant_homepage(pkg, &path, &cargo_lints, &mut run_error_count, self.gctx)?;
             missing_lints_inheritance(

--- a/src/cargo/lints/mod.rs
+++ b/src/cargo/lints/mod.rs
@@ -250,6 +250,12 @@ impl AsIndex for &str {
     }
 }
 
+impl AsIndex for String {
+    fn as_index<'i>(&'i self) -> TomlIndex<'i> {
+        TomlIndex::Key(self.as_str())
+    }
+}
+
 impl AsIndex for usize {
     fn as_index<'i>(&'i self) -> TomlIndex<'i> {
         TomlIndex::Offset(*self)
@@ -451,7 +457,7 @@ impl Lint {
         (l, r)
     }
 
-    fn emitted_source(&self, lint_level: LintLevel, reason: LintLevelReason) -> String {
+    pub fn emitted_source(&self, lint_level: LintLevel, reason: LintLevelReason) -> String {
         format!("`cargo::{}` is set to `{lint_level}` {reason}", self.name,)
     }
 }
@@ -476,6 +482,10 @@ impl Display for LintLevel {
 }
 
 impl LintLevel {
+    pub fn is_warn(&self) -> bool {
+        self == &LintLevel::Warn
+    }
+
     pub fn is_error(&self) -> bool {
         self == &LintLevel::Forbid || self == &LintLevel::Deny
     }
@@ -489,7 +499,7 @@ impl LintLevel {
         }
     }
 
-    fn force(self) -> bool {
+    pub fn force(self) -> bool {
         match self {
             Self::Allow => false,
             Self::Warn => true,

--- a/src/cargo/lints/rules/mod.rs
+++ b/src/cargo/lints/rules/mod.rs
@@ -27,6 +27,7 @@ pub use non_snake_case_packages::non_snake_case_packages;
 pub use redundant_homepage::redundant_homepage;
 pub use redundant_readme::redundant_readme;
 pub use unknown_lints::output_unknown_lints;
+pub use unused_dependencies::unused_build_dependencies_no_build_rs;
 pub use unused_workspace_dependencies::unused_workspace_dependencies;
 pub use unused_workspace_package_fields::unused_workspace_package_fields;
 

--- a/src/cargo/lints/rules/mod.rs
+++ b/src/cargo/lints/rules/mod.rs
@@ -10,6 +10,7 @@ mod non_snake_case_packages;
 mod redundant_homepage;
 mod redundant_readme;
 mod unknown_lints;
+mod unused_dependencies;
 mod unused_workspace_dependencies;
 mod unused_workspace_package_fields;
 
@@ -42,6 +43,7 @@ pub static LINTS: &[&crate::lints::Lint] = &[
     redundant_homepage::LINT,
     redundant_readme::LINT,
     unknown_lints::LINT,
+    unused_dependencies::LINT,
     unused_workspace_dependencies::LINT,
     unused_workspace_package_fields::LINT,
 ];

--- a/src/cargo/lints/rules/mod.rs
+++ b/src/cargo/lints/rules/mod.rs
@@ -10,7 +10,7 @@ mod non_snake_case_packages;
 mod redundant_homepage;
 mod redundant_readme;
 mod unknown_lints;
-mod unused_dependencies;
+pub mod unused_dependencies;
 mod unused_workspace_dependencies;
 mod unused_workspace_package_fields;
 

--- a/src/cargo/lints/rules/unused_dependencies.rs
+++ b/src/cargo/lints/rules/unused_dependencies.rs
@@ -52,7 +52,8 @@ Examples:
 
 There can be false positives when depending on a transitive dependency to activate a feature.
 
-There an be false positives when pinning the version of a transitive dependency in `Cargo.toml`.
+For false positives from pinning the version of a transitive dependency in `Cargo.toml`,
+move the dependency to the `target."cfg(false)".dependencies` table.
 
 ### Example
 

--- a/src/cargo/lints/rules/unused_dependencies.rs
+++ b/src/cargo/lints/rules/unused_dependencies.rs
@@ -1,5 +1,22 @@
+use std::path::Path;
+
+use cargo_util_schemas::manifest::TomlPackageBuild;
+use cargo_util_schemas::manifest::TomlToolLints;
+use cargo_util_terminal::report::AnnotationKind;
+use cargo_util_terminal::report::Group;
+use cargo_util_terminal::report::Level;
+use cargo_util_terminal::report::Origin;
+use cargo_util_terminal::report::Patch;
+use cargo_util_terminal::report::Snippet;
+
+use crate::CargoResult;
+use crate::GlobalContext;
+use crate::core::Package;
 use crate::lints::Lint;
+use crate::lints::LintLevel;
 use crate::lints::STYLE;
+use crate::lints::get_key_value_span;
+use crate::lints::rel_cwd_manifest_path;
 
 pub static LINT: &Lint = &Lint {
     name: "unused_dependencies",
@@ -56,3 +73,90 @@ name = "foo"
 "#,
     ),
 };
+
+/// Lint for `[build-dependencies]` without a `build.rs`
+///
+/// These are always unused.
+///
+/// This must be determined independent of the compiler since there are no build targets to pass to
+/// rustc to report on these.
+pub fn unused_build_dependencies_no_build_rs(
+    pkg: &Package,
+    manifest_path: &Path,
+    cargo_lints: &TomlToolLints,
+    error_count: &mut usize,
+    gctx: &GlobalContext,
+) -> CargoResult<()> {
+    let (lint_level, reason) = LINT.level(
+        cargo_lints,
+        pkg.rust_version(),
+        pkg.manifest().unstable_features(),
+    );
+
+    if lint_level == LintLevel::Allow {
+        return Ok(());
+    }
+
+    let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
+
+    let manifest = pkg.manifest();
+    let Some(package) = &manifest.normalized_toml().package else {
+        return Ok(());
+    };
+    if package.build != Some(TomlPackageBuild::Auto(false)) {
+        return Ok(());
+    }
+
+    let document = manifest.document();
+    let contents = manifest.contents();
+
+    for (i, dep_name) in manifest
+        .normalized_toml()
+        .build_dependencies()
+        .iter()
+        .flat_map(|m| m.keys())
+        .enumerate()
+    {
+        let level = lint_level.to_diagnostic_level();
+        let emitted_source = LINT.emitted_source(lint_level, reason);
+
+        let mut primary = Group::with_title(level.primary_title(LINT.desc));
+        if let Some(document) = document
+            && let Some(contents) = contents
+            && let Some(span) = get_key_value_span(document, &["build-dependencies", dep_name])
+        {
+            let span = span.key.start..span.value.end;
+            primary = primary.element(
+                Snippet::source(contents)
+                    .path(&manifest_path)
+                    .annotation(AnnotationKind::Primary.span(span)),
+            );
+        } else {
+            primary = primary.element(Origin::path(&manifest_path));
+        }
+        if i == 0 {
+            primary = primary.element(Level::NOTE.message(emitted_source));
+        }
+        let mut report = vec![primary];
+        if let Some(document) = document
+            && let Some(contents) = contents
+            && let Some(span) = get_key_value_span(document, &["build-dependencies", dep_name])
+        {
+            let span = span.key.start..span.value.end;
+            let mut help = Group::with_title(Level::HELP.secondary_title("remove the dependency"));
+            help = help.element(
+                Snippet::source(contents)
+                    .path(&manifest_path)
+                    .patch(Patch::new(span, "")),
+            );
+            report.push(help);
+        }
+
+        if lint_level.is_error() {
+            *error_count += 1;
+        }
+        gctx.shell().print_report(&report, lint_level.force())?;
+    }
+
+    Ok(())
+}

--- a/src/cargo/lints/rules/unused_dependencies.rs
+++ b/src/cargo/lints/rules/unused_dependencies.rs
@@ -1,0 +1,58 @@
+use crate::lints::Lint;
+use crate::lints::STYLE;
+
+pub static LINT: &Lint = &Lint {
+    name: "unused_dependencies",
+    desc: "unused dependency",
+    primary_group: &STYLE,
+    msrv: Some(super::CARGO_LINTS_MSRV),
+    feature_gate: None,
+    docs: Some(
+        r#"
+### What it does
+
+Checks for dependencies that are not used by any of the cargo targets.
+
+### Why it is bad
+
+Slows down compilation time.
+
+### Drawbacks
+
+The lint is only emitted in specific circumstances as multiple cargo targets exist for the
+different dependencies tables and they must all be built to know if a dependency is unused.
+Currently, only the selected packages are checked and not all `path` dependencies like most lints.
+The cargo target selection flags,
+independent of which packages are selected, determine which dependencies tables are checked.
+As there is no way to select all cargo targets that use `[dev-dependencies]`,
+they are unchecked.
+
+Examples:
+- `cargo check` will lint `[build-dependencies]` and `[dependencies]`
+- `cargo check --all-targets` will still only lint `[build-dependencies]` and `[dependencies]` and not `[dev-dependencoes]`
+- `cargo check --bin foo` will not lint `[dependencies]` even if `foo` is the only bin though `[build-dependencies]` will be checked
+- `cargo check -p foo` will not lint any dependencies tables for the `path` dependency `bar` even if `bar` only has a `[lib]`
+
+There can be false positives when depending on a transitive dependency to activate a feature.
+
+There an be false positives when pinning the version of a transitive dependency in `Cargo.toml`.
+
+### Example
+
+```toml
+[package]
+name = "foo"
+
+[dependencies]
+unused = "1"
+```
+
+Should be written as:
+
+```toml
+[package]
+name = "foo"
+```
+"#,
+    ),
+};

--- a/src/cargo/lints/rules/unused_dependencies.rs
+++ b/src/cargo/lints/rules/unused_dependencies.rs
@@ -70,6 +70,10 @@ Should be written as:
 [package]
 name = "foo"
 ```
+
+### Configuration
+
+- `ignore`: a list of dependency names to allow the lint on
 "#,
     ),
 };
@@ -110,6 +114,23 @@ pub fn unused_build_dependencies_no_build_rs(
     let document = manifest.document();
     let contents = manifest.contents();
 
+    let mut ignore = Vec::new();
+    if let Some(unused_dependencies) = cargo_lints.get("unused_dependencies") {
+        if let Some(config) = unused_dependencies.config() {
+            if let Some(config_ignore) = config.get("ignore") {
+                if let Ok(config_ignore) =
+                    toml::Value::try_into::<Vec<String>>(config_ignore.clone())
+                {
+                    ignore = config_ignore
+                } else {
+                    anyhow::bail!(
+                        "`lints.cargo.unused_dependencies.ignore` must be a list of string"
+                    );
+                }
+            }
+        }
+    }
+
     for (i, dep_name) in manifest
         .normalized_toml()
         .build_dependencies()
@@ -117,6 +138,10 @@ pub fn unused_build_dependencies_no_build_rs(
         .flat_map(|m| m.keys())
         .enumerate()
     {
+        if ignore.contains(&dep_name) {
+            continue;
+        }
+
         let level = lint_level.to_diagnostic_level();
         let emitted_source = LINT.emitted_source(lint_level, reason);
 

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -23,6 +23,7 @@ pub use self::progress::{Progress, ProgressStyle};
 pub use self::queue::Queue;
 pub use self::rustc::Rustc;
 pub use self::semver_ext::{OptVersionReq, VersionExt};
+pub use self::unhashed::Unhashed;
 pub use self::vcs::{FossilRepo, GitRepo, HgRepo, PijulRepo, existing_vcs_repo};
 pub use self::workspace::{
     add_path_args, path_args, print_available_benches, print_available_binaries,
@@ -68,6 +69,7 @@ mod semver_ext;
 pub mod sqlite;
 pub mod toml;
 pub mod toml_mut;
+mod unhashed;
 mod vcs;
 mod workspace;
 

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -2706,8 +2706,7 @@ supported tools: {}",
                     // manually report unused manifest key warning since we collect all the "extra"
                     // keys and values inside the config table
                     let expected = EXPECTED_LINT_CONFIG.contains(&(tool, name, config_name));
-                    if !expected
-                    {
+                    if !expected {
                         let message =
                             format!("unused manifest key: `lints.{tool}.{name}.{config_name}`");
                         warnings.push(message);
@@ -2721,6 +2720,7 @@ supported tools: {}",
 }
 
 static EXPECTED_LINT_CONFIG: &[(&str, &str, &str)] = &[
+    ("cargo", "unused_dependencies", "ignore"),
     // forwarded to rustc/rustdoc
     ("rust", "unexpected_cfgs", "check-cfg"),
 ];

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -2705,9 +2705,8 @@ supported tools: {}",
                 for config_name in config.keys() {
                     // manually report unused manifest key warning since we collect all the "extra"
                     // keys and values inside the config table
-                    //
-                    // except for `rust.unexpected_cfgs.check-cfg` which is used by rustc/rustdoc
-                    if !(tool == "rust" && name == "unexpected_cfgs" && config_name == "check-cfg")
+                    let expected = EXPECTED_LINT_CONFIG.contains(&(tool, name, config_name));
+                    if !expected
                     {
                         let message =
                             format!("unused manifest key: `lints.{tool}.{name}.{config_name}`");
@@ -2720,6 +2719,11 @@ supported tools: {}",
 
     Ok(())
 }
+
+static EXPECTED_LINT_CONFIG: &[(&str, &str, &str)] = &[
+    // forwarded to rustc/rustdoc
+    ("rust", "unexpected_cfgs", "check-cfg"),
+];
 
 fn warn_for_cargo_lint_feature(gctx: &GlobalContext, warnings: &mut Vec<String>) {
     use std::fmt::Write as _;

--- a/src/cargo/util/unhashed.rs
+++ b/src/cargo/util/unhashed.rs
@@ -1,0 +1,29 @@
+/// Avoid hashing `T` when included in another type
+#[derive(Copy, Clone, Default, Debug)]
+pub struct Unhashed<T>(pub T);
+
+impl<T> std::hash::Hash for Unhashed<T> {
+    fn hash<H: std::hash::Hasher>(&self, _: &mut H) {
+        // ...
+    }
+}
+
+impl<T> PartialEq for Unhashed<T> {
+    fn eq(&self, _: &Self) -> bool {
+        true
+    }
+}
+
+impl<T> Eq for Unhashed<T> {}
+
+impl<T> PartialOrd for Unhashed<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(other.cmp(&self))
+    }
+}
+
+impl<T> Ord for Unhashed<T> {
+    fn cmp(&self, _: &Self) -> std::cmp::Ordering {
+        std::cmp::Ordering::Equal
+    }
+}

--- a/src/doc/src/reference/lints.md
+++ b/src/doc/src/reference/lints.md
@@ -469,6 +469,10 @@ Should be written as:
 name = "foo"
 ```
 
+### Configuration
+
+- `ignore`: a list of dependency names to allow the lint on
+
 
 ## `unused_workspace_dependencies`
 Group: `suspicious`

--- a/src/doc/src/reference/lints.md
+++ b/src/doc/src/reference/lints.md
@@ -34,6 +34,7 @@ These lints are all set to the 'warn' level by default.
 - [`redundant_homepage`](#redundant_homepage)
 - [`redundant_readme`](#redundant_readme)
 - [`unknown_lints`](#unknown_lints)
+- [`unused_dependencies`](#unused_dependencies)
 - [`unused_workspace_dependencies`](#unused_workspace_dependencies)
 - [`unused_workspace_package_fields`](#unused_workspace_package_fields)
 
@@ -413,6 +414,59 @@ Checks for unknown lints in the `[lints.cargo]` table
 ```toml
 [lints.cargo]
 this-lint-does-not-exist = "warn"
+```
+
+
+## `unused_dependencies`
+Group: `style`
+
+Level: `warn`
+
+MSRV: `1.79.0`
+
+### What it does
+
+Checks for dependencies that are not used by any of the cargo targets.
+
+### Why it is bad
+
+Slows down compilation time.
+
+### Drawbacks
+
+The lint is only emitted in specific circumstances as multiple cargo targets exist for the
+different dependencies tables and they must all be built to know if a dependency is unused.
+Currently, only the selected packages are checked and not all `path` dependencies like most lints.
+The cargo target selection flags,
+independent of which packages are selected, determine which dependencies tables are checked.
+As there is no way to select all cargo targets that use `[dev-dependencies]`,
+they are unchecked.
+
+Examples:
+- `cargo check` will lint `[build-dependencies]` and `[dependencies]`
+- `cargo check --all-targets` will still only lint `[build-dependencies]` and `[dependencies]` and not `[dev-dependencoes]`
+- `cargo check --bin foo` will not lint `[dependencies]` even if `foo` is the only bin though `[build-dependencies]` will be checked
+- `cargo check -p foo` will not lint any dependencies tables for the `path` dependency `bar` even if `bar` only has a `[lib]`
+
+There can be false positives when depending on a transitive dependency to activate a feature.
+
+There an be false positives when pinning the version of a transitive dependency in `Cargo.toml`.
+
+### Example
+
+```toml
+[package]
+name = "foo"
+
+[dependencies]
+unused = "1"
+```
+
+Should be written as:
+
+```toml
+[package]
+name = "foo"
 ```
 
 

--- a/src/doc/src/reference/lints.md
+++ b/src/doc/src/reference/lints.md
@@ -450,7 +450,8 @@ Examples:
 
 There can be false positives when depending on a transitive dependency to activate a feature.
 
-There an be false positives when pinning the version of a transitive dependency in `Cargo.toml`.
+For false positives from pinning the version of a transitive dependency in `Cargo.toml`,
+move the dependency to the `target."cfg(false)".dependencies` table.
 
 ### Example
 

--- a/tests/testsuite/lints/implicit_minimum_version_req.rs
+++ b/tests/testsuite/lints/implicit_minimum_version_req.rs
@@ -50,6 +50,17 @@ implicit_minimum_version_req = "warn"
 [DOWNLOADED] dep v1.0.0 (registry `dummy-registry`)
 [CHECKING] dep v1.0.0
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
+[WARNING] unused dependency
+ --> Cargo.toml:7:1
+  |
+7 | dep = "1"
+  | ^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+7 - dep = "1"
+  |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -98,6 +109,17 @@ implicit_minimum_version_req = "warn"
 [DOWNLOADED] dep v1.0.0 (registry `dummy-registry`)
 [CHECKING] dep v1.0.0
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
+[WARNING] unused dependency
+ --> Cargo.toml:7:1
+  |
+7 | dep = "1.0"
+  | ^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+7 - dep = "1.0"
+  |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -135,6 +157,17 @@ implicit_minimum_version_req = "warn"
 [DOWNLOADED] dep v1.2.3 (registry `dummy-registry`)
 [CHECKING] dep v1.2.3
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
+[WARNING] unused dependency
+ --> Cargo.toml:7:1
+  |
+7 | dep = "1.0.0"
+  | ^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+7 - dep = "1.0.0"
+  |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -183,6 +216,17 @@ implicit_minimum_version_req = "warn"
 [DOWNLOADED] dep v1.0.0 (registry `dummy-registry`)
 [CHECKING] dep v1.0.0
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
+[WARNING] unused dependency
+ --> Cargo.toml:7:1
+  |
+7 | dep = { version = "1" }
+  | ^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+7 - dep = { version = "1" }
+  |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -231,6 +275,17 @@ implicit_minimum_version_req = "warn"
 [DOWNLOADED] dep v1.0.0 (registry `dummy-registry`)
 [CHECKING] dep v1.0.0
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
+[WARNING] unused dependency
+ --> Cargo.toml:7:1
+  |
+7 | dep = ">=1.0"
+  | ^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+7 - dep = ">=1.0"
+  |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -268,6 +323,17 @@ implicit_minimum_version_req = "warn"
 [DOWNLOADED] dep v1.0.0 (registry `dummy-registry`)
 [CHECKING] dep v1.0.0
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
+[WARNING] unused dependency
+ --> Cargo.toml:7:1
+  |
+7 | dep = "<2.0"
+  | ^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+7 - dep = "<2.0"
+  |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -305,6 +371,17 @@ implicit_minimum_version_req = "warn"
 [DOWNLOADED] dep v1.0.0 (registry `dummy-registry`)
 [CHECKING] dep v1.0.0
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
+[WARNING] unused dependency
+ --> Cargo.toml:7:1
+  |
+7 | dep = "1.*"
+  | ^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+7 - dep = "1.*"
+  |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -342,6 +419,17 @@ implicit_minimum_version_req = "warn"
 [DOWNLOADED] dep v1.0.0 (registry `dummy-registry`)
 [CHECKING] dep v1.0.0
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
+[WARNING] unused dependency
+ --> Cargo.toml:7:1
+  |
+7 | dep = "1.0.*"
+  | ^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+7 - dep = "1.0.*"
+  |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -379,6 +467,17 @@ implicit_minimum_version_req = "warn"
 [DOWNLOADED] dep v1.1.0 (registry `dummy-registry`)
 [CHECKING] dep v1.1.0
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
+[WARNING] unused dependency
+ --> Cargo.toml:7:1
+  |
+7 | dep = ">1.0"
+  | ^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+7 - dep = ">1.0"
+  |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -416,6 +515,17 @@ implicit_minimum_version_req = "warn"
 [DOWNLOADED] dep v1.0.0 (registry `dummy-registry`)
 [CHECKING] dep v1.0.0
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
+[WARNING] unused dependency
+ --> Cargo.toml:7:1
+  |
+7 | dep = "<=2.0"
+  | ^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+7 - dep = "<=2.0"
+  |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -464,6 +574,17 @@ implicit_minimum_version_req = "warn"
 [DOWNLOADED] dep v1.0.0 (registry `dummy-registry`)
 [CHECKING] dep v1.0.0
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
+[WARNING] unused dependency
+ --> Cargo.toml:7:1
+  |
+7 | dep = ">=1.0, <2.0"
+  | ^^^^^^^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+7 - dep = ">=1.0, <2.0"
+  |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -501,6 +622,17 @@ implicit_minimum_version_req = "warn"
 [DOWNLOADED] dep v1.0.0 (registry `dummy-registry`)
 [CHECKING] dep v1.0.0
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
+[WARNING] unused dependency
+ --> Cargo.toml:7:1
+  |
+7 | dep = "~1.0"
+  | ^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+7 - dep = "~1.0"
+  |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -538,6 +670,17 @@ implicit_minimum_version_req = "warn"
 [DOWNLOADED] dep v1.0.0 (registry `dummy-registry`)
 [CHECKING] dep v1.0.0
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
+[WARNING] unused dependency
+ --> Cargo.toml:7:1
+  |
+7 | dep = "=1"
+  | ^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+7 - dep = "=1"
+  |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -580,6 +723,17 @@ edition = "2021"
 [LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
+[WARNING] unused dependency
+ --> Cargo.toml:7:1
+  |
+7 | bar = { path = "bar" }
+  | ^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+7 - bar = { path = "bar" }
+  |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -634,6 +788,17 @@ edition = "2021"
 [LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
+[WARNING] unused dependency
+ --> Cargo.toml:7:1
+  |
+7 | bar = { path = "bar", version = "0.1" }
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+7 - bar = { path = "bar", version = "0.1" }
+  |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -676,6 +841,17 @@ implicit_minimum_version_req = "warn"
 [LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.1.0 ([ROOTURL]/bar#[..])
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
+[WARNING] unused dependency
+ --> Cargo.toml:7:1
+  |
+7 | bar = { git = '[ROOTURL]/bar' }
+  | ^^^^^^^^^^^^^^^[..]^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+7 - bar = { git = '[ROOTURL]/bar' }
+  |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -729,6 +905,17 @@ implicit_minimum_version_req = "warn"
 [LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.1.0 ([ROOTURL]/bar#[..])
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
+[WARNING] unused dependency
+ --> Cargo.toml:7:1
+  |
+7 | bar = { git = '[ROOTURL]/bar', version = "0.1" }
+  | ^^^^^^^^^^^^^^^[..]^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+7 - bar = { git = '[ROOTURL]/bar', version = "0.1" }
+  |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -823,6 +1010,17 @@ implicit_minimum_version_req = "warn"
 [DOWNLOADED] dep v1.0.0 (registry `dummy-registry`)
 [COMPILING] dep v1.0.0
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
+[WARNING] unused dependency
+ --> Cargo.toml:7:1
+  |
+7 | dep = "1.0"
+  | ^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+7 - dep = "1.0"
+  |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -872,6 +1070,9 @@ implicit_minimum_version_req = "warn"
 [DOWNLOADED] dep v1.0.0 (registry `dummy-registry`)
 [CHECKING] dep v1.0.0
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
+[WARNING] unused dependency
+ --> Cargo.toml
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -972,6 +1173,27 @@ implicit_minimum_version_req = "warn"
   |
 8 | regex = "1.0.0"
   |             ++
+[WARNING] unused dependency
+ --> Cargo.toml:7:1
+  |
+7 | dep = "1"
+  | ^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+7 - dep = "1"
+  |
+[WARNING] unused dependency
+ --> Cargo.toml:8:1
+  |
+8 | regex = "1.0"
+  | ^^^^^^^^^^^^^
+  |
+[HELP] remove the dependency
+  |
+8 - regex = "1.0"
+  |
 
 "#]])
         .run();
@@ -1033,6 +1255,18 @@ workspace = true
 [DOWNLOADED] dep v1.0.0 (registry `dummy-registry`)
 [CHECKING] dep v1.0.0
 [CHECKING] member v0.0.0 ([ROOT]/foo/member)
+[WARNING] unused dependency
+ --> member/Cargo.toml:7:1
+  |
+7 | dep.workspace = true
+  | ^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+7 - dep.workspace = true
+7 + .workspace = true
+  |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -1183,6 +1417,17 @@ workspace = true
 [DOWNLOADED] dep v1.0.0 (registry `dummy-registry`)
 [CHECKING] dep v1.0.0
 [CHECKING] member v0.0.0 ([ROOT]/foo/member)
+[WARNING] unused dependency
+ --> member/Cargo.toml:7:1
+  |
+7 | dep = "1.0"
+  | ^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+7 - dep = "1.0"
+  |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])

--- a/tests/testsuite/lints/mod.rs
+++ b/tests/testsuite/lints/mod.rs
@@ -248,6 +248,17 @@ bar = "0.1.0"
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [CHECKING] bar v0.1.0
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
+[WARNING] unused dependency
+ --> Cargo.toml:8:1
+  |
+8 | bar = "0.1.0"
+  | ^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+8 - bar = "0.1.0"
+  |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])

--- a/tests/testsuite/lints/mod.rs
+++ b/tests/testsuite/lints/mod.rs
@@ -16,6 +16,7 @@ mod non_snake_case_packages;
 mod redundant_homepage;
 mod redundant_readme;
 mod unknown_lints;
+mod unused_dependencies;
 mod unused_workspace_dependencies;
 mod unused_workspace_package_fields;
 mod warning;

--- a/tests/testsuite/lints/unused_dependencies.rs
+++ b/tests/testsuite/lints/unused_dependencies.rs
@@ -1373,18 +1373,6 @@ fn config_ignore() {
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(
             str![[r#"
-[WARNING] unused dependency
- --> Cargo.toml:9:13
-  |
-9 |             unused_build = "0.1.0"
-  |             ^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
-[HELP] remove the dependency
-  |
-9 -             unused_build = "0.1.0"
-  |
-[WARNING] unused manifest key: `lints.cargo.unused_dependencies.ignore`
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
@@ -1392,17 +1380,6 @@ fn config_ignore() {
 [DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
 [CHECKING] unused v0.1.0
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
-[WARNING] unused dependency
-  --> Cargo.toml:12:13
-   |
-12 |             unused_renamed = { package = "unused", version = "0.1.0" }
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
-[HELP] remove the dependency
-   |
-12 -             unused_renamed = { package = "unused", version = "0.1.0" }
-   |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]]

--- a/tests/testsuite/lints/unused_dependencies.rs
+++ b/tests/testsuite/lints/unused_dependencies.rs
@@ -1212,6 +1212,8 @@ fn pinned_transitive_dep() {
 
             [dependencies]
             intermediate = "0.1.0"
+
+            [target."cfg(false)".dependencies]
             transitive = "=0.1.1"
 
             [lints.cargo]
@@ -1237,17 +1239,6 @@ fn pinned_transitive_dep() {
 [CHECKING] transitive v0.1.1
 [CHECKING] intermediate v0.1.0
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
-[WARNING] unused dependency
-  --> Cargo.toml:10:13
-   |
-10 |             transitive = "=0.1.1"
-   |             ^^^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
-[HELP] remove the dependency
-   |
-10 -             transitive = "=0.1.1"
-   |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])

--- a/tests/testsuite/lints/unused_dependencies.rs
+++ b/tests/testsuite/lints/unused_dependencies.rs
@@ -36,13 +36,6 @@ fn unused_dep_normal() {
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `unused_dependencies`
-  --> Cargo.toml:12:13
-   |
-12 |             unused_dependencies = "warn"
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
@@ -92,13 +85,6 @@ fn unused_dep_build() {
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `unused_dependencies`
-  --> Cargo.toml:12:13
-   |
-12 |             unused_dependencies = "warn"
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
@@ -142,13 +128,6 @@ fn unused_dep_build_no_build_rs() {
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `unused_dependencies`
-  --> Cargo.toml:12:13
-   |
-12 |             unused_dependencies = "warn"
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
@@ -212,13 +191,6 @@ fn unused_dep_lib_bins() {
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(
             str![[r#"
-[WARNING] unknown lint: `unused_dependencies`
-  --> Cargo.toml:14:13
-   |
-14 |             unused_dependencies = "warn"
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
@@ -239,13 +211,6 @@ fn unused_dep_lib_bins() {
     p.cargo("check -Zcargo-lints --lib")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `unused_dependencies`
-  --> Cargo.toml:14:13
-   |
-14 |             unused_dependencies = "warn"
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -254,13 +219,6 @@ fn unused_dep_lib_bins() {
     p.cargo("check -Zcargo-lints --bins")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `unused_dependencies`
-  --> Cargo.toml:14:13
-   |
-14 |             unused_dependencies = "warn"
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -269,13 +227,6 @@ fn unused_dep_lib_bins() {
     p.cargo("check -Zcargo-lints --bin foo")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `unused_dependencies`
-  --> Cargo.toml:14:13
-   |
-14 |             unused_dependencies = "warn"
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -325,13 +276,6 @@ fn unused_dep_build_with_used_dep_normal() {
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `unused_dependencies`
-  --> Cargo.toml:15:13
-   |
-15 |             unused_dependencies = "warn"
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
@@ -384,13 +328,6 @@ fn unused_dep_normal_but_implicit_used_dep_dev() {
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `unused_dependencies`
-  --> Cargo.toml:12:13
-   |
-12 |             unused_dependencies = "warn"
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
@@ -446,13 +383,6 @@ fn unused_dep_normal_but_explicit_used_dep_dev() {
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `unused_dependencies`
-  --> Cargo.toml:15:13
-   |
-15 |             unused_dependencies = "warn"
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
@@ -509,13 +439,6 @@ fn unused_dep_dev_but_explicit_used_dep_normal() {
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `unused_dependencies`
-  --> Cargo.toml:15:13
-   |
-15 |             unused_dependencies = "warn"
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
@@ -565,13 +488,6 @@ fn optional_dependency() {
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `unused_dependencies`
-  --> Cargo.toml:13:13
-   |
-13 |             unused_dependencies = "warn"
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
@@ -584,13 +500,6 @@ fn optional_dependency() {
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(
             str![[r#"
-[WARNING] unknown lint: `unused_dependencies`
-  --> Cargo.toml:13:13
-   |
-13 |             unused_dependencies = "warn"
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [DOWNLOADING] crates ...
 [DOWNLOADED] used v0.1.0 (registry `dummy-registry`)
 [DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
@@ -641,13 +550,6 @@ fn unused_dep_renamed() {
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(
             str![[r#"
-[WARNING] unknown lint: `unused_dependencies`
-  --> Cargo.toml:13:13
-   |
-13 |             unused_dependencies = "warn"
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
@@ -696,13 +598,6 @@ fn warning_replay() {
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `unused_dependencies`
-  --> Cargo.toml:12:13
-   |
-12 |             unused_dependencies = "warn"
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
@@ -717,13 +612,6 @@ fn warning_replay() {
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `unused_dependencies`
-  --> Cargo.toml:12:13
-   |
-12 |             unused_dependencies = "warn"
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -769,13 +657,6 @@ fn unused_dep_target() {
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(
             str![[r#"
-[WARNING] unknown lint: `unused_dependencies`
-  --> Cargo.toml:13:13
-   |
-13 |             unused_dependencies = "warn"
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
@@ -863,13 +744,6 @@ fn unused_dev_deps() {
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `unused_dependencies`
-  --> Cargo.toml:17:13
-   |
-17 |             unused_dependencies = "warn"
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [UPDATING] `dummy-registry` index
 [LOCKING] 6 packages to latest compatible versions
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
@@ -883,13 +757,6 @@ fn unused_dev_deps() {
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(
             str![[r#"
-[WARNING] unknown lint: `unused_dependencies`
-  --> Cargo.toml:17:13
-   |
-17 |             unused_dependencies = "warn"
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [DOWNLOADING] crates ...
 [DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
 [DOWNLOADED] unit_used v0.1.0 (registry `dummy-registry`)
@@ -916,13 +783,6 @@ fn unused_dev_deps() {
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(
             str![[r#"
-[WARNING] unknown lint: `unused_dependencies`
-  --> Cargo.toml:17:13
-   |
-17 |             unused_dependencies = "warn"
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [COMPILING] example_used v0.1.0
 [COMPILING] unit_used v0.1.0
 [COMPILING] unused v0.1.0
@@ -943,13 +803,6 @@ fn unused_dev_deps() {
     p.cargo("test -Zcargo-lints --no-run --all-targets")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `unused_dependencies`
-  --> Cargo.toml:17:13
-   |
-17 |             unused_dependencies = "warn"
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [EXECUTABLE] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
@@ -965,13 +818,6 @@ fn unused_dev_deps() {
     p.cargo("test -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `unused_dependencies`
-  --> Cargo.toml:17:13
-   |
-17 |             unused_dependencies = "warn"
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
 [RUNNING] tests/hello.rs (target/debug/deps/hello-[HASH][EXE])
@@ -1075,24 +921,10 @@ fn package_selection() {
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(
             str![[r#"
-[WARNING] unknown lint: `unused_dependencies`
-  --> bar/Cargo.toml:13:13
-   |
-13 |             unused_dependencies = "warn"
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
-[WARNING] unknown lint: `unused_dependencies`
-   |
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-  --> foo/Cargo.toml:15:13
-15 |             unused_dependencies = "warn"
 [LOCKING] 5 packages to latest compatible versions
 [DOWNLOADED] used_foo v0.1.0 (registry `dummy-registry`)
 [DOWNLOADED] used_external v0.1.0 (registry `dummy-registry`)
@@ -1114,21 +946,7 @@ fn package_selection() {
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(
             str![[r#"
-[WARNING] unknown lint: `unused_dependencies`
-  --> bar/Cargo.toml:13:13
-   |
-13 |             unused_dependencies = "warn"
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
-[WARNING] unknown lint: `unused_dependencies`
-   |
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-  --> foo/Cargo.toml:15:13
-15 |             unused_dependencies = "warn"
 
 "#]]
             .unordered(),
@@ -1139,21 +957,7 @@ fn package_selection() {
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(
             str![[r#"
-[WARNING] unknown lint: `unused_dependencies`
-  --> bar/Cargo.toml:13:13
-   |
-13 |             unused_dependencies = "warn"
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
-[WARNING] unknown lint: `unused_dependencies`
-   |
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-  --> foo/Cargo.toml:15:13
-15 |             unused_dependencies = "warn"
 
 "#]]
             .unordered(),
@@ -1203,13 +1007,6 @@ fn pinned_transitive_dep() {
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `unused_dependencies`
-  --> Cargo.toml:13:13
-   |
-13 |             unused_dependencies = "warn"
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
@@ -1281,13 +1078,6 @@ pub fn fun() -> &'static str {
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `unused_dependencies`
-  --> Cargo.toml:13:13
-   |
-13 |             unused_dependencies = "warn"
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
@@ -1338,13 +1128,6 @@ fn config_ignore() {
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `unused_dependencies`
-  --> Cargo.toml:15:13
-   |
-15 |             unused_dependencies = { level = "warn", ignore = ["unused_build", "unused_renamed"] }
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [WARNING] unused manifest key: `lints.cargo.unused_dependencies.ignore`
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions

--- a/tests/testsuite/lints/unused_dependencies.rs
+++ b/tests/testsuite/lints/unused_dependencies.rs
@@ -1,0 +1,1360 @@
+use crate::prelude::*;
+use cargo_test_support::project;
+use cargo_test_support::registry::Package;
+use cargo_test_support::rustc_host;
+use cargo_test_support::str;
+
+#[cargo_test]
+fn unused_dep_normal() {
+    // The most basic case where there is an unused dependency
+    Package::new("unused", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dependencies]
+            unused = "0.1.0"
+
+            [lints.cargo]
+            unused_dependencies = "warn"
+        "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+            fn main() {}
+            "#,
+        )
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] unknown lint: `unused_dependencies`
+  --> Cargo.toml:12:13
+   |
+12 |             unused_dependencies = "warn"
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[UPDATING] `dummy-registry` index
+[LOCKING] 1 package to latest compatible version
+[DOWNLOADING] crates ...
+[DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
+[CHECKING] unused v0.1.0
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn unused_dep_build() {
+    Package::new("unused", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [build-dependencies]
+            unused = "0.1.0"
+
+            [lints.cargo]
+            unused_dependencies = "warn"
+        "#,
+        )
+        .file(
+            "build.rs",
+            r#"
+            fn main() {}
+            "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+            fn main() {}
+            "#,
+        )
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] unknown lint: `unused_dependencies`
+  --> Cargo.toml:12:13
+   |
+12 |             unused_dependencies = "warn"
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[UPDATING] `dummy-registry` index
+[LOCKING] 1 package to latest compatible version
+[DOWNLOADING] crates ...
+[DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
+[COMPILING] unused v0.1.0
+[COMPILING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn unused_dep_build_no_build_rs() {
+    Package::new("unused", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [build-dependencies]
+            unused = "0.1.0"
+
+            [lints.cargo]
+            unused_dependencies = "warn"
+        "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+            fn main() {}
+            "#,
+        )
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] unknown lint: `unused_dependencies`
+  --> Cargo.toml:12:13
+   |
+12 |             unused_dependencies = "warn"
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[UPDATING] `dummy-registry` index
+[LOCKING] 1 package to latest compatible version
+[DOWNLOADING] crates ...
+[DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn unused_dep_lib_bins() {
+    // Make sure that dependency uses by both binaries and libraries
+    // are being registered as used
+    Package::new("unused", "0.1.0").publish();
+    Package::new("lib_used", "0.1.0").publish();
+    Package::new("bins_used", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dependencies]
+            unused = "0.1.0"
+            lib_used = "0.1.0"
+            bins_used = "0.1.0"
+
+            [lints.cargo]
+            unused_dependencies = "warn"
+        "#,
+        )
+        .file(
+            "src/lib.rs",
+            r#"
+            use lib_used as _;
+            "#,
+        )
+        .file(
+            "src/bin/foo.rs",
+            r#"
+            use bins_used as _;
+            fn main() {}
+            "#,
+        )
+        .file(
+            "src/bin/bar.rs",
+            r#"
+            use bins_used as _;
+            fn main() {}
+            "#,
+        )
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(
+            str![[r#"
+[WARNING] unknown lint: `unused_dependencies`
+  --> Cargo.toml:14:13
+   |
+14 |             unused_dependencies = "warn"
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[UPDATING] `dummy-registry` index
+[LOCKING] 3 packages to latest compatible versions
+[DOWNLOADING] crates ...
+[DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
+[DOWNLOADED] lib_used v0.1.0 (registry `dummy-registry`)
+[DOWNLOADED] bins_used v0.1.0 (registry `dummy-registry`)
+[CHECKING] bins_used v0.1.0
+[CHECKING] unused v0.1.0
+[CHECKING] lib_used v0.1.0
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]]
+            .unordered(),
+        )
+        .run();
+
+    p.cargo("check -Zcargo-lints --lib")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] unknown lint: `unused_dependencies`
+  --> Cargo.toml:14:13
+   |
+14 |             unused_dependencies = "warn"
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+
+    p.cargo("check -Zcargo-lints --bins")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] unknown lint: `unused_dependencies`
+  --> Cargo.toml:14:13
+   |
+14 |             unused_dependencies = "warn"
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+
+    p.cargo("check -Zcargo-lints --bin foo")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] unknown lint: `unused_dependencies`
+  --> Cargo.toml:14:13
+   |
+14 |             unused_dependencies = "warn"
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn unused_dep_build_with_used_dep_normal() {
+    // Check sharing of a dependency
+    // between build and proper deps
+    Package::new("unused_build", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [build-dependencies]
+            unused_build = "0.1.0"
+
+            [dependencies]
+            unused_build = "0.1.0"
+
+            [lints.cargo]
+            unused_dependencies = "warn"
+        "#,
+        )
+        .file(
+            "build.rs",
+            r#"
+            fn main() {}
+            "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+            use unused_build as _;
+            fn main() {}
+            "#,
+        )
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] unknown lint: `unused_dependencies`
+  --> Cargo.toml:15:13
+   |
+15 |             unused_dependencies = "warn"
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[UPDATING] `dummy-registry` index
+[LOCKING] 1 package to latest compatible version
+[DOWNLOADING] crates ...
+[DOWNLOADED] unused_build v0.1.0 (registry `dummy-registry`)
+[COMPILING] unused_build v0.1.0
+[COMPILING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn unused_dep_normal_but_implicit_used_dep_dev() {
+    Package::new("used_dev", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dependencies]
+            used_dev = "0.1.0"
+
+            [lints.cargo]
+            unused_dependencies = "warn"
+        "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+            fn main() {}
+            "#,
+        )
+        .file(
+            "tests/foo.rs",
+            r#"
+            #[test]
+            fn foo {
+                use used_dev as _;
+            }
+            "#,
+        )
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] unknown lint: `unused_dependencies`
+  --> Cargo.toml:12:13
+   |
+12 |             unused_dependencies = "warn"
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[UPDATING] `dummy-registry` index
+[LOCKING] 1 package to latest compatible version
+[DOWNLOADING] crates ...
+[DOWNLOADED] used_dev v0.1.0 (registry `dummy-registry`)
+[CHECKING] used_dev v0.1.0
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn unused_dep_normal_but_explicit_used_dep_dev() {
+    Package::new("used_once", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dependencies]
+            used_once = "0.1.0"
+
+            [dev-dependencies]
+            used_once = "0.1.0"
+
+            [lints.cargo]
+            unused_dependencies = "warn"
+        "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+            fn main() {}
+            "#,
+        )
+        .file(
+            "tests/foo.rs",
+            r#"
+            #[test]
+            fn foo {
+                use used_once as _;
+            }
+            "#,
+        )
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] unknown lint: `unused_dependencies`
+  --> Cargo.toml:15:13
+   |
+15 |             unused_dependencies = "warn"
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[UPDATING] `dummy-registry` index
+[LOCKING] 1 package to latest compatible version
+[DOWNLOADING] crates ...
+[DOWNLOADED] used_once v0.1.0 (registry `dummy-registry`)
+[CHECKING] used_once v0.1.0
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn unused_dep_dev_but_explicit_used_dep_normal() {
+    Package::new("used_once", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dependencies]
+            used_once = "0.1.0"
+
+            [dev-dependencies]
+            used_once = "0.1.0"
+
+            [lints.cargo]
+            unused_dependencies = "warn"
+        "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+            fn main() {
+                use used_once as _;
+            }
+            "#,
+        )
+        .file(
+            "tests/foo.rs",
+            r#"
+            #[test]
+            fn foo {
+            }
+            "#,
+        )
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] unknown lint: `unused_dependencies`
+  --> Cargo.toml:15:13
+   |
+15 |             unused_dependencies = "warn"
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[UPDATING] `dummy-registry` index
+[LOCKING] 1 package to latest compatible version
+[DOWNLOADING] crates ...
+[DOWNLOADED] used_once v0.1.0 (registry `dummy-registry`)
+[CHECKING] used_once v0.1.0
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn optional_dependency() {
+    // The most basic case where there is an unused dependency
+    Package::new("unused", "0.1.0").publish();
+    Package::new("used", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dependencies]
+            unused = { version = "0.1.0", optional = true }
+            used = { version = "0.1.0", optional = true }
+
+            [lints.cargo]
+            unused_dependencies = "warn"
+        "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+            #[cfg(feature = "used")]
+            use used as _;
+
+            fn main() {}
+            "#,
+        )
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] unknown lint: `unused_dependencies`
+  --> Cargo.toml:13:13
+   |
+13 |             unused_dependencies = "warn"
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[UPDATING] `dummy-registry` index
+[LOCKING] 2 packages to latest compatible versions
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+
+    p.cargo("check -Zcargo-lints -F used,unused")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(
+            str![[r#"
+[WARNING] unknown lint: `unused_dependencies`
+  --> Cargo.toml:13:13
+   |
+13 |             unused_dependencies = "warn"
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[DOWNLOADING] crates ...
+[DOWNLOADED] used v0.1.0 (registry `dummy-registry`)
+[DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
+[CHECKING] unused v0.1.0
+[CHECKING] used v0.1.0
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]]
+            .unordered(),
+        )
+        .run();
+}
+
+#[cargo_test]
+fn unused_dep_renamed() {
+    // Make sure that package renaming works
+    Package::new("bar", "0.1.0").publish();
+    Package::new("baz", "0.2.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dependencies]
+            baz = { package = "bar", version = "0.1.0" }
+            bar = { package = "baz", version = "0.2.0" }
+
+            [lints.cargo]
+            unused_dependencies = "warn"
+        "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+            use bar as _;
+            fn main() {}
+            "#,
+        )
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(
+            str![[r#"
+[WARNING] unknown lint: `unused_dependencies`
+  --> Cargo.toml:13:13
+   |
+13 |             unused_dependencies = "warn"
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[UPDATING] `dummy-registry` index
+[LOCKING] 2 packages to latest compatible versions
+[DOWNLOADING] crates ...
+[DOWNLOADED] baz v0.2.0 (registry `dummy-registry`)
+[DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
+[CHECKING] baz v0.2.0
+[CHECKING] bar v0.1.0
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]]
+            .unordered(),
+        )
+        .run();
+}
+
+#[cargo_test]
+fn warning_replay() {
+    // The most basic case where there is an unused dependency
+    Package::new("unused", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dependencies]
+            unused = "0.1.0"
+
+            [lints.cargo]
+            unused_dependencies = "warn"
+        "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+            fn main() {}
+            "#,
+        )
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] unknown lint: `unused_dependencies`
+  --> Cargo.toml:12:13
+   |
+12 |             unused_dependencies = "warn"
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[UPDATING] `dummy-registry` index
+[LOCKING] 1 package to latest compatible version
+[DOWNLOADING] crates ...
+[DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
+[CHECKING] unused v0.1.0
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] unknown lint: `unused_dependencies`
+  --> Cargo.toml:12:13
+   |
+12 |             unused_dependencies = "warn"
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn unused_dep_target() {
+    // The most basic case where there is an unused dependency
+    Package::new("unused", "0.1.0").publish();
+    Package::new("used", "0.1.0").publish();
+    let host = rustc_host();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            &format!(
+                r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [target.{host}.dependencies]
+            unused = "0.1.0"
+            used = "0.1.0"
+
+            [lints.cargo]
+            unused_dependencies = "warn"
+        "#
+            ),
+        )
+        .file(
+            "src/main.rs",
+            r#"
+            use used as _;
+            fn main() {}
+            "#,
+        )
+        .build();
+
+    p.cargo(&format!("check -Zcargo-lints --target {host}"))
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(
+            str![[r#"
+[WARNING] unknown lint: `unused_dependencies`
+  --> Cargo.toml:13:13
+   |
+13 |             unused_dependencies = "warn"
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[UPDATING] `dummy-registry` index
+[LOCKING] 2 packages to latest compatible versions
+[DOWNLOADING] crates ...
+[DOWNLOADED] used v0.1.0 (registry `dummy-registry`)
+[DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
+[CHECKING] unused v0.1.0
+[CHECKING] used v0.1.0
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]]
+            .unordered(),
+        )
+        .run();
+}
+
+#[cargo_test]
+fn unused_dev_deps() {
+    // Test for unused dev dependencies
+    Package::new("unit_used", "0.1.0").publish();
+    Package::new("doctest_used", "0.1.0").publish();
+    Package::new("test_used", "0.1.0").publish();
+    Package::new("example_used", "0.1.0").publish();
+    Package::new("bench_used", "0.1.0").publish();
+    Package::new("unused", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dev-dependencies]
+            unit_used = "0.1.0"
+            doctest_used = "0.1.0"
+            test_used = "0.1.0"
+            example_used = "0.1.0"
+            bench_used = "0.1.0"
+            unused = "0.1.0"
+
+            [lints.cargo]
+            unused_dependencies = "warn"
+        "#,
+        )
+        .file(
+            "src/lib.rs",
+            r#"
+            /// ```
+            /// use doctest_used as _;
+            /// ```
+            pub fn foo() {}
+
+            #[test]
+            fn test() {
+                use unit_used as _;
+            }
+        "#,
+        )
+        .file(
+            "tests/hello.rs",
+            r#"
+            use test_used as _;
+            "#,
+        )
+        .file(
+            "examples/hello.rs",
+            r#"
+            use example_used as _;
+            fn main() {}
+            "#,
+        )
+        .file(
+            "benches/hello.rs",
+            r#"
+            use bench_used as _;
+            fn main() {}
+            "#,
+        )
+        .build();
+
+    // doesn't check any tests, still no unused dev dep warnings
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] unknown lint: `unused_dependencies`
+  --> Cargo.toml:17:13
+   |
+17 |             unused_dependencies = "warn"
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[UPDATING] `dummy-registry` index
+[LOCKING] 6 packages to latest compatible versions
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+
+    // doesn't check doctests, still no unused dev dep warnings
+    p.cargo("check -Zcargo-lints --all-targets")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(
+            str![[r#"
+[WARNING] unknown lint: `unused_dependencies`
+  --> Cargo.toml:17:13
+   |
+17 |             unused_dependencies = "warn"
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[DOWNLOADING] crates ...
+[DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
+[DOWNLOADED] unit_used v0.1.0 (registry `dummy-registry`)
+[DOWNLOADED] test_used v0.1.0 (registry `dummy-registry`)
+[DOWNLOADED] example_used v0.1.0 (registry `dummy-registry`)
+[DOWNLOADED] doctest_used v0.1.0 (registry `dummy-registry`)
+[DOWNLOADED] bench_used v0.1.0 (registry `dummy-registry`)
+[CHECKING] bench_used v0.1.0
+[CHECKING] unused v0.1.0
+[CHECKING] doctest_used v0.1.0
+[CHECKING] example_used v0.1.0
+[CHECKING] unit_used v0.1.0
+[CHECKING] test_used v0.1.0
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]]
+            .unordered(),
+        )
+        .run();
+
+    // doesn't test doctests and benches and thus doesn't create unused dev dep warnings
+    p.cargo("test -Zcargo-lints --no-run")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(
+            str![[r#"
+[WARNING] unknown lint: `unused_dependencies`
+  --> Cargo.toml:17:13
+   |
+17 |             unused_dependencies = "warn"
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[COMPILING] example_used v0.1.0
+[COMPILING] unit_used v0.1.0
+[COMPILING] unused v0.1.0
+[COMPILING] test_used v0.1.0
+[COMPILING] bench_used v0.1.0
+[COMPILING] doctest_used v0.1.0
+[COMPILING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[EXECUTABLE] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[EXECUTABLE] tests/hello.rs (target/debug/deps/hello-[HASH][EXE])
+
+"#]]
+            .unordered(),
+        )
+        .run();
+
+    // doesn't test doctests, still no unused dev dep warnings
+    p.cargo("test -Zcargo-lints --no-run --all-targets")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] unknown lint: `unused_dependencies`
+  --> Cargo.toml:17:13
+   |
+17 |             unused_dependencies = "warn"
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[COMPILING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[EXECUTABLE] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[EXECUTABLE] tests/hello.rs (target/debug/deps/hello-[HASH][EXE])
+[EXECUTABLE] benches/hello.rs (target/debug/deps/hello-[HASH][EXE])
+[EXECUTABLE] unittests examples/hello.rs (target/debug/examples/hello-[HASH][EXE])
+
+"#]])
+        .run();
+
+    // tests everything including doctests, but not
+    // the benches
+    p.cargo("test -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] unknown lint: `unused_dependencies`
+  --> Cargo.toml:17:13
+   |
+17 |             unused_dependencies = "warn"
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] tests/hello.rs (target/debug/deps/hello-[HASH][EXE])
+[DOCTEST] foo
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn package_selection() {
+    // Make sure that workspaces are supported,
+    // --all params, -p params, etc.
+    Package::new("used_bar", "0.1.0").publish();
+    Package::new("used_foo", "0.1.0").publish();
+    Package::new("used_external", "0.1.0").publish();
+    Package::new("unused", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["foo", "bar"]
+            exclude = ["external"]
+        "#,
+        )
+        .file(
+            "foo/Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dependencies]
+            unused = "0.1.0"
+            used_foo = "0.1.0"
+            bar.path = "../bar"
+            external.path = "../external"
+
+            [lints.cargo]
+            unused_dependencies = "warn"
+            "#,
+        )
+        .file(
+            "foo/src/lib.rs",
+            r#"
+            use used_foo as _;
+            "#,
+        )
+        .file(
+            "bar/Cargo.toml",
+            r#"
+            [package]
+            name = "bar"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dependencies]
+            unused = "0.1.0"
+            used_bar = "0.1.0"
+
+            [lints.cargo]
+            unused_dependencies = "warn"
+            "#,
+        )
+        .file(
+            "bar/src/lib.rs",
+            r#"
+            use used_bar as _;
+            "#,
+        )
+        .file(
+            "external/Cargo.toml",
+            r#"
+            [package]
+            name = "external"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dependencies]
+            unused = "0.1.0"
+            used_external = "0.1.0"
+
+            [lints.cargo]
+            unused_dependencies = "warn"
+            "#,
+        )
+        .file(
+            "external/src/lib.rs",
+            r#"
+            use used_external as _;
+            "#,
+        )
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(
+            str![[r#"
+[WARNING] unknown lint: `unused_dependencies`
+  --> bar/Cargo.toml:13:13
+   |
+13 |             unused_dependencies = "warn"
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[WARNING] unknown lint: `unused_dependencies`
+   |
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[UPDATING] `dummy-registry` index
+[DOWNLOADING] crates ...
+[CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+  --> foo/Cargo.toml:15:13
+15 |             unused_dependencies = "warn"
+[LOCKING] 5 packages to latest compatible versions
+[DOWNLOADED] used_foo v0.1.0 (registry `dummy-registry`)
+[DOWNLOADED] used_external v0.1.0 (registry `dummy-registry`)
+[DOWNLOADED] used_bar v0.1.0 (registry `dummy-registry`)
+[DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
+[CHECKING] unused v0.1.0
+[CHECKING] used_bar v0.1.0
+[CHECKING] used_external v0.1.0
+[CHECKING] used_foo v0.1.0
+[CHECKING] external v0.1.0 ([ROOT]/foo/external)
+[CHECKING] foo v0.1.0 ([ROOT]/foo/foo)
+
+"#]]
+            .unordered(),
+        )
+        .run();
+
+    p.cargo("check -Zcargo-lints -p foo")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(
+            str![[r#"
+[WARNING] unknown lint: `unused_dependencies`
+  --> bar/Cargo.toml:13:13
+   |
+13 |             unused_dependencies = "warn"
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[WARNING] unknown lint: `unused_dependencies`
+   |
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+  --> foo/Cargo.toml:15:13
+15 |             unused_dependencies = "warn"
+
+"#]]
+            .unordered(),
+        )
+        .run();
+
+    p.cargo("check -Zcargo-lints -p bar")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(
+            str![[r#"
+[WARNING] unknown lint: `unused_dependencies`
+  --> bar/Cargo.toml:13:13
+   |
+13 |             unused_dependencies = "warn"
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[WARNING] unknown lint: `unused_dependencies`
+   |
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+  --> foo/Cargo.toml:15:13
+15 |             unused_dependencies = "warn"
+
+"#]]
+            .unordered(),
+        )
+        .run();
+}
+
+#[cargo_test]
+fn pinned_transitive_dep() {
+    // The most basic case where there is an unused dependency
+    Package::new("transitive", "0.1.0")
+        .file("src/lib.rs", "pub fn fun() {}")
+        .publish();
+    Package::new("transitive", "0.1.1")
+        .file("src/lib.rs", "pub fn fun() {}")
+        .publish();
+    Package::new("intermediate", "0.1.0")
+        .dep("transitive", "0.1")
+        .file("src/lib.rs", "pub fn fun() { transitive::fun(); }")
+        .publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dependencies]
+            intermediate = "0.1.0"
+            transitive = "=0.1.1"
+
+            [lints.cargo]
+            unused_dependencies = "warn"
+        "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+            fn main() { intermediate::fun(); }
+            "#,
+        )
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] unknown lint: `unused_dependencies`
+  --> Cargo.toml:13:13
+   |
+13 |             unused_dependencies = "warn"
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[UPDATING] `dummy-registry` index
+[LOCKING] 2 packages to latest compatible versions
+[DOWNLOADING] crates ...
+[DOWNLOADED] transitive v0.1.1 (registry `dummy-registry`)
+[DOWNLOADED] intermediate v0.1.0 (registry `dummy-registry`)
+[CHECKING] transitive v0.1.1
+[CHECKING] intermediate v0.1.0
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn activated_transitive_dep() {
+    // The most basic case where there is an unused dependency
+    Package::new("transitive", "0.1.1")
+        .feature("a", &[])
+        .file(
+            "src/lib.rs",
+            r#"
+pub fn fun() -> &'static str {
+    #[cfg(feature = "a")]
+    {
+        "a"
+    }
+    #[cfg(not(feature = "a"))]
+    {
+        "not a"
+    }
+}
+"#,
+        )
+        .publish();
+    Package::new("intermediate", "0.1.0")
+        .dep("transitive", "0.1")
+        .file(
+            "src/lib.rs",
+            "pub fn fun() -> &'static str { transitive::fun() }",
+        )
+        .publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dependencies]
+            intermediate = "0.1.0"
+            transitive = { version = "0.1.1", features = ["a"] }
+
+            [lints.cargo]
+            unused_dependencies = "warn"
+        "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+            fn main() { assert_eq!(intermediate::fun(), "a"); }
+            "#,
+        )
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] unknown lint: `unused_dependencies`
+  --> Cargo.toml:13:13
+   |
+13 |             unused_dependencies = "warn"
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[UPDATING] `dummy-registry` index
+[LOCKING] 2 packages to latest compatible versions
+[DOWNLOADING] crates ...
+[DOWNLOADED] transitive v0.1.1 (registry `dummy-registry`)
+[DOWNLOADED] intermediate v0.1.0 (registry `dummy-registry`)
+[CHECKING] transitive v0.1.1
+[CHECKING] intermediate v0.1.0
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn config_ignore() {
+    // The most basic case where there is an unused dependency
+    Package::new("unused_build", "0.1.0").publish();
+    Package::new("unused", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [build-dependencies]
+            unused_build = "0.1.0"
+
+            [dependencies]
+            unused_renamed = { package = "unused", version = "0.1.0" }
+
+            [lints.cargo]
+            unused_dependencies = { level = "warn", ignore = ["unused_build", "unused_renamed"] }
+        "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+            fn main() {}
+            "#,
+        )
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] unknown lint: `unused_dependencies`
+  --> Cargo.toml:15:13
+   |
+15 |             unused_dependencies = { level = "warn", ignore = ["unused_build", "unused_renamed"] }
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[WARNING] unused manifest key: `lints.cargo.unused_dependencies.ignore`
+[UPDATING] `dummy-registry` index
+[LOCKING] 2 packages to latest compatible versions
+[DOWNLOADING] crates ...
+[DOWNLOADED] unused_build v0.1.0 (registry `dummy-registry`)
+[DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
+[CHECKING] unused v0.1.0
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]].unordered())
+        .run();
+}

--- a/tests/testsuite/lints/unused_dependencies.rs
+++ b/tests/testsuite/lints/unused_dependencies.rs
@@ -128,6 +128,17 @@ fn unused_dep_build_no_build_rs() {
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
+[WARNING] unused dependency
+ --> Cargo.toml:9:13
+  |
+9 |             unused = "0.1.0"
+  |             ^^^^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+9 -             unused = "0.1.0"
+  |
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
@@ -1127,7 +1138,19 @@ fn config_ignore() {
 
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
-        .with_stderr_data(str![[r#"
+        .with_stderr_data(
+            str![[r#"
+[WARNING] unused dependency
+ --> Cargo.toml:9:13
+  |
+9 |             unused_build = "0.1.0"
+  |             ^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+9 -             unused_build = "0.1.0"
+  |
 [WARNING] unused manifest key: `lints.cargo.unused_dependencies.ignore`
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
@@ -1138,6 +1161,8 @@ fn config_ignore() {
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
-"#]].unordered())
+"#]]
+            .unordered(),
+        )
         .run();
 }

--- a/tests/testsuite/lints/unused_dependencies.rs
+++ b/tests/testsuite/lints/unused_dependencies.rs
@@ -42,6 +42,17 @@ fn unused_dep_normal() {
 [DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
 [CHECKING] unused v0.1.0
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
+[WARNING] unused dependency
+ --> Cargo.toml:9:13
+  |
+9 |             unused = "0.1.0"
+  |             ^^^^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+9 -             unused = "0.1.0"
+  |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -91,6 +102,17 @@ fn unused_dep_build() {
 [DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
 [COMPILING] unused v0.1.0
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
+[WARNING] unused dependency
+ --> Cargo.toml:9:13
+  |
+9 |             unused = "0.1.0"
+  |             ^^^^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+9 -             unused = "0.1.0"
+  |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -213,6 +235,17 @@ fn unused_dep_lib_bins() {
 [CHECKING] lib_used v0.1.0
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[WARNING] unused dependency
+ --> Cargo.toml:9:13
+  |
+9 |             unused = "0.1.0"
+  |             ^^^^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+9 -             unused = "0.1.0"
+  |
 
 "#]]
             .unordered(),
@@ -293,6 +326,17 @@ fn unused_dep_build_with_used_dep_normal() {
 [DOWNLOADED] unused_build v0.1.0 (registry `dummy-registry`)
 [COMPILING] unused_build v0.1.0
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
+[WARNING] unused dependency
+ --> Cargo.toml:9:13
+  |
+9 |             unused_build = "0.1.0"
+  |             ^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+9 -             unused_build = "0.1.0"
+  |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -345,6 +389,17 @@ fn unused_dep_normal_but_implicit_used_dep_dev() {
 [DOWNLOADED] used_dev v0.1.0 (registry `dummy-registry`)
 [CHECKING] used_dev v0.1.0
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
+[WARNING] unused dependency
+ --> Cargo.toml:9:13
+  |
+9 |             used_dev = "0.1.0"
+  |             ^^^^^^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+9 -             used_dev = "0.1.0"
+  |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -400,6 +455,17 @@ fn unused_dep_normal_but_explicit_used_dep_dev() {
 [DOWNLOADED] used_once v0.1.0 (registry `dummy-registry`)
 [CHECKING] used_once v0.1.0
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
+[WARNING] unused dependency
+ --> Cargo.toml:9:13
+  |
+9 |             used_once = "0.1.0"
+  |             ^^^^^^^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+9 -             used_once = "0.1.0"
+  |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -447,6 +513,8 @@ fn unused_dep_dev_but_explicit_used_dep_normal() {
         )
         .build();
 
+    // No warning because the dependency is used at test time by the unit tests and the two
+    // dependencies are indistinguishable
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
@@ -518,6 +586,17 @@ fn optional_dependency() {
 [CHECKING] used v0.1.0
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[WARNING] unused dependency
+ --> Cargo.toml:9:13
+  |
+9 |             unused = { version = "0.1.0", optional = true }
+  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+9 -             unused = { version = "0.1.0", optional = true }
+  |
 
 "#]]
             .unordered(),
@@ -570,6 +649,17 @@ fn unused_dep_renamed() {
 [CHECKING] bar v0.1.0
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[WARNING] unused dependency
+ --> Cargo.toml:9:13
+  |
+9 |             baz = { package = "bar", version = "0.1.0" }
+  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+9 -             baz = { package = "bar", version = "0.1.0" }
+  |
 
 "#]]
             .unordered(),
@@ -615,6 +705,17 @@ fn warning_replay() {
 [DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
 [CHECKING] unused v0.1.0
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
+[WARNING] unused dependency
+ --> Cargo.toml:9:13
+  |
+9 |             unused = "0.1.0"
+  |             ^^^^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+9 -             unused = "0.1.0"
+  |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -623,6 +724,17 @@ fn warning_replay() {
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
+[WARNING] unused dependency
+ --> Cargo.toml:9:13
+  |
+9 |             unused = "0.1.0"
+  |             ^^^^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+9 -             unused = "0.1.0"
+  |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -677,6 +789,17 @@ fn unused_dep_target() {
 [CHECKING] used v0.1.0
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[WARNING] unused dependency
+ --> Cargo.toml:9:13
+  |
+9 |             unused = "0.1.0"
+  |             ^^^^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+9 -             unused = "0.1.0"
+  |
 
 "#]]
             .unordered(),
@@ -947,6 +1070,50 @@ fn package_selection() {
 [CHECKING] used_foo v0.1.0
 [CHECKING] external v0.1.0 ([ROOT]/foo/external)
 [CHECKING] foo v0.1.0 ([ROOT]/foo/foo)
+[WARNING] unused dependency
+ --> bar/Cargo.toml:9:13
+  |
+9 |             unused = "0.1.0"
+  |             ^^^^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+9 -             unused = "0.1.0"
+  |
+[WARNING] unused dependency
+  --> foo/Cargo.toml:11:13
+   |
+11 |             bar.path = "../bar"
+   |             ^^^
+   |
+   = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+   |
+11 -             bar.path = "../bar"
+11 +             .path = "../bar"
+   |
+[WARNING] unused dependency
+  --> foo/Cargo.toml:12:13
+   |
+12 |             external.path = "../external"
+   |             ^^^^^^^^
+   |
+[HELP] remove the dependency
+   |
+12 -             external.path = "../external"
+12 +             .path = "../external"
+   |
+[WARNING] unused dependency
+ --> foo/Cargo.toml:9:13
+  |
+9 |             unused = "0.1.0"
+  |             ^^^^^^^^^^^^^^^^
+  |
+[HELP] remove the dependency
+  |
+9 -             unused = "0.1.0"
+  |
 
 "#]]
             .unordered(),
@@ -958,6 +1125,39 @@ fn package_selection() {
         .with_stderr_data(
             str![[r#"
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[WARNING] unused dependency
+  --> foo/Cargo.toml:11:13
+   |
+11 |             bar.path = "../bar"
+   |             ^^^
+   |
+   = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+   |
+11 -             bar.path = "../bar"
+11 +             .path = "../bar"
+   |
+[WARNING] unused dependency
+  --> foo/Cargo.toml:12:13
+   |
+12 |             external.path = "../external"
+   |             ^^^^^^^^
+   |
+[HELP] remove the dependency
+   |
+12 -             external.path = "../external"
+12 +             .path = "../external"
+   |
+[WARNING] unused dependency
+ --> foo/Cargo.toml:9:13
+  |
+9 |             unused = "0.1.0"
+  |             ^^^^^^^^^^^^^^^^
+  |
+[HELP] remove the dependency
+  |
+9 -             unused = "0.1.0"
+  |
 
 "#]]
             .unordered(),
@@ -969,6 +1169,17 @@ fn package_selection() {
         .with_stderr_data(
             str![[r#"
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[WARNING] unused dependency
+ --> bar/Cargo.toml:9:13
+  |
+9 |             unused = "0.1.0"
+  |             ^^^^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+9 -             unused = "0.1.0"
+  |
 
 "#]]
             .unordered(),
@@ -1026,6 +1237,17 @@ fn pinned_transitive_dep() {
 [CHECKING] transitive v0.1.1
 [CHECKING] intermediate v0.1.0
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
+[WARNING] unused dependency
+  --> Cargo.toml:10:13
+   |
+10 |             transitive = "=0.1.1"
+   |             ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+   |
+10 -             transitive = "=0.1.1"
+   |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -1097,6 +1319,17 @@ pub fn fun() -> &'static str {
 [CHECKING] transitive v0.1.1
 [CHECKING] intermediate v0.1.0
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
+[WARNING] unused dependency
+  --> Cargo.toml:10:13
+   |
+10 |             transitive = { version = "0.1.1", features = ["a"] }
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+   |
+10 -             transitive = { version = "0.1.1", features = ["a"] }
+   |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -1159,6 +1392,17 @@ fn config_ignore() {
 [DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
 [CHECKING] unused v0.1.0
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
+[WARNING] unused dependency
+  --> Cargo.toml:12:13
+   |
+12 |             unused_renamed = { package = "unused", version = "0.1.0" }
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+   |
+12 -             unused_renamed = { package = "unused", version = "0.1.0" }
+   |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]]

--- a/tests/testsuite/lints/unused_workspace_dependencies.rs
+++ b/tests/testsuite/lints/unused_workspace_dependencies.rs
@@ -99,6 +99,18 @@ workspace = true
    |
 11 - unused = "1"
    |
+[WARNING] unused dependency
+ --> bar/Cargo.toml:9:1
+  |
+9 | build-dep.workspace = true
+  | ^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+9 - build-dep.workspace = true
+9 + .workspace = true
+  |
 [UPDATING] `dummy-registry` index
 [LOCKING] 6 packages to latest compatible versions
 [DOWNLOADING] crates ...

--- a/tests/testsuite/lints/unused_workspace_dependencies.rs
+++ b/tests/testsuite/lints/unused_workspace_dependencies.rs
@@ -117,6 +117,18 @@ workspace = true
 [DOWNLOADED] in-package v1.0.0 (registry `dummy-registry`)
 [CHECKING] in-package v1.0.0
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
+[WARNING] unused dependency
+  --> Cargo.toml:24:1
+   |
+24 | in-package.workspace = true
+   | ^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+   |
+24 - in-package.workspace = true
+24 + .workspace = true
+   |
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/cargo/pull/16600)*

### What does this PR try to resolve?

Fixes #15813

```toml
[lints.cargo]
unused_dependencies = "warn"
```

This checks only build and normal dependencies (see below for more details).  I would expect we'd open a new issue to track dev-dependencies.  I don't consider this a false-positive because there technically isn't a way to ask for everything that uses dev-dependencies to be built.

This only checks selected packages, and not all local packages, and only if the build target selection flags are exhaustive without consideration for the selected packages.  See https://github.com/rust-lang/cargo/pull/16600#discussion_r2789501482

Known false positives:
- activating a feature on a transitive dependency
- pinning a transitive dependency (instead use `target.cfg(false).dependencies`)

To handle false positives,
```toml
[lints.cargo]
unused_dependencies = { level = "warn", ignore = ["dep_name"] }
```
- Some prior art use `ignored` but I felt like `ignore` fit in better with `allow`
- Per-dep-table is more complicated for users, tricky to get the design right (`udeps` cares about dep kinds but not target cfgs), these shouldn't be too common, and using dep names gives users control over uniqueness
- For more background on alternatives, see https://github.com/rust-lang/rfcs/pull/3920

### How to test and review this PR?

Built-on #8437

This does nothing for dev-dependencies because there isn't really a way
to select all targets today without
- tracking selected dep kinds to check on a per-package basis
- checking the status of every bench to see if it can work as a test

because `cargo test` (no args) with benches set to test is the only
command today that can exercise all dev-dependencies as it is the only
one that will compile tests and doctests.

See also
- https://blog.rust-lang.org/inside-rust/2024/10/01/this-development-cycle-in-cargo-1.82/#detecting-unused-dependencies
- https://blog.rust-lang.org/inside-rust/2024/10/01/this-development-cycle-in-cargo-1.82/#all-targets-and-doc-tests
- https://blog.rust-lang.org/inside-rust/2024/10/31/this-development-cycle-in-cargo-1.83/#target-and-target

As for the commits, I did something unusual for myself in that I made changes with dead code so it is easier to understand what goes into one step in this process without seeing the entire process at once and getting confused.