### PR TITLE
fix(init): Use detected project kind in status message

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -510,7 +510,7 @@ pub fn init(opts: &NewOptions, gctx: &GlobalContext) -> CargoResult<NewProjectKi
     detect_source_paths_and_types(path, name, &mut src_paths_types)?;
     let kind = calculate_new_project_kind(opts.kind, opts.auto_detect_kind, &src_paths_types);
     gctx.shell()
-        .status("Creating", format!("{} package", opts.kind))?;
+        .status("Creating", format!("{} package", kind))?;
 
     if path.join("Cargo.toml").exists() {
         anyhow::bail!(

--- a/tests/testsuite/cargo_init/inferred_lib_with_git/stderr.term.svg
+++ b/tests/testsuite/cargo_init/inferred_lib_with_git/stderr.term.svg
@@ -1,7 +1,7 @@
 <svg width="970px" height="74px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>

--- a/tests/testsuite/cargo_init/lib_already_exists_nosrc/stderr.term.svg
+++ b/tests/testsuite/cargo_init/lib_already_exists_nosrc/stderr.term.svg
@@ -1,7 +1,7 @@
 <svg width="970px" height="74px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>

--- a/tests/testsuite/cargo_init/lib_already_exists_src/stderr.term.svg
+++ b/tests/testsuite/cargo_init/lib_already_exists_src/stderr.term.svg
@@ -1,7 +1,7 @@
 <svg width="970px" height="74px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> binary (application) package</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Creating</tspan><tspan> library package</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">note</tspan><tspan>: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html</tspan>
 </tspan>

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -147,12 +147,16 @@ fn simple_install() {
     cargo_process("install bar")
         .with_stderr_data(str![[r#"
 [INSTALLING] bar v0.1.0
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [LOCKING] 1 package to latest compatible version
 [COMPILING] foo v0.0.1
 [COMPILING] bar v0.1.0
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [..]bar[..]
-[INSTALLED] package `bar v0.1.0` (executable `bar[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/bar
+[INSTALLED] package `bar v0.1.0` (executable `bar`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -192,7 +196,11 @@ fn simple_install_fail() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [INSTALLING] bar v0.1.0
-[ERROR] failed to compile `bar v0.1.0`, intermediate artifacts can be found at `[..]`.
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
+[ERROR] failed to compile `bar v0.1.0`, intermediate artifacts can be found at `/var/folders/78/tfh4ck1s0nv0h4ztpq0l8x8m0000gn/T/cargo-installBoQ1KK`.
 To reuse those artifacts with a future compilation, set the environment variable `CARGO_BUILD_BUILD_DIR` to that path.
 
 Caused by:
@@ -241,12 +249,16 @@ fn install_without_feature_dep() {
     cargo_process("install bar")
         .with_stderr_data(str![[r#"
 [INSTALLING] bar v0.1.0
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [LOCKING] 1 package to latest compatible version
 [COMPILING] foo v0.0.1
 [COMPILING] bar v0.1.0
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [..]bar[..]
-[INSTALLED] package `bar v0.1.0` (executable `bar[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/bar
+[INSTALLED] package `bar v0.1.0` (executable `bar`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -770,13 +782,17 @@ fn version_missing() {
     cargo_process("install bar")
         .with_stderr_data(str![[r#"
 [INSTALLING] bar v0.1.0
-[ERROR] failed to compile [..], intermediate artifacts can be found at `[..]`.
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
+[ERROR] failed to compile `bar v0.1.0`, intermediate artifacts can be found at `/var/folders/78/tfh4ck1s0nv0h4ztpq0l8x8m0000gn/T/cargo-installri16vj`.
 To reuse those artifacts with a future compilation, set the environment variable `CARGO_BUILD_BUILD_DIR` to that path.
 
 Caused by:
   failed to select a version for the requirement `foo = "^2"`
   candidate versions found which didn't match: 0.0.1
-  location searched: directory source `[..] (which is replacing registry `[..]`)
+  location searched: directory source `[ROOT]/index` (which is replacing registry `crates-io`)
   required by package `bar v0.1.0`
   perhaps a crate was updated and forgotten to be re-vendored?
 

--- a/tests/testsuite/feature_unification.rs
+++ b/tests/testsuite/feature_unification.rs
@@ -900,11 +900,15 @@ fn cargo_install_ignores_config() {
         .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "workspace")
         .with_stderr_data(str![[r#"
 [INSTALLING] a v0.1.0 ([ROOT]/foo)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] common v0.1.0 ([ROOT]/foo/common)
 [COMPILING] a v0.1.0 ([ROOT]/foo)
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/a[EXE]
-[INSTALLED] package `a v0.1.0 ([ROOT]/foo)` (executable `a[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/a
+[INSTALLED] package `a v0.1.0 ([ROOT]/foo)` (executable `a`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -916,9 +920,13 @@ fn cargo_install_ignores_config() {
         .env("CARGO_RESOLVER_FEATURE_UNIFICATION", "package")
         .with_stderr_data(str![[r#"
 [INSTALLING] a v0.1.0 ([ROOT]/foo)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[REPLACING] [ROOT]/home/.cargo/bin/a[EXE]
-[REPLACED] package `a v0.1.0 ([ROOT]/foo)` with `a v0.1.0 ([ROOT]/foo)` (executable `a[EXE]`)
+[REPLACING] [ROOT]/home/.cargo/bin/a
+[REPLACED] package `a v0.1.0 ([ROOT]/foo)` with `a v0.1.0 ([ROOT]/foo)` (executable `a`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])

--- a/tests/testsuite/glob_targets.rs
+++ b/tests/testsuite/glob_targets.rs
@@ -351,10 +351,14 @@ fn install_example() {
         .cargo("install --path . --example 'ex*1'")
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.0.1 ([ROOT]/foo)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/example1[EXE]
-[INSTALLED] package `foo v0.0.1 ([ROOT]/foo)` (executable `example1[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/example1
+[INSTALLED] package `foo v0.0.1 ([ROOT]/foo)` (executable `example1`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -367,10 +371,14 @@ fn install_bin() {
         .cargo("install --path . --bin 'bi*1'")
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.0.1 ([ROOT]/foo)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/bin1[EXE]
-[INSTALLED] package `foo v0.0.1 ([ROOT]/foo)` (executable `bin1[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/bin1
+[INSTALLED] package `foo v0.0.1 ([ROOT]/foo)` (executable `bin1`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -40,10 +40,14 @@ fn simple() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
 [INSTALLING] foo v0.0.1
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v0.0.1
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
-[INSTALLED] package `foo v0.0.1` (executable `foo[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/foo
+[INSTALLED] package `foo v0.0.1` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]]).run();
@@ -68,10 +72,14 @@ fn install_the_same_version_twice() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
 [INSTALLING] foo v0.0.1
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v0.0.1
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
-[INSTALLED] package `foo v0.0.1` (executable `foo[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/foo
+[INSTALLED] package `foo v0.0.1` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -116,11 +124,15 @@ fn simple_with_message_format() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
 [INSTALLING] foo v0.0.1
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v0.0.1
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
-[INSTALLED] package `foo v0.0.1` (executable `foo[EXE]`)
-[WARNING] be sure to add `[..]` to your PATH to be able to run the installed binaries
+[INSTALLING] [ROOT]/home/.cargo/bin/foo
+[INSTALLED] package `foo v0.0.1` (executable `foo`)
+[WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
         .with_stdout_data(
@@ -199,10 +211,14 @@ fn with_index() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.1 (registry `[ROOT]/registry`)
 [INSTALLING] foo v0.0.1 (registry `[ROOT]/registry`)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v0.0.1 (registry `[ROOT]/registry`)
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
-[INSTALLED] package `foo v0.0.1 (registry `[ROOT]/registry`)` (executable `foo[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/foo
+[INSTALLED] package `foo v0.0.1 (registry `[ROOT]/registry`)` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -233,15 +249,23 @@ fn multiple_pkgs() {
 [DOWNLOADED] bar v0.0.2 (registry `dummy-registry`)
 [ERROR] could not find `baz` in registry `crates-io` with version `*`
 [INSTALLING] foo v0.0.1
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v0.0.1
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
-[INSTALLED] package `foo v0.0.1` (executable `foo[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/foo
+[INSTALLED] package `foo v0.0.1` (executable `foo`)
 [INSTALLING] bar v0.0.2
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] bar v0.0.2
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/bar[EXE]
-[INSTALLED] package `bar v0.0.2` (executable `bar[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/bar
+[INSTALLED] package `bar v0.0.2` (executable `bar`)
 [SUMMARY] Successfully installed foo, bar! Failed to install baz (see error(s) above).
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 [ERROR] some crates failed to install
@@ -291,15 +315,23 @@ fn multiple_pkgs_path_set() {
 [DOWNLOADED] bar v0.0.2 (registry `dummy-registry`)
 [ERROR] could not find `baz` in registry `crates-io` with version `*`
 [INSTALLING] foo v0.0.1
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v0.0.1
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
-[INSTALLED] package `foo v0.0.1` (executable `foo[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/foo
+[INSTALLED] package `foo v0.0.1` (executable `foo`)
 [INSTALLING] bar v0.0.2
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] bar v0.0.2
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/bar[EXE]
-[INSTALLED] package `bar v0.0.2` (executable `bar[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/bar
+[INSTALLED] package `bar v0.0.2` (executable `bar`)
 [SUMMARY] Successfully installed foo, bar! Failed to install baz (see error(s) above).
 [ERROR] some crates failed to install
 
@@ -334,10 +366,14 @@ fn pick_max_version() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.2.1 (registry `dummy-registry`)
 [INSTALLING] foo v0.2.1
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v0.2.1
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
-[INSTALLED] package `foo v0.2.1` (executable `foo[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/foo
+[INSTALLED] package `foo v0.2.1` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]]).run();
@@ -528,10 +564,14 @@ fn relative_install_location_without_trailing_slash() {
   = [HELP] add a trailing slash (`t1/`) to adopt the correct behavior and silence this warning
   = [NOTE] see more at https://doc.rust-lang.org/cargo/reference/config.html#config-relative-paths
 [INSTALLING] foo v0.0.1 ([ROOT]/foo)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/foo/t1/bin/foo[EXE]
-[INSTALLED] package `foo v0.0.1 ([ROOT]/foo)` (executable `foo[EXE]`)
+[INSTALLING] [ROOT]/foo/t1/bin/foo
+[INSTALLED] package `foo v0.0.1 ([ROOT]/foo)` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/foo/t1/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -557,10 +597,14 @@ fn cli_root_argument_without_deprecation_warning() {
         .cwd(p.root())
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.0.1 ([ROOT]/foo)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/foo/t1/bin/foo[EXE]
-[INSTALLED] package `foo v0.0.1 ([ROOT]/foo)` (executable `foo[EXE]`)
+[INSTALLING] [ROOT]/foo/t1/bin/foo
+[INSTALLED] package `foo v0.0.1 ([ROOT]/foo)` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/foo/t1/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -592,10 +636,14 @@ fn relative_install_location_with_trailing_slash() {
     cmd.cwd(p.root());
     cmd.with_stderr_data(str![[r#"
 [INSTALLING] foo v0.0.1 ([ROOT]/foo)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/t1/bin/foo[EXE]
-[INSTALLED] package `foo v0.0.1 ([ROOT]/foo)` (executable `foo[EXE]`)
+[INSTALLING] [ROOT]/t1/bin/foo
+[INSTALLED] package `foo v0.0.1 ([ROOT]/foo)` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/t1/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -640,10 +688,14 @@ fn relative_install_location_with_path_set() {
   = [HELP] add a trailing slash (`t1/`) to adopt the correct behavior and silence this warning
   = [NOTE] see more at https://doc.rust-lang.org/cargo/reference/config.html#config-relative-paths
 [INSTALLING] foo v0.0.1 ([ROOT]/foo)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/foo/t1/bin/foo[EXE]
-[INSTALLED] package `foo v0.0.1 ([ROOT]/foo)` (executable `foo[EXE]`)
+[INSTALLING] [ROOT]/foo/t1/bin/foo
+[INSTALLED] package `foo v0.0.1 ([ROOT]/foo)` (executable `foo`)
 
 "#]])
         .run();
@@ -660,9 +712,13 @@ fn install_path() {
     // path-style installs force a reinstall
     p.cargo("install --path .").with_stderr_data(str![[r#"
 [INSTALLING] foo v0.0.1 ([ROOT]/foo)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[REPLACING] [ROOT]/home/.cargo/bin/foo[EXE]
-[REPLACED] package `foo v0.0.1 ([ROOT]/foo)` with `foo v0.0.1 ([ROOT]/foo)` (executable `foo[EXE]`)
+[REPLACING] [ROOT]/home/.cargo/bin/foo
+[REPLACED] package `foo v0.0.1 ([ROOT]/foo)` with `foo v0.0.1 ([ROOT]/foo)` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]]).run();
@@ -676,10 +732,14 @@ fn install_target_dir() {
         .with_stderr_data(str![[r#"
 [WARNING] using `cargo install` to install the binaries from the package in current working directory is deprecated, use `cargo install --path .` instead. [NOTE] use `cargo build` if you want to simply build the package.
 [INSTALLING] foo v0.0.1 ([ROOT]/foo)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
-[INSTALLED] package `foo v0.0.1 ([ROOT]/foo)` (executable `foo[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/foo
+[INSTALLED] package `foo v0.0.1 ([ROOT]/foo)` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -751,10 +811,14 @@ fn install_relative_path_outside_current_ws() {
     p.cargo("install --path ../bar/foo")
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.0.1 ([ROOT]/bar/foo)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v0.0.1 ([ROOT]/bar/foo)
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
-[INSTALLED] package `foo v0.0.1 ([ROOT]/bar/foo)` (executable `foo[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/foo
+[INSTALLED] package `foo v0.0.1 ([ROOT]/bar/foo)` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -1059,10 +1123,14 @@ fn install_force() {
         .arg(p.root())
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.2.0 ([ROOT]/foo2)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v0.2.0 ([ROOT]/foo2)
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[REPLACING] [ROOT]/home/.cargo/bin/foo[EXE]
-[REPLACED] package `foo v0.0.1 ([ROOT]/foo)` with `foo v0.2.0 ([ROOT]/foo2)` (executable `foo[EXE]`)
+[REPLACING] [ROOT]/home/.cargo/bin/foo
+[REPLACED] package `foo v0.0.1 ([ROOT]/foo)` with `foo v0.2.0 ([ROOT]/foo2)` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -1097,13 +1165,17 @@ fn install_force_partial_overlap() {
         .arg(p.root())
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.2.0 ([ROOT]/foo2)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v0.2.0 ([ROOT]/foo2)
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/foo-bin3[EXE]
-[REPLACING] [ROOT]/home/.cargo/bin/foo-bin2[EXE]
-[REMOVING] executable `[ROOT]/home/.cargo/bin/foo-bin1[EXE]` from previous version foo v0.0.1 ([ROOT]/foo)
-[INSTALLED] package `foo v0.2.0 ([ROOT]/foo2)` (executable `foo-bin3[EXE]`)
-[REPLACED] package `foo v0.0.1 ([ROOT]/foo)` with `foo v0.2.0 ([ROOT]/foo2)` (executable `foo-bin2[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/foo-bin3
+[REPLACING] [ROOT]/home/.cargo/bin/foo-bin2
+[REMOVING] executable `[ROOT]/home/.cargo/bin/foo-bin1` from previous version foo v0.0.1 ([ROOT]/foo)
+[INSTALLED] package `foo v0.2.0 ([ROOT]/foo2)` (executable `foo-bin3`)
+[REPLACED] package `foo v0.0.1 ([ROOT]/foo)` with `foo v0.2.0 ([ROOT]/foo2)` (executable `foo-bin2`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -1139,10 +1211,14 @@ fn install_force_bin() {
         .arg(p.root())
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.2.0 ([ROOT]/foo2)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v0.2.0 ([ROOT]/foo2)
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[REPLACING] [ROOT]/home/.cargo/bin/foo-bin2[EXE]
-[REPLACED] package `foo v0.0.1 ([ROOT]/foo)` with `foo v0.2.0 ([ROOT]/foo2)` (executable `foo-bin2[EXE]`)
+[REPLACING] [ROOT]/home/.cargo/bin/foo-bin2
+[REPLACED] package `foo v0.0.1 ([ROOT]/foo)` with `foo v0.2.0 ([ROOT]/foo2)` (executable `foo-bin2`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -1190,10 +1266,14 @@ fn git_repo() {
 [UPDATING] git repository `[ROOTURL]/foo`
 [WARNING] no Cargo.lock file published in foo v0.1.0 ([ROOTURL]/foo#[..])
 [INSTALLING] foo v0.1.0 ([ROOTURL]/foo#[..])
-[COMPILING] foo v0.1.0 ([ROOT]/home/.cargo/git/checkouts/foo-[HASH]/[..])
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
+[COMPILING] foo v0.1.0 ([ROOT]/home/.cargo/git/checkouts/foo-[HASH]/5cf2583)
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
-[INSTALLED] package `foo v0.1.0 ([ROOTURL]/foo#[..])` (executable `foo[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/foo
+[INSTALLED] package `foo v0.1.0 ([ROOTURL]/foo#5cf2583d)` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -1407,10 +1487,14 @@ fn uninstall_cwd() {
     let p = project().file("src/main.rs", "fn main() {}").build();
     p.cargo("install --path .").with_stderr_data(str![[r#"
 [INSTALLING] foo v0.0.1 ([ROOT]/foo)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
-[INSTALLED] package `foo v0.0.1 ([ROOT]/foo)` (executable `foo[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/foo
+[INSTALLED] package `foo v0.0.1 ([ROOT]/foo)` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]]).run();
@@ -1463,9 +1547,13 @@ fn do_not_rebuilds_on_local_install() {
         .arg(p.root())
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.0.1 ([ROOT]/foo)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
-[INSTALLED] package `foo v0.0.1 ([ROOT]/foo)` (executable `foo[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/foo
+[INSTALLED] package `foo v0.0.1 ([ROOT]/foo)` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -1631,10 +1719,14 @@ fn path_install_workspace_root_despite_default_members() {
         .arg("ws-root")
         .with_stderr_data(str![[r#"
 [INSTALLING] ws-root v0.1.0 ([ROOT]/foo)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] ws-root v0.1.0 ([ROOT]/foo)
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/ws-root[EXE]
-[INSTALLED] package `ws-root v0.1.0 ([ROOT]/foo)` (executable `ws-root[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/ws-root
+[INSTALLED] package `ws-root v0.1.0 ([ROOT]/foo)` (executable `ws-root`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -2149,9 +2241,13 @@ fn workspace_uses_workspace_target_dir() {
         .arg(p.root().join("bar"))
         .with_stderr_data(str![[r#"
 [INSTALLING] bar v0.1.0 ([ROOT]/foo/bar)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/bar[EXE]
-[INSTALLED] package `bar v0.1.0 ([ROOT]/foo/bar)` (executable `bar[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/bar
+[INSTALLED] package `bar v0.1.0 ([ROOT]/foo/bar)` (executable `bar`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -2353,10 +2449,14 @@ fn install_git_with_symlink_home() {
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/foo`
 [INSTALLING] foo v1.0.0 ([ROOTURL]/foo#[..])
-[COMPILING] foo v1.0.0 ([ROOT]/home/.cargo/git/checkouts/foo-[HASH]/[..])
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
+[COMPILING] foo v1.0.0 ([ROOT]/home/.cargo/git/checkouts/foo-[HASH]/05f25cd)
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
-[INSTALLED] package `foo v1.0.0 ([ROOTURL]/foo#[..])` (executable `foo[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/foo
+[INSTALLED] package `foo v1.0.0 ([ROOTURL]/foo#05f25cdf)` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -2430,10 +2530,14 @@ workspace: [ROOT]/foo/Cargo.toml
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.1.0 (registry `dummy-registry`)
 [INSTALLING] foo v0.1.0
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v0.1.0
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
-[INSTALLED] package `foo v0.1.0` (executable `foo[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/foo
+[INSTALLED] package `foo v0.1.0` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]]).run();
@@ -2487,10 +2591,14 @@ fn install_semver_metadata() {
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
 [INSTALLING] foo v1.0.0+abc (registry `alternative`)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v1.0.0+abc (registry `alternative`)
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[REPLACING] [ROOT]/home/.cargo/bin/foo[EXE]
-[REPLACED] package `foo v1.0.0+abc (registry `alternative`)` with `foo v1.0.0+abc (registry `alternative`)` (executable `foo[EXE]`)
+[REPLACING] [ROOT]/home/.cargo/bin/foo
+[REPLACED] package `foo v1.0.0+abc (registry `alternative`)` with `foo v1.0.0+abc (registry `alternative`)` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -2504,10 +2612,14 @@ fn install_semver_metadata() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v1.0.0+abc (registry `alternative`)
 [INSTALLING] foo v1.0.0+abc (registry `alternative`)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v1.0.0+abc (registry `alternative`)
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
-[INSTALLED] package `foo v1.0.0+abc (registry `alternative`)` (executable `foo[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/foo
+[INSTALLED] package `foo v1.0.0+abc (registry `alternative`)` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -2534,10 +2646,14 @@ fn no_auto_fix_note() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] auto_fix v0.0.1 (registry `dummy-registry`)
 [INSTALLING] auto_fix v0.0.1
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] auto_fix v0.0.1
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/auto_fix[EXE]
-[INSTALLED] package `auto_fix v0.0.1` (executable `auto_fix[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/auto_fix
+[INSTALLED] package `auto_fix v0.0.1` (executable `auto_fix`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -2567,15 +2683,19 @@ fn failed_install_retains_temp_directory() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
 [INSTALLING] foo v0.0.1
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v0.0.1
 [ERROR] expected one of `!` or `::`, found `<eof>`
- --> [ROOT]/home/.cargo/registry/src/-[..]/foo-0.0.1/src/main.rs:1:1
+ --> [ROOT]/home/.cargo/registry/src/-[HASH]/foo-0.0.1/src/main.rs:1:1
   |
 1 | x
   | ^ expected one of `!` or `::`
 
 [ERROR] could not compile `foo` (bin "foo") due to 1 previous error
-[ERROR] failed to compile `foo v0.0.1`, intermediate artifacts can be found at `[..]`.
+[ERROR] failed to compile `foo v0.0.1`, intermediate artifacts can be found at `/var/folders/78/tfh4ck1s0nv0h4ztpq0l8x8m0000gn/T/cargo-install6ZFzC6`.
 To reuse those artifacts with a future compilation, set the environment variable `CARGO_BUILD_BUILD_DIR` to that path.
 
 "#]]);
@@ -2617,6 +2737,10 @@ fn failed_install_points_to_build_dir_for_intermediate_artifacts() {
     let stderr = String::from_utf8(err.stderr.unwrap()).unwrap();
     assert_e2e().eq(&stderr, str![[r#"
 [INSTALLING] foo v0.0.1 ([ROOT]/foo)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [ERROR] expected one of `!` or `::`, found `<eof>`
  --> src/main.rs:1:1
@@ -2647,11 +2771,15 @@ fn sparse_install() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
 [INSTALLING] foo v0.0.1 (registry `dummy-registry`)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [UPDATING] `dummy-registry` index
 [COMPILING] foo v0.0.1 (registry `dummy-registry`)
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
-[INSTALLED] package `foo v0.0.1 (registry `dummy-registry`)` (executable `foo[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/foo
+[INSTALLED] package `foo v0.0.1 (registry `dummy-registry`)` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -2720,6 +2848,10 @@ fn self_referential() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.2 (registry `dummy-registry`)
 [INSTALLING] foo v0.0.2
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [LOCKING] 1 package to latest compatible version
 [ADDING] foo v0.0.1 (available: v0.0.2)
 [DOWNLOADING] crates ...
@@ -2727,8 +2859,8 @@ fn self_referential() {
 [COMPILING] foo v0.0.1
 [COMPILING] foo v0.0.2
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
-[INSTALLED] package `foo v0.0.2` (executable `foo[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/foo
+[INSTALLED] package `foo v0.0.2` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]]).run();
@@ -2764,6 +2896,10 @@ fn ambiguous_registry_vs_local_package() {
         .arg(p.root())
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.1.0 ([ROOT]/foo)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
@@ -2771,8 +2907,8 @@ fn ambiguous_registry_vs_local_package() {
 [COMPILING] foo v0.0.1
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
-[INSTALLED] package `foo v0.1.0 ([ROOT]/foo)` (executable `foo[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/foo
+[INSTALLED] package `foo v0.1.0 ([ROOT]/foo)` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -2870,10 +3006,14 @@ fn uninstall_running_binary() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
 [INSTALLING] foo v0.0.1
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v0.0.1
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
-[INSTALLED] package `foo v0.0.1` (executable `foo[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/foo
+[INSTALLED] package `foo v0.0.1` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]]).run();
@@ -2933,10 +3073,14 @@ fn uninstall_running_binary() {
     cargo_process("install foo").with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [INSTALLING] foo v0.0.1
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v0.0.1
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
-[INSTALLED] package `foo v0.0.1` (executable `foo[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/foo
+[INSTALLED] package `foo v0.0.1` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]]).run();
@@ -2953,7 +3097,11 @@ fn dry_run() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
 [INSTALLING] foo v0.0.1
-[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
+[INSTALLING] [ROOT]/home/.cargo/bin/foo
 [WARNING] aborting install due to dry run
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
@@ -3017,12 +3165,16 @@ fn dry_run_incompatible_package_dependency() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.1.0 ([ROOT]/foo)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [LOCKING] 1 package to latest compatible version
 [ERROR] failed to compile `foo v0.1.0 ([ROOT]/foo)`, intermediate artifacts can be found at `[ROOT]/foo/target`.
 To reuse those artifacts with a future compilation, set the environment variable `CARGO_BUILD_BUILD_DIR` to that path.
 
 Caused by:
-  rustc [..] is not supported by the following package:
+  rustc 1.94.0 is not supported by the following package:
     some-package-from-the-distant-future@0.1.0 requires rustc 1.2345.0
 
 "#]])
@@ -3044,7 +3196,11 @@ fn dry_run_upgrade() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.2 (registry `dummy-registry`)
 [INSTALLING] foo v0.0.2
-[REPLACING] [ROOT]/home/.cargo/bin/foo[EXE]
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
+[REPLACING] [ROOT]/home/.cargo/bin/foo
 [WARNING] aborting install due to dry run
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
@@ -3066,11 +3222,15 @@ fn dry_run_remove_orphan() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [INSTALLING] bar v1.0.0
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] bar v1.0.0
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/client[EXE]
-[INSTALLING] [ROOT]/home/.cargo/bin/server[EXE]
-[INSTALLED] package `bar v1.0.0` (executables `client[EXE]`, `server[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/client
+[INSTALLING] [ROOT]/home/.cargo/bin/server
+[INSTALLED] package `bar v1.0.0` (executables `client`, `server`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -3089,8 +3249,12 @@ fn dry_run_remove_orphan() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v2.0.0 (registry `dummy-registry`)
 [INSTALLING] bar v2.0.0
-[REPLACING] [ROOT]/home/.cargo/bin/client[EXE]
-[REMOVING] executable `[ROOT]/home/.cargo/bin/server[EXE]` from previous version bar v1.0.0
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
+[REPLACING] [ROOT]/home/.cargo/bin/client
+[REMOVING] executable `[ROOT]/home/.cargo/bin/server` from previous version bar v1.0.0
 [WARNING] aborting install due to dry run
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 

--- a/tests/testsuite/install_upgrade.rs
+++ b/tests/testsuite/install_upgrade.rs
@@ -131,10 +131,14 @@ fn registry_upgrade() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v1.0.0 (registry `dummy-registry`)
 [INSTALLING] foo v1.0.0
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v1.0.0
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
-[INSTALLED] package `foo v1.0.0` (executable `foo[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/foo
+[INSTALLED] package `foo v1.0.0` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]]).run();
@@ -160,10 +164,14 @@ fn registry_upgrade() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v1.0.1 (registry `dummy-registry`)
 [INSTALLING] foo v1.0.1
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v1.0.1
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[REPLACING] [ROOT]/home/.cargo/bin/foo[EXE]
-[REPLACED] package `foo v1.0.0` with `foo v1.0.1` (executable `foo[EXE]`)
+[REPLACING] [ROOT]/home/.cargo/bin/foo
+[REPLACED] package `foo v1.0.0` with `foo v1.0.1` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]]).run();
@@ -235,10 +243,14 @@ fn upgrade_force() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [INSTALLING] foo v1.0.0
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v1.0.0
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[REPLACING] [ROOT]/home/.cargo/bin/foo[EXE]
-[REPLACED] package `foo v1.0.0` with `foo v1.0.0` (executable `foo[EXE]`)
+[REPLACING] [ROOT]/home/.cargo/bin/foo
+[REPLACED] package `foo v1.0.0` with `foo v1.0.0` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -735,22 +747,34 @@ fn multiple_report() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] three v1.0.0 (registry `dummy-registry`)
 [INSTALLING] one v1.0.0
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] one v1.0.0
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/one[EXE]
-[INSTALLED] package `one v1.0.0` (executable `one[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/one
+[INSTALLED] package `one v1.0.0` (executable `one`)
 [INSTALLING] two v1.0.0
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] two v1.0.0
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/two[EXE]
-[INSTALLED] package `two v1.0.0` (executable `two[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/two
+[INSTALLED] package `two v1.0.0` (executable `two`)
 [INSTALLING] three v1.0.0
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] three v1.0.0
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/three[EXE]
-[INSTALLING] [ROOT]/home/.cargo/bin/x[EXE]
-[INSTALLING] [ROOT]/home/.cargo/bin/y[EXE]
-[INSTALLED] package `three v1.0.0` (executables `three[EXE]`, `x[EXE]`, `y[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/three
+[INSTALLING] [ROOT]/home/.cargo/bin/x
+[INSTALLING] [ROOT]/home/.cargo/bin/y
+[INSTALLED] package `three v1.0.0` (executables `three`, `x`, `y`)
 [SUMMARY] Successfully installed one, two, three!
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
@@ -767,12 +791,16 @@ fn multiple_report() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] three v1.0.1 (registry `dummy-registry`)
 [INSTALLING] three v1.0.1
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] three v1.0.1
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[REPLACING] [ROOT]/home/.cargo/bin/three[EXE]
-[REPLACING] [ROOT]/home/.cargo/bin/x[EXE]
-[REPLACING] [ROOT]/home/.cargo/bin/y[EXE]
-[REPLACED] package `three v1.0.0` with `three v1.0.1` (executables `three[EXE]`, `x[EXE]`, `y[EXE]`)
+[REPLACING] [ROOT]/home/.cargo/bin/three
+[REPLACING] [ROOT]/home/.cargo/bin/x
+[REPLACING] [ROOT]/home/.cargo/bin/y
+[REPLACED] package `three v1.0.0` with `three v1.0.1` (executables `three`, `x`, `y`)
 [SUMMARY] Successfully installed one, two, three!
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
@@ -790,10 +818,14 @@ fn multiple_report() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [INSTALLING] three v1.0.1
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] three v1.0.1
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/x[EXE]
-[INSTALLED] package `three v1.0.1` (executable `x[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/x
+[INSTALLED] package `three v1.0.1` (executable `x`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -802,13 +834,17 @@ fn multiple_report() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [INSTALLING] three v1.0.1
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] three v1.0.1
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/three[EXE]
-[INSTALLING] [ROOT]/home/.cargo/bin/y[EXE]
-[REPLACING] [ROOT]/home/.cargo/bin/x[EXE]
-[INSTALLED] package `three v1.0.1` (executables `three[EXE]`, `y[EXE]`)
-[REPLACED] package `three v1.0.1` with `three v1.0.1` (executable `x[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/three
+[INSTALLING] [ROOT]/home/.cargo/bin/y
+[REPLACING] [ROOT]/home/.cargo/bin/x
+[INSTALLED] package `three v1.0.1` (executables `three`, `y`)
+[REPLACED] package `three v1.0.1` with `three v1.0.1` (executable `x`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -865,14 +901,18 @@ fn deletes_orphaned() {
     p.cargo("install --path . --bins --examples")
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.2.0 ([ROOT]/foo)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v0.2.0 ([ROOT]/foo)
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/ex2[EXE]
-[REPLACING] [ROOT]/home/.cargo/bin/ex1[EXE]
-[REPLACING] [ROOT]/home/.cargo/bin/foo[EXE]
-[REMOVING] executable `[ROOT]/home/.cargo/bin/other[EXE]` from previous version foo v0.1.0 ([ROOT]/foo)
-[INSTALLED] package `foo v0.2.0 ([ROOT]/foo)` (executable `ex2[EXE]`)
-[REPLACED] package `foo v0.1.0 ([ROOT]/foo)` with `foo v0.2.0 ([ROOT]/foo)` (executables `ex1[EXE]`, `foo[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/ex2
+[REPLACING] [ROOT]/home/.cargo/bin/ex1
+[REPLACING] [ROOT]/home/.cargo/bin/foo
+[REMOVING] executable `[ROOT]/home/.cargo/bin/other` from previous version foo v0.1.0 ([ROOT]/foo)
+[INSTALLED] package `foo v0.2.0 ([ROOT]/foo)` (executable `ex2`)
+[REPLACED] package `foo v0.1.0 ([ROOT]/foo)` with `foo v0.2.0 ([ROOT]/foo)` (executables `ex1`, `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -910,10 +950,14 @@ fn already_installed_exact_does_not_update() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v1.0.1 (registry `dummy-registry`)
 [INSTALLING] foo v1.0.1
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v1.0.1
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[REPLACING] [ROOT]/home/.cargo/bin/foo[EXE]
-[REPLACED] package `foo v1.0.0` with `foo v1.0.1` (executable `foo[EXE]`)
+[REPLACING] [ROOT]/home/.cargo/bin/foo
+[REPLACED] package `foo v1.0.0` with `foo v1.0.1` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -944,10 +988,14 @@ fn already_installed_updates_yank_status_on_upgrade() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v1.0.1 (registry `dummy-registry`)
 [INSTALLING] foo v1.0.1
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v1.0.1
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[REPLACING] [ROOT]/home/.cargo/bin/foo[EXE]
-[REPLACED] package `foo v1.0.0` with `foo v1.0.1` (executable `foo[EXE]`)
+[REPLACING] [ROOT]/home/.cargo/bin/foo
+[REPLACED] package `foo v1.0.0` with `foo v1.0.1` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -969,15 +1017,23 @@ fn partially_already_installed_does_one_update() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v1.0.0 (registry `dummy-registry`)
 [INSTALLING] bar v1.0.0
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] bar v1.0.0
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/bar[EXE]
-[INSTALLED] package `bar v1.0.0` (executable `bar[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/bar
+[INSTALLED] package `bar v1.0.0` (executable `bar`)
 [INSTALLING] baz v1.0.0
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] baz v1.0.0
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/baz[EXE]
-[INSTALLED] package `baz v1.0.0` (executable `baz[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/baz
+[INSTALLED] package `baz v1.0.0` (executable `baz`)
 [SUMMARY] Successfully installed foo, bar, baz!
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 

--- a/tests/testsuite/publish_lockfile.rs
+++ b/tests/testsuite/publish_lockfile.rs
@@ -384,14 +384,18 @@ dependencies = [
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.1.0 (registry `dummy-registry`)
 [INSTALLING] foo v0.1.0
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [WARNING] package `bar v0.1.0` in Cargo.lock is yanked in registry `crates-io`, consider running without --locked
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [COMPILING] bar v0.1.0
 [COMPILING] foo v0.1.0
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
-[INSTALLED] package `foo v0.1.0` (executable `foo[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/foo
+[INSTALLED] package `foo v0.1.0` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -402,14 +406,18 @@ dependencies = [
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [INSTALLING] foo v0.1.0
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.1 (registry `dummy-registry`)
 [COMPILING] bar v0.1.1
 [COMPILING] foo v0.1.0
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[REPLACING] [ROOT]/home/.cargo/bin/foo[EXE]
-[REPLACED] package `foo v0.1.0` with `foo v0.1.0` (executable `foo[EXE]`)
+[REPLACING] [ROOT]/home/.cargo/bin/foo
+[REPLACED] package `foo v0.1.0` with `foo v0.1.0` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])

--- a/tests/testsuite/required_features.rs
+++ b/tests/testsuite/required_features.rs
@@ -747,6 +747,10 @@ fn install_default_features() {
     p.cargo("install --path . --no-default-features")
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.0.1 ([ROOT]/foo)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 [WARNING] none of the package's binaries are available for install using the selected features
   bin "foo" requires the features: `a`
@@ -765,6 +769,10 @@ Consider enabling some of the needed features by passing, e.g., `--features="a"`
         .with_status(101)
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.0.1 ([ROOT]/foo)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [ERROR] failed to compile `foo v0.0.1 ([ROOT]/foo)`, intermediate artifacts can be found at `[ROOT]/foo/target`.
 To reuse those artifacts with a future compilation, set the environment variable `CARGO_BUILD_BUILD_DIR` to that path.
 
@@ -784,6 +792,10 @@ Caused by:
         .with_status(101)
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.0.1 ([ROOT]/foo)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [ERROR] failed to compile `foo v0.0.1 ([ROOT]/foo)`, intermediate artifacts can be found at `[ROOT]/foo/target`.
 To reuse those artifacts with a future compilation, set the environment variable `CARGO_BUILD_BUILD_DIR` to that path.
 
@@ -901,6 +913,10 @@ fn install_multiple_required_features() {
     p.cargo("install --path . --no-default-features")
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.0.1 ([ROOT]/foo)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 [WARNING] none of the package's binaries are available for install using the selected features
   bin "foo_1" requires the features: `b`, `c`
@@ -914,6 +930,10 @@ Consider enabling some of the needed features by passing, e.g., `--features="b c
     p.cargo("install --path . --no-default-features --bins")
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.0.1 ([ROOT]/foo)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [WARNING] target filter `bins` specified, but no targets matched; this is a no-op
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 [WARNING] none of the package's binaries are available for install using the selected features
@@ -928,6 +948,10 @@ Consider enabling some of the needed features by passing, e.g., `--features="b c
     p.cargo("install --path . --no-default-features --examples")
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.0.1 ([ROOT]/foo)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [WARNING] target filter `examples` specified, but no targets matched; this is a no-op
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 [WARNING] none of the package's binaries are available for install using the selected features
@@ -942,6 +966,10 @@ Consider enabling some of the needed features by passing, e.g., `--features="b c
     p.cargo("install --path . --no-default-features --bins --examples")
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.0.1 ([ROOT]/foo)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [WARNING] target filters `bins`, `examples` specified, but no targets matched; this is a no-op
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 [WARNING] none of the package's binaries are available for install using the selected features
@@ -1251,6 +1279,10 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured; 0 filtered out; fini
     p.cargo("install --path .")
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.0.1 ([ROOT]/foo)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [LOCKING] 1 package to latest compatible version
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 [WARNING] none of the package's binaries are available for install using the selected features
@@ -1614,6 +1646,10 @@ fn truncated_install_warning_message() {
 
     p.cargo("install --path .").with_stderr_data(str![[r#"
 [INSTALLING] foo v0.1.0 ([ROOT]/foo)
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 [WARNING] none of the package's binaries are available for install using the selected features
   bin "foo1" requires the features: `feature1`, `feature2`, `feature3`

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -910,14 +910,18 @@ fn cargo_install_ignores_msrv_config() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
 [INSTALLING] foo v0.0.1
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v1.1.0 (registry `dummy-registry`)
 [COMPILING] dep v1.1.0
 [COMPILING] foo v0.0.1
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
-[INSTALLED] package `foo v0.0.1` (executable `foo[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/foo
+[INSTALLED] package `foo v0.0.1` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])
@@ -947,14 +951,18 @@ fn cargo_install_ignores_resolver_v3_msrv_change() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
 [INSTALLING] foo v0.0.1
+[WARNING] default toolchain implicitly overridden with `1.94.0-[HOST_TARGET]` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v1.1.0 (registry `dummy-registry`)
 [COMPILING] dep v1.1.0
 [COMPILING] foo v0.0.1
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
-[INSTALLED] package `foo v0.0.1` (executable `foo[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/foo
+[INSTALLED] package `foo v0.0.1` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]])

--- a/tests/testsuite/rustup.rs
+++ b/tests/testsuite/rustup.rs
@@ -338,10 +338,14 @@ fn cargo_install_with_toolchain_source_unset() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
 [INSTALLING] foo v0.0.1
+[WARNING] default toolchain implicitly overridden with `test-toolchain` by rustup directory override
+  |
+  = [HELP] use `cargo +stable install` if you meant to use the stable toolchain
+  = [NOTE] rustup selects the toolchain based on the parent environment and not the environment of the package being installed
 [COMPILING] foo v0.0.1
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
-[INSTALLED] package `foo v0.0.1` (executable `foo[EXE]`)
+[INSTALLING] [ROOT]/home/.cargo/bin/foo
+[INSTALLED] package `foo v0.0.1` (executable `foo`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
 
 "#]],


### PR DESCRIPTION
## What

When `cargo init` auto-detects the project kind, the shell status line previously printed the kind from CLI options (`opts.kind`) instead of the resolved `kind` after detection.

## Change

Use the computed `kind` in the `Creating … package` status so the message matches the package type actually being created.

## Testing

- [ ] `cargo init` in a directory where kind is auto-detected shows the correct kind in the status message.