### PR TITLE
fix: Avoid panic for package specs with an empty fragment

### DIFF
--- a/crates/cargo-util-schemas/src/core/package_id_spec.rs
+++ b/crates/cargo-util-schemas/src/core/package_id_spec.rs
@@ -159,7 +159,11 @@ impl PackageIdSpec {
                 Some(fragment) => match parse_spec(&fragment)? {
                     Some((name, ver)) => (name, ver),
                     None => {
-                        if fragment.chars().next().unwrap().is_alphabetic() {
+                        let Some(f) = fragment.chars().next() else {
+                            return Err(PackageIdSpecError(ErrorKind::EmptyFragment));
+                        };
+
+                        if f.is_alphabetic() {
                             (String::from(fragment.as_str()), None)
                         } else {
                             let version = fragment.parse::<PartialVersion>()?;
@@ -321,6 +325,9 @@ enum ErrorKind {
 
     #[error("package ID specification `{spec}` looks like a file path, maybe try {maybe_url}")]
     MaybeFilePath { spec: String, maybe_url: String },
+
+    #[error("pkgid url cannot have an empty fragment")]
+    EmptyFragment,
 
     #[error(transparent)]
     NameValidation(#[from] crate::restricted_names::NameValidationError),
@@ -764,8 +771,6 @@ mod tests {
         err!("@1.2.3", ErrorKind::NameValidation(_));
         err!("registry+https://github.com", ErrorKind::NameValidation(_));
         err!("https://crates.io/1foo#1.2.3", ErrorKind::NameValidation(_));
-        assert!(std::panic::catch_unwind(|| {
-            err!("https://example.com/foo#", ErrorKind::NameValidation(_));
-        }).is_err());
+        err!("https://example.com/foo#", ErrorKind::EmptyFragment);
     }
 }


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes #16731

`PackageIdSpec::parse` panics on URL package specs with an empty fragment (...#)
This change would return `PackageIdSpecError(ErrorKind::EmptyFragment)` instead of panicing

### How to test and review this PR?

Earlier the following code would panic
``` rust
let _ = PackageIdSpec::parse("https://example.com/foo#");
```
but now it should return an error
