### PR TITLE
refactor(registry): avoid dynamic dispatch for Registry trait

### DIFF
--- a/src/cargo/core/resolver/context.rs
+++ b/src/cargo/core/resolver/context.rs
@@ -2,7 +2,7 @@ use super::RequestedFeatures;
 use super::dep_cache::RegistryQueryer;
 use super::errors::ActivateResult;
 use super::types::{ActivationsKey, ConflictMap, ConflictReason, FeaturesSet, ResolveOpts};
-use crate::core::{Dependency, PackageId, Summary};
+use crate::core::{Dependency, PackageId, Registry, Summary};
 use crate::util::Graph;
 use crate::util::interning::{INTERNED_DEFAULT, InternedString};
 use anyhow::format_err;
@@ -178,7 +178,7 @@ impl ResolverContext {
 
     pub fn resolve_replacements(
         &self,
-        registry: &RegistryQueryer<'_>,
+        registry: &RegistryQueryer<'_, impl Registry>,
     ) -> HashMap<PackageId, PackageId> {
         self.activations
             .values()

--- a/src/cargo/core/resolver/dep_cache.rs
+++ b/src/cargo/core/resolver/dep_cache.rs
@@ -31,8 +31,8 @@ use std::rc::Rc;
 use std::task::Poll;
 use tracing::debug;
 
-pub struct RegistryQueryer<'a> {
-    pub registry: &'a mut (dyn Registry + 'a),
+pub struct RegistryQueryer<'a, T: Registry> {
+    pub registry: &'a mut T,
     replacements: &'a [(PackageIdSpec, Dependency)],
     version_prefs: &'a VersionPreferences,
     /// a cache of `Candidate`s that fulfil a `Dependency` (and whether `first_version`)
@@ -50,9 +50,9 @@ pub struct RegistryQueryer<'a> {
     used_replacements: HashMap<PackageId, Summary>,
 }
 
-impl<'a> RegistryQueryer<'a> {
+impl<'a, T: Registry> RegistryQueryer<'a, T> {
     pub fn new(
-        registry: &'a mut dyn Registry,
+        registry: &'a mut T,
         replacements: &'a [(PackageIdSpec, Dependency)],
         version_prefs: &'a VersionPreferences,
     ) -> Self {

--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -74,7 +74,7 @@ impl From<(PackageId, ConflictReason)> for ActivateError {
 
 pub(super) fn activation_error(
     resolver_ctx: &ResolverContext,
-    registry: &mut dyn Registry,
+    registry: &mut impl Registry,
     parent: &Summary,
     dep: &Dependency,
     conflicting_activations: &ConflictMap,
@@ -429,7 +429,7 @@ pub(super) fn activation_error(
 // was meant. So we re-query the registry with `dep="*"` so we can
 // list a few versions that were actually found.
 fn alt_versions(
-    registry: &mut dyn Registry,
+    registry: &mut impl Registry,
     dep: &Dependency,
 ) -> Option<CargoResult<Vec<Summary>>> {
     let mut wild_dep = dep.clone();
@@ -456,7 +456,7 @@ fn alt_versions(
 
 /// Maybe something is wrong with the available versions
 fn rejected_versions(
-    registry: &mut dyn Registry,
+    registry: &mut impl Registry,
     dep: &Dependency,
 ) -> Option<CargoResult<Vec<IndexSummary>>> {
     let mut version_candidates = loop {
@@ -480,7 +480,7 @@ fn rejected_versions(
 /// Maybe the user mistyped the name? Like `dep-thing` when `Dep_Thing`
 /// was meant. So we try asking the registry for a `fuzzy` search for suggestions.
 fn alt_names(
-    registry: &mut dyn Registry,
+    registry: &mut impl Registry,
     dep: &Dependency,
 ) -> Option<CargoResult<Vec<(usize, Summary)>>> {
     let mut wild_dep = dep.clone();

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -122,7 +122,7 @@ mod version_prefs;
 pub fn resolve(
     summaries: &[(Summary, ResolveOpts)],
     replacements: &[(PackageIdSpec, Dependency)],
-    registry: &mut dyn Registry,
+    registry: &mut impl Registry,
     version_prefs: &VersionPreferences,
     resolve_version: ResolveVersion,
     gctx: Option<&GlobalContext>,
@@ -194,7 +194,7 @@ pub fn resolve(
 /// If all dependencies can be activated and resolved to a version in the
 /// dependency graph, `cx` is returned.
 fn activate_deps_loop(
-    registry: &mut RegistryQueryer<'_>,
+    registry: &mut RegistryQueryer<'_, impl Registry>,
     summaries: &[(Summary, ResolveOpts)],
     first_version: Option<VersionOrdering>,
     gctx: Option<&GlobalContext>,
@@ -622,7 +622,7 @@ fn activate_deps_loop(
 /// iterate through next.
 fn activate(
     cx: &mut ResolverContext,
-    registry: &mut RegistryQueryer<'_>,
+    registry: &mut RegistryQueryer<'_, impl Registry>,
     parent: Option<(&Summary, &Dependency)>,
     candidate: Summary,
     first_version: Option<VersionOrdering>,
@@ -808,7 +808,7 @@ impl RemainingCandidates {
 /// It will add the new conflict to the cache if one is found.
 fn generalize_conflicting(
     cx: &ResolverContext,
-    registry: &mut RegistryQueryer<'_>,
+    registry: &mut RegistryQueryer<'_, impl Registry>,
     past_conflicting_activations: &mut conflict_cache::ConflictCache,
     parent: &Summary,
     dep: &Dependency,


### PR DESCRIPTION
Avoid making trait objects from the `Registry` trait and the associated dynamic dispatch.

The `Registry` trait only has two implementations `PackageRegistry` and `MyRegistry`. `MyRegistry` is only used for tests.

This change came out of #16745 where query functions are changed to `async`. Dynamic dispatch on async functions requires boxing. The other two key registry-related traits ( `RegistryData` and `Source`) *do* have multiple implementations and cannot be easily changed like `Registry` here.