### PR TITLE
fix: apply `host.runner` only when `host-config` enabled

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -235,7 +235,11 @@ impl<'gctx> Compilation<'gctx> {
         cmd: T,
         pkg: &Package,
     ) -> CargoResult<ProcessBuilder> {
-        let builder = if let Some((runner, args)) = self.target_runner(CompileKind::Host) {
+        // Only use host runner when -Zhost-config is enabled
+        // to ensure `target.<host>.runner` does not wrap build scripts.
+        let builder = if !self.gctx.target_applies_to_host()?
+            && let Some((runner, args)) = self.target_runner(CompileKind::Host)
+        {
             let mut builder = ProcessBuilder::new(runner);
             builder.args(args);
             builder.arg(cmd);

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -982,18 +982,10 @@ fn target_runner_does_not_apply_to_build_script() {
         .file("src/lib.rs", "")
         .build();
 
-    // FIXME: target runner should not apply to build scripts.
     p.cargo("check")
-        .with_status(101)
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[ERROR] failed to run custom build command for `foo v0.0.1 ([ROOT]/foo)`
-
-Caused by:
-  could not execute process `nonexistent-runner [ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build` (never executed)
-
-Caused by:
-  [NOT_FOUND]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

This is a regression found in rust-lang/compiler-builtins#1087
and introduced by rust-lang/cargo#16599

There are other regression that `host.runner` and `host.linker`
are accidentally applied to target builds which I plan to fix
both in a follow-up PR.
(rust-lang/cargo#12535 introduced the `host.linker` bug btw)

