### PR TITLE
test(replace): Mark a test as non-deterministic

### DIFF
--- a/tests/testsuite/replace.rs
+++ b/tests/testsuite/replace.rs
@@ -469,7 +469,8 @@ fn use_a_spec_to_select() {
         .build();
 
     p.cargo("check")
-        .with_stderr_data(str![[r#"
+        .with_stderr_data(
+            str![[r#"
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[ROOTURL]/override`
 [LOCKING] 4 packages to latest compatible versions
@@ -483,7 +484,9 @@ fn use_a_spec_to_select() {
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
-"#]])
+"#]]
+            .unordered(),
+        )
         .run();
 }
 


### PR DESCRIPTION
### What does this PR try to resolve?

Blocks a compiler change, see [#t-cargo > &#96;replace::use_a_spec_to_select&#96; test failure @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/.60replace.3A.3Ause_a_spec_to_select.60.20test.20failure/near/577341461)

### How to test and review this PR?
