### PR TITLE
fix(core): typo

### DIFF
--- a/src/cargo/core/package_id_spec.rs
+++ b/src/cargo/core/package_id_spec.rs
@@ -112,7 +112,7 @@ impl PackageIdSpecQuery for PackageIdSpec {
         return match ids.next() {
             Some(other) => {
                 let mut msg = format!(
-                    "specificationm `{self}` is ambiguous
+                    "specification `{self}` is ambiguous
 help: re-run this command with one of the following specifications",
                 );
                 let mut vec = vec![ret, other];

--- a/tests/testsuite/cargo_tree/deps.rs
+++ b/tests/testsuite/cargo_tree/deps.rs
@@ -1631,7 +1631,7 @@ fn ambiguous_name() {
 [DOWNLOADED] dep v2.0.0 (registry `dummy-registry`)
 [DOWNLOADED] dep v1.0.0 (registry `dummy-registry`)
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
-[ERROR] specificationm `dep` is ambiguous
+[ERROR] specification `dep` is ambiguous
 [HELP] re-run this command with one of the following specifications
   dep@1.0.0
   dep@2.0.0

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -2139,7 +2139,7 @@ fn update_ambiguous() {
     p.cargo("update bar")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] specificationm `bar` is ambiguous
+[ERROR] specification `bar` is ambiguous
 [HELP] re-run this command with one of the following specifications
   bar@0.5.0
   bar@0.6.0

--- a/tests/testsuite/pkgid.rs
+++ b/tests/testsuite/pkgid.rs
@@ -163,7 +163,7 @@ registry+https://github.com/rust-lang/crates.io-index#two-ver@0.2.0
     p.cargo("pkgid two-ver@0")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] specificationm `two-ver@0` is ambiguous
+[ERROR] specification `two-ver@0` is ambiguous
 [HELP] re-run this command with one of the following specifications
   two-ver@0.1.0
   two-ver@0.2.0
@@ -183,7 +183,7 @@ registry+https://github.com/rust-lang/crates.io-index#two-ver@0.2.0
     p.cargo("pkgid two-ver")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] specificationm `two-ver` is ambiguous
+[ERROR] specification `two-ver` is ambiguous
 [HELP] re-run this command with one of the following specifications
   two-ver@0.1.0
   two-ver@0.2.0
@@ -278,7 +278,7 @@ foo v0.1.0 ([ROOT]/foo)
     p.cargo("pkgid xyz")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] specificationm `xyz` is ambiguous
+[ERROR] specification `xyz` is ambiguous
 [HELP] re-run this command with one of the following specifications
   git+[ROOTURL]/xyz?rev=[..]#0.5.0
   git+[ROOTURL]/xyz?rev=[..]#0.5.0

--- a/tests/testsuite/replace.rs
+++ b/tests/testsuite/replace.rs
@@ -868,7 +868,7 @@ fn test_override_dep() {
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[ROOTURL]/override`
 [LOCKING] 2 packages to latest compatible versions
-[ERROR] specificationm `bar` is ambiguous
+[ERROR] specification `bar` is ambiguous
 [HELP] re-run this command with one of the following specifications
   registry+https://github.com/rust-lang/crates.io-index#bar@0.1.0
   git+[ROOTURL]/override#bar@0.1.0


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes typo: specificationm -> specification

### How to test and review this PR?

I didn't test this since it is a simple search-and-replace
