### PR TITLE
fix(ops): correct error messages for cargo fix on broken code

### DIFF
--- a/src/ops/cargo_fix/mod.rs
+++ b/src/ops/cargo_fix/mod.rs
@@ -770,31 +770,42 @@ pub fn fix_exec_rustc(gctx: &GlobalContext, lock_addr: &str) -> CargoResult<()> 
         }
     }
 
-    // If there were any fixes, let the user know that there was a failure
-    // attempting to apply them, and to ask for a bug report.
-    //
-    // FIXME: The error message here is not correct with --broken-code.
-    //        https://github.com/rust-lang/cargo/issues/10955
+    let krate = {
+        let mut iter = rustc.get_args();
+        let mut krate = None;
+        while let Some(arg) = iter.next() {
+            if arg == "--crate-name" {
+                krate = iter.next().and_then(|s| s.to_owned().into_string().ok());
+            }
+        }
+        krate
+    };
+
     if fixes.files.is_empty() {
+        if !fixes.first_output.status.success() {
+            Message::FixFailed {
+                files: vec![],
+                krate,
+                errors: vec![],
+                abnormal_exit: None,
+                started_broken: true,
+                allow_broken_code,
+                fixes_applied: false,
+            }
+            .post(gctx)?;
+        }
         // No fixes were available. Display whatever errors happened.
         emit_output(&fixes.last_output)?;
         exit_with(fixes.last_output.status);
     } else {
-        let krate = {
-            let mut iter = rustc.get_args();
-            let mut krate = None;
-            while let Some(arg) = iter.next() {
-                if arg == "--crate-name" {
-                    krate = iter.next().and_then(|s| s.to_owned().into_string().ok());
-                }
-            }
-            krate
-        };
         log_failed_fix(
             gctx,
             krate,
             &fixes.last_output.stderr,
             fixes.last_output.status,
+            !fixes.first_output.status.success(),
+            allow_broken_code,
+            true, // fixes were applied since fixes.files is not empty
         )?;
         // Display the diagnostics that appeared at the start, before the
         // fixes failed. This can help with diagnosing which suggestions
@@ -1152,6 +1163,9 @@ fn log_failed_fix(
     krate: Option<String>,
     stderr: &[u8],
     status: ExitStatus,
+    started_broken: bool,
+    allow_broken_code: bool,
+    fixes_applied: bool,
 ) -> CargoResult<()> {
     let stderr = str::from_utf8(stderr).context("failed to parse rustc stderr as utf-8")?;
 
@@ -1186,6 +1200,9 @@ fn log_failed_fix(
         krate,
         errors,
         abnormal_exit,
+        started_broken,
+        allow_broken_code,
+        fixes_applied,
     }
     .post(gctx)?;
 

--- a/src/util/diagnostic_server.rs
+++ b/src/util/diagnostic_server.rs
@@ -43,6 +43,11 @@ pub enum Message {
         krate: Option<String>,
         errors: Vec<String>,
         abnormal_exit: Option<String>,
+        started_broken: bool,
+        /// Whether `--broken-code` was passed by the user.
+        allow_broken_code: bool,
+        /// Whether any fixes were actually applied.
+        fixes_applied: bool,
     },
     ReplaceFailed {
         file: String,
@@ -146,6 +151,9 @@ impl<'a> DiagnosticPrinter<'a> {
                 krate,
                 errors,
                 abnormal_exit,
+                started_broken,
+                allow_broken_code,
+                fixes_applied,
             } => {
                 let to_crate = if let Some(ref krate) = *krate {
                     format!(" to crate `{krate}`",)
@@ -160,9 +168,15 @@ impl<'a> DiagnosticPrinter<'a> {
                     None
                 };
 
-                let report = &[
+                let title = if !*fixes_applied {
+                    format!("cargo fix could not apply any fixes{to_crate}")
+                } else {
+                    format!("errors present after applying fixes{to_crate}")
+                };
+
+                let mut report = vec![
                     Level::ERROR
-                        .secondary_title(format!("errors present after applying fixes{to_crate}"))
+                        .secondary_title(title)
                         .elements(files.iter().map(|f| Origin::path(f)))
                         .elements(
                             cause_message
@@ -174,14 +188,38 @@ impl<'a> DiagnosticPrinter<'a> {
                                 .with_name("cause")
                                 .message(format!("rustc exited abnormally: {exit}"))
                         })),
-                    gen_please_report_this_bug_group(issue_link),
-                    gen_suggest_broken_code_group(),
-                    Group::with_title(
-                        Level::NOTE.secondary_title("original diagnostics will follow:"),
-                    ),
                 ];
 
-                self.gctx.shell().print_report(report, false)?;
+                if *started_broken && !*allow_broken_code {
+                    report.push(Group::with_title(Level::HELP.secondary_title(
+                        "cargo fix requires the code to compile before fixes can be applied; the code has errors that must be fixed manually",
+                    )));
+                    report.push(gen_suggest_broken_code_group());
+                } else if *started_broken && *allow_broken_code {
+                    if !*fixes_applied {
+                        report.push(Group::with_title(Level::HELP.secondary_title(
+                            "no fixes were applicable; the code already had errors prior to cargo fix",
+                        )));
+                    } else {
+                        report.push(Group::with_title(Level::HELP.secondary_title(
+                            "the broken code has been saved as requested via `--broken-code`; the code already had errors prior to cargo fix",
+                        )));
+                    }
+                } else if !*started_broken && *allow_broken_code {
+                    report.push(gen_please_report_this_bug_group(issue_link));
+                    report.push(Group::with_title(Level::HELP.secondary_title(
+                        "the broken code has been saved as requested via `--broken-code`",
+                    )));
+                } else {
+                    report.push(gen_please_report_this_bug_group(issue_link));
+                    report.push(gen_suggest_broken_code_group());
+                }
+
+                report.push(Group::with_title(
+                    Level::NOTE.secondary_title("original diagnostics will follow:"),
+                ));
+
+                self.gctx.shell().print_report(&report, false)?;
                 Ok(())
             }
             Message::EditionAlreadyEnabled { message, edition } => {

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -1436,7 +1436,7 @@ fn fix_to_broken_code() {
            explicit panic
            [NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 [HELP] to report this as a bug, open an issue at https://github.com/rust-lang/rust/issues, quoting the full output of this command
-[HELP] to possibly apply more fixes, pass in the `--broken-code` flag
+[HELP] the broken code has been saved as requested via `--broken-code`
 [NOTE] original diagnostics will follow:
 ...
 
@@ -2381,6 +2381,9 @@ fn fix_in_rust_src() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
+[ERROR] cargo fix could not apply any fixes to crate `foo`
+[HELP] no fixes were applicable; the code already had errors prior to cargo fix
+[NOTE] original diagnostics will follow:
 error[E0308]: mismatched types
  --> lib.rs:5:9
   |

--- a/tests/testsuite/fix_n_times.rs
+++ b/tests/testsuite/fix_n_times.rs
@@ -532,6 +532,10 @@ fn starts_with_error() {
         },
         str![[r#"
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
+[ERROR] cargo fix could not apply any fixes to crate `foo`
+[HELP] cargo fix requires the code to compile before fixes can be applied; the code has errors that must be fixed manually
+[HELP] to possibly apply more fixes, pass in the `--broken-code` flag
+[NOTE] original diagnostics will follow:
 rustc fix shim error count=1
 [ERROR] could not compile `foo` (lib) due to 1 previous error
 
@@ -550,6 +554,9 @@ fn broken_code_no_suggestions() {
         },
         str![[r#"
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
+[ERROR] cargo fix could not apply any fixes to crate `foo`
+[HELP] no fixes were applicable; the code already had errors prior to cargo fix
+[NOTE] original diagnostics will follow:
 rustc fix shim error count=1
 [ERROR] could not compile `foo` (lib) due to 1 previous error
 
@@ -571,8 +578,7 @@ fn broken_code_one_suggestion() {
 [ERROR] errors present after applying fixes to crate `foo`
  --> src/lib.rs
   = cause: rustc fix shim error count=2
-[HELP] to report this as a bug, open an issue at https://github.com/rust-lang/rust/issues, quoting the full output of this command
-[HELP] to possibly apply more fixes, pass in the `--broken-code` flag
+[HELP] the broken code has been saved as requested via `--broken-code`; the code already had errors prior to cargo fix
 [NOTE] original diagnostics will follow:
 rustc fix shim comment 1
 rustc fix shim error count=2


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/cargo/pull/16681)*

Fixes #10955

- Tracks whether code started broken (before any fix attempt) and whether any fixes were actually applied, instead of only checking `--broken-code`.
- Bug-report suggestion now only shows when fixes broke previously working code; suppressed when the code was already broken.
- `--broken-code` suggestion no longer repeated when already passed.