### PR TITLE
feat(fix): Inject an edition into scripts

### DIFF
--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -3078,7 +3078,7 @@ fn script_without_frontmatter() {
         .with_stdout_data(str![""])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
-[WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[FIXED] echo.rs (1 fix)
 [CHECKING] echo v0.0.0 ([ROOT]/foo/echo.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -3087,7 +3087,14 @@ fn script_without_frontmatter() {
 
     assert_e2e().eq(
         p.read_file("echo.rs"),
-        str!["fn main() {}"],
+        str![[r#"
+---
+[package]
+edition = "2024"
+---
+
+fn main() {}
+"#]],
     );
 }
 
@@ -3109,7 +3116,7 @@ fn main() {}",
         .with_stdout_data(str![""])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
-[WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[FIXED] echo.rs (1 fix)
 [CHECKING] echo v0.0.0 ([ROOT]/foo/echo.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -3118,13 +3125,15 @@ fn main() {}",
 
     assert_e2e().eq(
         p.read_file("echo.rs"),
-        str![[r#"
+        str![[r##"
 #!/usr/bin/env cargo
 ---
+[package]
+edition = "2024"
 [dependencies]
 ---
 fn main() {}
-"#]],
+"##]],
     );
 }
 
@@ -3147,7 +3156,7 @@ fn main() {}"#,
         .with_stdout_data(str![""])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
-[WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[FIXED] echo.rs (1 fix)
 [CHECKING] foo v0.0.0 ([ROOT]/foo/echo.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -3161,6 +3170,7 @@ fn main() {}"#,
 ---
 [package]
 name = "foo"
+edition = "2024"
 ---
 fn main() {}
 "##]],
@@ -3185,7 +3195,7 @@ fn main() {}"#,
         .with_stdout_data(str![""])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
-[WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[FIXED] echo.rs (1 fix)
 [CHECKING] foo v0.0.0 ([ROOT]/foo/echo.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -3198,6 +3208,7 @@ fn main() {}"#,
 #!/usr/bin/env cargo
 ---
 package.name = "foo"
+package.edition = "2024"
 ---
 fn main() {}
 "##]],


### PR DESCRIPTION
### What does this PR try to resolve?


### How to test and review this PR?

This is stacked on top of #16676.

 I was originally not worrying about `cargo fix` being able to inject the edition because I figured we'd wait for proper `cargo fix` for `Cargo.toml` files.  However, that would be designed for lints and this wouldn't be a lint but a hard warning, so that may no work out, so I went and hard coded this in `cargo fix.