### PR TITLE
fix(host-config): fix panic when cross-compiling with host-config

### DIFF
--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -1367,11 +1367,6 @@ fn cross_with_host_config() {
     p.cargo("build -Z target-applies-to-host -Z host-config --target")
         .arg(&target)
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
-        .with_status(101)
-        .with_stderr_data(str![[r#"
-...
-no entry found for key
-...
-"#]])
+        .with_status(0)
         .run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?

When cross compiling (with `--target`), cargo panics with -Zhost-config.

This changes the explicit addition of the host target to only occur if the `requested_kinds` includes the host.

Otherwise, looking up the target_runner for the explicit_host_kind attempts to look up an entry in the target_config map that does not exist.

### How to test and review this PR?

Validate that new test passes and does not panic.

Fixes #16664
