### PR TITLE
Enable triagebot new `[view-all-comments-link]` feature

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -44,6 +44,11 @@ label = "O-windows"
 # Documentation at: https://forge.rust-lang.org/triagebot/review-changes-since.html
 [review-changes-since]
 
+# Adds a "View all comments" link on the issue body that shows all the comments of an issue/PR
+# Documentation at: https://forge.rust-lang.org/triagebot/view-all-comments-link.html
+[view-all-comments-link]
+threshold = 20
+
 [merge-conflicts]
 remove = []
 add = ["S-waiting-on-author"]


### PR DESCRIPTION
Triagebot implemented a GitHub comments viewer, that loads and shows all the comment (and review comments) of an issue or pull-request.

In order to facilitate it's usage we also added a feature to automatically have triagebot add a "View all comments" link to that viewer, which this PR enables for this repository.

See [this link](https://triage.rust-lang.org/gh-comments/rust-lang/cargo/issues/545) for an example of the result looks like.

r? @epage