### PR TITLE
Fixed Job_queue message to say Compiled instead of Compiling

### DIFF
--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -1206,7 +1206,9 @@ impl<'gctx> DrainState<'gctx> {
                     if unit.mode.is_check() {
                         gctx.shell().status("Checking", &unit.pkg)?;
                     } else {
-                        gctx.shell().status("Compiling", &unit.pkg)?;
+                        // Say `Compiled` for packages finished compiling instead of `Compiling`
+                        // As the bottom bar already has the status of the packages being currently compiled.
+                        gctx.shell().status("Compiled", &unit.pkg)?;
                     }
                 }
             }


### PR DESCRIPTION
### What does this PR try to resolve?
There is confusion whether the packages have finished compiling or are being compiled.

###### Before:
<img width="953" height="915" alt="image" src="https://github.com/user-attachments/assets/d13b97d1-5779-48ba-a4e4-20fdf146f558" />

###### After :
<img width="953" height="344" alt="image" src="https://github.com/user-attachments/assets/5bba7d87-017b-4e9b-b295-bffed79736a3" />


### How to test and review this PR?
Just changed from `Compiling` to `Compiled` so I guess no tests needed.

Even if you don't accept this PR please try to resolve this issue as it can cause alot of ambiguity about the current state.
Maybe make it more descriptive:

``` Finished Compiling *pkg*```

If that is too verbose switch to:
``` Compiled *pkg* ```

Thanks.
