### PR TITLE
chore: downgrade to libc@0.2.179

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2764,9 +2764,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.179"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "c5a2d376baa530d1238d133232d15e239abad80d05838b4b59354e5268af431f"
 
 [[package]]
 name = "libgit2-sys"


### PR DESCRIPTION
rust-lang/rust CI failure on dist-loongarch64-musl job:

- https://github.com/rust-lang/rust/pull/152240
- https://github.com/rust-lang/rust/actions/runs/21809002005/job/62917474088

gix-index used the old mtime field that 0.2.180 fixes it. Will file an issue to gix repo.
Lets downgrade first