### PR TITLE
refactor(fix): Prep for annotate-snippets

### DIFF
--- a/src/cargo/util/diagnostic_server.rs
+++ b/src/cargo/util/diagnostic_server.rs
@@ -128,14 +128,14 @@ impl<'a> DiagnosticPrinter<'a> {
             Message::ReplaceFailed { file, message } => {
                 let issue_link = get_bug_report_url(self.workspace_wrapper);
 
-                let mut msg = format!("error applying suggestions to `{file}`\n\n");
-                write!(&mut msg, "The full error message was:\n\n> {message}\n\n",)?;
-                write!(
-                    &mut msg,
-                    "{}\n",
-                    gen_please_report_this_bug_text(issue_link)
-                )?;
-                write!(&mut msg, "{}\n", gen_suggest_broken_code())?;
+                let mut msg = format!("error applying suggestions to `{file}`\n");
+                writeln!(&mut msg)?;
+                writeln!(&mut msg, "The full error message was:")?;
+                writeln!(&mut msg)?;
+                writeln!(&mut msg, "> {message}")?;
+                writeln!(&mut msg)?;
+                writeln!(&mut msg, "{}", gen_please_report_this_bug_text(issue_link))?;
+                writeln!(&mut msg, "{}", gen_suggest_broken_code())?;
                 self.gctx.shell().warn(&msg)?;
                 Ok(())
             }
@@ -155,11 +155,13 @@ impl<'a> DiagnosticPrinter<'a> {
                 let mut msg =
                     format!("failed to automatically apply fixes suggested by rustc{to_crate}\n");
                 if !files.is_empty() {
+                    writeln!(&mut msg)?;
                     writeln!(
                         &mut msg,
-                        "\nafter fixes were automatically applied the compiler \
-                         reported errors within these files:\n"
+                        "after fixes were automatically applied the compiler \
+                         reported errors within these files:"
                     )?;
+                    writeln!(&mut msg)?;
                     for file in files {
                         writeln!(&mut msg, "  * {file}")?;
                     }


### PR DESCRIPTION
### What does this PR try to resolve?

Instead of printing a warning as a
- a warning
- many individual blocks of text

this switches us to print it all as a single warning.  This will make it easier to adapt to annotate-snippets in the future (work is in progress).

This was noticed while reviewing #16681 which led us down the wrong path there.

### How to test and review this PR?
