### PR TITLE
feat(cli): complete `--config` and `--color` before command

### DIFF
--- a/src/etc/cargo.bashcomp.sh
+++ b/src/etc/cargo.bashcomp.sh
@@ -16,6 +16,13 @@ _cargo()
 	for (( cmd_i=1; cmd_i<$nwords; cmd_i++ ));
 	do
 		if [[ ! "${words[$cmd_i]}" =~ ^[+-] ]]; then
+			if [[ $cmd_i -gt 0 ]]; then
+				case "${words[(( $cmd_i - 1 ))]}" in
+					--color|--config)
+						continue
+						;;
+				esac
+			fi
 			cmd="${words[$cmd_i]}"
 			break
 		fi
@@ -109,8 +116,18 @@ _cargo()
 		elif [[ "$cur" == +* ]]; then
 			COMPREPLY=( $( compgen -W "$(_toolchains)" -- "$cur" ) )
 		else
-			_ensure_cargo_commands_cache_filled
-			COMPREPLY=( $( compgen -W "$__cargo_commands_cache" -- "$cur" ) )
+			case "${prev}" in
+				--color)
+					COMPREPLY=( $( compgen -W "$color" -- "$cur" ) )
+					;;
+				--config)
+					_filedir
+					;;
+				*)
+					_ensure_cargo_commands_cache_filled
+					COMPREPLY=( $( compgen -W "$__cargo_commands_cache" -- "$cur" ) )
+					;;
+			esac
 		fi
 	else
 		case "${prev}" in


### PR DESCRIPTION
### What does this PR try to resolve?

Split from https://github.com/rust-lang/cargo/pull/16245 (see https://github.com/rust-lang/cargo/pull/16245#issuecomment-3522316727).

Currently, `cargo.bashcomp.sh` supports completing values for `--color` and `--config` only in cases where they appear after the subcommand. This PR add support for completing values for these two flags when they appear before the subcommand.

### How to test and review this PR?

In a Bash shell, run:

```
source src/etc/cargo.bashcomp.sh
```

Before this patch, the following behaves as expected (suggests colors or paths):

```
cargo build --co<tab>
cargo build --config <tab>
```

but the following does not behave as expected (colors or paths are not suggested):

```
cargo --config <tab>
cargo --color <tab>
```

With this patch applied, all of the following behave as expected:

```
cargo --config <tab>
cargo --color <tab>
cargo build --co<tab>
cargo build --config <tab>
```