### PR TITLE
fix(compile): Turn warning summaries into errors also

### DIFF
--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -679,6 +679,7 @@ impl<'gctx> DrainState<'gctx> {
                             build_runner,
                             id,
                             &build_runner.bcx.rustc().workspace_wrapper,
+                            warning_handling,
                         );
                         self.active.remove(&id).unwrap()
                     }
@@ -1053,6 +1054,7 @@ impl<'gctx> DrainState<'gctx> {
         runner: &mut BuildRunner<'_, '_>,
         id: JobId,
         rustc_workspace_wrapper: &Option<PathBuf>,
+        warning_handling: WarningHandling,
     ) {
         let gctx = runner.bcx.gctx;
         let count = match self.warning_count.get(&id) {
@@ -1131,7 +1133,11 @@ impl<'gctx> DrainState<'gctx> {
         }
         // Errors are ignored here because it is tricky to handle them
         // correctly, and they aren't important.
-        let _ = gctx.shell().warn(message);
+        let _ = if warning_handling == WarningHandling::Deny && 0 < count.lints {
+            gctx.shell().error(message)
+        } else {
+            gctx.shell().warn(message)
+        };
     }
 
     fn finish(

--- a/tests/testsuite/warning_override.rs
+++ b/tests/testsuite/warning_override.rs
@@ -50,7 +50,7 @@ fn rustc_caching_allow_first() {
   |
   = [NOTE] `#[warn(unused_variables)]` [..]on by default
 
-[WARNING] `foo` (bin "foo") generated 1 warning[..]
+[ERROR] `foo` (bin "foo") generated 1 warning[..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [ERROR] warnings are denied by `build.warnings` configuration
 
@@ -77,7 +77,7 @@ fn rustc_caching_deny_first() {
   |
   = [NOTE] `#[warn(unused_variables)]` [..]on by default
 
-[WARNING] `foo` (bin "foo") generated 1 warning[..]
+[ERROR] `foo` (bin "foo") generated 1 warning[..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [ERROR] warnings are denied by `build.warnings` configuration
 
@@ -114,7 +114,7 @@ fn config() {
   |
   = [NOTE] `#[warn(unused_variables)]` [..]on by default
 
-[WARNING] `foo` (bin "foo") generated 1 warning[..]
+[ERROR] `foo` (bin "foo") generated 1 warning[..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [ERROR] warnings are denied by `build.warnings` configuration
 
@@ -194,7 +194,7 @@ fn clippy() {
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [WARNING] unused import: `std::io`
 ...
-[WARNING] `foo` (lib) generated 1 warning (run `cargo clippy --fix --lib -p foo` to apply 1 suggestion)
+[ERROR] `foo` (lib) generated 1 warning (run `cargo clippy --fix --lib -p foo` to apply 1 suggestion)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [ERROR] warnings are denied by `build.warnings` configuration
 


### PR DESCRIPTION
### What does this PR try to resolve?

rust-lang/rust is dogfooding `build.warnings` and I got usability feedback that they assume they can ignore warnings and then miss the lone error message at the end.

While I think it is appropriate to report each warnings as a warning (to preserve the original level of importance and improve caching), turning the summaries into errors I think can help draw attention to this.

### How to test and review this PR?

The warning summary line is already quiet large, so I left the talk of `build.warnings` to the last message still.
