### PR TITLE
[stable 1.94] Downgrade curl-sys to 0.4.83

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.84+curl-8.17.0"
+version = "0.4.83+curl-8.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abc4294dc41b882eaff37973c2ec3ae203d0091341ee68fbadd1d06e0c18a73b"
+checksum = "5830daf304027db10c82632a464879d46a3f7c4ba17a31592657ad16c719b483"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ criterion = { version = "0.8.1", features = ["html_reports"] }
 curl = "0.4.49"
 # Do not upgrade curl-sys past 0.4.83
 # https://github.com/rust-lang/cargo/issues/16357
-curl-sys = "0.4.84"
+curl-sys = "=0.4.83"
 filetime = "0.2.26"
 flate2 = { version = "1.1.5", default-features = false, features = ["zlib-rs"] }
 git2 = "0.20.3"


### PR DESCRIPTION
Stable backport of #16570 to fix certificate validation errors on FreeBSD.

cc #16357
r? @weihanglo 