### PR TITLE
Corrected doc comment for build script root_output path

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -1437,7 +1437,7 @@ struct BuildScriptRunFiles {
     stdout: PathBuf,
     /// The stderr produced by the build script
     stderr: PathBuf,
-    /// A file that contains the path of `root`.
+    /// A file that contains the path to the `out` dir of the build script.
     /// This is used for detect if the directory was moved since the previous run.
     root_output: PathBuf,
 }


### PR DESCRIPTION
### What does this PR try to resolve?

Follow up on #16644 

Sorry, I realized I had confused the path that this file tracks

We write the `script_out_dir` not the `script_run_dir`

https://github.com/rust-lang/cargo/blob/78ca56f39202efa78d522594cfe1ffa5d1720e0d/src/cargo/core/compiler/custom_build.rs#L674

r? @weihanglo 