### PR TITLE
Adding cpu usage in cargo log

### DIFF
--- a/src/cargo/core/compiler/timings/report.rs
+++ b/src/cargo/core/compiler/timings/report.rs
@@ -108,7 +108,7 @@ pub struct RenderContext<'a> {
     /// Recorded CPU states, stored as tuples. First element is when the
     /// recording was taken and second element is percentage usage of the
     /// system.
-    pub cpu_usage: &'a [(f64, f64)],
+    pub cpu_usage: Cow<'a, [(f64, f64)]>,
     /// Compiler version info, i.e., `rustc 1.92.0-beta.2 (0a411606e 2025-10-31)`.
     pub rustc_version: String,
     /// The host triple (arch-platform-OS).
@@ -257,7 +257,7 @@ fn write_js_data(ctx: &RenderContext<'_>, f: &mut impl Write) -> CargoResult<()>
     writeln!(
         f,
         "const CPU_USAGE = {};",
-        serde_json::to_string_pretty(&ctx.cpu_usage)?
+        serde_json::to_string_pretty(ctx.cpu_usage.as_ref())?
     )?;
     Ok(())
 }

--- a/src/cargo/ops/cargo_report/timings.rs
+++ b/src/cargo/ops/cargo_report/timings.rs
@@ -156,6 +156,8 @@ where
 
     let mut requested_units: HashSet<UnitIndex> = HashSet::new();
 
+    let mut cpu_usage: Vec<(f64, f64)> = Vec::new();
+
     for msg in log {
         match msg {
             LogMessage::BuildStarted {
@@ -327,6 +329,9 @@ where
                     tracing::warn!("unit {index} ended, but it has no start recorded");
                 }
             },
+            LogMessage::CpuUsage { elapsed, usage } => {
+                cpu_usage.push((elapsed, usage));
+            }
             _ => {} // skip non-timing logs
         }
     }
@@ -382,6 +387,7 @@ where
     ctx.unit_data = unit_data;
     ctx.concurrency = compute_concurrency(&ctx.unit_data);
     ctx.requested_targets = platform_targets.into_iter().sorted_unstable().collect();
+    ctx.cpu_usage = std::borrow::Cow::Owned(cpu_usage);
 
     Ok(ctx)
 }

--- a/src/cargo/util/log_message.rs
+++ b/src/cargo/util/log_message.rs
@@ -152,6 +152,13 @@ pub enum LogMessage {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         cause: Option<DirtyReason>,
     },
+    /// Emitted periodically with CPU usage samples.
+    CpuUsage {
+        /// Seconds elapsed from build start.
+        elapsed: f64,
+        /// CPU usage percentage (0.0 to 100.0).
+        usage: f64,
+    },
 }
 
 /// Cargo target information.

--- a/tests/testsuite/build_analysis.rs
+++ b/tests/testsuite/build_analysis.rs
@@ -173,7 +173,8 @@ fn log_msg_timing_info() {
     "reason": "unit-finished",
     "run_id": "[..]T[..]Z-[..]",
     "timestamp": "[..]T[..]Z"
-  }
+  },
+  "{...}"
 ]
 "#]]
         .is_json()
@@ -319,7 +320,8 @@ fn log_msg_timing_info_section_timings() {
     "reason": "unit-finished",
     "run_id": "[..]T[..]Z-[..]",
     "timestamp": "[..]T[..]Z"
-  }
+  },
+  "{...}"
 ]
 "#]]
         .is_json()


### PR DESCRIPTION
## Add CPU usage data to `cargo report timings`

### Summary

This PR adds CPU usage tracking to the log files generated by `-Z build-analysis`, enabling `cargo report timings` to reconstruct and display CPU usage graphs in the HTML timing report.

Previously, CPU usage data was only available in the live `--timings` path (collected in-memory by [record_cpu()](cci:1://file:///home/suryansh/dev/GSOC/cargo/src/cargo/core/compiler/timings/mod.rs:231:4-256:5) and passed directly to [RenderContext](cci:2://file:///home/suryansh/dev/GSOC/cargo/src/cargo/core/compiler/timings/report.rs:89:0-123:1)). When using `cargo report timings` to reconstruct a report from log files, the CPU usage graph was always empty — even though the HTML legend still displayed a "CPU Usage" entry.

Closes #16651

### Changes

**[src/cargo/util/log_message.rs](cci:7://file:///home/suryansh/dev/GSOC/cargo/src/cargo/util/log_message.rs:0:0-0:0)**
- Added `CpuUsage { elapsed: f64, usage: f64 }` variant to the `LogMessage` enum, representing a periodic CPU usage sample.

**[src/cargo/core/compiler/timings/mod.rs](cci:7://file:///home/suryansh/dev/GSOC/cargo/src/cargo/core/compiler/timings/mod.rs:0:0-0:0)**
- In [finished()](cci:1://file:///home/suryansh/dev/GSOC/cargo/src/cargo/core/compiler/timings/mod.rs:258:4-291:5), log all accumulated CPU usage samples to the file logger before generating the HTML report.
- Moved CPU logging outside the [get_logs()](cci:1://file:///home/suryansh/dev/GSOC/cargo/src/cargo/util/logger.rs:148:4-155:5) guard (which only succeeds for `--timings`) into the outer `if let Some(logger)` block, so data is written whenever any logger exists (including the file logger used by `-Z build-analysis`).
- Updated the live path to use `Cow::Borrowed` for the `cpu_usage` field.

**[src/cargo/core/compiler/timings/report.rs](cci:7://file:///home/suryansh/dev/GSOC/cargo/src/cargo/core/compiler/timings/report.rs:0:0-0:0)**
- Changed `RenderContext::cpu_usage` from `&'a [(f64, f64)]` to `Cow<'a, [(f64, f64)]>` to support both borrowed data (live `--timings` path) and owned data (log reconstruction path).

**[src/cargo/ops/cargo_report/timings.rs](cci:7://file:///home/suryansh/dev/GSOC/cargo/src/cargo/ops/cargo_report/timings.rs:0:0-0:0)**
- Added handling of `LogMessage::CpuUsage` in [prepare_context()](cci:1://file:///home/suryansh/dev/GSOC/cargo/src/cargo/ops/cargo_report/timings.rs:132:0-392:1) to collect CPU samples from log files and store them as `Cow::Owned` in the render context.

# Updating tests
Added a "{...}" trailing wildcard to match the cpu-usage entries, same pattern used by other tests in the file (e.g., log_rebuild_reason_fresh_build). Also proactively applied the same fix to log_msg_timing_info_section_timings (nightly-only test) for consistency.

### Testing

- All existing [cargo_report_timings](cci:7://file:///home/suryansh/dev/GSOC/cargo/tests/testsuite/cargo_report_timings:0:0-0:0) tests pass (16 passed, 1 ignored for nightly-only).
- All existing [timings](cci:7://file:///home/suryansh/dev/GSOC/cargo/src/cargo/core/compiler/timings:0:0-0:0) tests pass.
- End-to-end verified: built a project with `CARGO_BUILD_ANALYSIS_ENABLED=true cargo check -Z build-analysis`, confirmed 120 `cpu-usage` entries in the log file, and verified `cargo report timings` produces an HTML report with populated `CPU_USAGE` JavaScript data.

Sample log entry:
```json
{"reason":"cpu-usage","elapsed":1.255,"usage":76.72}