### PR TITLE
fix(tests): allow for 'could not' as well as couldn't in test output

### DIFF
--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -1805,7 +1805,7 @@ fn proc_macro_in_artifact_dep() {
 [ERROR] failed to download from `[ROOTURL]/dl/pm/1.0.0/download`
 
 Caused by:
-  [37] Could[..]t read a file:// file (Couldn't open file [ROOT]/dl/pm/1.0.0/download)
+  [37] Could[..]t read a file:// file (Could[..]t open file [ROOT]/dl/pm/1.0.0/download)
 "#,
         )
         .with_status(101)

--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -2082,7 +2082,7 @@ Caused by:
   failed to download from `[ROOTURL]/dl/bar/1.0.0/download`
 
 Caused by:
-  [37] Could[..]t read a file:// file (Couldn't open file [ROOT]/dl/bar/1.0.0/download)
+  [37] Could[..]t read a file:// file (Could[..]t open file [ROOT]/dl/bar/1.0.0/download)
 
 "#]])
         .run();


### PR DESCRIPTION
The error message on my system is `Could not`, rather than `Couldn't` which causes these tests to fail. The first occurrence is handled with `[..]`, but the 2nd is not.