### PR TITLE
cargo clean: Add target directory validation

### DIFF
--- a/src/bin/cargo/commands/clean.rs
+++ b/src/bin/cargo/commands/clean.rs
@@ -163,6 +163,7 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
         profile_specified: args.contains_id("profile") || args.flag("release"),
         doc: args.flag("doc"),
         dry_run: args.dry_run(),
+        explicit_target_dir_arg: args.contains_id("target-dir"),
     };
     ops::clean(&ws, &opts)?;
     Ok(())

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -13,9 +13,10 @@ use cargo_util::paths;
 use indexmap::{IndexMap, IndexSet};
 
 use std::ffi::OsString;
-use std::fs;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
+use std::{fs, io};
 
 pub struct CleanOptions<'gctx> {
     pub gctx: &'gctx GlobalContext,
@@ -31,6 +32,8 @@ pub struct CleanOptions<'gctx> {
     pub doc: bool,
     /// If set, doesn't delete anything.
     pub dry_run: bool,
+    /// true if target-dir was was explicitly specified via --target-dir
+    pub explicit_target_dir_arg: bool,
 }
 
 pub struct CleanContext<'gctx> {
@@ -58,6 +61,22 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
         // do not error if target_dir is symlink; let cargo delete it
         if !meta.is_symlink() && !meta.is_dir() {
             let title = format!("cannot clean `{}`: not a directory", target_dir.display());
+            let report = [Level::ERROR
+                .primary_title(title)
+                .element(Level::NOTE.message(CLEAN_ABORT_NOTE))];
+            gctx.shell().print_report(&report, false)?;
+            return Err(crate::AlreadyPrintedError::new(anyhow::anyhow!("")).into());
+        }
+    }
+
+    // do some validation on target_dir if it was specified via --target-dir
+    if opts.explicit_target_dir_arg {
+        let target_dir_path = target_dir.as_path_unlocked();
+
+        // check if the target directory has a valid CACHEDIR.TAG
+        if let Err(err) = validate_target_dir_tag(target_dir_path) {
+            // if target_dir was passed explicitly via --target-dir, then hard error if validation fails
+            let title = format!("cannot clean `{}`: {err}", target_dir_path.display());
             let report = [Level::ERROR
                 .primary_title(title)
                 .element(Level::NOTE.message(CLEAN_ABORT_NOTE))];
@@ -119,6 +138,37 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
     }
 
     clean_ctx.display_summary()?;
+    Ok(())
+}
+
+fn validate_target_dir_tag(target_dir_path: &Path) -> CargoResult<()> {
+    const TAG_SIGNATURE: &[u8] = b"Signature: 8a477f597d28d172789f06886806bc55";
+
+    let tag_path = target_dir_path.join("CACHEDIR.TAG");
+
+    // per https://bford.info/cachedir the tag file must not be a symlink
+    if tag_path.is_symlink() {
+        bail!("expect `CACHEDIR.TAG` to be a regular file, got a symlink");
+    }
+
+    if !tag_path.is_file() {
+        bail!("missing or invalid `CACHEDIR.TAG` file");
+    }
+
+    let mut file = fs::File::open(&tag_path)
+        .map_err(|err| anyhow::anyhow!("failed to open `{}`: {}", tag_path.display(), err))?;
+
+    let mut buf = [0u8; TAG_SIGNATURE.len()];
+    match file.read_exact(&mut buf) {
+        Ok(()) if &buf[..] == TAG_SIGNATURE => {}
+        Err(e) if e.kind() != io::ErrorKind::UnexpectedEof => {
+            bail!("failed to read `{}`: {e}", tag_path.display());
+        }
+        _ => {
+            bail!("invalid signature in `CACHEDIR.TAG` file");
+        }
+    }
+
     Ok(())
 }
 

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -1222,10 +1222,12 @@ fn explicit_target_dir_tag_not_present() {
     p.cargo("clean --target-dir bar")
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
-[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
+[ERROR] cannot clean `[ROOT]/foo/bar`: missing or invalid `CACHEDIR.TAG` file
+  |
+  = [NOTE] cleaning has been aborted to prevent accidental deletion of unrelated files
 
 "#]])
-        .with_status(0)
+        .with_status(101)
         .run();
 }
 
@@ -1240,10 +1242,12 @@ fn explicit_target_dir_tag_invalid_signature() {
     p.cargo("clean --target-dir bar")
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
-[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
+[ERROR] cannot clean `[ROOT]/foo/bar`: invalid signature in `CACHEDIR.TAG` file
+  |
+  = [NOTE] cleaning has been aborted to prevent accidental deletion of unrelated files
 
 "#]])
-        .with_status(0)
+        .with_status(101)
         .run();
 }
 
@@ -1262,10 +1266,12 @@ fn explicit_target_dir_tag_symlink() {
     p.cargo("clean --target-dir bar")
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
-[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
+[ERROR] cannot clean `[ROOT]/foo/bar`: expect `CACHEDIR.TAG` to be a regular file, got a symlink
+  |
+  = [NOTE] cleaning has been aborted to prevent accidental deletion of unrelated files
 
 "#]])
-        .with_status(0)
+        .with_status(101)
         .run();
 }
 

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -1208,3 +1208,236 @@ fn target_dir_is_symlink_file() {
     // make sure cargo has not deleted the file of the symlinked target dir
     assert!(p.root().join("bar-dest").exists());
 }
+
+#[cargo_test]
+fn explicit_target_dir_tag_not_present() {
+    // invalid target dir explicitly specified via --target-dir cli arg
+
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .file("bar/.keep", "")
+        .build();
+
+    p.cargo("clean --target-dir bar")
+        .with_stdout_data("")
+        .with_stderr_data(str![[r#"
+[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
+
+"#]])
+        .with_status(0)
+        .run();
+}
+
+#[cargo_test]
+fn explicit_target_dir_tag_invalid_signature() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .file("bar/CACHEDIR.TAG", "Signature: 1234")
+        .build();
+
+    p.cargo("clean --target-dir bar")
+        .with_stdout_data("")
+        .with_stderr_data(str![[r#"
+[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
+
+"#]])
+        .with_status(0)
+        .run();
+}
+
+#[cargo_test]
+fn explicit_target_dir_tag_symlink() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .file(
+            "src/CACHEDIR.TAG",
+            "Signature: 8a477f597d28d172789f06886806bc55",
+        )
+        .symlink("src/CACHEDIR.TAG", "bar/CACHEDIR.TAG")
+        .build();
+
+    p.cargo("clean --target-dir bar")
+        .with_stdout_data("")
+        .with_stderr_data(str![[r#"
+[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
+
+"#]])
+        .with_status(0)
+        .run();
+}
+
+#[cargo_test]
+fn explicit_target_dir_tag_valid() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .file(
+            "bar/CACHEDIR.TAG",
+            "Signature: 8a477f597d28d172789f06886806bc55",
+        )
+        .build();
+
+    p.cargo("clean --target-dir bar").run();
+}
+
+#[cargo_test]
+fn env_target_dir_tag_not_present() {
+    // invalid target dir specified via env var
+
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("bar/.keep", "")
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
+
+    p.cargo("clean")
+        .env("CARGO_TARGET_DIR", "bar")
+        .with_stderr_data(str![[r#"
+[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn env_target_dir_tag_invalid_signature() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .file("bar/CACHEDIR.TAG", "Signature: 1234")
+        .build();
+
+    p.cargo("clean")
+        .env("CARGO_TARGET_DIR", "bar")
+        .with_stderr_data(str![[r#"
+[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn env_target_dir_tag_symlink() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .file(
+            "src/CACHEDIR.TAG",
+            "Signature: 8a477f597d28d172789f06886806bc55",
+        )
+        .symlink("src/CACHEDIR.TAG", "bar/CACHEDIR.TAG")
+        .build();
+
+    p.cargo("clean")
+        .env("CARGO_TARGET_DIR", "bar")
+        .with_stderr_data(str![[r#"
+[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn env_target_dir_tag_valid() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .file(
+            "bar/CACHEDIR.TAG",
+            "Signature: 8a477f597d28d172789f06886806bc55",
+        )
+        .build();
+
+    p.cargo("clean").env("CARGO_TARGET_DIR", "bar").run();
+}
+
+#[cargo_test]
+fn config_target_dir_tag_not_present() {
+    // invalid target dir specified via build config
+
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("bar/.keep", "")
+        .file("src/foo.rs", "")
+        .file(
+            ".cargo/config.toml",
+            "[build]
+        target-dir = 'bar'",
+        )
+        .build();
+
+    p.cargo("clean")
+        .with_stderr_data(str![[r#"
+[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn config_target_dir_tag_invalid_signature() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .file("bar/CACHEDIR.TAG", "Signature: 1234")
+        .file(
+            ".cargo/config.toml",
+            "[build]
+        target-dir = 'bar'",
+        )
+        .build();
+
+    p.cargo("clean")
+        .with_stderr_data(str![[r#"
+[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn config_target_dir_tag_symlink() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .file(
+            "src/CACHEDIR.TAG",
+            "Signature: 8a477f597d28d172789f06886806bc55",
+        )
+        .symlink("src/CACHEDIR.TAG", "bar/CACHEDIR.TAG")
+        .file(
+            ".cargo/config.toml",
+            "[build]
+        target-dir = 'bar'",
+        )
+        .build();
+
+    p.cargo("clean")
+        .with_stderr_data(str![[r#"
+[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn config_target_dir_tag_valid() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .file(
+            "bar/CACHEDIR.TAG",
+            "Signature: 8a477f597d28d172789f06886806bc55",
+        )
+        .file(
+            ".cargo/config.toml",
+            "[build]
+        target-dir = 'bar'",
+        )
+        .build();
+
+    p.cargo("clean").run();
+}


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/cargo/pull/16712)*

### What does this PR try to resolve?

Fixes #9192 

Implements the checks mentioned in [this comment](https://github.com/rust-lang/cargo/issues/9192#issuecomment-3517689516)

To summarise, when `cargo clean` is run with a specified target directory:
- If a target directory is explicitly passed via `--target-dir`: check if a valid `CACHEDIR.TAG` exists in the target directory and hard error otherwise.
- In other cases where target directory is specified(via env vars or build config): ~~emit a future incompat warning if the target directory does not contain a valid `CACHEDIR.TAG`~~ No longer this case. See <https://github.com/rust-lang/cargo/pull/16712#issuecomment-4035491505>

### Tests

I've added 3 sets of unit tests for:
- When `--target-dir` is used explicitly
- When target directory is specified via the build config
- When target directory is specified via the `CARGO_TARGET_DIR` env variable 

Let me know if there is a case I've missed or if i need to merge multiple tests into a single one.