### PR TITLE
cargo clean: Validate that target_dir is not a file 

### DIFF
--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -7,6 +7,7 @@ use crate::util::edit_distance;
 use crate::util::errors::CargoResult;
 use crate::util::interning::InternedString;
 use crate::util::{GlobalContext, Progress, ProgressStyle};
+use annotate_snippets::Level;
 use anyhow::bail;
 use cargo_util::paths;
 use indexmap::{IndexMap, IndexSet};
@@ -48,6 +49,22 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
     let gctx = opts.gctx;
     let mut clean_ctx = CleanContext::new(gctx);
     clean_ctx.dry_run = opts.dry_run;
+
+    const CLEAN_ABORT_NOTE: &str =
+        "cleaning has been aborted to prevent accidental deletion of unrelated files";
+
+    // make sure target_dir is a directory if it exists so that we don't delete files
+    if let Ok(meta) = fs::symlink_metadata(target_dir.as_path_unlocked()) {
+        // do not error if target_dir is symlink; let cargo delete it
+        if !meta.is_symlink() && !meta.is_dir() {
+            let title = format!("cannot clean `{}`: not a directory", target_dir.display());
+            let report = [Level::ERROR
+                .primary_title(title)
+                .element(Level::NOTE.message(CLEAN_ABORT_NOTE))];
+            gctx.shell().print_report(&report, false)?;
+            return Err(crate::AlreadyPrintedError::new(anyhow::anyhow!("")).into());
+        }
+    }
 
     if opts.doc {
         if !opts.spec.is_empty() {

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -1069,13 +1069,15 @@ fn target_dir_is_file() {
 
     p.cargo("clean")
         .with_stderr_data(str![[r#"
-[REMOVED] 1 file
+[ERROR] cannot clean `[ROOT]/foo/target`: not a directory
+  |
+  = [NOTE] cleaning has been aborted to prevent accidental deletion of unrelated files
 
 "#]])
-        .with_status(0)
+        .with_status(101)
         .run();
 
-    assert!(!p.root().join("target").exists());
+    assert!(p.root().join("target").exists());
 }
 
 #[cargo_test]
@@ -1088,13 +1090,15 @@ fn explicit_target_dir_is_file() {
 
     p.cargo("clean --target-dir bar")
         .with_stderr_data(str![[r#"
-[REMOVED] 1 file
+[ERROR] cannot clean `[ROOT]/foo/bar`: not a directory
+  |
+  = [NOTE] cleaning has been aborted to prevent accidental deletion of unrelated files
 
 "#]])
-        .with_status(0)
+        .with_status(101)
         .run();
 
-    assert!(!p.root().join("bar").exists());
+    assert!(p.root().join("bar").exists());
 }
 
 #[cargo_test]
@@ -1108,13 +1112,15 @@ fn env_target_dir_is_file() {
     p.cargo("clean")
         .env("CARGO_TARGET_DIR", "bar")
         .with_stderr_data(str![[r#"
-[REMOVED] 1 file
+[ERROR] cannot clean `[ROOT]/foo/bar`: not a directory
+  |
+  = [NOTE] cleaning has been aborted to prevent accidental deletion of unrelated files
 
 "#]])
-        .with_status(0)
+        .with_status(101)
         .run();
 
-    assert!(!p.root().join("bar").exists());
+    assert!(p.root().join("bar").exists());
 }
 
 #[cargo_test]
@@ -1132,13 +1138,15 @@ fn config_target_dir_is_file() {
 
     p.cargo("clean")
         .with_stderr_data(str![[r#"
-[REMOVED] 1 file
+[ERROR] cannot clean `[ROOT]/foo/bar`: not a directory
+  |
+  = [NOTE] cleaning has been aborted to prevent accidental deletion of unrelated files
 
 "#]])
-        .with_status(0)
+        .with_status(101)
         .run();
 
-    assert!(!p.root().join("bar").exists());
+    assert!(p.root().join("bar").exists());
 }
 
 #[cargo_test]


### PR DESCRIPTION
As discussed in #16712 , this is a separate PR that adds validation to `cargo clean` to make sure target-dir is not a file


#### Tests:

- Added unit tests for when target-dir is found to be a file.
- I also noticed that there was no unit test asserting the expected behaviour discussed  in <https://github.com/rust-lang/cargo/issues/7510#issuecomment-551912667> when the target-dir is a symlink. I added a unit test that asserts that when the target-dir is a symlink, cargo should just delete the symlink and should not delete the content it is pointing to.