### PR TITLE
Fix typo in cargo-yank docs

### DIFF
--- a/src/doc/man/cargo-yank.md
+++ b/src/doc/man/cargo-yank.md
@@ -51,7 +51,7 @@ requirements, following a given release being yanked:
 ### When to yank
 
 Crates should only be yanked in exceptional circumstances, for example, an
-accidental publish, an unintentional SemVer breakages, or a significantly
+accidental publish, unintentional SemVer breakages, or a significantly
 broken and unusable crate. In the case of security vulnerabilities, [RustSec]
 is typically a less disruptive mechanism to inform users and encourage them
 to upgrade, and avoids the possibility of significant downstream disruption

--- a/src/doc/man/generated_txt/cargo-yank.txt
+++ b/src/doc/man/generated_txt/cargo-yank.txt
@@ -55,7 +55,7 @@ DESCRIPTION
 
    When to yank
        Crates should only be yanked in exceptional circumstances, for example,
-       an accidental publish, an unintentional SemVer breakages, or a
+       an accidental publish, unintentional SemVer breakages, or a
        significantly broken and unusable crate. In the case of security
        vulnerabilities, RustSec <https://rustsec.org/> is typically a less
        disruptive mechanism to inform users and encourage them to upgrade, and

--- a/src/doc/src/commands/cargo-yank.md
+++ b/src/doc/src/commands/cargo-yank.md
@@ -51,7 +51,7 @@ requirements, following a given release being yanked:
 ### When to yank
 
 Crates should only be yanked in exceptional circumstances, for example, an
-accidental publish, an unintentional SemVer breakages, or a significantly
+accidental publish, unintentional SemVer breakages, or a significantly
 broken and unusable crate. In the case of security vulnerabilities, [RustSec]
 is typically a less disruptive mechanism to inform users and encourage them
 to upgrade, and avoids the possibility of significant downstream disruption

--- a/src/etc/man/cargo-yank.1
+++ b/src/etc/man/cargo-yank.1
@@ -82,7 +82,7 @@ T}
 .sp
 .SS "When to yank"
 Crates should only be yanked in exceptional circumstances, for example, an
-accidental publish, an unintentional SemVer breakages, or a significantly
+accidental publish, unintentional SemVer breakages, or a significantly
 broken and unusable crate. In the case of security vulnerabilities, \fIRustSec\fR <https://rustsec.org/>
 is typically a less disruptive mechanism to inform users and encourage them
 to upgrade, and avoids the possibility of significant downstream disruption


### PR DESCRIPTION
This fixes a (very small) typo in the docs for `cargo-yank`. Specifically, since "unintentional SemVer breakages" is plural, the "an" that was at the beginning of that sentence was incorrect.

### What does this PR try to resolve?

There wasn't an issue, just a very tiny typo

### How to test and review this PR?

Hopefully this shouldn't need any testing... it's just a change to a markdown file
