### PR TITLE
Fix deduplication in cargo tree (fixes #9599)

### DIFF
--- a/src/cargo/ops/tree/graph.rs
+++ b/src/cargo/ops/tree/graph.rs
@@ -327,22 +327,9 @@ impl<'a> Graph<'a> {
             .filter(|(_name, indexes)| {
                 indexes
                     .into_iter()
-                    .map(|(node, _)| {
-                        match node {
-                            Node::Package {
-                                package_id,
-                                features,
-                                ..
-                            } => {
-                                // Do not treat duplicates on the host or target as duplicates.
-                                Node::Package {
-                                    package_id: package_id.clone(),
-                                    features: features.clone(),
-                                    kind: CompileKind::Host,
-                                }
-                            }
-                            _ => unreachable!(),
-                        }
+                    .map(|(node, _)| match node {
+                        Node::Package { package_id, .. } => package_id.clone(),
+                        _ => unreachable!(),
                     })
                     .collect::<HashSet<_>>()
                     .len()

--- a/tests/testsuite/cargo_tree/deps.rs
+++ b/tests/testsuite/cargo_tree/deps.rs
@@ -1307,6 +1307,7 @@ foo v0.1.0 ([ROOT]/foo)
 fn host_dep_feature() {
     // New feature resolver with optional build dep
     Package::new("optdep", "1.0.0").publish();
+    Package::new("optdep", "2.0.0").publish();
     Package::new("bar", "1.0.0")
         .add_dep(Dependency::new("optdep", "1.0").optional(true))
         .publish();
@@ -1318,11 +1319,9 @@ fn host_dep_feature() {
             name = "foo"
             version = "0.1.0"
 
-            [build-dependencies]
-            bar = { version = "1.0", features = ["optdep"] }
-
             [dependencies]
-            bar = "1.0"
+            optdep = "2.0"
+            bar = { version = "1.0", features = ["optdep"] }
             "#,
         )
         .file("src/lib.rs", "")
@@ -1351,7 +1350,7 @@ bar v1.0.0
         .run();
 
     // invert
-    p.cargo("tree -i optdep")
+    p.cargo("tree -i optdep@1.0.0")
         .with_stdout_data(str![[r#"
 optdep v1.0.0
 └── bar v1.0.0
@@ -1386,7 +1385,7 @@ bar v1.0.0
 "#]])
         .run();
 
-    p.cargo("tree -i optdep")
+    p.cargo("tree -i optdep@1.0.0")
         .with_stdout_data(str![[r#"
 optdep v1.0.0
 └── bar v1.0.0

--- a/tests/testsuite/cargo_tree/deps.rs
+++ b/tests/testsuite/cargo_tree/deps.rs
@@ -1332,10 +1332,9 @@ fn host_dep_feature() {
     p.cargo("tree")
         .with_stdout_data(str![[r#"
 foo v0.1.0 ([ROOT]/foo)
-└── bar v1.0.0
-    └── optdep v1.0.0
-[build-dependencies]
-└── bar v1.0.0 (*)
+├── bar v1.0.0
+│   └── optdep v1.0.0
+└── optdep v2.0.0
 
 "#]])
         .run();
@@ -1355,8 +1354,6 @@ bar v1.0.0
 optdep v1.0.0
 └── bar v1.0.0
     └── foo v0.1.0 ([ROOT]/foo)
-    [build-dependencies]
-    └── foo v0.1.0 ([ROOT]/foo)
 
 "#]])
         .run();
@@ -1367,18 +1364,15 @@ optdep v1.0.0
     p.cargo("tree")
         .with_stdout_data(str![[r#"
 foo v0.1.0 ([ROOT]/foo)
-└── bar v1.0.0
-[build-dependencies]
-└── bar v1.0.0
-    └── optdep v1.0.0
+├── bar v1.0.0
+│   └── optdep v1.0.0
+└── optdep v2.0.0
 
 "#]])
         .run();
 
     p.cargo("tree -p bar")
         .with_stdout_data(str![[r#"
-bar v1.0.0
-
 bar v1.0.0
 └── optdep v1.0.0
 
@@ -1389,7 +1383,6 @@ bar v1.0.0
         .with_stdout_data(str![[r#"
 optdep v1.0.0
 └── bar v1.0.0
-    [build-dependencies]
     └── foo v0.1.0 ([ROOT]/foo)
 
 "#]])
@@ -1398,11 +1391,11 @@ optdep v1.0.0
     // Check that -d handles duplicates with features.
     p.cargo("tree -d")
         .with_stdout_data(str![[r#"
-bar v1.0.0
-└── foo v0.1.0 ([ROOT]/foo)
+optdep v1.0.0
+└── bar v1.0.0
+    └── foo v0.1.0 ([ROOT]/foo)
 
-bar v1.0.0
-[build-dependencies]
+optdep v2.0.0
 └── foo v0.1.0 ([ROOT]/foo)
 
 "#]])


### PR DESCRIPTION
### What does this PR try to resolve?

`cargo tree --duplicates` wrongly shows the same crate version multiple times if it is used with different features, or as both normal dependency and dev dependency. #9599 has more details.

### How to test and review this PR?

Ran the code as `cargo run -- tree --manifest-path /path/to/Cargo.toml -d` and compared the output to stable cargo. 