### PR TITLE
CARGO_TARGET_DIR doesn't have to be relative

### DIFF
--- a/src/doc/man/cargo-install.md
+++ b/src/doc/man/cargo-install.md
@@ -52,7 +52,7 @@ force Cargo to always reinstall the package.
 
 If the source is crates.io or `--git` then by default the crate will be built
 in a temporary target directory. To avoid this, the target directory can be
-specified by setting the `CARGO_TARGET_DIR` environment variable to a relative
+specified by setting the `CARGO_TARGET_DIR` environment variable to a
 path. In particular, this can be useful for caching build artifacts on
 continuous integration systems.
 

--- a/src/doc/man/generated_txt/cargo-install.txt
+++ b/src/doc/man/generated_txt/cargo-install.txt
@@ -64,8 +64,8 @@ DESCRIPTION
        If the source is crates.io or --git then by default the crate will be
        built in a temporary target directory. To avoid this, the target
        directory can be specified by setting the CARGO_TARGET_DIR environment
-       variable to a relative path. In particular, this can be useful for
-       caching build artifacts on continuous integration systems.
+       variable to a path. In particular, this can be useful for caching build
+       artifacts on continuous integration systems.
 
    Dealing with the Lockfile
        By default, the Cargo.lock file that is included with the package will

--- a/src/doc/src/commands/cargo-install.md
+++ b/src/doc/src/commands/cargo-install.md
@@ -54,7 +54,7 @@ force Cargo to always reinstall the package.
 
 If the source is crates.io or `--git` then by default the crate will be built
 in a temporary target directory. To avoid this, the target directory can be
-specified by setting the `CARGO_TARGET_DIR` environment variable to a relative
+specified by setting the `CARGO_TARGET_DIR` environment variable to a
 path. In particular, this can be useful for caching build artifacts on
 continuous integration systems.
 

--- a/src/etc/man/cargo-install.1
+++ b/src/etc/man/cargo-install.1
@@ -84,7 +84,7 @@ force Cargo to always reinstall the package.
 .sp
 If the source is crates.io or \fB\-\-git\fR then by default the crate will be built
 in a temporary target directory. To avoid this, the target directory can be
-specified by setting the \fBCARGO_TARGET_DIR\fR environment variable to a relative
+specified by setting the \fBCARGO_TARGET_DIR\fR environment variable to a
 path. In particular, this can be useful for caching build artifacts on
 continuous integration systems.
 .SS "Dealing with the Lockfile"


### PR DESCRIPTION
### What does this PR try to resolve?

The manual being wrong.

### How to test and review this PR?

By observing that other places where this variable is set don't mention relativeness and that CARGO_TARGET_DIR=q/b/c and CARGO_TARGET_DIR=/tmp/a/b/c work.