### PR TITLE
chore: bump to curl-sys@0.4.87

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,9 +941,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.86+curl-8.19.0"
+version = "0.4.87+curl-8.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1dd6a487cf4532ce0d801634b82aa2deb7c9c3ed930b9dadfce904df000745"
+checksum = "61a460380f0ef783703dcbe909107f39c162adeac050d73c850055118b5b6327"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ core-foundation = { version = "0.10.1", features = ["mac_os_10_7_support"] }
 crates-io = { version = "0.40.18", path = "crates/crates-io" }
 criterion = { version = "0.8.2", features = ["html_reports"] }
 curl = "0.4.49"
-curl-sys = "0.4.86"
+curl-sys = "0.4.87"
 filetime = "0.2.27"
 flate2 = { version = "1.1.9", default-features = false, features = ["zlib-rs"] }
 git2 = "0.20.4"


### PR DESCRIPTION
### What does this PR try to resolve?

See

* https://github.com/alexcrichton/curl-rust/pull/643
* https://github.com/rust-lang/rust/pull/154482#issuecomment-4151854340

This will unblock cargo submodule update in rust-lang/rust