### PR TITLE
fix(host-config): host.linker should not apply to non host unit

### DIFF
--- a/src/cargo/core/compiler/build_runner/mod.rs
+++ b/src/cargo/core/compiler/build_runner/mod.rs
@@ -282,7 +282,10 @@ impl<'a, 'gctx> BuildRunner<'a, 'gctx> {
                     unit: unit.clone(),
                     args,
                     unstable_opts,
-                    linker: self.compilation.target_linker(unit.kind).clone(),
+                    linker: self
+                        .compilation
+                        .target_linker(unit.kind)
+                        .map(|p| p.to_path_buf()),
                     script_metas,
                     env: artifact::get_env(&self, unit, self.unit_deps(unit))?,
                 });

--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -132,7 +132,7 @@ pub struct Compilation<'gctx> {
     /// The runner to use for each host or target process.
     runners: HashMap<CompileKind, Option<(PathBuf, Vec<String>)>>,
     /// The linker to use for each host or target.
-    target_linkers: HashMap<CompileKind, Option<PathBuf>>,
+    linkers: HashMap<CompileKind, Option<PathBuf>>,
 
     /// The total number of lint warnings emitted by the compilation.
     pub lint_warning_count: usize,
@@ -160,7 +160,7 @@ impl<'gctx> Compilation<'gctx> {
             runners.insert(kind, target_runner(bcx, kind)?);
         }
 
-        let mut target_linkers = bcx
+        let mut linkers = bcx
             .build_config
             .requested_kinds
             .iter()
@@ -170,7 +170,7 @@ impl<'gctx> Compilation<'gctx> {
         if !bcx.gctx.target_applies_to_host()? {
             // See above reason in runner why we do this.
             let kind = explicit_host_kind(&host);
-            target_linkers.insert(kind, target_linker(bcx, kind)?);
+            linkers.insert(kind, target_linker(bcx, kind)?);
         }
         Ok(Compilation {
             native_dirs: BTreeSet::new(),
@@ -190,7 +190,7 @@ impl<'gctx> Compilation<'gctx> {
             rustc_workspace_wrapper_process,
             primary_rustc_process,
             runners,
-            target_linkers,
+            linkers,
             lint_warning_count: 0,
         })
     }
@@ -287,7 +287,7 @@ impl<'gctx> Compilation<'gctx> {
 
     /// Gets the `[host.linker]` for host build target (build scripts and proc macros).
     pub fn host_linker(&self) -> Option<&Path> {
-        self.target_linkers
+        self.linkers
             .get(&CompileKind::Host)
             .and_then(|x| x.as_ref())
             .map(|x| x.as_path())
@@ -303,7 +303,7 @@ impl<'gctx> Compilation<'gctx> {
         } else {
             kind
         };
-        self.target_linkers
+        self.linkers
             .get(&kind)
             .and_then(|x| x.as_ref())
             .map(|x| x.as_path())

--- a/src/cargo/core/compiler/fingerprint/mod.rs
+++ b/src/cargo/core/compiler/fingerprint/mod.rs
@@ -1635,7 +1635,12 @@ fn calculate_normal(
         unit.pkg.manifest().lint_rustflags(),
     ));
     let mut config = StableHasher::new();
-    if let Some(linker) = build_runner.compilation.target_linker(unit.kind) {
+    let linker = if unit.target.for_host() && !build_runner.bcx.gctx.target_applies_to_host()? {
+        build_runner.compilation.host_linker()
+    } else {
+        build_runner.compilation.target_linker(unit.kind)
+    };
+    if let Some(linker) = linker {
         linker.hash(&mut config);
     }
     if unit.mode.is_doc() && build_runner.bcx.gctx.cli_unstable().rustdoc_map {

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1414,16 +1414,16 @@ fn build_base_args(
 
     unit.kind.add_target_arg(cmd);
 
-    opt(
-        cmd,
-        "-C",
-        "linker=",
-        build_runner
-            .compilation
-            .target_linker(unit.kind)
-            .as_ref()
-            .map(|s| s.as_ref()),
-    );
+    opt(cmd, "-C", "linker=", {
+        if unit.target.for_host() && !bcx.gctx.target_applies_to_host()? {
+            build_runner.compilation.host_linker().map(|s| s.as_ref())
+        } else {
+            build_runner
+                .compilation
+                .target_linker(unit.kind)
+                .map(|s| s.as_ref())
+        }
+    });
     if incremental {
         let dir = build_runner.files().incremental_dir(&unit);
         opt(cmd, "-C", "incremental=", Some(dir.as_os_str()));

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1404,29 +1404,12 @@ fn build_base_args(
     cmd.arg("--out-dir")
         .arg(&build_runner.files().output_dir(unit));
 
-    fn opt(cmd: &mut ProcessBuilder, key: &str, prefix: &str, val: Option<&OsStr>) {
-        if let Some(val) = val {
-            let mut joined = OsString::from(prefix);
-            joined.push(val);
-            cmd.arg(key).arg(joined);
-        }
-    }
-
     unit.kind.add_target_arg(cmd);
 
-    opt(cmd, "-C", "linker=", {
-        if unit.target.for_host() && !bcx.gctx.target_applies_to_host()? {
-            build_runner.compilation.host_linker().map(|s| s.as_ref())
-        } else {
-            build_runner
-                .compilation
-                .target_linker(unit.kind)
-                .map(|s| s.as_ref())
-        }
-    });
+    add_codegen_linker(cmd, build_runner, unit, bcx.gctx.target_applies_to_host()?);
+
     if incremental {
-        let dir = build_runner.files().incremental_dir(&unit);
-        opt(cmd, "-C", "incremental=", Some(dir.as_os_str()));
+        add_codegen_incremental(cmd, build_runner, unit)
     }
 
     let pkg_hint_mostly_unused = match hints.mostly_unused {
@@ -1960,6 +1943,44 @@ pub fn extern_args(
     }
 
     Ok(result)
+}
+
+/// Adds `-C linker=<path>` if specified.
+fn add_codegen_linker(
+    cmd: &mut ProcessBuilder,
+    build_runner: &BuildRunner<'_, '_>,
+    unit: &Unit,
+    target_applies_to_host: bool,
+) {
+    let linker = if unit.target.for_host() && !target_applies_to_host {
+        build_runner
+            .compilation
+            .host_linker()
+            .map(|s| s.as_os_str())
+    } else {
+        build_runner
+            .compilation
+            .target_linker(unit.kind)
+            .map(|s| s.as_os_str())
+    };
+
+    if let Some(linker) = linker {
+        let mut arg = OsString::from("linker=");
+        arg.push(linker);
+        cmd.arg("-C").arg(arg);
+    }
+}
+
+/// Adds `-C incremental=<path>`.
+fn add_codegen_incremental(
+    cmd: &mut ProcessBuilder,
+    build_runner: &BuildRunner<'_, '_>,
+    unit: &Unit,
+) {
+    let dir = build_runner.files().incremental_dir(&unit);
+    let mut arg = OsString::from("incremental=");
+    arg.push(dir.as_os_str());
+    cmd.arg("-C").arg(arg);
 }
 
 fn envify(s: &str) -> String {

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -1335,7 +1335,8 @@ fn host_linker_does_not_apply_to_binary_build() {
 "#]])
         .run();
 
-    // FIXME: without --target, host.linker incorrectly applies to normal binaries.
+    // with target-applies-to-host=false,
+    // host.linker should not be applied but target.linker
     p.cargo("build -Z target-applies-to-host -Z host-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_status(101)
@@ -1344,7 +1345,7 @@ fn host_linker_does_not_apply_to_binary_build() {
         // https://github.com/rust-lang/rust/blob/7ad4e69ad585d8ff214f7b42d01f1959eda08f40/compiler/rustc_codegen_ssa/src/back/link.rs?plain=1#L971-L975
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[ERROR] linker `nonexistent-host-linker` not found
+[ERROR] linker `nonexistent-target-linker` not found
   |
   = [NOTE] [NOT_FOUND]
 ...


### PR DESCRIPTION
### What does this PR try to resolve?

Similar to <https://github.com/rust-lang/cargo/pull/16638>,
this prevents `host.linker` from applying to non-host build targets.

### How to test and review this PR?

This behavior has been there since the integration of host-config, so it _might_ break somebody's assumption.

I've checked the use of `target_linker`:

* doctest continues using `target_linker` as it is more a target builds: https://github.com/rust-lang/cargo/blob/312145c006c53906c7bd6c585e52f2639d37a191/src/cargo/core/compiler/build_runner/mod.rs?plain=1#L281-L289
* `RUSTC_LINKER` set for build scripts is on the same boat. It indicates the linker to use for the associated crate, which is always a target build: https://github.com/rust-lang/cargo/blob/312145c006c53906c7bd6c585e52f2639d37a191/src/cargo/core/compiler/custom_build.rs?plain=1#L389-L391

Other than the two above, the other usages of it (fingerprint, and rustc invocation) should respect host.linker when building build script exectuables.





