### PR TITLE
Docs: Clarify build script current directory

### DIFF
--- a/src/doc/src/reference/build-scripts.md
+++ b/src/doc/src/reference/build-scripts.md
@@ -63,7 +63,7 @@ When the build script is run, there are a number of inputs to the build script,
 all passed in the form of [environment variables][build-env].
 
 In addition to environment variables, the build script’s current directory is
-the source directory of the build script’s package.
+the root directory of the build script’s package.
 
 [build-env]: environment-variables.md#environment-variables-cargo-sets-for-build-scripts
 


### PR DESCRIPTION
The current language on the build script reference page talks about “source directory”. However, the [layout page](https://doc.rust-lang.org/cargo/guide/project-layout.html) calls this the *package root*. “Source directory” could be confused with `src`.