### PR TITLE
fix(script): surpress `unused_features` lint for embedded

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -802,6 +802,7 @@ fn prepare_rustc(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> CargoResult
             );
         }
         base.arg("-Z").arg("crate-attr=feature(frontmatter)");
+        base.arg("-Z").arg("crate-attr=allow(unused_features)");
     }
 
     base.inherit_jobserver(&build_runner.jobserver);
@@ -857,6 +858,7 @@ fn prepare_rustdoc(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> CargoResu
             );
         }
         rustdoc.arg("-Z").arg("crate-attr=feature(frontmatter)");
+        rustdoc.arg("-Z").arg("crate-attr=allow(unused_features)");
     }
     rustdoc.inherit_jobserver(&build_runner.jobserver);
     let crate_name = unit.target.crate_name();


### PR DESCRIPTION
### What does this PR try to resolve?

https://github.com/rust-lang/rust/pull/152164 added a warn-by-default `unused_features` lint.
Cargo injects  `#![feature(frontmatter)]` for all embedded scripts,
but scripts without frontmatter syntax never trigger feature gate check,
and causes causing the lint warning.

Given the stabilization FCP of frontmatter [is complete](https://github.com/rust-lang/rust/pull/148051#issuecomment-3868109254) already,
we could expect it will soon be stabilized (?).

It should be fine we suppress this new unstable lint.

### How to test and review this PR?

Test suite passes.
See <https://github.com/rust-lang/cargo/pull/16713#issuecomment-4009762370> for more.