### PR TITLE
fix: ignore implicit std dependencies in `unused-crate-dependencies` lint

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1874,68 +1874,75 @@ pub fn extern_args(
     let no_embed_metadata = build_runner.bcx.gctx.cli_unstable().no_embed_metadata;
 
     // Closure to add one dependency to `result`.
-    let mut link_to =
-        |dep: &UnitDep, extern_crate_name: InternedString, noprelude: bool| -> CargoResult<()> {
-            let mut value = OsString::new();
-            let mut opts = Vec::new();
-            let is_public_dependency_enabled = unit
-                .pkg
-                .manifest()
-                .unstable_features()
-                .require(Feature::public_dependency())
-                .is_ok()
-                || build_runner.bcx.gctx.cli_unstable().public_dependency;
-            if !dep.public && unit.target.is_lib() && is_public_dependency_enabled {
-                opts.push("priv");
-                *unstable_opts = true;
-            }
-            if noprelude {
-                opts.push("noprelude");
-                *unstable_opts = true;
-            }
-            if !opts.is_empty() {
-                value.push(opts.join(","));
-                value.push(":");
-            }
-            value.push(extern_crate_name.as_str());
-            value.push("=");
+    let mut link_to = |dep: &UnitDep,
+                       extern_crate_name: InternedString,
+                       noprelude: bool,
+                       nounused: bool|
+     -> CargoResult<()> {
+        let mut value = OsString::new();
+        let mut opts = Vec::new();
+        let is_public_dependency_enabled = unit
+            .pkg
+            .manifest()
+            .unstable_features()
+            .require(Feature::public_dependency())
+            .is_ok()
+            || build_runner.bcx.gctx.cli_unstable().public_dependency;
+        if !dep.public && unit.target.is_lib() && is_public_dependency_enabled {
+            opts.push("priv");
+            *unstable_opts = true;
+        }
+        if noprelude {
+            opts.push("noprelude");
+            *unstable_opts = true;
+        }
+        if nounused {
+            opts.push("nounused");
+            *unstable_opts = true;
+        }
+        if !opts.is_empty() {
+            value.push(opts.join(","));
+            value.push(":");
+        }
+        value.push(extern_crate_name.as_str());
+        value.push("=");
 
-            let mut pass = |file| {
-                let mut value = value.clone();
-                value.push(file);
-                result.push(OsString::from("--extern"));
-                result.push(value);
-            };
+        let mut pass = |file| {
+            let mut value = value.clone();
+            value.push(file);
+            result.push(OsString::from("--extern"));
+            result.push(value);
+        };
 
-            let outputs = build_runner.outputs(&dep.unit)?;
+        let outputs = build_runner.outputs(&dep.unit)?;
 
-            if build_runner.only_requires_rmeta(unit, &dep.unit) || dep.unit.mode.is_check() {
-                // Example: rlib dependency for an rlib, rmeta is all that is required.
-                let output = outputs
-                    .iter()
-                    .find(|output| output.flavor == FileFlavor::Rmeta)
-                    .expect("failed to find rmeta dep for pipelined dep");
-                pass(&output.path);
-            } else {
-                // Example: a bin needs `rlib` for dependencies, it cannot use rmeta.
-                for output in outputs.iter() {
-                    if output.flavor == FileFlavor::Linkable {
-                        pass(&output.path);
-                    }
-                    // If we use -Zembed-metadata=no, we also need to pass the path to the
-                    // corresponding .rmeta file to the linkable artifact, because the
-                    // normal dependency (rlib) doesn't contain the full metadata.
-                    else if no_embed_metadata && output.flavor == FileFlavor::Rmeta {
-                        pass(&output.path);
-                    }
+        if build_runner.only_requires_rmeta(unit, &dep.unit) || dep.unit.mode.is_check() {
+            // Example: rlib dependency for an rlib, rmeta is all that is required.
+            let output = outputs
+                .iter()
+                .find(|output| output.flavor == FileFlavor::Rmeta)
+                .expect("failed to find rmeta dep for pipelined dep");
+            pass(&output.path);
+        } else {
+            // Example: a bin needs `rlib` for dependencies, it cannot use rmeta.
+            for output in outputs.iter() {
+                if output.flavor == FileFlavor::Linkable {
+                    pass(&output.path);
+                }
+                // If we use -Zembed-metadata=no, we also need to pass the path to the
+                // corresponding .rmeta file to the linkable artifact, because the
+                // normal dependency (rlib) doesn't contain the full metadata.
+                else if no_embed_metadata && output.flavor == FileFlavor::Rmeta {
+                    pass(&output.path);
                 }
             }
-            Ok(())
-        };
+        }
+        Ok(())
+    };
 
     for dep in deps {
         if dep.unit.target.is_linkable() && !dep.unit.mode.is_doc() {
-            link_to(dep, dep.extern_crate_name, dep.noprelude)?;
+            link_to(dep, dep.extern_crate_name, dep.noprelude, dep.nounused)?;
         }
     }
     if unit.target.proc_macro() {

--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -206,6 +206,7 @@ fn attach_std_deps(
                 // TODO: Does this `public` make sense?
                 public: true,
                 noprelude: true,
+                nounused: true,
             }));
             found = true;
         }
@@ -911,6 +912,7 @@ fn new_unit_dep_with_profile(
         dep_name,
         public,
         noprelude: false,
+        nounused: false,
     })
 }
 

--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -472,15 +472,9 @@ fn build_std_does_not_warn_about_implicit_std_deps() {
         .env("RUSTFLAGS", "-W unused-crate-dependencies")
         .with_stderr_data(
             str![[r#"
-[WARNING] extern crate `alloc` is unused in crate `bar`
-[WARNING] extern crate `alloc` is unused in crate `buildstd_test`
 [WARNING] extern crate `bar` is unused in crate `buildstd_test`
-[WARNING] extern crate `compiler_builtins` is unused in crate `buildstd_test`
-[WARNING] extern crate `core` is unused in crate `buildstd_test`
-[WARNING] extern crate `proc_macro` is unused in crate `buildstd_test`
-[WARNING] `buildstd_test` (bin "buildstd_test") generated 5 warnings
+[WARNING] `buildstd_test` (bin "buildstd_test") generated 1 warning
 ...
-
 "#]]
             .unordered(),
         )

--- a/tests/testsuite/unit_graph.rs
+++ b/tests/testsuite/unit_graph.rs
@@ -61,6 +61,7 @@ fn simple() {
           "extern_crate_name": "b",
           "index": 1,
           "noprelude": false,
+          "nounused": false,
           "public": false
         }
       ],
@@ -106,6 +107,7 @@ fn simple() {
           "extern_crate_name": "c",
           "index": 2,
           "noprelude": false,
+          "nounused": false,
           "public": false
         }
       ],
@@ -189,6 +191,7 @@ fn simple() {
           "extern_crate_name": "a",
           "index": 0,
           "noprelude": false,
+          "nounused": false,
           "public": false
         }
       ],


### PR DESCRIPTION
fixes [152561](https://github.com/rust-lang/rust/issues/152561)

### What does this PR try to solve?
Cargo explicitly passes standard library crates (core, alloc, etc.) as
extern dependencies when using `-Zbuild-std`, which causes "erroneous" 
warnings because these crates are not listed in the user's Cargo.toml.

### The working

This was initially issued on the `rust` repo, for which i filed a PR, using `noprelude` to exclude linting, but it was correctly pointed out that this was not the correct approach. 
Following [Zulip](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/unused_crate_dependencies.20with.20cargo.20-Zbuild-std/with/575423436) discussions, I added a `nounused` flag to the `UnitDeps` struct which is similar in working to the `noprelude` flag.
`--extern nounused:foo` already exists as an unstable compiler option. 

### How to test and review this PR?

1. To demonstrate that the implicitly injected crates no longer trigger linting warnings, use this test command: `rustup run nightly cargo test build_std_does_not_warn_about_implicit_std_deps`. 
2. Verify that `core`, `alloc`, `compiler_builtins` do not throw unused warnings.

**Note:** this makes build-std stabilization blocked on https://github.com/rust-lang/rust/issues/98400 which is blocked on https://github.com/rust-lang/rust/issues/98405 (which I think is already a dependence of build-std)

---

Currently, `nounused` is emitted only for implicitly injected standard library dependencies when using `-Zbuild-std`.

If Cargo ever gains support for explicit builtin dependencies declared by users, it may be desirable to revisit whether `nounused` should apply in those cases. This PR does not change behavior for explicit dependencies.