### PR TITLE
chore(deps): bump curl-sys from 0.4.83 to 0.4.86

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,9 +941,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.83+curl-8.15.0"
+version = "0.4.86+curl-8.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5830daf304027db10c82632a464879d46a3f7c4ba17a31592657ad16c719b483"
+checksum = "3a1dd6a487cf4532ce0d801634b82aa2deb7c9c3ed930b9dadfce904df000745"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,9 +44,7 @@ core-foundation = { version = "0.10.1", features = ["mac_os_10_7_support"] }
 crates-io = { version = "0.40.18", path = "crates/crates-io" }
 criterion = { version = "0.8.2", features = ["html_reports"] }
 curl = "0.4.49"
-# Do not upgrade curl-sys past 0.4.83
-# https://github.com/rust-lang/cargo/issues/16357
-curl-sys = "=0.4.83"
+curl-sys = "0.4.86"
 filetime = "0.2.27"
 flate2 = { version = "1.1.9", default-features = false, features = ["zlib-rs"] }
 git2 = "0.20.4"


### PR DESCRIPTION
This skips over the problematic 0.4.84 version which caused certificate validation errors on FreeBSD 14.3

Based on alexcrichton/curl-rust#632, the issue only occurs on `0.4.84`.

Fixes #16357