### PR TITLE
fix(compile): Stop on denying warnings without --keep-going 

### DIFF
--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -668,7 +668,7 @@ impl<'gctx> DrainState<'gctx> {
             Message::FixDiagnostic(msg) => {
                 self.print.print(&msg)?;
             }
-            Message::Finish(id, artifact, result) => {
+            Message::Finish(id, artifact, mut result) => {
                 let unit = match artifact {
                     // If `id` has completely finished we remove it
                     // from the `active` map ...
@@ -692,6 +692,14 @@ impl<'gctx> DrainState<'gctx> {
                                 &build_runner.bcx.rustc().workspace_wrapper,
                                 warning_handling,
                             );
+                            let stop_on_warnings = warning_handling == WarningHandling::Deny
+                                && 0 < count.lints
+                                && !build_runner.bcx.build_config.keep_going;
+                            if stop_on_warnings {
+                                result = Err(anyhow::format_err!(
+                                    "warnings are denied by `build.warnings` configuration"
+                                ))
+                            }
                         }
                         unit
                     }

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1859,7 +1859,7 @@ in the future.
 Controls how Cargo handles warnings. Allowed values are:
 * `warn`: warnings are emitted as warnings (default).
 * `allow`: warnings are hidden.
-* `deny`: if warnings are emitted, an error will be raised at the end of the operation and the process will exit with a failure exit code. 
+* `deny`: if warnings are emitted, an error will be raised at the end of the current crate and the process. Use `--keep-going` to see all warnings.
 
 ## feature unification
 

--- a/tests/testsuite/warning_override.rs
+++ b/tests/testsuite/warning_override.rs
@@ -51,7 +51,6 @@ fn rustc_caching_allow_first() {
   = [NOTE] `#[warn(unused_variables)]` [..]on by default
 
 [ERROR] `foo` (bin "foo") generated 1 warning[..]
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [ERROR] warnings are denied by `build.warnings` configuration
 
 "#]])
@@ -78,7 +77,6 @@ fn rustc_caching_deny_first() {
   = [NOTE] `#[warn(unused_variables)]` [..]on by default
 
 [ERROR] `foo` (bin "foo") generated 1 warning[..]
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [ERROR] warnings are denied by `build.warnings` configuration
 
 "#]])
@@ -115,7 +113,6 @@ fn config() {
   = [NOTE] `#[warn(unused_variables)]` [..]on by default
 
 [ERROR] `foo` (bin "foo") generated 1 warning[..]
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [ERROR] warnings are denied by `build.warnings` configuration
 
 "#]])
@@ -195,7 +192,6 @@ fn clippy() {
 [WARNING] unused import: `std::io`
 ...
 [ERROR] `foo` (lib) generated 1 warning (run `cargo clippy --fix --lib -p foo` to apply 1 suggestion)
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [ERROR] warnings are denied by `build.warnings` configuration
 
 "#]])
@@ -318,10 +314,6 @@ fn keep_going() {
 [WARNING] unused variable: `x`
 ...
 [ERROR] `foo` (build script) generated 1 warning
-[WARNING] unused variable: `y`
-...
-[ERROR] `foo` (bin "foo") generated 1 warning (run `cargo fix --bin "foo" -p foo` to apply 1 suggestion)
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [ERROR] warnings are denied by `build.warnings` configuration
 
 "#]])
@@ -337,7 +329,7 @@ fn keep_going() {
 [WARNING] unused variable: `x`
 ...
 [ERROR] `foo` (build script) generated 1 warning
-[WARNING] unused variable: `y`
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
 ...
 [ERROR] `foo` (bin "foo") generated 1 warning (run `cargo fix --bin "foo" -p foo` to apply 1 suggestion)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s


### PR DESCRIPTION
### What does this PR try to resolve?

This had been discussed a little bit on [zulip](https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/Environment.20variable.20for.20.5Blints.5D.20table.3F/near/553969201).
This then came up in usability feedback from @Urgau with
rust-lang/rust's x.py having adopted `build.warnings`.
The output from all of the other build targets causes the warnings to
disappear off the screen which doesn't happen with errors because the
build ends immediately.

So we're making warnings act more like errors.

### How to test and review this PR?

This is a follow up to #16721