### PR TITLE
chore: Remove edition_lint_opts from Lint

### DIFF
--- a/src/cargo/lints/mod.rs
+++ b/src/cargo/lints/mod.rs
@@ -45,12 +45,7 @@ pub enum ManifestFor<'a> {
 
 impl ManifestFor<'_> {
     fn lint_level(&self, pkg_lints: &TomlToolLints, lint: &Lint) -> (LintLevel, LintLevelReason) {
-        lint.level(
-            pkg_lints,
-            self.rust_version(),
-            self.edition(),
-            self.unstable_features(),
-        )
+        lint.level(pkg_lints, self.rust_version(), self.unstable_features())
     }
 
     pub fn rust_version(&self) -> Option<&RustVersion> {
@@ -111,20 +106,12 @@ pub fn analyze_cargo_lints_table(
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
     let mut unknown_lints = Vec::new();
     for lint_name in cargo_lints.keys().map(|name| name) {
-        let Some((name, default_level, edition_lint_opts, feature_gate)) =
-            find_lint_or_group(lint_name)
-        else {
+        let Some((name, default_level, feature_gate)) = find_lint_or_group(lint_name) else {
             unknown_lints.push(lint_name);
             continue;
         };
 
-        let (_, reason, _) = level_priority(
-            name,
-            *default_level,
-            *edition_lint_opts,
-            cargo_lints,
-            manifest.edition(),
-        );
+        let (_, reason, _) = level_priority(name, *default_level, cargo_lints);
 
         // Only run analysis on user-specified lints
         if !reason.is_user_specified() {
@@ -160,21 +147,15 @@ pub fn analyze_cargo_lints_table(
 
 fn find_lint_or_group<'a>(
     name: &str,
-) -> Option<(
-    &'static str,
-    &LintLevel,
-    &Option<(Edition, LintLevel)>,
-    &Option<&'static Feature>,
-)> {
+) -> Option<(&'static str, &LintLevel, &Option<&'static Feature>)> {
     if let Some(lint) = LINTS.iter().find(|l| l.name == name) {
         Some((
             lint.name,
             &lint.primary_group.default_level,
-            &lint.edition_lint_opts,
             &lint.feature_gate,
         ))
     } else if let Some(group) = LINT_GROUPS.iter().find(|g| g.name == name) {
-        Some((group.name, &group.default_level, &None, &group.feature_gate))
+        Some((group.name, &group.default_level, &group.feature_gate))
     } else {
         None
     }
@@ -423,7 +404,6 @@ pub struct Lint {
     /// linting system, then at earliest an MSRV of 1.78 is required as `[lints.cargo]` was a hard
     /// error before then.
     pub msrv: Option<RustVersion>,
-    pub edition_lint_opts: Option<(Edition, LintLevel)>,
     pub feature_gate: Option<&'static Feature>,
     /// This is a markdown formatted string that will be used when generating
     /// the lint documentation. If docs is `None`, the lint will not be
@@ -436,7 +416,6 @@ impl Lint {
         &self,
         pkg_lints: &TomlToolLints,
         pkg_rust_version: Option<&RustVersion>,
-        edition: Edition,
         unstable_features: &Features,
     ) -> (LintLevel, LintLevelReason) {
         // We should return `Allow` if a lint is behind a feature, but it is
@@ -455,20 +434,13 @@ impl Lint {
             }
         }
 
-        let lint_level_priority = level_priority(
-            self.name,
-            self.primary_group.default_level,
-            self.edition_lint_opts,
-            pkg_lints,
-            edition,
-        );
+        let lint_level_priority =
+            level_priority(self.name, self.primary_group.default_level, pkg_lints);
 
         let group_level_priority = level_priority(
             self.primary_group.name,
             self.primary_group.default_level,
-            None,
             pkg_lints,
-            edition,
         );
 
         let (_, (l, r, _)) = max_by_key(
@@ -541,7 +513,6 @@ impl From<TomlLintLevel> for LintLevel {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum LintLevelReason {
     Default,
-    Edition(Edition),
     Package,
 }
 
@@ -549,7 +520,6 @@ impl Display for LintLevelReason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             LintLevelReason::Default => write!(f, "by default"),
-            LintLevelReason::Edition(edition) => write!(f, "in edition {}", edition),
             LintLevelReason::Package => write!(f, "in `[lints]`"),
         }
     }
@@ -559,7 +529,6 @@ impl LintLevelReason {
     fn is_user_specified(&self) -> bool {
         match self {
             LintLevelReason::Default => false,
-            LintLevelReason::Edition(_) => false,
             LintLevelReason::Package => true,
         }
     }
@@ -568,24 +537,8 @@ impl LintLevelReason {
 fn level_priority(
     name: &str,
     default_level: LintLevel,
-    edition_lint_opts: Option<(Edition, LintLevel)>,
     pkg_lints: &TomlToolLints,
-    edition: Edition,
 ) -> (LintLevel, LintLevelReason, i8) {
-    let (unspecified_level, reason) = if let Some(level) = edition_lint_opts
-        .filter(|(e, _)| edition >= *e)
-        .map(|(_, l)| l)
-    {
-        (level, LintLevelReason::Edition(edition))
-    } else {
-        (default_level, LintLevelReason::Default)
-    };
-
-    // Don't allow the group to be overridden if the level is `Forbid`
-    if unspecified_level == LintLevel::Forbid {
-        return (unspecified_level, reason, 0);
-    }
-
     if let Some(defined_level) = pkg_lints.get(name) {
         (
             defined_level.level().into(),
@@ -593,7 +546,7 @@ fn level_priority(
             defined_level.priority(),
         )
     } else {
-        (unspecified_level, reason, 0)
+        (default_level, LintLevelReason::Default, 0)
     }
 }
 

--- a/src/cargo/lints/rules/blanket_hint_mostly_unused.rs
+++ b/src/cargo/lints/rules/blanket_hint_mostly_unused.rs
@@ -24,7 +24,6 @@ pub static LINT: &Lint = &Lint {
     desc: "blanket_hint_mostly_unused lint",
     primary_group: &SUSPICIOUS,
     msrv: Some(super::CARGO_LINTS_MSRV),
-    edition_lint_opts: None,
     feature_gate: None,
     docs: Some(
         r#"
@@ -66,7 +65,6 @@ pub fn blanket_hint_mostly_unused(
     let (lint_level, reason) = LINT.level(
         pkg_lints,
         ws.lowest_rust_version(),
-        maybe_pkg.edition(),
         maybe_pkg.unstable_features(),
     );
 

--- a/src/cargo/lints/rules/im_a_teapot.rs
+++ b/src/cargo/lints/rules/im_a_teapot.rs
@@ -23,7 +23,6 @@ pub static LINT: &Lint = &Lint {
     desc: "`im_a_teapot` is specified",
     primary_group: &TEST_DUMMY_UNSTABLE,
     msrv: None,
-    edition_lint_opts: None,
     feature_gate: Some(Feature::test_dummy_unstable()),
     docs: None,
 };
@@ -36,12 +35,8 @@ pub fn check_im_a_teapot(
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let manifest = pkg.manifest();
-    let (lint_level, reason) = LINT.level(
-        pkg_lints,
-        pkg.rust_version(),
-        manifest.edition(),
-        manifest.unstable_features(),
-    );
+    let (lint_level, reason) =
+        LINT.level(pkg_lints, pkg.rust_version(), manifest.unstable_features());
 
     if lint_level == LintLevel::Allow {
         return Ok(());

--- a/src/cargo/lints/rules/implicit_minimum_version_req.rs
+++ b/src/cargo/lints/rules/implicit_minimum_version_req.rs
@@ -31,7 +31,6 @@ pub static LINT: &Lint = &Lint {
     desc: "dependency version requirement without an explicit minimum version",
     primary_group: &PEDANTIC,
     msrv: None,
-    edition_lint_opts: None,
     feature_gate: None,
     docs: Some(
         r#"
@@ -93,7 +92,6 @@ pub fn implicit_minimum_version_req_pkg(
     let (lint_level, reason) = LINT.level(
         cargo_lints,
         pkg.rust_version(),
-        pkg.manifest().edition(),
         pkg.manifest().unstable_features(),
     );
 
@@ -161,7 +159,6 @@ pub fn implicit_minimum_version_req_ws(
     let (lint_level, reason) = LINT.level(
         cargo_lints,
         ws.lowest_rust_version(),
-        maybe_pkg.edition(),
         maybe_pkg.unstable_features(),
     );
 

--- a/src/cargo/lints/rules/missing_lints_inheritance.rs
+++ b/src/cargo/lints/rules/missing_lints_inheritance.rs
@@ -21,7 +21,6 @@ pub static LINT: &Lint = &Lint {
     desc: "missing `[lints]` to inherit `[workspace.lints]`",
     primary_group: &SUSPICIOUS,
     msrv: Some(super::CARGO_LINTS_MSRV),
-    edition_lint_opts: None,
     feature_gate: None,
     docs: Some(
         r#"
@@ -64,7 +63,6 @@ pub fn missing_lints_inheritance(
     let (lint_level, reason) = LINT.level(
         cargo_lints,
         pkg.rust_version(),
-        pkg.manifest().edition(),
         pkg.manifest().unstable_features(),
     );
 

--- a/src/cargo/lints/rules/non_kebab_case_bins.rs
+++ b/src/cargo/lints/rules/non_kebab_case_bins.rs
@@ -25,7 +25,6 @@ pub static LINT: &Lint = &Lint {
     desc: "binaries should have a kebab-case name",
     primary_group: &STYLE,
     msrv: Some(super::CARGO_LINTS_MSRV),
-    edition_lint_opts: None,
     feature_gate: None,
     docs: Some(
         r#"
@@ -73,7 +72,6 @@ pub fn non_kebab_case_bins(
     let (lint_level, reason) = LINT.level(
         cargo_lints,
         pkg.rust_version(),
-        pkg.manifest().edition(),
         pkg.manifest().unstable_features(),
     );
 

--- a/src/cargo/lints/rules/non_kebab_case_features.rs
+++ b/src/cargo/lints/rules/non_kebab_case_features.rs
@@ -23,7 +23,6 @@ pub static LINT: &Lint = &Lint {
     desc: "features should have a kebab-case name",
     primary_group: &RESTRICTION,
     msrv: None,
-    edition_lint_opts: None,
     feature_gate: None,
     docs: Some(
         r#"
@@ -66,7 +65,6 @@ pub fn non_kebab_case_features(
     let (lint_level, reason) = LINT.level(
         cargo_lints,
         pkg.rust_version(),
-        pkg.manifest().edition(),
         pkg.manifest().unstable_features(),
     );
 

--- a/src/cargo/lints/rules/non_kebab_case_packages.rs
+++ b/src/cargo/lints/rules/non_kebab_case_packages.rs
@@ -23,7 +23,6 @@ pub static LINT: &Lint = &Lint {
     desc: "packages should have a kebab-case name",
     primary_group: &RESTRICTION,
     msrv: None,
-    edition_lint_opts: None,
     feature_gate: None,
     docs: Some(
         r#"
@@ -66,7 +65,6 @@ pub fn non_kebab_case_packages(
     let (lint_level, reason) = LINT.level(
         cargo_lints,
         pkg.rust_version(),
-        pkg.manifest().edition(),
         pkg.manifest().unstable_features(),
     );
 

--- a/src/cargo/lints/rules/non_snake_case_features.rs
+++ b/src/cargo/lints/rules/non_snake_case_features.rs
@@ -23,7 +23,6 @@ pub static LINT: &Lint = &Lint {
     desc: "features should have a snake-case name",
     primary_group: &RESTRICTION,
     msrv: None,
-    edition_lint_opts: None,
     feature_gate: None,
     docs: Some(
         r#"
@@ -66,7 +65,6 @@ pub fn non_snake_case_features(
     let (lint_level, reason) = LINT.level(
         cargo_lints,
         pkg.rust_version(),
-        pkg.manifest().edition(),
         pkg.manifest().unstable_features(),
     );
 

--- a/src/cargo/lints/rules/non_snake_case_packages.rs
+++ b/src/cargo/lints/rules/non_snake_case_packages.rs
@@ -23,7 +23,6 @@ pub static LINT: &Lint = &Lint {
     desc: "packages should have a snake-case name",
     primary_group: &RESTRICTION,
     msrv: None,
-    edition_lint_opts: None,
     feature_gate: None,
     docs: Some(
         r#"
@@ -66,7 +65,6 @@ pub fn non_snake_case_packages(
     let (lint_level, reason) = LINT.level(
         cargo_lints,
         pkg.rust_version(),
-        pkg.manifest().edition(),
         pkg.manifest().unstable_features(),
     );
 

--- a/src/cargo/lints/rules/redundant_homepage.rs
+++ b/src/cargo/lints/rules/redundant_homepage.rs
@@ -24,7 +24,6 @@ pub static LINT: &Lint = &Lint {
     desc: "`package.homepage` is redundant with another manifest field",
     primary_group: &STYLE,
     msrv: Some(super::CARGO_LINTS_MSRV),
-    edition_lint_opts: None,
     feature_gate: None,
     docs: Some(
         r#"
@@ -70,7 +69,6 @@ pub fn redundant_homepage(
     let (lint_level, reason) = LINT.level(
         cargo_lints,
         pkg.rust_version(),
-        pkg.manifest().edition(),
         pkg.manifest().unstable_features(),
     );
 

--- a/src/cargo/lints/rules/redundant_readme.rs
+++ b/src/cargo/lints/rules/redundant_readme.rs
@@ -26,7 +26,6 @@ pub static LINT: &Lint = &Lint {
     desc: "explicit `package.readme` can be inferred",
     primary_group: &STYLE,
     msrv: Some(super::CARGO_LINTS_MSRV),
-    edition_lint_opts: None,
     feature_gate: None,
     docs: Some(
         r#"
@@ -72,7 +71,6 @@ pub fn redundant_readme(
     let (lint_level, reason) = LINT.level(
         cargo_lints,
         pkg.rust_version(),
-        pkg.manifest().edition(),
         pkg.manifest().unstable_features(),
     );
 

--- a/src/cargo/lints/rules/unknown_lints.rs
+++ b/src/cargo/lints/rules/unknown_lints.rs
@@ -20,7 +20,6 @@ pub static LINT: &Lint = &Lint {
     desc: "unknown lint",
     primary_group: &SUSPICIOUS,
     msrv: Some(super::CARGO_LINTS_MSRV),
-    edition_lint_opts: None,
     feature_gate: None,
     docs: Some(
         r#"

--- a/src/cargo/lints/rules/unused_workspace_dependencies.rs
+++ b/src/cargo/lints/rules/unused_workspace_dependencies.rs
@@ -25,7 +25,6 @@ pub static LINT: &Lint = &Lint {
     desc: "unused workspace dependency",
     primary_group: &SUSPICIOUS,
     msrv: Some(super::CARGO_LINTS_MSRV),
-    edition_lint_opts: None,
     feature_gate: None,
     docs: Some(
         r#"
@@ -57,7 +56,6 @@ pub fn unused_workspace_dependencies(
     let (lint_level, reason) = LINT.level(
         cargo_lints,
         ws.lowest_rust_version(),
-        maybe_pkg.edition(),
         maybe_pkg.unstable_features(),
     );
     if lint_level == LintLevel::Allow {

--- a/src/cargo/lints/rules/unused_workspace_package_fields.rs
+++ b/src/cargo/lints/rules/unused_workspace_package_fields.rs
@@ -24,7 +24,6 @@ pub static LINT: &Lint = &Lint {
     desc: "unused field in `workspace.package`",
     primary_group: &SUSPICIOUS,
     msrv: Some(super::CARGO_LINTS_MSRV),
-    edition_lint_opts: None,
     feature_gate: None,
     docs: Some(
         r#"
@@ -57,7 +56,6 @@ pub fn unused_workspace_package_fields(
     let (lint_level, reason) = LINT.level(
         cargo_lints,
         ws.lowest_rust_version(),
-        maybe_pkg.edition(),
         maybe_pkg.unstable_features(),
     );
     if lint_level == LintLevel::Allow {


### PR DESCRIPTION
`edition_lint_opts` was originally added as a way for a `Lint` to have a different level starting in a specific edition, which is something that the [Edition-specific lints](https://rustc-dev-guide.rust-lang.org/guides/editions.html#edition-specific-lints) section in the `rustc-dev-guide` explicitly discourages:
> This should generally be used sparingly, as there are other options

Since the `rustc-dev-guide` discourages the use of Edition-specific lints and no `Lint` currently uses `edition_lint_opts`, I decided to go ahead and remove it.


Note: This removes an early return from `level_priority` when `default_level` is `forbid`, but this shouldn't be a problem as `forbid` should never be the `default` for a `Lint` or `LintGroup`. I added a test to ensure this is always the case.