### PR TITLE
chore: downgrade to libc@0.2.180

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2769,9 +2769,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.181"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libgit2-sys"


### PR DESCRIPTION
Right after git-index changed accordingly via GitoxideLabs/gitoxide#2428 for the loongarch timestamp API issue,
libc reverted it back rust-lang/libc#4958 and released 0.2.181

We pin to libc@0.2.180 for now. And when gitoxide reverts, we can safely upgrade them

Previous relevnat PRs:

* https://github.com/rust-lang/cargo/pull/16615
* https://github.com/rust-lang/cargo/pull/16613