### PR TITLE
fix(job_queue): Handle Clippy CLI arguments in `fix` message

### DIFF
--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -1558,7 +1558,7 @@ fn check_fixable_warning_for_clippy() {
         .env("CLIPPY_ARGS", "-Wclippy::pedantic__CLIPPY_HACKERY__-Aclippy::allow_attributes__CLIPPY_HACKERY__") // Set -Wclippy::pedantic
         .with_stderr_data(str![[r#"
 ...
-[WARNING] `foo` (lib) generated 1 warning (run `cargo clippy --fix --lib -p foo` to apply 1 suggestion)
+[WARNING] `foo` (lib) generated 1 warning (run `cargo clippy --fix --lib -p foo -- -Wclippy::pedantic -Aclippy::allow_attributes` to apply 1 suggestion)
 ...
 "#]])
         .run();


### PR DESCRIPTION
fixes #16637

### What does this PR try to resolve?

Clippy lints can be enabled via the command line via `cargo clippy -- -Wclippy::lint`, and these need to be included in the `cargo fix` command (because if a lint is not emitted, it's not fixed, and some lints are allow-by-default)

---

When `cargo clippy` is executed, Clippy sets the env. var `CLIPPY_ARGS` to the arguments that were passed to Clippy, separated by the string `__CLIPPY_HACKERY__`. To avoid breaking behaviour in between runs (like in `fix`), we should maintain those arguments.

This PR takes that `CLIPPY_ARGS` env var (if it exists), replaces the `__CLIPPY_HACKERY__` separator and appends it to the suggested `cargo clippy --fix` command when emitting fixable warnings.

### How to test and review this PR?

Via copying a crate (in my case, `tokio-1.38.1`) and executing the following commands:

```bash
rustup run nightly ~/git/cargo/target/debug/cargo clippy -- -Wclippy::pedantic -Aclippy::allow_attributes -Wclippy::dbg_macro -Wclippy::eq_op
```

In order to get some warnings. If any fixable warning is emitted, the output message should end with:

```text
warning: `tokio` (lib) generated 42 warnings (run `cargo clippy --fix --lib -p tokio -- -Wclippy::pedantic -Aclippy::allow_attributes -Wclippy::dbg_macro -Wclippy::eq_op` to apply 16 suggestions)
```

Now, testing with the suggested command (in this case, also with the version pinned @1.38.1):

```bash
rustup run nightly ~/git/cargo/target/debug/cargo clippy --fix --lib -p tokio@1.38.1 -- -Wclippy::pedantic -Aclippy::allow_attributes -Wclippy::dbg_macro -Wclippy::eq_op
```

All warnings (including those allow-by-default `pedantic` lints!) should be fixed now.