### PR TITLE
Add lint to enforce repository inheritance in workspaces

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -34,6 +34,7 @@ use crate::lints::rules::non_snake_case_features;
 use crate::lints::rules::non_snake_case_packages;
 use crate::lints::rules::redundant_homepage;
 use crate::lints::rules::redundant_readme;
+use crate::lints::rules::uninherited_repository;
 use crate::lints::rules::unused_workspace_dependencies;
 use crate::lints::rules::unused_workspace_package_fields;
 use crate::ops;
@@ -1391,6 +1392,14 @@ impl<'gctx> Workspace<'gctx> {
             non_snake_case_features(pkg, &path, &cargo_lints, &mut run_error_count, self.gctx)?;
             redundant_readme(pkg, &path, &cargo_lints, &mut run_error_count, self.gctx)?;
             redundant_homepage(pkg, &path, &cargo_lints, &mut run_error_count, self.gctx)?;
+            uninherited_repository(
+                self,
+                pkg,
+                &path,
+                &cargo_lints,
+                &mut run_error_count,
+                self.gctx,
+            )?;
             missing_lints_inheritance(
                 self,
                 pkg,

--- a/src/cargo/lints/rules/mod.rs
+++ b/src/cargo/lints/rules/mod.rs
@@ -9,6 +9,7 @@ mod non_snake_case_features;
 mod non_snake_case_packages;
 mod redundant_homepage;
 mod redundant_readme;
+mod uninherited_repository;
 mod unknown_lints;
 mod unused_workspace_dependencies;
 mod unused_workspace_package_fields;
@@ -25,6 +26,7 @@ pub use non_snake_case_features::non_snake_case_features;
 pub use non_snake_case_packages::non_snake_case_packages;
 pub use redundant_homepage::redundant_homepage;
 pub use redundant_readme::redundant_readme;
+pub use uninherited_repository::uninherited_repository;
 pub use unknown_lints::output_unknown_lints;
 pub use unused_workspace_dependencies::unused_workspace_dependencies;
 pub use unused_workspace_package_fields::unused_workspace_package_fields;
@@ -41,6 +43,7 @@ pub static LINTS: &[&crate::lints::Lint] = &[
     non_snake_case_packages::LINT,
     redundant_homepage::LINT,
     redundant_readme::LINT,
+    uninherited_repository::LINT,
     unknown_lints::LINT,
     unused_workspace_dependencies::LINT,
     unused_workspace_package_fields::LINT,

--- a/src/cargo/lints/rules/uninherited_repository.rs
+++ b/src/cargo/lints/rules/uninherited_repository.rs
@@ -1,0 +1,183 @@
+use std::path::Path;
+
+use annotate_snippets::AnnotationKind;
+use annotate_snippets::Group;
+use annotate_snippets::Level;
+use annotate_snippets::Origin;
+use annotate_snippets::Patch;
+use annotate_snippets::Snippet;
+use cargo_util_schemas::manifest::InheritableField;
+use cargo_util_schemas::manifest::TomlToolLints;
+
+use crate::CargoResult;
+use crate::GlobalContext;
+use crate::core::Package;
+use crate::core::Workspace;
+use crate::lints::Lint;
+use crate::lints::LintLevel;
+use crate::lints::LintLevelReason;
+use crate::lints::PEDANTIC;
+use crate::lints::get_key_value_span;
+use crate::lints::rel_cwd_manifest_path;
+
+pub static LINT: &Lint = &Lint {
+    name: "uninherited_repository",
+    desc: "`package.repository` in a workspace member should be inherited from `[workspace.package]`",
+    primary_group: &PEDANTIC,
+    msrv: Some(super::CARGO_LINTS_MSRV),
+    edition_lint_opts: None,
+    feature_gate: None,
+    docs: Some(
+        r#"
+### What it does
+
+Checks for `package.repository` fields in workspace members that are set
+explicitly instead of being inherited from `[workspace.package]`.
+
+See also [`package.repository` reference documentation](manifest.md#the-repository-field).
+
+### Why it is bad
+
+A common mistake is setting `package.repository` to the URL of the git host's
+file browser for the specific crate (e.g. a GitHub `/tree/` URL) rather than
+the root of the repository. Moving the field to `[workspace.package]` and
+inheriting it encourages using the correct root URL in one place and avoids
+per-crate drift.
+
+### Note
+
+This lint fires for any explicit `repository` value in a workspace member,
+regardless of whether the URL looks correct or not. It does not validate the
+URL itself; it only checks that the field is inherited rather than set
+explicitly.
+
+### Drawbacks
+
+A workspace that spans multiple repositories would need to suppress this lint,
+since each member legitimately has a different repository URL.
+
+### Example
+
+```toml
+[workspace]
+
+[package]
+repository = "https://github.com/rust-lang/cargo/tree/master/crates/cargo-test-macro"
+```
+
+Should be written as:
+
+```toml
+[workspace.package]
+repository = "https://github.com/rust-lang/cargo"
+
+[package]
+repository.workspace = true
+```
+"#,
+    ),
+};
+
+pub fn uninherited_repository(
+    ws: &Workspace<'_>,
+    pkg: &Package,
+    manifest_path: &Path,
+    cargo_lints: &TomlToolLints,
+    error_count: &mut usize,
+    gctx: &GlobalContext,
+) -> CargoResult<()> {
+    let (lint_level, reason) = LINT.level(
+        cargo_lints,
+        pkg.rust_version(),
+        pkg.manifest().edition(),
+        pkg.manifest().unstable_features(),
+    );
+
+    if lint_level == LintLevel::Allow {
+        return Ok(());
+    }
+
+    // Use normalized_toml here: we only need to know whether a [workspace]
+    // section exists at all.
+    let has_workspace = ws.root_maybe().normalized_toml().workspace.is_some();
+
+    if !has_workspace {
+        return Ok(());
+    }
+
+    let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
+
+    lint_package(pkg, &manifest_path, lint_level, reason, error_count, gctx)
+}
+
+pub fn lint_package(
+    pkg: &Package,
+    manifest_path: &str,
+    lint_level: LintLevel,
+    reason: LintLevelReason,
+    error_count: &mut usize,
+    gctx: &GlobalContext,
+) -> CargoResult<()> {
+    let manifest = pkg.manifest();
+
+    // Use original_toml so we see the raw InheritableField before workspace
+    // inheritance has been resolved into a plain Value.
+    let Some(original_toml) = manifest.original_toml() else {
+        return Ok(());
+    };
+    let Some(original_pkg) = &original_toml.package else {
+        return Ok(());
+    };
+    let Some(repository) = &original_pkg.repository else {
+        return Ok(());
+    };
+
+    let InheritableField::Value(_) = repository else {
+        // Already inheriting from workspace so nothing to do.
+        return Ok(());
+    };
+
+    let document = manifest.document();
+    let contents = manifest.contents();
+    let level = lint_level.to_diagnostic_level();
+    let emitted_source = LINT.emitted_source(lint_level, reason);
+
+    let mut primary = Group::with_title(level.primary_title(LINT.desc));
+    if let Some(document) = document
+        && let Some(contents) = contents
+        && let Some(span) = get_key_value_span(document, &["package", "repository"])
+    {
+        primary = primary.element(
+            Snippet::source(contents)
+                .path(manifest_path)
+                .annotation(AnnotationKind::Primary.span(span.key.start..span.value.end)),
+        );
+    } else {
+        primary = primary.element(Origin::path(manifest_path));
+    }
+    primary = primary.element(Level::NOTE.message(emitted_source));
+    let mut report = vec![primary];
+
+    if let Some(document) = document
+        && let Some(contents) = contents
+        && let Some(span) = get_key_value_span(document, &["package", "repository"])
+    {
+        let remove_span = span.key.start..span.value.end;
+        let mut help = Group::with_title(Level::HELP.secondary_title(
+            "consider moving `repository` to `[workspace.package]` and inheriting it",
+        ));
+        help = help.element(
+            Snippet::source(contents)
+                .path(manifest_path)
+                .patch(Patch::new(remove_span, "repository.workspace = true")),
+        );
+        report.push(help);
+    }
+
+    if lint_level.is_error() {
+        *error_count += 1;
+    }
+    gctx.shell().print_report(&report, lint_level.force())?;
+
+    Ok(())
+}

--- a/src/doc/src/reference/lints.md
+++ b/src/doc/src/reference/lints.md
@@ -24,6 +24,7 @@ These lints are all set to the 'allow' level by default.
 - [`non_kebab_case_packages`](#non_kebab_case_packages)
 - [`non_snake_case_features`](#non_snake_case_features)
 - [`non_snake_case_packages`](#non_snake_case_packages)
+- [`uninherited_repository`](#uninherited_repository)
 
 ## Warn-by-default
 
@@ -390,6 +391,60 @@ Should be written as:
 ```toml
 [package]
 name = "foo"
+```
+
+
+## `uninherited_repository`
+Group: `pedantic`
+
+Level: `allow`
+
+MSRV: `1.79.0`
+
+### What it does
+
+Checks for `package.repository` fields in workspace members that are set
+explicitly instead of being inherited from `[workspace.package]`.
+
+See also [`package.repository` reference documentation](manifest.md#the-repository-field).
+
+### Why it is bad
+
+A common mistake is setting `package.repository` to the URL of the git host's
+file browser for the specific crate (e.g. a GitHub `/tree/` URL) rather than
+the root of the repository. Moving the field to `[workspace.package]` and
+inheriting it encourages using the correct root URL in one place and avoids
+per-crate drift.
+
+### Note
+
+This lint fires for any explicit `repository` value in a workspace member,
+regardless of whether the URL looks correct or not. It does not validate the
+URL itself; it only checks that the field is inherited rather than set
+explicitly.
+
+### Drawbacks
+
+A workspace that spans multiple repositories would need to suppress this lint,
+since each member legitimately has a different repository URL.
+
+### Example
+
+```toml
+[workspace]
+
+[package]
+repository = "https://github.com/rust-lang/cargo/tree/master/crates/cargo-test-macro"
+```
+
+Should be written as:
+
+```toml
+[workspace.package]
+repository = "https://github.com/rust-lang/cargo"
+
+[package]
+repository.workspace = true
 ```
 
 

--- a/tests/testsuite/lints/mod.rs
+++ b/tests/testsuite/lints/mod.rs
@@ -15,6 +15,7 @@ mod non_snake_case_features;
 mod non_snake_case_packages;
 mod redundant_homepage;
 mod redundant_readme;
+mod uninherited_repository;
 mod unknown_lints;
 mod unused_workspace_dependencies;
 mod unused_workspace_package_fields;

--- a/tests/testsuite/lints/uninherited_repository.rs
+++ b/tests/testsuite/lints/uninherited_repository.rs
@@ -1,0 +1,280 @@
+use crate::prelude::*;
+use cargo_test_support::project;
+use cargo_test_support::str;
+
+#[cargo_test]
+fn fires_on_tree_url() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+[workspace]
+
+[package]
+name = "foo"
+version = "0.0.1"
+edition = "2015"
+repository = "https://github.com/rust-lang/cargo/repo/tree/main/crates/foo"
+
+[lints.cargo]
+uninherited_repository = "warn"
+"#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] `package.repository` in a workspace member should be inherited from `[workspace.package]`
+ --> Cargo.toml:8:1
+  |
+8 | repository = "https://github.com/rust-lang/cargo/repo/tree/main/crates/foo"
+  | [..]
+  |
+  = [NOTE] `cargo::uninherited_repository` is set to `warn` in `[lints]`
+[HELP] consider moving `repository` to `[workspace.package]` and inheriting it
+  |
+8 - repository = "https://github.com/rust-lang/cargo/repo/tree/main/crates/foo"
+8 + repository.workspace = true
+  |
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn fires_on_blob_url() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+[workspace]
+
+[package]
+name = "foo"
+version = "0.0.1"
+edition = "2015"
+repository = "https://github.com/rust-lang/cargo/repo/blob/main/README.md"
+
+[lints.cargo]
+uninherited_repository = "warn"
+"#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] `package.repository` in a workspace member should be inherited from `[workspace.package]`
+ --> Cargo.toml:8:1
+  |
+8 | repository = "https://github.com/rust-lang/cargo/repo/blob/main/README.md"
+  | [..]
+  |
+  = [NOTE] `cargo::uninherited_repository` is set to `warn` in `[lints]`
+[HELP] consider moving `repository` to `[workspace.package]` and inheriting it
+  |
+8 - repository = "https://github.com/rust-lang/cargo/repo/blob/main/README.md"
+8 + repository.workspace = true
+  |
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn fires_on_root_url() {
+    // Even a technically correct root URL should be inherited in a workspace.
+    // The lint encourages inheritance regardless of the URL content.
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+[workspace]
+
+[package]
+name = "foo"
+version = "0.0.1"
+edition = "2015"
+repository = "https://github.com/rust-lang/cargo/repo"
+
+[lints.cargo]
+uninherited_repository = "warn"
+"#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] `package.repository` in a workspace member should be inherited from `[workspace.package]`
+ --> Cargo.toml:8:1
+  |
+8 | repository = "https://github.com/rust-lang/cargo/repo"
+  | [..]
+  |
+  = [NOTE] `cargo::uninherited_repository` is set to `warn` in `[lints]`
+[HELP] consider moving `repository` to `[workspace.package]` and inheriting it
+  |
+8 - repository = "https://github.com/rust-lang/cargo/repo"
+8 + repository.workspace = true
+  |
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn no_fire_without_workspace() {
+    // Single-crate project (no explicit [workspace]) lint must not fire
+    // because there is no [workspace.package] to inherit from.
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+[package]
+name = "foo"
+version = "0.0.1"
+edition = "2015"
+repository = "https://github.com/rust-lang/cargo/repo/tree/main/crates/foo"
+
+[lints.cargo]
+uninherited_repository = "warn"
+"#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn no_fire_when_inherited() {
+    // Already using workspace inheritance lint must not fire.
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+[workspace.package]
+repository = "https://github.com/rust-lang/cargo/repo"
+
+[package]
+name = "foo"
+version = "0.0.1"
+edition = "2015"
+repository.workspace = true
+
+[lints.cargo]
+uninherited_repository = "warn"
+"#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn fires_in_workspace_member() {
+    // A member crate with an explicit repository should trigger the lint on
+    // its own manifest, not the workspace root.
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+[workspace]
+members = ["crates/foo"]
+"#,
+        )
+        .file(
+            "crates/foo/Cargo.toml",
+            r#"
+[package]
+name = "foo"
+version = "0.0.1"
+edition = "2015"
+repository = "https://github.com/rust-lang/cargo/repo/tree/main/crates/foo"
+
+[lints.cargo]
+uninherited_repository = "warn"
+"#,
+        )
+        .file("crates/foo/src/lib.rs", "")
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] `package.repository` in a workspace member should be inherited from `[workspace.package]`
+ --> crates/foo/Cargo.toml:6:1
+  |
+6 | repository = "https://github.com/rust-lang/cargo/repo/tree/main/crates/foo"
+  | [..]
+  |
+  = [NOTE] `cargo::uninherited_repository` is set to `warn` in `[lints]`
+[HELP] consider moving `repository` to `[workspace.package]` and inheriting it
+  |
+6 - repository = "https://github.com/rust-lang/cargo/repo/tree/main/crates/foo"
+6 + repository.workspace = true
+  |
+[CHECKING] foo v0.0.1 ([ROOT]/foo/crates/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn suppressed_by_allow() {
+    // Setting the lint to "allow" must silence it even when the field is explicit.
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+[workspace]
+
+[package]
+name = "foo"
+version = "0.0.1"
+edition = "2015"
+repository = "https://github.com/rust-lang/cargo/repo/tree/main/crates/foo"
+
+[lints.cargo]
+uninherited_repository = "allow"
+"#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}


### PR DESCRIPTION
### What does this PR try to resolve?

This patch adds a new pedantic lint, `uninherited_repository`, that fires whenever a workspace member sets `package.repository` explicitly rather than using `repository.workspace = true`. The lint suggests the fix inline.


Fixes:#15870

