### PR TITLE
Make the error messaging for `cargo install` aware of `build.build-dir`

### DIFF
--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -356,9 +356,9 @@ impl<'gctx> InstallablePackage<'gctx> {
                 "failed to compile `{}`, intermediate artifacts can be \
                  found at `{}`.\nTo reuse those artifacts with a future \
                  compilation, set the environment variable \
-                 `CARGO_TARGET_DIR` to that path.",
+                 `CARGO_BUILD_BUILD_DIR` to that path.",
                 self.pkg,
-                self.ws.target_dir().display()
+                self.ws.build_dir().display()
             )
         })?;
         let mut binaries: Vec<(&str, &Path)> = compile

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -193,7 +193,7 @@ fn simple_install_fail() {
         .with_stderr_data(str![[r#"
 [INSTALLING] bar v0.1.0
 [ERROR] failed to compile `bar v0.1.0`, intermediate artifacts can be found at `[..]`.
-To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
+To reuse those artifacts with a future compilation, set the environment variable `CARGO_BUILD_BUILD_DIR` to that path.
 
 Caused by:
   no matching package found
@@ -771,7 +771,7 @@ fn version_missing() {
         .with_stderr_data(str![[r#"
 [INSTALLING] bar v0.1.0
 [ERROR] failed to compile [..], intermediate artifacts can be found at `[..]`.
-To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
+To reuse those artifacts with a future compilation, set the environment variable `CARGO_BUILD_BUILD_DIR` to that path.
 
 Caused by:
   failed to select a version for the requirement `foo = "^2"`

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -1170,7 +1170,7 @@ fn compile_failure() {
 ...
 [ERROR] could not compile `foo` (bin "foo") due to 1 previous error
 [ERROR] failed to compile `foo v0.0.1 ([ROOT]/foo)`, intermediate artifacts can be found at `[ROOT]/foo/target`.
-To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
+To reuse those artifacts with a future compilation, set the environment variable `CARGO_BUILD_BUILD_DIR` to that path.
 ...
 "#]])
         .run();
@@ -2571,7 +2571,7 @@ fn failed_install_retains_temp_directory() {
 
 [ERROR] could not compile `foo` (bin "foo") due to 1 previous error
 [ERROR] failed to compile `foo v0.0.1`, intermediate artifacts can be found at `[..]`.
-To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
+To reuse those artifacts with a future compilation, set the environment variable `CARGO_BUILD_BUILD_DIR` to that path.
 
 "#]]);
 
@@ -2620,8 +2620,8 @@ fn failed_install_points_to_build_dir_for_intermediate_artifacts() {
   | ^ expected one of `!` or `::`
 
 [ERROR] could not compile `foo` (bin "foo") due to 1 previous error
-[ERROR] failed to compile `foo v0.0.1 ([ROOT]/foo)`, intermediate artifacts can be found at `[ROOT]/foo/target`.
-To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
+[ERROR] failed to compile `foo v0.0.1 ([ROOT]/foo)`, intermediate artifacts can be found at `[ROOT]/home/.cargo/build-artifacts`.
+To reuse those artifacts with a future compilation, set the environment variable `CARGO_BUILD_BUILD_DIR` to that path.
 
 "#]]);
 }
@@ -3014,7 +3014,7 @@ fn dry_run_incompatible_package_dependency() {
 [INSTALLING] foo v0.1.0 ([ROOT]/foo)
 [LOCKING] 1 package to latest compatible version
 [ERROR] failed to compile `foo v0.1.0 ([ROOT]/foo)`, intermediate artifacts can be found at `[ROOT]/foo/target`.
-To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
+To reuse those artifacts with a future compilation, set the environment variable `CARGO_BUILD_BUILD_DIR` to that path.
 
 Caused by:
   rustc [..] is not supported by the following package:

--- a/tests/testsuite/required_features.rs
+++ b/tests/testsuite/required_features.rs
@@ -766,7 +766,7 @@ Consider enabling some of the needed features by passing, e.g., `--features="a"`
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.0.1 ([ROOT]/foo)
 [ERROR] failed to compile `foo v0.0.1 ([ROOT]/foo)`, intermediate artifacts can be found at `[ROOT]/foo/target`.
-To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
+To reuse those artifacts with a future compilation, set the environment variable `CARGO_BUILD_BUILD_DIR` to that path.
 
 Caused by:
   target `foo` in package `foo` requires the features: `a`
@@ -785,7 +785,7 @@ Caused by:
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.0.1 ([ROOT]/foo)
 [ERROR] failed to compile `foo v0.0.1 ([ROOT]/foo)`, intermediate artifacts can be found at `[ROOT]/foo/target`.
-To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
+To reuse those artifacts with a future compilation, set the environment variable `CARGO_BUILD_BUILD_DIR` to that path.
 
 Caused by:
   target `foo` in package `foo` requires the features: `a`


### PR DESCRIPTION
When `cargo install` fails to compile a binary, it produces the following error output:

```
error: could not compile `issue-16622` (bin "issue-16622") due to 1 previous error
error: failed to compile `issue-16622 v0.0.0 ([…]/issue_16622)`, intermediate artifacts can be found at `[…]/issue_16622/target`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
```

which currently points to the target directory when discussing intermediate artifacts that can be reused in future reattempts.

However, intermediate artifacts are stored in the directory determined by `build.build-dir`, so the message should be updated to point to that path and corresponding environment variable instead.

Closes #16622.