### PR TITLE
chore: pin openssl-src to 300.5.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,6 +372,7 @@ dependencies = [
  "memfd",
  "opener",
  "openssl",
+ "openssl-src",
  "os_info",
  "pasetors",
  "pathdiff",
@@ -3273,9 +3274,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.5+3.5.5"
+version = "300.5.4+3.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+checksum = "a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,9 @@ memfd = "0.6.5"
 miow = "0.6.1"
 opener = "0.8.3"
 openssl = "0.10.75"
+# Pinned due to ppc64 ELFv1/v2 ABI issue in 3.5.5
+# https://github.com/openssl/openssl/issues/29815
+openssl-src = "=300.5.4"
 os_info = { version = "3.14.0", default-features = false }
 pasetors = { version = "0.7.7", features = ["v3", "paserk", "std", "serde"] }
 pathdiff = "0.2.3"
@@ -236,6 +239,7 @@ cargo-credential-macos-keychain.workspace = true
 
 [target.'cfg(not(windows))'.dependencies]
 openssl = { workspace = true, optional = true }
+openssl-src = { workspace = true, optional = true }
 
 [target.'cfg(windows)'.dependencies]
 cargo-credential-wincred.workspace = true


### PR DESCRIPTION
OpenSSL 3.5.5 has an ELFv1/ELFv2 ABI mismatch
that breaks powerpc64-unknown-linux-gnu builds.

The fix is merged in openssl/openssl#29827 but not yet released.

See

* https://github.com/openssl/openssl/issues/29815
* https://github.com/rust-lang/rust/pull/152240#issuecomment-3862979269