### PR TITLE
Simplify fine grain locking to lock before job execution

### DIFF
--- a/src/cargo/core/compiler/build_runner/compilation_files.rs
+++ b/src/cargo/core/compiler/build_runner/compilation_files.rs
@@ -444,6 +444,11 @@ impl<'a, 'gctx: 'a> CompilationFiles<'a, 'gctx> {
             .map(Arc::clone)
     }
 
+    /// Returns the path to the acquisition lock, used to avoid multiple Cargos from deadlocking
+    pub fn acquisition_lock(&self) -> &Path {
+        self.host.build_dir().acquisition_lock()
+    }
+
     /// Returns the path where the output for the given unit and `FileType`
     /// should be uplifted to.
     ///

--- a/src/cargo/core/compiler/job_queue/job_state.rs
+++ b/src/cargo/core/compiler/job_queue/job_state.rs
@@ -147,10 +147,6 @@ impl<'a, 'gctx> JobState<'a, 'gctx> {
             .push(Message::Finish(self.id, Artifact::Metadata, Ok(())));
     }
 
-    pub fn lock_exclusive(&self, lock: &LockKey) -> CargoResult<()> {
-        self.lock_manager.lock(lock)
-    }
-
     pub fn downgrade_to_shared(&self, lock: &LockKey) -> CargoResult<()> {
         self.lock_manager.downgrade_to_shared(lock)
     }

--- a/src/cargo/core/compiler/layout.rs
+++ b/src/cargo/core/compiler/layout.rs
@@ -286,6 +286,7 @@ impl Layout {
         let build_dest = build_dest.as_path_unlocked();
         let deps = build_dest.join("deps");
         let artifact = deps.join("artifact");
+        let acquisition_lock = build_dest.join(".acquisition-lock");
 
         let artifact_dir = if must_take_artifact_dir_lock {
             // For now we don't do any more finer-grained locking on the artifact
@@ -323,6 +324,7 @@ impl Layout {
                 fingerprint: build_dest.join(".fingerprint"),
                 examples: build_dest.join("examples"),
                 tmp: build_root.join("tmp"),
+                acquisition_lock,
                 _lock: build_dir_lock,
                 is_new_layout,
             },
@@ -405,6 +407,7 @@ pub struct BuildDirLayout {
     examples: PathBuf,
     /// The directory for temporary data of integration tests and benches
     tmp: PathBuf,
+    acquisition_lock: PathBuf,
     /// The lockfile for a build (`.cargo-lock`). Will be unlocked when this
     /// struct is `drop`ped.
     ///
@@ -504,5 +507,9 @@ impl BuildDirLayout {
     pub fn prepare_tmp(&self) -> CargoResult<&Path> {
         paths::create_dir_all(&self.tmp)?;
         Ok(&self.tmp)
+    }
+    // Fetch the acquisition lock path
+    pub fn acquisition_lock(&self) -> &Path {
+        &self.acquisition_lock
     }
 }

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -250,6 +250,12 @@ fn compile<'gctx>(
                     // the user from running `cargo build` while developing. Generally, only a few
                     // workspace units will be changing in each build and the units will not be
                     // shared between `build` and `check` allowing them to run in parallel.
+                    //
+                    // Also note that we unlock before taking the exclusive lock as not all
+                    // platforms support lock upgrading. This is safe as we hold the acquisition
+                    // lock so we should be the only one operating on the locks so we can assume
+                    // that the lock will not be stolen by another instance.
+                    build_runner.lock_manager.unlock(&lock)?;
                     build_runner.lock_manager.lock(&lock)?;
                     job.after(downgrade_lock_to_shared(lock));
                 }

--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -40,6 +40,7 @@ fn binary_with_debug() {
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
 [ROOT]/foo/build-dir/debug/.cargo-lock
+[ROOT]/foo/build-dir/debug/.acquisition-lock
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
@@ -95,6 +96,7 @@ fn binary_with_release() {
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
 [ROOT]/foo/build-dir/release/.cargo-lock
+[ROOT]/foo/build-dir/release/.acquisition-lock
 [ROOT]/foo/build-dir/release/build/foo/[HASH]/fingerprint/bin-foo
 [ROOT]/foo/build-dir/release/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/foo/build-dir/release/build/foo/[HASH]/fingerprint/dep-bin-foo
@@ -205,6 +207,7 @@ fn should_default_to_target() {
 [ROOT]/foo/target/.rustc_info.json
 [ROOT]/foo/target/CACHEDIR.TAG
 [ROOT]/foo/target/debug/.cargo-lock
+[ROOT]/foo/target/debug/.acquisition-lock
 [ROOT]/foo/target/debug/build/foo/[HASH]/fingerprint/bin-foo
 [ROOT]/foo/target/debug/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/foo/target/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
@@ -234,6 +237,7 @@ fn should_respect_env_var() {
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
 [ROOT]/foo/build-dir/debug/.cargo-lock
+[ROOT]/foo/build-dir/debug/.acquisition-lock
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
@@ -279,6 +283,7 @@ fn build_script_should_output_to_build_dir() {
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/CACHEDIR.TAG
 [ROOT]/foo/build-dir/debug/.cargo-lock
+[ROOT]/foo/build-dir/debug/.acquisition-lock
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo.txt
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/build_script_build[..].d
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/build_script_build[..][EXE]
@@ -342,6 +347,7 @@ fn cargo_tmpdir_should_output_to_build_dir() {
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/CACHEDIR.TAG
 [ROOT]/foo/build-dir/debug/.cargo-lock
+[ROOT]/foo/build-dir/debug/.acquisition-lock
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo-[HASH].d
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo.d
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
@@ -402,6 +408,7 @@ fn examples_should_output_to_build_dir_and_uplift_to_target_dir() {
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
 [ROOT]/foo/build-dir/debug/.cargo-lock
+[ROOT]/foo/build-dir/debug/.acquisition-lock
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-example-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/example-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/example-foo.json
@@ -448,6 +455,7 @@ fn benches_should_output_to_build_dir() {
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/CACHEDIR.TAG
 [ROOT]/foo/build-dir/debug/.cargo-lock
+[ROOT]/foo/build-dir/debug/.acquisition-lock
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo-[HASH].d
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo-[HASH][EXE]
@@ -527,6 +535,7 @@ fn cargo_package_should_build_in_build_dir_and_output_to_target_dir() {
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/debug/.cargo-lock
+[ROOT]/foo/build-dir/debug/.acquisition-lock
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
@@ -608,6 +617,7 @@ fn cargo_clean_should_clean_the_target_dir_and_build_dir() {
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
 [ROOT]/foo/build-dir/debug/.cargo-lock
+[ROOT]/foo/build-dir/debug/.acquisition-lock
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
@@ -678,6 +688,7 @@ fn cargo_clean_should_remove_correct_files() {
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
 [ROOT]/foo/build-dir/debug/.cargo-lock
+[ROOT]/foo/build-dir/debug/.acquisition-lock
 [ROOT]/foo/build-dir/debug/build/bar/[HASH]/out/bar-[HASH].d
 [ROOT]/foo/build-dir/debug/build/bar/[HASH]/out/libbar-[HASH].rlib
 [ROOT]/foo/build-dir/debug/build/bar/[HASH]/out/libbar-[HASH].rmeta
@@ -705,6 +716,7 @@ fn cargo_clean_should_remove_correct_files() {
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
 [ROOT]/foo/build-dir/debug/.cargo-lock
+[ROOT]/foo/build-dir/debug/.acquisition-lock
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo
@@ -841,6 +853,7 @@ fn template_workspace_root() {
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
 [ROOT]/foo/build-dir/debug/.cargo-lock
+[ROOT]/foo/build-dir/debug/.acquisition-lock
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
@@ -889,6 +902,7 @@ fn template_cargo_cache_home() {
 [ROOT]/home/.cargo/build-dir/.rustc_info.json
 [ROOT]/home/.cargo/build-dir/CACHEDIR.TAG
 [ROOT]/home/.cargo/build-dir/debug/.cargo-lock
+[ROOT]/home/.cargo/build-dir/debug/.acquisition-lock
 [ROOT]/home/.cargo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo
 [ROOT]/home/.cargo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/home/.cargo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
@@ -951,6 +965,7 @@ fn template_workspace_path_hash() {
 [ROOT]/foo/foo/[HASH]/build-dir/.rustc_info.json
 [ROOT]/foo/foo/[HASH]/build-dir/CACHEDIR.TAG
 [ROOT]/foo/foo/[HASH]/build-dir/debug/.cargo-lock
+[ROOT]/foo/foo/[HASH]/build-dir/debug/.acquisition-lock
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
@@ -1019,6 +1034,7 @@ fn template_workspace_path_hash_should_handle_symlink() {
 [ROOT]/foo/foo/[HASH]/build-dir/.rustc_info.json
 [ROOT]/foo/foo/[HASH]/build-dir/CACHEDIR.TAG
 [ROOT]/foo/foo/[HASH]/build-dir/debug/.cargo-lock
+[ROOT]/foo/foo/[HASH]/build-dir/debug/.acquisition-lock
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/dep-lib-foo
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/lib-foo
@@ -1058,6 +1074,7 @@ fn template_workspace_path_hash_should_handle_symlink() {
 [ROOT]/foo/foo/[HASH]/build-dir/.rustc_info.json
 [ROOT]/foo/foo/[HASH]/build-dir/CACHEDIR.TAG
 [ROOT]/foo/foo/[HASH]/build-dir/debug/.cargo-lock
+[ROOT]/foo/foo/[HASH]/build-dir/debug/.acquisition-lock
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/dep-lib-foo
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/lib-foo


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/cargo/pull/16657)*

# What does this PR try to resolve?

Tracking issue: https://github.com/rust-lang/cargo/issues/4282

This PR simplifies the locking design by taking the exclusive lock BEFORE executing the jobs.
This means that ALL exclusive locks are taken before executing the job queue.

The rational for why this is better:
1. We are optimizing for the "development iteration" workflow where small frequent changes are being made with a `cargo build` between changes.
    * This means that builds are "warm" and we are generally only recompiling a small subset of the dependency tree.
    * In most cases the small subset of units that need to be recompiled will NOT be shared between `cargo build` and `cargo check`. 
    * Since units are not shared both `cargo build` and `cargo check` will be able to take all of their locks up front and still be able to run in parallel.  
2. This approach simplifies the locking design 
    * No communication is needed with in flight jobs
    * No need to worry about a blocked job preventing other jobs from executing  
    * Blocking messages are easier to implement  

**Drawbacks**
* Clean build/checks will get less parallelism as the second build will block until the last shared unit (often a build script or proc macro) is built
* The build/check blocking problem may still be an issue when making changes to a proc-macro crate or build script itself 

<details><summary>Original Description</summary>


# What does this PR try to resolve?

This PR fixes a bug in `-Zfine-grain-locking` that prevent prevent other jobs from running when a job is waiting on a lock.
Cargo's job queue has previously never support the ability to suspend a job that is already executing. 
This PR adds support to suspend and resume jobs being executed.

This also paves the way to add better blocking messages to the user (originally attempted in https://github.com/rust-lang/cargo/pull/16463)

Tracking issue: #4282

## Flow

* Before taking an exclusive lock (and potentially blocking) we do a [`.try_lock()` ](https://doc.rust-lang.org/std/fs/struct.File.html#method.try_lock) to see if we will block.
  * If we are going to block, we send a `Message::Blocked` letting the job queue reclaim the token for another job to run while we are blocked
  * If `try_lock` succeeds, we have the lock and never blocked, so we simply start compiling. 
* Once we acquire the lock, we sending a `Message::Unblocked` letting the job queue know we are ready to continue
* But before compiling, to respect the `--jobs` limit, wait for the job queue to reschedule us by calling `JobState.resume.recv()` which blocks the current thread.
* The job queue will eventually call `ActiveJob.resume.send()` which will let the job resume exection.

## Design

* We leverage the existing [`Queue<Message>`](https://github.com/rust-lang/cargo/blob/master/src/cargo/core/compiler/job_queue/mod.rs#L176) in `JobState` to notify the job queue that we are going to block.
* For resuming tasks that are blocked, I used a `std::sync::mpsc::channel`. 

```mermaid
flowchart LR
    JQ["Job Queue (DrainState)"]
    J["Jobs"]

    J -- "Queue&lt;Message&gt;" --> JQ
    JQ -- "resume mpsc::channel" --> J
```

# How to test and review this PR?

To test this I found the easiest to way to do it synthetically by injecting a `std::thread::sleep` in the lock manager for a given lock. Along with passing `--jobs 1` to make a blocked job block the entire build.

```rs
pub fn lock(&self, key: &LockKey) -> CargoResult<()> {
      let locks = self.locks.read().unwrap();
      if key.0.to_str().unwrap().contains("libc") {
          std::thread::sleep(std::time::Duration::from_secs(5));
      }
      // ....
}
```


Test script
```sh
cargo new foo; cd foo; cargo add tokio --features full

rm -rf target build
alias lc=/path/to/cargo
CARGO_BUILD_BUILD_DIR=build lc -Zbuild-dir-new-layout -Zfine-grain-locking build --jobs 1
```

Doing this on `master` will result in blocked build that never completes, while changes in this PR will finish the build.

</details> 


r? @epage 


