### PR TITLE
feat(shell): Support OSC 9;4 progress on ptyxis

### DIFF
--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -646,8 +646,14 @@ fn supports_term_integration(stream: &dyn IsTerminal) -> bool {
         && std::env::var("TERM_FEATURES")
             .ok()
             .is_some_and(|v| term_features_has_progress(&v));
+    // Ptyxis added OSC 9;4 support in 48.0.
+    // See https://gitlab.gnome.org/chergert/ptyxis/-/issues/305
+    let ptyxis = std::env::var("PTYXIS_VERSION")
+        .ok()
+        .and_then(|version| version.split(".").next()?.parse::<i32>().ok())
+        .is_some_and(|major_version| major_version >= 48);
 
-    (windows_terminal || conemu || wezterm || ghostty || iterm) && stream.is_terminal()
+    (windows_terminal || conemu || wezterm || ghostty || iterm || ptyxis) && stream.is_terminal()
 }
 
 // For iTerm, the TERM_FEATURES value "P" indicates OSC 9;4 support.


### PR DESCRIPTION
### What does this PR try to resolve?

Ptyxis supports OSC 9;4 progress reporting since version 48.0 but hasn't been part of the support whitelist in cargo yet. See https://gitlab.gnome.org/chergert/ptyxis/-/issues/305.

### How to test and review this PR?

This PR will check for the `PTYXIS_VERSION` variable, extract the major version, and report support for the terminal integration if the major version is larger than or equal to 48.

Try a cargo build in a recent Ptyxis terminal window with multiple tabs. Ptyxis shows the progress as a circle in the tab-bar which is hidden for a single tab by default.

<img width="3148" height="3492" alt="ptyxis window building release cargo using a debug cargo with a progress indicator in the tab bar" src="https://github.com/user-attachments/assets/ba8b2729-bf68-4527-bba1-1051602e6028" />