### PR TITLE
Switch testsuite to use GNU tar headers

### DIFF
--- a/crates/cargo-test-support/src/registry.rs
+++ b/crates/cargo-test-support/src/registry.rs
@@ -1746,24 +1746,26 @@ impl Package {
         mode: u32,
         contents: &EntryData,
     ) {
-        let mut header = Header::new_ustar();
-        let contents = match contents {
-            EntryData::Regular(contents) => contents.as_str(),
+        let mut header = Header::new_gnu();
+        header.set_mode(mode);
+        match contents {
+            EntryData::Regular(contents) => {
+                header.set_size(contents.len() as u64);
+                t!(ar.append_data(&mut header, path, contents.as_bytes()));
+            }
             EntryData::Symlink(src) => {
                 header.set_entry_type(tar::EntryType::Symlink);
-                t!(header.set_link_name(src));
-                "" // Symlink has no contents.
+                header.set_size(0);
+                t!(ar.append_link(&mut header, path, src));
             }
             EntryData::Directory => {
                 header.set_entry_type(tar::EntryType::Directory);
-                ""
+                t!(header.set_path(path));
+                header.set_size(0);
+                header.set_cksum();
+                t!(ar.append(&header, &[][..]));
             }
         };
-        header.set_size(contents.len() as u64);
-        t!(header.set_path(path));
-        header.set_mode(mode);
-        header.set_cksum();
-        t!(ar.append(&header, contents.as_bytes()));
     }
 
     /// Returns the path to the compressed package file.

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -1804,7 +1804,7 @@ dependencies = [
 name = "foo"
 version = "0.1.0"
 source = "sparse+http://127.0.0.1:[..]/index/"
-checksum = "458c1addb23fde7dfbca0410afdbcc0086f96197281ec304d9e0e10def3cb899"
+checksum = "02da3acb8b30d60a1f825a40308c224c233760749d18be53b7ed49bd82898b8b"
 
 "##]],
     );

--- a/tests/testsuite/cargo_add/locked_unchanged/in/Cargo.lock
+++ b/tests/testsuite/cargo_add/locked_unchanged/in/Cargo.lock
@@ -13,4 +13,4 @@ dependencies = [
 name = "my-package"
 version = "99999.0.0+my-package"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cfa03cf28feb001362b377a837910c5a6ec1cc5cceaa562b97fc14d15edec8"
+checksum = "5a5f44b789373bb6a8ba3c00b128c92988245035210879e7d7f8312d92167cf0"

--- a/tests/testsuite/cargo_add/lockfile_updated/in/Cargo.lock
+++ b/tests/testsuite/cargo_add/lockfile_updated/in/Cargo.lock
@@ -14,4 +14,4 @@ dependencies = [
 name = "unrelateed-crate"
 version = "0.2.0+my-package"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16af1a8ba7e4331ca62d945483a3028c2afbbe06a7f2ffaa0a3538ef0a7d63e"
+checksum = "ab9bcb03df75fcba470549967100c58f77794e1721b987c3ef561ceb5ff37689"

--- a/tests/testsuite/cargo_add/lockfile_updated/out/Cargo.lock
+++ b/tests/testsuite/cargo_add/lockfile_updated/out/Cargo.lock
@@ -14,10 +14,10 @@ dependencies = [
 name = "my-package"
 version = "99999.0.0+my-package"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cfa03cf28feb001362b377a837910c5a6ec1cc5cceaa562b97fc14d15edec8"
+checksum = "5a5f44b789373bb6a8ba3c00b128c92988245035210879e7d7f8312d92167cf0"
 
 [[package]]
 name = "unrelateed-crate"
 version = "0.2.0+my-package"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16af1a8ba7e4331ca62d945483a3028c2afbbe06a7f2ffaa0a3538ef0a7d63e"
+checksum = "ab9bcb03df75fcba470549967100c58f77794e1721b987c3ef561ceb5ff37689"

--- a/tests/testsuite/cargo_info/not_found/out/Cargo.lock
+++ b/tests/testsuite/cargo_info/not_found/out/Cargo.lock
@@ -13,4 +13,4 @@ dependencies = [
 name = "my-package"
 version = "0.1.1+my-package"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21c0013931e013e890da011e601d9e8514359837da12125e7e89157d9349dcb7"
+checksum = "bf7a0646a7aebd2fc03e98aa33fd89a68bd35e8c6893a4f68dbd9721899c6545"

--- a/tests/testsuite/cargo_info/specify_version_within_ws_and_conflict_with_lockfile/out/Cargo.lock
+++ b/tests/testsuite/cargo_info/specify_version_within_ws_and_conflict_with_lockfile/out/Cargo.lock
@@ -13,4 +13,4 @@ dependencies = [
 name = "my-package"
 version = "0.1.1+my-package"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21c0013931e013e890da011e601d9e8514359837da12125e7e89157d9349dcb7"
+checksum = "bf7a0646a7aebd2fc03e98aa33fd89a68bd35e8c6893a4f68dbd9721899c6545"

--- a/tests/testsuite/cargo_info/specify_version_within_ws_and_match_with_lockfile/out/Cargo.lock
+++ b/tests/testsuite/cargo_info/specify_version_within_ws_and_match_with_lockfile/out/Cargo.lock
@@ -13,4 +13,4 @@ dependencies = [
 name = "my-package"
 version = "0.1.1+my-package"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21c0013931e013e890da011e601d9e8514359837da12125e7e89157d9349dcb7"
+checksum = "bf7a0646a7aebd2fc03e98aa33fd89a68bd35e8c6893a4f68dbd9721899c6545"

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/in/Cargo.lock
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/in/Cargo.lock
@@ -77,9 +77,9 @@ dependencies = [
 ]
 
 [metadata]
-"checksum dep1 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad5d1a0cb2ca0bb8c8ed7623c0309c3b25092b11cb2d578e35ec8e5d280faa5c"
-"checksum dep2 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed104779d80bde57bdbefd4bcd27e6948caab7f0b8ded30a5cb125a8cba814c8"
-"checksum dep3 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "15fd0baaa7ffd9dd001841b029542f4744180449bc01fff2c40a6d2fd974457e"
-"checksum my-package 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3325a560d0542c9d7bc4a0737e74ea3734fd756a707fd50bea8bc0e5ad1ae74f"
-"checksum my-package 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "597285c86228731859f5b5f08b11731cc5cb150d0a5373572522ff726cb97411"
-"checksum my-package 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3beee062f199bc0f6afc7e97e1518710462b921272773202d8636a59a12a791a"
+"checksum dep1 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "04d8b4f31fd5567a6fdff0ed6e8cefef7cf3e6c78901da2fc30d8d5e29234e6b"
+"checksum dep2 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "89c67d07ff6ba145890649315b474c237e1ae6ebc52f4a975e2faacaca90e022"
+"checksum dep3 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eaa4f0d447e37f991ed1a95b64f344525f57e26cf3583b0f540d78c98924d176"
+"checksum my-package 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7e14eaabf99a0a524c663f4877b800c8cc326688b164d02f852e6bddc5638791"
+"checksum my-package 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d359681509e8f342b300242a33e406eb8ff16e1c5781de4ea4bf5e9ee6c9d931"
+"checksum my-package 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9028f7c57d3e7f5a8f999cb88de5cd64a79fd172d220ce2f3a1a4f28037ffe4b"

--- a/tests/testsuite/cargo_info/transitive_dependency_within_ws/out/Cargo.lock
+++ b/tests/testsuite/cargo_info/transitive_dependency_within_ws/out/Cargo.lock
@@ -77,9 +77,9 @@ dependencies = [
 ]
 
 [metadata]
-"checksum dep1 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad5d1a0cb2ca0bb8c8ed7623c0309c3b25092b11cb2d578e35ec8e5d280faa5c"
-"checksum dep2 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed104779d80bde57bdbefd4bcd27e6948caab7f0b8ded30a5cb125a8cba814c8"
-"checksum dep3 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "15fd0baaa7ffd9dd001841b029542f4744180449bc01fff2c40a6d2fd974457e"
-"checksum my-package 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3325a560d0542c9d7bc4a0737e74ea3734fd756a707fd50bea8bc0e5ad1ae74f"
-"checksum my-package 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "597285c86228731859f5b5f08b11731cc5cb150d0a5373572522ff726cb97411"
-"checksum my-package 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3beee062f199bc0f6afc7e97e1518710462b921272773202d8636a59a12a791a"
+"checksum dep1 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "04d8b4f31fd5567a6fdff0ed6e8cefef7cf3e6c78901da2fc30d8d5e29234e6b"
+"checksum dep2 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "89c67d07ff6ba145890649315b474c237e1ae6ebc52f4a975e2faacaca90e022"
+"checksum dep3 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eaa4f0d447e37f991ed1a95b64f344525f57e26cf3583b0f540d78c98924d176"
+"checksum my-package 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7e14eaabf99a0a524c663f4877b800c8cc326688b164d02f852e6bddc5638791"
+"checksum my-package 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d359681509e8f342b300242a33e406eb8ff16e1c5781de4ea4bf5e9ee6c9d931"
+"checksum my-package 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9028f7c57d3e7f5a8f999cb88de5cd64a79fd172d220ce2f3a1a4f28037ffe4b"

--- a/tests/testsuite/cargo_info/with_frozen_within_ws/out/Cargo.lock
+++ b/tests/testsuite/cargo_info/with_frozen_within_ws/out/Cargo.lock
@@ -13,4 +13,4 @@ dependencies = [
 name = "my-package"
 version = "0.1.1+my-package"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21c0013931e013e890da011e601d9e8514359837da12125e7e89157d9349dcb7"
+checksum = "bf7a0646a7aebd2fc03e98aa33fd89a68bd35e8c6893a4f68dbd9721899c6545"

--- a/tests/testsuite/cargo_info/with_locked_within_ws/out/Cargo.lock
+++ b/tests/testsuite/cargo_info/with_locked_within_ws/out/Cargo.lock
@@ -13,4 +13,4 @@ dependencies = [
 name = "my-package"
 version = "0.1.1+my-package"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21c0013931e013e890da011e601d9e8514359837da12125e7e89157d9349dcb7"
+checksum = "bf7a0646a7aebd2fc03e98aa33fd89a68bd35e8c6893a4f68dbd9721899c6545"

--- a/tests/testsuite/cargo_info/within_workspace.in/Cargo.lock
+++ b/tests/testsuite/cargo_info/within_workspace.in/Cargo.lock
@@ -13,4 +13,4 @@ dependencies = [
 name = "my-package"
 version = "0.1.1+my-package"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21c0013931e013e890da011e601d9e8514359837da12125e7e89157d9349dcb7"
+checksum = "bf7a0646a7aebd2fc03e98aa33fd89a68bd35e8c6893a4f68dbd9721899c6545"

--- a/tests/testsuite/cargo_info/within_ws/out/Cargo.lock
+++ b/tests/testsuite/cargo_info/within_ws/out/Cargo.lock
@@ -13,4 +13,4 @@ dependencies = [
 name = "my-package"
 version = "0.1.1+my-package"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21c0013931e013e890da011e601d9e8514359837da12125e7e89157d9349dcb7"
+checksum = "bf7a0646a7aebd2fc03e98aa33fd89a68bd35e8c6893a4f68dbd9721899c6545"

--- a/tests/testsuite/cargo_info/within_ws_with_alternative_registry/out/Cargo.lock
+++ b/tests/testsuite/cargo_info/within_ws_with_alternative_registry/out/Cargo.lock
@@ -13,4 +13,4 @@ dependencies = [
 name = "my-package"
 version = "0.1.1+my-package"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21c0013931e013e890da011e601d9e8514359837da12125e7e89157d9349dcb7"
+checksum = "bf7a0646a7aebd2fc03e98aa33fd89a68bd35e8c6893a4f68dbd9721899c6545"

--- a/tests/testsuite/cargo_info/within_ws_without_lockfile/out/Cargo.lock
+++ b/tests/testsuite/cargo_info/within_ws_without_lockfile/out/Cargo.lock
@@ -13,4 +13,4 @@ dependencies = [
 name = "my-package"
 version = "0.2.3+my-package"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da91d4048b3b4623431ca790831b8b334ef87b6c1b0338889029a9b199f08a8"
+checksum = "2dbcdb89505ee50a962b03281cee2a247a934f99ae03afc2edb8d6ab12a35284"

--- a/tests/testsuite/cargo_info/without_requiring_registry_auth/in/Cargo.lock
+++ b/tests/testsuite/cargo_info/without_requiring_registry_auth/in/Cargo.lock
@@ -13,4 +13,4 @@ dependencies = [
 name = "my-package"
 version = "0.1.1+my-package"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21c0013931e013e890da011e601d9e8514359837da12125e7e89157d9349dcb7"
+checksum = "bf7a0646a7aebd2fc03e98aa33fd89a68bd35e8c6893a4f68dbd9721899c6545"

--- a/tests/testsuite/cargo_info/without_requiring_registry_auth/out/Cargo.lock
+++ b/tests/testsuite/cargo_info/without_requiring_registry_auth/out/Cargo.lock
@@ -13,4 +13,4 @@ dependencies = [
 name = "my-package"
 version = "0.1.1+my-package"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21c0013931e013e890da011e601d9e8514359837da12125e7e89157d9349dcb7"
+checksum = "bf7a0646a7aebd2fc03e98aa33fd89a68bd35e8c6893a4f68dbd9721899c6545"

--- a/tests/testsuite/cargo_remove/update_lock_file/in/Cargo.lock
+++ b/tests/testsuite/cargo_remove/update_lock_file/in/Cargo.lock
@@ -19,40 +19,40 @@ dependencies = [
 name = "clippy"
 version = "0.4.1+my-package"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e95568c5ce98de9c470c1d9b387466f4d5efa9687d3af7998e7c9c1da5e399fb"
+checksum = "361a17c5973f080da56ec9e935ba3d7c26d6f4420a77d6f32af614cc7ab8c05a"
 
 [[package]]
 name = "docopt"
 version = "0.6.2+my-package"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4414d2705e6b42fe10772b4ab4e3260f362669e45606eb562dc4c0023e911f6"
+checksum = "40f86a53a77e66eeb6f6c5b60492f83a9e3cce31070b1a8fd06536cd1613a4d8"
 
 [[package]]
 name = "regex"
 version = "0.1.1+my-package"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc4552a1d503f3a436bb18d1efff62eb95bd97f724d06466c55ef151ea2de9e0"
+checksum = "cac06f5223a615e35001725f1ea80158fcf16119da48a06c89f8aece2266d904"
 
 [[package]]
 name = "rustc-serialize"
 version = "0.4.0+my-package"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c3645ec42f69a343fbe9734a477ae59448192e779206dbcb1a9c3397563fd8"
+checksum = "c726e91bab74d6f6361f75d4feadfbd052ee1353eac041aa85e732ee1b155215"
 
 [[package]]
 name = "semver"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20070289360e74dcdc28f437b08dda0c0c861c2328d749bb0d6e1a428013af83"
+checksum = "0c91d844d2725f9540f93a60b3ae204c9dffe17de96d77c4bb0da42cc1e56dc3"
 
 [[package]]
 name = "serde"
 version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba76b226746eabf28375d5ad184926bbb9cd727425c8d027ea10f6c508895c6c"
+checksum = "d1cfba94cf07cdf199adaa091379fde0e09819e8f00764c3cae1c4f7a4ee15fa"
 
 [[package]]
 name = "toml"
 version = "0.1.1+my-package"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ea5fa6eaed7d7e6d9fb4571bb9d915b577e19bf2a95321ebb70fd3d894ce49"
+checksum = "02831f5db37072e8ac66fa3c172b3427cdd0f748f547682a3e5c61a7ecc78539"

--- a/tests/testsuite/cargo_remove/update_lock_file/out/Cargo.lock
+++ b/tests/testsuite/cargo_remove/update_lock_file/out/Cargo.lock
@@ -18,34 +18,34 @@ dependencies = [
 name = "clippy"
 version = "0.4.1+my-package"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e95568c5ce98de9c470c1d9b387466f4d5efa9687d3af7998e7c9c1da5e399fb"
+checksum = "361a17c5973f080da56ec9e935ba3d7c26d6f4420a77d6f32af614cc7ab8c05a"
 
 [[package]]
 name = "docopt"
 version = "0.6.2+my-package"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4414d2705e6b42fe10772b4ab4e3260f362669e45606eb562dc4c0023e911f6"
+checksum = "40f86a53a77e66eeb6f6c5b60492f83a9e3cce31070b1a8fd06536cd1613a4d8"
 
 [[package]]
 name = "regex"
 version = "0.1.1+my-package"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc4552a1d503f3a436bb18d1efff62eb95bd97f724d06466c55ef151ea2de9e0"
+checksum = "cac06f5223a615e35001725f1ea80158fcf16119da48a06c89f8aece2266d904"
 
 [[package]]
 name = "semver"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20070289360e74dcdc28f437b08dda0c0c861c2328d749bb0d6e1a428013af83"
+checksum = "0c91d844d2725f9540f93a60b3ae204c9dffe17de96d77c4bb0da42cc1e56dc3"
 
 [[package]]
 name = "serde"
 version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba76b226746eabf28375d5ad184926bbb9cd727425c8d027ea10f6c508895c6c"
+checksum = "d1cfba94cf07cdf199adaa091379fde0e09819e8f00764c3cae1c4f7a4ee15fa"
 
 [[package]]
 name = "toml"
 version = "0.1.1+my-package"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ea5fa6eaed7d7e6d9fb4571bb9d915b577e19bf2a95321ebb70fd3d894ce49"
+checksum = "02831f5db37072e8ac66fa3c172b3427cdd0f748f547682a3e5c61a7ecc78539"

--- a/tests/testsuite/generate_lockfile.rs
+++ b/tests/testsuite/generate_lockfile.rs
@@ -368,13 +368,13 @@ dependencies = [
 name = "has_time"
 version = "2025.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "105ca3acbc796da3e728ff310cafc6961cebc48d0106285edb8341015b5cc2d7"
+checksum = "7c2b785233e952a06d7587a6ff52bbff3c80dba6e0d4de75fa9e242b540f002c"
 
 [[package]]
 name = "no_time"
 version = "2025.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e688c07975f1e85f526c033322273181a4d8fe97800543d813d0a0adc134e3"
+checksum = "1954af12e2672ec49b44fa45ff51f5f38c800946a480147e16229ebed6abd914"
 
 "##]],
     );


### PR DESCRIPTION
This updates the testsuite's publishing code to use GNU tar headers instead of USTAR. We are having problems with the new `symlink_and_directory` test in rust-lang/rust because the target directory is longer than typical, and it is causing a failure. USTAR symlink entries are restricted to 100 bytes long. GNU is capable of using the `@LongLink` extension which does not have a limit.

Cargo's own publishing code was switched to GNU in Rust 1.46 (2020) via https://github.com/rust-lang/cargo/pull/8453.

I double checked the old tar 0.4.44, and the test fails as expected.
