### PR TITLE
fix(auth): add auth scheme hint to token rejected error for alt registries

### DIFF
--- a/src/cargo/util/auth/mod.rs
+++ b/src/cargo/util/auth/mod.rs
@@ -400,6 +400,8 @@ pub struct AuthorizationError {
     reason: AuthorizationErrorReason,
     /// Should `cargo login` and the `_TOKEN` env var be included when displaying this error?
     supports_cargo_token_credential_provider: bool,
+    /// Whether the cached token appears to lack an authentication scheme (no space found).
+    token_lacks_scheme: Option<bool>,
 }
 
 impl AuthorizationError {
@@ -416,12 +418,17 @@ impl AuthorizationError {
             credential_provider(gctx, &sid, false, false)?
                 .iter()
                 .any(|p| p.first().map(String::as_str) == Some("cargo:token"));
+        let cache = gctx.credential_cache();
+        let token_lacks_scheme = cache
+            .get(sid.canonical_url())
+            .map(|entry| !entry.token_value.as_deref().expose().contains(' '));
         Ok(AuthorizationError {
             sid,
             default_registry: gctx.default_registry()?,
             login_url,
             reason,
             supports_cargo_token_credential_provider,
+            token_lacks_scheme,
         })
     }
 }
@@ -460,6 +467,15 @@ impl fmt::Display for AuthorizationError {
                     f,
                     "\nYou may need to log in using this registry's credential provider"
                 )?;
+            }
+
+            if self.reason == AuthorizationErrorReason::TokenRejected {
+                if self.token_lacks_scheme == Some(true) {
+                    write!(
+                        f,
+                        "\nnote: the token does not include an authentication scheme"
+                    )?;
+                }
             }
             Ok(())
         } else if self.reason == AuthorizationErrorReason::TokenMissing {

--- a/tests/testsuite/credential_process.rs
+++ b/tests/testsuite/credential_process.rs
@@ -104,6 +104,7 @@ fn credential_provider_auth_failure() {
 [UPDATING] `alternative` index
 [ERROR] token rejected for `alternative`
 You may need to log in using this registry's credential provider
+[NOTE] the token does not include an authentication scheme
 
 Caused by:
   failed to get successful HTTP response from [..]
@@ -629,7 +630,7 @@ fn basic_provider() {
             eprintln!("CARGO={:?}", std::env::var("CARGO").ok());
             eprintln!("CARGO_REGISTRY_NAME_OPT={:?}", std::env::var("CARGO_REGISTRY_NAME_OPT").ok());
             eprintln!("CARGO_REGISTRY_INDEX_URL={:?}", std::env::var("CARGO_REGISTRY_INDEX_URL").ok());
-            print!("sekrit"); 
+            print!("sekrit");
         }"#)
         .build();
     cred_proj.cargo("build").run();

--- a/tests/testsuite/registry_auth.rs
+++ b/tests/testsuite/registry_auth.rs
@@ -231,6 +231,7 @@ Caused by:
 Caused by:
   token rejected for `alternative`, please run `cargo login --registry alternative`
   or use environment variable CARGO_REGISTRIES_ALTERNATIVE_TOKEN
+  [NOTE] the token does not include an authentication scheme
 
 Caused by:
   failed to get successful HTTP response from `http://127.0.0.1:[..]/index/config.json`, got 401
@@ -272,6 +273,7 @@ Caused by:
 Caused by:
   token rejected for `alternative`, please run `cargo login --registry alternative`
   or use environment variable CARGO_REGISTRIES_ALTERNATIVE_TOKEN
+  [NOTE] the token does not include an authentication scheme
 
 Caused by:
   failed to get successful HTTP response from `http://127.0.0.1:[..]/index/config.json`, got 401
@@ -316,6 +318,7 @@ Caused by:
 Caused by:
   token rejected for `alternative`, please run `cargo login --registry alternative`
   or use environment variable CARGO_REGISTRIES_ALTERNATIVE_TOKEN
+  [NOTE] the token does not include an authentication scheme
 
 Caused by:
   failed to get successful HTTP response from `http://127.0.0.1:[..]/index/config.json`, got 401
@@ -410,6 +413,7 @@ Caused by:
 Caused by:
   token rejected for `alternative`, please run `cargo login --registry alternative`
   or use environment variable CARGO_REGISTRIES_ALTERNATIVE_TOKEN
+  [NOTE] the token does not include an authentication scheme
 
 Caused by:
   failed to get successful HTTP response from `http://127.0.0.1:[..]/index/config.json`, got 401
@@ -464,6 +468,12 @@ fn incorrect_token_bearer_scheme() {
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
 [ERROR] failed to get `bar` as a dependency of package `foo v0.0.1 ([ROOT]/foo)`
+
+Caused by:
+  failed to load source for dependency `bar`
+
+Caused by:
+  unable to update registry `alternative`
 
 Caused by:
   token rejected for `alternative`, please run `cargo login --registry alternative`


### PR DESCRIPTION
### What does this PR try to resolve?

Based on the POC PR https://github.com/rust-lang/cargo/pull/15985, expand token rejected error message with authorization scheme.

Addresses issue https://github.com/rust-lang/cargo/issues/15021.

### How to test and review this PR?

Run the tests in `tests/testsuite/registry_auth.rs`:
- `incorrect_token_unrecognized_scheme`
- `incorrect_token_bearer_scheme`
- `incorrect_token`