### PR TITLE
util: Exclude from iCloud Drive sync on macOS

### DIFF
--- a/crates/cargo-util/src/paths.rs
+++ b/crates/cargo-util/src/paths.rs
@@ -798,7 +798,7 @@ pub fn exclude_from_backups_and_indexing(p: impl AsRef<Path>) {
 /// * A dedicated resource property excluding from Time Machine backups on macOS
 /// * CACHEDIR.TAG files supported by various tools in a platform-independent way
 fn exclude_from_backups(path: &Path) {
-    exclude_from_time_machine(path);
+    exclude_from_time_machine_and_cloud_sync(path);
     let file = path.join("CACHEDIR.TAG");
     if !file.exists() {
         let _ = std::fs::write(
@@ -808,7 +808,7 @@ fn exclude_from_backups(path: &Path) {
 # For information about cache directory tags see https://bford.info/cachedir/
 ",
         );
-        // Similarly to exclude_from_time_machine() we ignore errors here as it's an optional feature.
+        // Similarly to exclude_from_time_machine_and_cloud_sync() we ignore errors here as it's an optional feature.
     }
 }
 
@@ -843,19 +843,31 @@ fn exclude_from_content_indexing(path: &Path) {
 }
 
 #[cfg(not(target_os = "macos"))]
-fn exclude_from_time_machine(_: &Path) {}
+fn exclude_from_time_machine_and_cloud_sync(_: &Path) {}
 
 #[cfg(target_os = "macos")]
-/// Marks files or directories as excluded from Time Machine on macOS
-fn exclude_from_time_machine(path: &Path) {
+/// Marks files or directories as excluded from Time Machine and iCloud Drive on macOS
+fn exclude_from_time_machine_and_cloud_sync(path: &Path) {
     use core_foundation::base::TCFType;
     use core_foundation::{number, string, url};
     use std::ptr;
 
-    // For compatibility with 10.7 a string is used instead of global kCFURLIsExcludedFromBackupKey
-    let is_excluded_key: Result<string::CFString, _> = "NSURLIsExcludedFromBackupKey".parse();
-    let path = url::CFURL::from_path(path, false);
-    if let (Some(path), Ok(is_excluded_key)) = (path, is_excluded_key) {
+    let path = match url::CFURL::from_path(path, false) {
+        Some(url) => url,
+        None => return,
+    };
+
+    // For compatibility with old systems strings are used instead of global symbols
+    const KEY_NAMES: [&str; 2] = [
+        "NSURLIsExcludedFromBackupKey", // kCFURLIsExcludedFromBackupKey
+        "NSURLUbiquitousItemIsExcludedFromSyncKey", // kCFURLUbiquitousItemIsExcludedFromSyncKey
+    ];
+
+    for key_name in KEY_NAMES {
+        let is_excluded_key = match key_name.parse::<string::CFString>() {
+            Ok(key) => key,
+            Err(_) => continue,
+        };
         unsafe {
             url::CFURLSetResourcePropertyForKey(
                 path.as_concrete_TypeRef(),


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes #16724

As discussed and agreed upon in the linked issue, this PR adds the iCloud Drive exclusion property alongside the existing Time Machine exclusion for macOS.

The specific code changes include:

- Renamed `exclude_from_time_machine` to `exclude_from_time_machine_and_cloud_sync`, and updated the related doc comments and inline comments.
- Replaced the deeply nested `if let` tuple match with early returns (`match`).
- Added the `"NSURLUbiquitousItemIsExcludedFromSyncKey"` property to exclude the directory from sync.
- Introduced a `KEY_NAMES` array and a `for` loop to apply the exclusion keys.

### How to test and review this PR?

On macOS 11.3+:
1. Create an arbitrary project under a directory with iCloud sync.
```bash
cd ~/Documents
cargo new foo
```
2. Build the project via Cargo.
```bash
cd foo
cargo build
```
3. Inspect the directory.
```bash
ls -l@
```
4. The output should contain a special extended attribute.
```
drwxr-xr-x@ 5 hguandl  staff  160  Mar 10 12:34 target
	com.apple.fileprovider.ignore#P	  1  <-------------- This!
```
5. In Finder, the `target` directory should be marked with "Ignored".