### PR TITLE
docs: Call out `rustflags` exception to array merging in config

### DIFF
--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -29,7 +29,8 @@ If a key is specified in multiple config files, the values will get merged
 together. Numbers, strings, and booleans will use the value in the deeper
 config directory taking precedence over ancestor directories, where the
 home directory is the lowest priority. Arrays will be joined together
-with higher precedence items being placed later in the merged array.
+with higher precedence items being placed later in the merged array (does not
+apply to [`build.rustflags`](#buildrustflags)).
 
 At present, when being invoked from a workspace, Cargo does not read config
 files from crates within the workspace. i.e. if a workspace has two crates in


### PR DESCRIPTION
<!-- 
_Thanks for the pull request 🎉!_
 _Please read the contribution guide: <https://doc.crates.io/contrib/>._
-->


### What does this PR try to resolve?

Based on the current docs on how the hierarchical `config.toml` merge, it says that arrays will merge:

https://github.com/rust-lang/cargo/blob/17627c4f546412d575045f6b3c473482a2884f34/src/doc/src/reference/config.md#L31-L32

But this isn't true for `rustflags` and is a common foot-gun given the activity on https://github.com/rust-lang/cargo/issues/5376. This PR is spawning from running into the problem myself (even after checking these docs).


### How to test and review this PR?

<!-- 
_Demonstrate how you test this change and guide reviewers through your PR._
_With a smooth review process, a pull request usually gets reviewed quicker._
-->

Review docs

