### PR TITLE
missing -Zjson-target-spec error: mention that this is a cargo flag

### DIFF
--- a/src/cargo/core/compiler/compile_kind.rs
+++ b/src/cargo/core/compiler/compile_kind.rs
@@ -202,7 +202,9 @@ impl CompileTarget {
         }
 
         if !unstable_json {
-            bail!("`.json` target specs require -Zjson-target-spec");
+            bail!(
+                "`.json` target specs require -Zjson-target-spec to be added to the cargo invocation"
+            );
         }
 
         // If `name` ends in `.json` then it's likely a custom target

--- a/tests/testsuite/custom_target.rs
+++ b/tests/testsuite/custom_target.rs
@@ -45,7 +45,7 @@ fn custom_target_gated() {
     p.cargo("build --target custom-target.json")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] `.json` target specs require -Zjson-target-spec
+[ERROR] `.json` target specs require -Zjson-target-spec to be added to the cargo invocation
 
 "#]])
         .run();
@@ -55,7 +55,7 @@ fn custom_target_gated() {
         .env("CARGO_BUILD_TARGET", "custom-target.json")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] `.json` target specs require -Zjson-target-spec
+[ERROR] `.json` target specs require -Zjson-target-spec to be added to the cargo invocation
 
 "#]])
         .run();
@@ -79,7 +79,7 @@ fn custom_target_gated() {
 [ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
 
 Caused by:
-  `.json` target specs require -Zjson-target-spec
+  `.json` target specs require -Zjson-target-spec to be added to the cargo invocation
 
 "#]])
         .run();


### PR DESCRIPTION
_Thanks for the pull request 🎉!_
_Please read the contribution guide: <https://doc.crates.io/contrib/>._

### What does this PR try to resolve?

When I first saw this error, I thought it was a rustc error, so I figured out how to patch cargo-miri to add this to RUSTFLAGS -- only to then be told that the flag doesn't exist. Only then I realized that it's actually cargo emitting the error. Something similar just happened in https://github.com/rust-lang/rust/issues/154340.

I think the error would be more helpful if it gave an indication of where that flag it mentions should be added.