### PR TITLE
fix(git): convert SCP-like submodule URLs to ssh:// format

### DIFF
--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -511,8 +511,9 @@ impl CheckoutGuard {
 ///   (`git@github.com:rust-lang/cargo.git` is not a valid WHATWG URL)
 ///
 /// To overcome these, this patch always tries [`Url::parse`] first to normalize
-/// the path. If it couldn't, append the relative path as the last resort and
-/// pray the remote git service supports non-normalized URLs.
+/// the path. If it couldn't, append the relative path and/or convert SCP-like URLs
+/// to ssh:// format as the last resorts and pray the remote git service supports
+/// non-normalized URLs.
 ///
 /// See also rust-lang/cargo#12404 and rust-lang/cargo#12295.
 ///
@@ -544,6 +545,15 @@ fn absolute_submodule_url<'s>(base_url: &str, submodule_url: &'s str) -> CargoRe
         }
     } else {
         Cow::from(submodule_url)
+    };
+
+    let absolute_url = match gix::url::parse(gix::bstr::BStr::new(absolute_url.as_ref().as_bytes()))
+    {
+        Ok(mut url) if url.serialize_alternative_form && url.scheme == gix::url::Scheme::Ssh => {
+            url.serialize_alternative_form = false;
+            Cow::from(url.to_bstring().to_string())
+        }
+        _ => absolute_url,
     };
 
     Ok(absolute_url)
@@ -1623,7 +1633,7 @@ mod tests {
             (
                 "ssh://git@gitub.com/rust-lang/cargo",
                 "git@github.com:rust-lang/cargo.git",
-                "git@github.com:rust-lang/cargo.git",
+                "ssh://git@github.com/rust-lang/cargo.git",
             ),
             (
                 "ssh://git@gitub.com/rust-lang/cargo",
@@ -1668,37 +1678,37 @@ mod tests {
             (
                 "git@github.com:rust-lang/cargo.git",
                 "./",
-                "git@github.com:rust-lang/cargo.git/./",
+                "ssh://git@github.com/rust-lang/cargo.git/./",
             ),
             (
                 "git@github.com:rust-lang/cargo.git",
                 "../",
-                "git@github.com:rust-lang/cargo.git/../",
+                "ssh://git@github.com/rust-lang/cargo.git/../",
             ),
             (
                 "git@github.com:rust-lang/cargo.git",
                 "./foo",
-                "git@github.com:rust-lang/cargo.git/./foo",
+                "ssh://git@github.com/rust-lang/cargo.git/./foo",
             ),
             (
                 "git@github.com:rust-lang/cargo.git/",
                 "./foo",
-                "git@github.com:rust-lang/cargo.git/./foo",
+                "ssh://git@github.com/rust-lang/cargo.git/./foo",
             ),
             (
                 "git@github.com:rust-lang/cargo.git",
                 "../foo",
-                "git@github.com:rust-lang/cargo.git/../foo",
+                "ssh://git@github.com/rust-lang/cargo.git/../foo",
             ),
             (
                 "git@github.com:rust-lang/cargo.git/",
                 "../foo",
-                "git@github.com:rust-lang/cargo.git/../foo",
+                "ssh://git@github.com/rust-lang/cargo.git/../foo",
             ),
             (
                 "git@github.com:rust-lang/cargo.git",
                 "../foo/bar/../baz",
-                "git@github.com:rust-lang/cargo.git/../foo/bar/../baz",
+                "ssh://git@github.com/rust-lang/cargo.git/../foo/bar/../baz",
             ),
         ];
 

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -4421,8 +4421,9 @@ fn dep_with_scp_like_submodule_url() {
         .file("src/lib.rs", "extern crate dep1;")
         .build();
 
-    // since Cargo can't parse SCP-like URL, it will fail earlier with invalid
-    // URL error before reaching the non-existing SSH server.
+    // With the SCP-like URL fix, Cargo converts `git@github.com:foo/bar.git`
+    // to `ssh://git@github.com/foo/bar.git` and tries to fetch, which fails
+    // with other errors like authentication failure or SSH server not reachable.
     p.cargo("fetch")
         .env(
             "GIT_SSH_COMMAND",
@@ -4431,6 +4432,7 @@ fn dep_with_scp_like_submodule_url() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep1`
+[UPDATING] git submodule `ssh://git@github.com/foo/bar.git`
 [ERROR] failed to get `dep1` as a dependency of package `foo v0.5.0 ([ROOT]/foo)`
 
 Caused by:
@@ -4443,8 +4445,8 @@ Caused by:
   failed to update submodule `submod`
 
 Caused by:
-  invalid url `git@github.com:foo/bar.git`: relative URL without a base; try using `ssh://git@github.com/foo/bar.git` instead
-
+  failed to fetch submodule `submod` from ssh://git@github.com/foo/bar.git
+...
 "#]])
         .run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?

PR #16246 introduced a regression where submodules using SCP-like URLs fail because `child_remote_url.into_url()` requires WHATWG-parsable URLs.

This commit fixes the issue by detecting SCP-like URLs in `absolute_submodule_url()` and converting them to the equivalent `ssh://` format.

### How to test and review this PR?

1. Add a dependency to `Cargo.toml` and configure the dependency repository to pull its submodules using the following `.gitmodules` entry:

```
[submodule "common/path/apis"]
	path = third_party/apis
	url = git@github.com:common/apis.git
```
2. `cargo fetch` should succeed