### PR TITLE
fix(toml): show required rust-version in unstable edition error

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -733,6 +733,19 @@ impl Features {
 
     /// Checks if the given feature is enabled.
     pub fn require(&self, feature: &Feature) -> CargoResult<()> {
+        self.require_with_hint(feature, None)
+    }
+
+    /// Like [`require`][Self::require], but appends an optional help message
+    /// to the error, placed just before the documentation link.
+    ///
+    /// Use this when the call site has additional context (e.g. the package's
+    /// `rust-version`) that can make the error more actionable.
+    pub(crate) fn require_with_hint(
+        &self,
+        feature: &Feature,
+        hint: Option<&str>,
+    ) -> CargoResult<()> {
         if feature.is_enabled(self) {
             return Ok(());
         }
@@ -773,6 +786,9 @@ impl Features {
              about the status of this feature.",
             feature.docs
         );
+        if let Some(hint) = hint {
+            let _ = writeln!(msg, "{hint}");
+        }
 
         bail!("{}", msg);
     }

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1359,7 +1359,15 @@ pub fn to_real_manifest(
         default_edition
     };
     if !edition.is_stable() {
-        features.require(Feature::unstable_editions())?;
+        let version = normalized_package
+            .normalized_version()
+            .expect("previously normalized")
+            .map(|v| format!("@{v}"))
+            .unwrap_or_default();
+        let hint = rust_version
+            .as_ref()
+            .map(|rv| format!("help: {package_name}{version} requires rust {rv}"));
+        features.require_with_hint(Feature::unstable_editions(), hint.as_deref())?;
     }
 
     if original_toml.project.is_some() {

--- a/tests/testsuite/edition.rs
+++ b/tests/testsuite/edition.rs
@@ -273,6 +273,7 @@ Caused by:
   The package requires the Cargo feature called `unstable-editions`, but that feature is not stabilized in this version of Cargo ([..]).
   Consider trying a newer version of Cargo (this may require the nightly release).
   See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#unstable-editions for more information about the status of this feature.
+  [HELP] foo@0.1.0 requires rust 1.90
 
 "#]])
         .run();


### PR DESCRIPTION
## What does this PR try to resolve?

Fixes the unhelpful error when a package declares an unstable edition on a 
stable Cargo toolchain. Previously the error told the user to "try a newer 
version of Cargo" but gave no indication of *which* version, forcing them to 
dig through docs.

This PR adds a `help:` line that names the required toolchain version,
derived from the package's `rust-version` field (or from
`Edition::first_version()` once that is set at unstable time).

Before:
```
Consider trying a newer version of Cargo (this may require the nightly release).
See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#unstable-editions
```

After:
```
Consider trying a newer version of Cargo (this may require the nightly release).
help: mypackage@0.1.0 requires rustc 1.90
See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#unstable-editions
```

Also fixes a latent bug in `edition_unstable_gated`: it expected
`feature 'edition{next}'` but current code emits `feature 'unstable-editions'`.
The test was silently skipping because `Edition::LATEST_UNSTABLE` is `None`.

Fixes #15305