### PR TITLE
feat(config): Stabilize `resolver.lockfile-path` config

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -887,7 +887,6 @@ unstable_cli_options!(
     gitoxide: Option<GitoxideFeatures> = ("Use gitoxide for the given git interactions, or all of them if no argument is given"),
     host_config: bool = ("Enable the `[host]` section in the .cargo/config.toml file"),
     json_target_spec: bool = ("Enable `.json` target spec files"),
-    lockfile_path: bool = ("Enable the `resolver.lockfile-path` config option"),
     minimal_versions: bool = ("Resolve minimal dependency versions instead of maximum"),
     msrv_policy: bool = ("Enable rust-version aware policy within cargo"),
     mtime_on_use: bool = ("Configure Cargo to update the mtime of used files"),
@@ -1000,6 +999,8 @@ const STABILIZED_PACKAGE_WORKSPACE: &str =
 const STABILIZED_BUILD_DIR: &str = "build.build-dir is now always enabled.";
 
 const STABILIZED_CONFIG_INCLUDE: &str = "The `include` config key is now always available";
+
+const STABILIZED_LOCKFILE_PATH: &str = "The `lockfile-path` config key is now always available";
 
 fn deserialize_comma_separated_list<'de, D>(
     deserializer: D,
@@ -1389,6 +1390,7 @@ impl CliUnstable {
             "package-workspace" => stabilized_warn(k, "1.89", STABILIZED_PACKAGE_WORKSPACE),
             "build-dir" => stabilized_warn(k, "1.91", STABILIZED_BUILD_DIR),
             "config-include" => stabilized_warn(k, "1.93", STABILIZED_CONFIG_INCLUDE),
+            "lockfile-path" => stabilized_warn(k, "1.97", STABILIZED_LOCKFILE_PATH),
 
             // Unstable features
             // Sorted alphabetically:
@@ -1427,7 +1429,6 @@ impl CliUnstable {
             }
             "host-config" => self.host_config = parse_empty(k, v)?,
             "json-target-spec" => self.json_target_spec = parse_empty(k, v)?,
-            "lockfile-path" => self.lockfile_path = parse_empty(k, v)?,
             "next-lockfile-bump" => self.next_lockfile_bump = parse_empty(k, v)?,
             "minimal-versions" => self.minimal_versions = parse_empty(k, v)?,
             "msrv-policy" => self.msrv_policy = parse_empty(k, v)?,

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -369,10 +369,9 @@ impl<'gctx> Workspace<'gctx> {
         };
 
         if let Some(lockfile_path) = config.lockfile_path {
-            if self.gctx().cli_unstable().lockfile_path {
-                // Reserve the ability to add templates in the future.
-                let replacements: [(&str, &str); 0] = [];
-                let path = lockfile_path
+            // Reserve the ability to add templates in the future.
+            let replacements: [(&str, &str); 0] = [];
+            let path = lockfile_path
                     .resolve_templated_path(self.gctx(), replacements)
                     .map_err(|e| match e {
                         context::ResolveTemplateError::UnexpectedVariable {
@@ -394,21 +393,16 @@ impl<'gctx> Workspace<'gctx> {
                             )
                         }
                     })?;
-                if !path.ends_with(LOCKFILE_NAME) {
-                    bail!("the `resolver.lockfile-path` must be a path to a {LOCKFILE_NAME} file");
-                }
-                if path.is_dir() {
-                    bail!(
-                        "`resolver.lockfile-path` `{}` is a directory but expected a file",
-                        path.display()
-                    );
-                }
-                self.requested_lockfile_path = Some(path);
-            } else {
-                self.gctx().shell().warn(
-                    "ignoring `resolver.lockfile-path`, pass `-Zlockfile-path` to enable it",
-                )?;
+            if !path.ends_with(LOCKFILE_NAME) {
+                bail!("the `resolver.lockfile-path` must be a path to a {LOCKFILE_NAME} file");
             }
+            if path.is_dir() {
+                bail!(
+                    "`resolver.lockfile-path` `{}` is a directory but expected a file",
+                    path.display()
+                );
+            }
+            self.requested_lockfile_path = Some(path);
         }
 
         Ok(())

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -149,6 +149,7 @@ rpath = false            # Sets the rpath linking option.
 # Same keys for a normal profile (minus `panic`, `lto`, and `rpath`).
 
 [resolver]
+lockfile-path = "…"  # Overrides the path used for
 incompatible-rust-versions = "allow"  # Specifies how resolver reacts to these
 
 [registries.<name>]  # registries other than crates.io
@@ -1100,6 +1101,18 @@ See [strip](profiles.md#strip).
 ### `[resolver]`
 
 The `[resolver]` table overrides [dependency resolution behavior](resolver.md) for local development (e.g. excludes `cargo install`).
+
+#### `resolver.lockfile-path`
+* Type: string (path)
+* Default: `<workspace_root>/Cargo.lock`
+* Environment: `CARGO_RESOLVER_LOCKFILE_PATH`
+
+Specifies the path to the lockfile to use when resolving dependencies.
+This option is useful when working with read-only source directories.
+
+The path must end with `Cargo.lock`.
+
+> **MSRV:** Requires 1.97+
 
 #### `resolver.incompatible-rust-versions`
 * Type: string

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -130,7 +130,6 @@ Each new feature described below should explain how to use it.
 * Other
     * [gitoxide](#gitoxide) --- Use `gitoxide` instead of `git2` for a set of operations.
     * [script](#script) --- Enable support for single-file `.rs` packages.
-    * [lockfile-path](#lockfile-path) --- Allows to specify a path to lockfile other than the default path `<workspace_root>/Cargo.lock`.
     * [native-completions](#native-completions) --- Move cargo shell completions to native completions.
     * [warnings](#warnings) --- controls warning behavior; options for allowing or denying warnings.
     * [Package message format](#package-message-format) --- Message format for `cargo package`.
@@ -1766,43 +1765,6 @@ will prefer the value in the configuration. The allows Cargo to add new built-in
 path bases without compatibility issues (as existing uses will shadow the
 built-in name).
 
-## lockfile-path
-
-* Original Issue: [#5707](https://github.com/rust-lang/cargo/issues/5707)
-* Tracking Issue: [#14421](https://github.com/rust-lang/cargo/issues/14421)
-
-The `-Zlockfile-path` flag enables the `resolver.lockfile-path` configuration option,
-which allows you to specify the path of the lockfile `Cargo.lock`.
-
-By default, lockfile is written into `<workspace_root>/Cargo.lock`. 
-However, when sources are stored in read-only directory,
-most of the cargo commands would fail when trying to write a lockfile.
-This configuration makes it easier to work with readonly sources. 
-
-Note, that currently path must end with `Cargo.lock`.
-If you want to use this feature in multiple projects,
-lockfiles should be stored in different directories.
-
-### Documentation updates
-
-*as a new `resolver.lockfile-path` entry in config.md*
-
-*Keep in mind, the `[resolver]` section has this clarification:*
-
-> *The `[resolver]` table overrides dependency resolution behavior for local development (e.g. excludes `cargo install`).*
-
-#### `resolver.lockfile-path`
-
-* Type: string (path)
-* Default: `<workspace_root>/Cargo.lock`
-* Environment: `CARGO_RESOLVER_LOCKFILE_PATH`
-
-Specifies the path to the lockfile.
-By default, the lockfile is written to `<workspace_root>/Cargo.lock`.
-This option is useful when working with read-only source directories.
-
-The path must end with `Cargo.lock`.
-
 ## native-completions
 * Original Issue: [#6645](https://github.com/rust-lang/cargo/issues/6645)
 * Tracking Issue: [#14520](https://github.com/rust-lang/cargo/issues/14520)
@@ -2353,3 +2315,7 @@ See the [`include` config documentation](config.md#include) for more.
 ## pubtime
 
 The `pubtime` index field  has been stabilized in Rust 1.94.0.
+
+## lockfile-path
+
+Support for `resolver.lockfile-path` config field has been stabilized in Rust 1.97.0.

--- a/tests/testsuite/cargo/z_help/stdout.term.svg
+++ b/tests/testsuite/cargo/z_help/stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="1255px" height="1010px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1255px" height="992px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -66,65 +66,63 @@
 </tspan>
     <tspan x="10px" y="460px"><tspan>    -Z json-target-spec            Enable `.json` target spec files</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>    -Z lockfile-path               Enable the `resolver.lockfile-path` config option</tspan>
+    <tspan x="10px" y="478px"><tspan>    -Z minimal-versions            Resolve minimal dependency versions instead of maximum</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>    -Z minimal-versions            Resolve minimal dependency versions instead of maximum</tspan>
+    <tspan x="10px" y="496px"><tspan>    -Z msrv-policy                 Enable rust-version aware policy within cargo</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>    -Z msrv-policy                 Enable rust-version aware policy within cargo</tspan>
+    <tspan x="10px" y="514px"><tspan>    -Z mtime-on-use                Configure Cargo to update the mtime of used files</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>    -Z mtime-on-use                Configure Cargo to update the mtime of used files</tspan>
+    <tspan x="10px" y="532px"><tspan>    -Z no-embed-metadata           Avoid embedding metadata in library artifacts</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>    -Z no-embed-metadata           Avoid embedding metadata in library artifacts</tspan>
+    <tspan x="10px" y="550px"><tspan>    -Z no-index-update             Do not update the registry index even if the cache is outdated</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>    -Z no-index-update             Do not update the registry index even if the cache is outdated</tspan>
+    <tspan x="10px" y="568px"><tspan>    -Z panic-abort-tests           Enable support to run tests with -Cpanic=abort</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>    -Z panic-abort-tests           Enable support to run tests with -Cpanic=abort</tspan>
+    <tspan x="10px" y="586px"><tspan>    -Z panic-immediate-abort       Enable setting `panic = "immediate-abort"` in profiles</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>    -Z panic-immediate-abort       Enable setting `panic = "immediate-abort"` in profiles</tspan>
+    <tspan x="10px" y="604px"><tspan>    -Z profile-hint-mostly-unused  Enable the `hint-mostly-unused` setting in profiles to mark a crate as mostly unused.</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>    -Z profile-hint-mostly-unused  Enable the `hint-mostly-unused` setting in profiles to mark a crate as mostly unused.</tspan>
+    <tspan x="10px" y="622px"><tspan>    -Z profile-rustflags           Enable the `rustflags` option in profiles in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>    -Z profile-rustflags           Enable the `rustflags` option in profiles in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="640px"><tspan>    -Z public-dependency           Respect a dependency's `public` field in Cargo.toml to control public/private dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>    -Z public-dependency           Respect a dependency's `public` field in Cargo.toml to control public/private dependencies</tspan>
+    <tspan x="10px" y="658px"><tspan>    -Z publish-timeout             Enable the `publish.timeout` key in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan>    -Z publish-timeout             Enable the `publish.timeout` key in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="676px"><tspan>    -Z root-dir                    Set the root directory relative to which paths are printed (defaults to workspace root)</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan>    -Z root-dir                    Set the root directory relative to which paths are printed (defaults to workspace root)</tspan>
+    <tspan x="10px" y="694px"><tspan>    -Z rustc-unicode               Enable `rustc`'s unicode error format in Cargo's error messages</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>    -Z rustc-unicode               Enable `rustc`'s unicode error format in Cargo's error messages</tspan>
+    <tspan x="10px" y="712px"><tspan>    -Z rustdoc-depinfo             Use dep-info files in rustdoc rebuild detection</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>    -Z rustdoc-depinfo             Use dep-info files in rustdoc rebuild detection</tspan>
+    <tspan x="10px" y="730px"><tspan>    -Z rustdoc-map                 Allow passing external documentation mappings to rustdoc</tspan>
 </tspan>
-    <tspan x="10px" y="748px"><tspan>    -Z rustdoc-map                 Allow passing external documentation mappings to rustdoc</tspan>
+    <tspan x="10px" y="748px"><tspan>    -Z rustdoc-mergeable-info      Use rustdoc mergeable cross-crate-info files</tspan>
 </tspan>
-    <tspan x="10px" y="766px"><tspan>    -Z rustdoc-mergeable-info      Use rustdoc mergeable cross-crate-info files</tspan>
+    <tspan x="10px" y="766px"><tspan>    -Z rustdoc-scrape-examples     Allows Rustdoc to scrape code examples from reverse-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan>    -Z rustdoc-scrape-examples     Allows Rustdoc to scrape code examples from reverse-dependencies</tspan>
+    <tspan x="10px" y="784px"><tspan>    -Z sbom                        Enable the `sbom` option in build config in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan>    -Z sbom                        Enable the `sbom` option in build config in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="802px"><tspan>    -Z script                      Enable support for single-file, `.rs` packages</tspan>
 </tspan>
-    <tspan x="10px" y="820px"><tspan>    -Z script                      Enable support for single-file, `.rs` packages</tspan>
+    <tspan x="10px" y="820px"><tspan>    -Z section-timings             Enable support for extended compilation sections in --timings output</tspan>
 </tspan>
-    <tspan x="10px" y="838px"><tspan>    -Z section-timings             Enable support for extended compilation sections in --timings output</tspan>
+    <tspan x="10px" y="838px"><tspan>    -Z target-applies-to-host      Enable the `target-applies-to-host` key in the .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="856px"><tspan>    -Z target-applies-to-host      Enable the `target-applies-to-host` key in the .cargo/config.toml file</tspan>
+    <tspan x="10px" y="856px"><tspan>    -Z trim-paths                  Enable the `trim-paths` option in profiles</tspan>
 </tspan>
-    <tspan x="10px" y="874px"><tspan>    -Z trim-paths                  Enable the `trim-paths` option in profiles</tspan>
+    <tspan x="10px" y="874px"><tspan>    -Z unstable-options            Allow the usage of unstable options</tspan>
 </tspan>
-    <tspan x="10px" y="892px"><tspan>    -Z unstable-options            Allow the usage of unstable options</tspan>
+    <tspan x="10px" y="892px"><tspan>    -Z warnings                    Allow use of the build.warnings config key</tspan>
 </tspan>
-    <tspan x="10px" y="910px"><tspan>    -Z warnings                    Allow use of the build.warnings config key</tspan>
+    <tspan x="10px" y="910px">
 </tspan>
-    <tspan x="10px" y="928px">
+    <tspan x="10px" y="928px"><tspan>Run with `cargo -Z [FLAG] [COMMAND]`</tspan>
 </tspan>
-    <tspan x="10px" y="946px"><tspan>Run with `cargo -Z [FLAG] [COMMAND]`</tspan>
+    <tspan x="10px" y="946px">
 </tspan>
-    <tspan x="10px" y="964px">
+    <tspan x="10px" y="964px"><tspan>See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html for more information about these flags.</tspan>
 </tspan>
-    <tspan x="10px" y="982px"><tspan>See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html for more information about these flags.</tspan>
-</tspan>
-    <tspan x="10px" y="1000px">
+    <tspan x="10px" y="982px">
 </tspan>
   </text>
 

--- a/tests/testsuite/lockfile_path.rs
+++ b/tests/testsuite/lockfile_path.rs
@@ -12,29 +12,11 @@ use cargo_test_support::{
 };
 
 #[cargo_test]
-fn config_lockfile_path_without_z_flag() {
-    let p = make_project().build();
-
-    p.cargo("generate-lockfile")
-        .arg("--config")
-        .arg("resolver.lockfile-path='my/Cargo.lock'")
-        .with_stderr_data(str![[r#"
-[WARNING] ignoring `resolver.lockfile-path`, pass `-Zlockfile-path` to enable it
-
-"#]])
-        .run();
-
-    assert!(p.root().join("Cargo.lock").exists());
-    assert!(!p.root().join("my/Cargo.lock").exists());
-}
-
-#[cargo_test]
 fn config_lockfile_created() {
     let lockfile_path = "mylockfile/Cargo.lock";
     let p = make_project().build();
 
-    p.cargo("generate-lockfile -Zlockfile-path")
-        .masquerade_as_nightly_cargo(&["lockfile-path"])
+    p.cargo("generate-lockfile")
         .arg("--config")
         .arg(&format!("resolver.lockfile-path='{lockfile_path}'"))
         .with_stderr_data(str![""])
@@ -49,8 +31,7 @@ fn config_basic_lockfile_read() {
     let lockfile_path = "mylockfile/Cargo.lock";
     let p = make_project().file(lockfile_path, VALID_LOCKFILE).build();
 
-    p.cargo("generate-lockfile -Zlockfile-path")
-        .masquerade_as_nightly_cargo(&["lockfile-path"])
+    p.cargo("generate-lockfile")
         .arg("--config")
         .arg(&format!("resolver.lockfile-path='{lockfile_path}'"))
         .run();
@@ -66,8 +47,7 @@ fn config_basic_lockfile_override() {
         .file("Cargo.lock", "This is an invalid lock file!")
         .build();
 
-    p.cargo("generate-lockfile -Zlockfile-path")
-        .masquerade_as_nightly_cargo(&["lockfile-path"])
+    p.cargo("generate-lockfile")
         .arg("--config")
         .arg(&format!("resolver.lockfile-path='{lockfile_path}'"))
         .run();
@@ -90,8 +70,7 @@ fn config_symlink_in_path() {
     fs::create_dir(p.root().join("dst")).unwrap();
     assert!(p.root().join(src).is_dir());
 
-    p.cargo("generate-lockfile -Zlockfile-path")
-        .masquerade_as_nightly_cargo(&["lockfile-path"])
+    p.cargo("generate-lockfile")
         .arg("--config")
         .arg(&format!("resolver.lockfile-path='{lockfile_path}'"))
         .run();
@@ -117,8 +96,7 @@ fn config_symlink_lockfile() {
 
     assert!(p.root().join(src).is_file());
 
-    p.cargo("generate-lockfile -Zlockfile-path")
-        .masquerade_as_nightly_cargo(&["lockfile-path"])
+    p.cargo("generate-lockfile")
         .arg("--config")
         .arg(&format!("resolver.lockfile-path='{lockfile_path}'"))
         .run();
@@ -139,8 +117,7 @@ fn config_broken_symlink() {
     let p = make_project().symlink_dir(invalid_dst, src).build();
     assert!(!p.root().join(src).is_dir());
 
-    p.cargo("generate-lockfile -Zlockfile-path")
-        .masquerade_as_nightly_cargo(&["lockfile-path"])
+    p.cargo("generate-lockfile")
         .arg("--config")
         .arg(&format!("resolver.lockfile-path='{lockfile_path}'"))
         .with_status(101)
@@ -168,8 +145,7 @@ fn config_loop_symlink() {
         .build();
     assert!(!p.root().join(src).is_dir());
 
-    p.cargo("generate-lockfile -Zlockfile-path")
-        .masquerade_as_nightly_cargo(&["lockfile-path"])
+    p.cargo("generate-lockfile")
         .arg("--config")
         .arg(&format!("resolver.lockfile-path='{lockfile_path}'"))
         .with_status(101)
@@ -192,8 +168,7 @@ fn config_add_lockfile_override() {
     let p = make_project()
         .file("Cargo.lock", "This is an invalid lock file!")
         .build();
-    p.cargo("add -Zlockfile-path")
-        .masquerade_as_nightly_cargo(&["lockfile-path"])
+    p.cargo("add")
         .arg("--config")
         .arg(&format!("resolver.lockfile-path='{lockfile_path}'"))
         .arg("--path")
@@ -209,8 +184,7 @@ fn config_clean_lockfile_override() {
     let p = make_project()
         .file("Cargo.lock", "This is an invalid lock file!")
         .build();
-    p.cargo("clean -Zlockfile-path")
-        .masquerade_as_nightly_cargo(&["lockfile-path"])
+    p.cargo("clean")
         .arg("--config")
         .arg(&format!("resolver.lockfile-path='{lockfile_path}'"))
         .arg("--package")
@@ -226,8 +200,7 @@ fn config_fix_lockfile_override() {
     let p = make_project()
         .file("Cargo.lock", "This is an invalid lock file!")
         .build();
-    p.cargo("fix -Zlockfile-path")
-        .masquerade_as_nightly_cargo(&["lockfile-path"])
+    p.cargo("fix")
         .arg("--config")
         .arg(&format!("resolver.lockfile-path='{lockfile_path}'"))
         .arg("--package")
@@ -244,8 +217,7 @@ fn config_publish_lockfile_read() {
     let p = make_project().file(lockfile_path, VALID_LOCKFILE).build();
     let registry = RegistryBuilder::new().http_api().http_index().build();
 
-    p.cargo("publish -Zlockfile-path")
-        .masquerade_as_nightly_cargo(&["lockfile-path"])
+    p.cargo("publish")
         .arg("--config")
         .arg(&format!("resolver.lockfile-path='{lockfile_path}'"))
         .replace_crates_io(registry.index_url())
@@ -285,8 +257,7 @@ fn config_remove_lockfile_override() {
         .file("src/main.rs", "fn main() {}")
         .file("Cargo.lock", "This is an invalid lock file!")
         .build();
-    p.cargo("remove -Zlockfile-path")
-        .masquerade_as_nightly_cargo(&["lockfile-path"])
+    p.cargo("remove")
         .arg("--config")
         .arg(&format!("resolver.lockfile-path='{lockfile_path}'"))
         .arg("test_bar")
@@ -321,8 +292,7 @@ bar = "0.1.0"
         .build();
 
     Package::new("bar", "0.1.0").publish();
-    p.cargo("generate-lockfile -Zlockfile-path")
-        .masquerade_as_nightly_cargo(&["lockfile-path"])
+    p.cargo("generate-lockfile")
         .arg("--config")
         .arg(&format!("resolver.lockfile-path='{lockfile_path}'"))
         .run();
@@ -333,8 +303,7 @@ bar = "0.1.0"
     let lockfile_original = fs::read_to_string(p.root().join(lockfile_path)).unwrap();
 
     Package::new("bar", "0.1.1").publish();
-    p.cargo("package -Zlockfile-path")
-        .masquerade_as_nightly_cargo(&["lockfile-path"])
+    p.cargo("package")
         .arg("--config")
         .arg(&format!("resolver.lockfile-path='{lockfile_path}'"))
         .run();
@@ -406,8 +375,7 @@ dependencies = [
 "#,
         )
         .build();
-    p.cargo("install foo --locked -Zlockfile-path")
-        .masquerade_as_nightly_cargo(&["lockfile-path"])
+    p.cargo("install foo --locked")
         .arg("--config")
         .arg("resolver.lockfile-path='../foo/Cargo.lock'")
         .run();
@@ -425,8 +393,8 @@ fn config_run_embed() {
         .file("Cargo.lock", "This is an invalid lock file!")
         .build();
 
-    p.cargo("run -Zlockfile-path")
-        .masquerade_as_nightly_cargo(&["lockfile-path"])
+    p.cargo("run")
+        .masquerade_as_nightly_cargo(&["script"])
         .arg("-Zscript")
         .arg("--config")
         .arg(&format!("resolver.lockfile-path='{lockfile_path}'"))
@@ -436,8 +404,8 @@ fn config_run_embed() {
 
     assert!(p.root().join(lockfile_path).is_file());
 
-    p.cargo("run -Zlockfile-path")
-        .masquerade_as_nightly_cargo(&["lockfile-path"])
+    p.cargo("run")
+        .masquerade_as_nightly_cargo(&["script"])
         .arg("-Zunstable-options")
         .arg("-Zscript")
         .arg("--config")
@@ -458,8 +426,7 @@ fn config_run_embed() {
 fn config_lockfile_path_rejects_templates() {
     let p = make_project().build();
 
-    p.cargo("generate-lockfile -Zlockfile-path")
-        .masquerade_as_nightly_cargo(&["lockfile-path"])
+    p.cargo("generate-lockfile")
         .arg("--config")
         .arg("resolver.lockfile-path='{var}/Cargo.lock'")
         .with_status(101)


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/cargo/pull/16694)*

### What does this PR try to resolve?

Closes #14421

Overall, this seems like a low policy knob for users to tweak in config (ie out of the way) so this seems relatively safe to stabilize.

`resolver.lockfile-path` is a mechanism to override the default location for lockfiles for local development
- The filename must be specified and must be `Cargo.lock`
- Making a decision about template support generally, and which variables more specifically, was deferred out
  - `{` and `}` are reserved to keep this a two-way door
- Besides changing the location, all other lockfile behavior remains the same, e.g. automatic creation of the lockfile, automatic parent directory creation, how `--locked` works'
- this remains consistent with config behavior
  - like `resolver.incompatible-rust-version`, `resolver.lockfile-path` does not apply to `cargo install`
  - like other paths in config, paths are relative to `.cargo`s parent directory if `.cargo/config.toml` is used and the current working directory for env variables and CLI.

This started out as a principled workaround to no or outdated lockfiles on read-only filesystems. This could also help with users who juggle multiple lockfiles (e.g. "latest" vs "msrv") particularly when they can have dedicated config files for the different lockfiles and override other relevant resolver settings in the same config file.

Alternatives
- `--lockfile-path`: which this feature started its life as, see #5707
  - #15510 has a use case for this also to be done via an env variable (pain on user to always specify the flag)
  - A dedicated CLI flag doesn't feel like it carries its own weight (see also #6100)
  - A config field more obvious semantics ("change the default") vs a flag which questions like "should `cargo install --lockfile-path foo` imply `--locked`?"

See also
- Summary of the original cargo team discussion: https://github.com/rust-lang/cargo/issues/5707#issuecomment-2231276362
- Discussion for changing to env variable https://github.com/rust-lang/cargo/issues/15510#issuecomment-2866887888

**Unresolved questions from the tracking issue:**

> Inconsistency in `resolver` table being applied to `cargo install`
>
>  `cargo install --lockfile-path=<path>` implies `--locked`, and requires the alternative lockfile to exist. 

`cargo install` no longer respects `resolver.lockfile-path` so we remain consistent on `[resolver]` never applying to `cargo install`.

> How this should work if the lockfile or a parent directory is not present 

This was from when the we had `--lockfile-path` instead which added its own set of policy questions.
By having this be a config that just overrides the default, all other policies should remain the same.

### How to test and review this PR?

