### PR TITLE
Changed build script run `output` dir to `stdout` in new build-dir layout

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -1445,7 +1445,11 @@ struct BuildScriptRunFiles {
 impl BuildScriptRunFiles {
     pub fn for_unit(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> Self {
         let root = build_runner.files().build_script_run_dir(unit);
-        let stdout = root.join("output");
+        let stdout = if build_runner.bcx.gctx.cli_unstable().build_dir_new_layout {
+            root.join("stdout")
+        } else {
+            root.join("output")
+        };
         let stderr = root.join("stderr");
         let root_output = root.join("root-output");
         Self {

--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -297,7 +297,7 @@ fn build_script_should_output_to_build_dir() {
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/build-script-build-script-build
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/build-script-build-script-build.json
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/run/invoked.timestamp
-[ROOT]/foo/build-dir/debug/build/foo/[HASH]/run/output
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/run/stdout
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/run/root-output
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/run/stderr
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/.lock


### PR DESCRIPTION
### What does this PR try to resolve?

Another `build-dir` layout change that was spawned out of discussion in this comment thread https://github.com/rust-lang/cargo/pull/16502#discussion_r2799757665

This PR changes `<build-dir>/<profile>/build/<pkgname>/[HASH]/run/output` to `<build-dir>/<profile>/build/<pkgname>/[HASH]/run/stdout` for the new `build-dir` layout. 

The motivation here is to change is to:

1. Better communicate what this file is used for. (it only contains `stdout` of a build script run)
   * Reduce the overloading of "output" as a term.
2. Match the corresponding `stderr` file

cc: https://github.com/rust-lang/cargo/issues/15010

### How to test and review this PR?

See the test changes

r? @epage 