### PR TITLE
fix(script): Load config relative to the script

### DIFF
--- a/src/bin/cargo/commands/run.rs
+++ b/src/bin/cargo/commands/run.rs
@@ -178,8 +178,12 @@ pub fn exec_manifest_command(gctx: &mut GlobalContext, cmd: &str, args: &[OsStri
 
     let manifest_path = root_manifest(Some(manifest_path), gctx)?;
 
-    // Reload to cargo home.
-    gctx.reload_rooted_at(gctx.home().clone().into_path_unlocked())?;
+    // Treat `cargo foo.rs` like `cargo install --path foo` and re-evaluate the config based on the
+    // location where the script resides, rather than the environment from where it's being run.
+    let parent_path = manifest_path
+        .parent()
+        .expect("a file should always have a parent");
+    gctx.reload_rooted_at(parent_path)?;
 
     let mut ws = Workspace::new(&manifest_path, gctx)?;
     if gctx.cli_unstable().avoid_dev_deps {


### PR DESCRIPTION
### What does this PR try to resolve?

This was the original behavior.
There was some concern over this previously and we switched to only loading config from CARGO_HOME in #14749.
After discussing this in today's cargo team meeting, we decided to switch it back.

A concern brought up previously was if you previously downloaded a config and now download and run a script, you could get surprising behavior, maybe even dangerous.
This does require some extra hoops because you don't have a `.cargo.toml` but a `.cargo/config.toml`.
You can't directly download that but must first download a zip file and then decompress it without it having a parent directory.

Contrast that with users who have a script in their repo and config that should apply to it.
This is an important use case but one we will get less feedback on during calls for testing.

In discussing this, we felt there are different use cases:
- The repo with a config file
- People surprised at how config loading works

We settled on this change because it is consistent with the current behavior, even if it can be confusing and undesirable. We can then work to improve the overall config search path experience and both regular cargo commands and running of cargo scripts would benefit.

### How to test and review this PR?

This reverts commit bd47da1ab129ac6c086f74892327f3896f9f847c.

