### PR TITLE
fix(compile): Make build.warnings ignore non-local deps

### DIFF
--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -1049,7 +1049,12 @@ impl<'gctx> DrainState<'gctx> {
         let count = self.warning_count.entry(id).or_default();
         count.total += 1;
         if lint {
-            count.lints += 1;
+            let unit = self.active.get(&id).unwrap();
+            // If this is an upstream dep but we *do* want warnings, make sure that they
+            // don't fail compilation.
+            if unit.is_local() {
+                count.lints += 1;
+            }
         }
         if !emitted {
             count.duplicates += 1;

--- a/tests/testsuite/warning_override.rs
+++ b/tests/testsuite/warning_override.rs
@@ -394,10 +394,11 @@ fn cap_lints() {
 [RUNNING] [..]
 [WARNING] unused variable: `x`
 ...
-[ERROR] `has_warning` (lib) generated 1 warning
-[ERROR] warnings are denied by `build.warnings` configuration
+[WARNING] `has_warning` (lib) generated 1 warning
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
-        .with_status(101)
         .run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?

This came up in rust-lang/rust#153809.
Considering we have the following, it seems reasonable to carry it
forward:
```
fn add_cap_lints(bcx: &BuildContext<'_, '_>, unit: &Unit, cmd: &mut ProcessBuilder) {
    // If this is an upstream dep we don't want warnings from, turn off all
    // lints.
    if !unit.show_warnings(bcx.gctx) {
        cmd.arg("--cap-lints").arg("allow");

    // If this is an upstream dep but we *do* want warnings, make sure that they
    // don't fail compilation.
    } else if !unit.is_local() {
        cmd.arg("--cap-lints").arg("warn");
    }
}
```

Part of #14802

### How to test and review this PR?

The test runs against `RUSTFLAGS=-Dwarnings` as well to
- Help verify the test
- To clearly compare their behavior