### PR TITLE
feat(manifest): allow git dependency alongside alternate registry

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -2362,21 +2362,17 @@ fn to_dependency_source_id<P: ResolveToPath + Clone>(
         orig.registry.as_deref(),
         orig.registry_index.as_ref(),
     ) {
-        (Some(_git), _, Some(_registry), _) | (Some(_git), _, _, Some(_registry)) => bail!(
-            "dependency ({name_in_toml}) specification is ambiguous. \
-                 Only one of `git` or `registry` is allowed.",
-        ),
-        (_, _, Some(_registry), Some(_registry_index)) => bail!(
-            "dependency ({name_in_toml}) specification is ambiguous. \
-                 Only one of `registry` or `registry-index` is allowed.",
-        ),
-        (Some(_git), Some(_path), None, None) => {
+        (Some(_git), Some(_path), _, _) => {
             bail!(
                 "dependency ({name_in_toml}) specification is ambiguous. \
                      Only one of `git` or `path` is allowed.",
             );
         }
-        (Some(git), None, None, None) => {
+        (_, _, Some(_registry), Some(_registry_index)) => bail!(
+            "dependency ({name_in_toml}) specification is ambiguous. \
+                 Only one of `registry` or `registry-index` is allowed.",
+        ),
+        (Some(git), None, _, _) => {
             let n_details = [&orig.branch, &orig.tag, &orig.rev]
                 .iter()
                 .filter(|d| d.is_some())

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -274,12 +274,12 @@ fn registry_and_git_dep_works() {
     Package::new("bar", "0.0.1").alternative(true).publish();
 
     p.cargo("check")
-        .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
-
-Caused by:
-  dependency (bar) specification is ambiguous. Only one of `git` or `registry` is allowed.
+[UPDATING] git repository `[ROOTURL]/bar`
+[LOCKING] 1 package to latest compatible version
+[CHECKING] bar v0.0.1 ([ROOTURL]/bar#[..])
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
         .run();
@@ -720,15 +720,62 @@ fn publish_with_git_and_registry_dep() {
     Package::new("bar", "0.0.1").alternative(true).publish();
 
     p.cargo("publish --registry alternative")
-        .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
-
-Caused by:
-  dependency (bar) specification is ambiguous. Only one of `git` or `registry` is allowed.
+[UPDATING] `alternative` index
+[PACKAGING] foo v0.0.1 ([ROOT]/foo)
+[UPDATING] `alternative` index
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[VERIFYING] foo v0.0.1 ([ROOT]/foo)
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v0.0.1 (registry `alternative`)
+[COMPILING] bar v0.0.1 (registry `alternative`)
+[COMPILING] foo v0.0.1 ([ROOT]/foo/target/package/foo-0.0.1)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[UPLOADING] foo v0.0.1 ([ROOT]/foo)
+[UPLOADED] foo v0.0.1 to registry `alternative`
+[NOTE] waiting for foo v0.0.1 to be available at registry `alternative`
+[HELP] you may press ctrl-c to skip waiting; the crate should be available shortly
+[PUBLISHED] foo v0.0.1 at registry `alternative`
 
 "#]])
         .run();
+
+    validate_alt_upload(
+        r#"{
+            "authors": [],
+            "badges": {},
+            "categories": [],
+            "deps": [
+                {
+                    "default_features": true,
+                    "features": [],
+                    "kind": "normal",
+                    "name": "bar",
+                    "optional": false,
+                    "target": null,
+                    "version_req": "^0.0.1"
+                }
+            ],
+            "description": null,
+            "documentation": null,
+            "features": {},
+            "homepage": null,
+            "keywords": [],
+            "license": null,
+            "license_file": null,
+            "links": null,
+            "name": "foo",
+            "readme": null,
+            "readme_file": null,
+            "repository": null,
+            "homepage": null,
+            "documentation": null,
+            "rust_version": null,
+            "vers": "0.0.1"
+        }"#,
+        "foo-0.0.1.crate",
+        &["Cargo.lock", "Cargo.toml", "Cargo.toml.orig", "src/main.rs"],
+    );
 }
 
 #[cargo_test]

--- a/tests/testsuite/cargo_add/git_registry/mod.rs
+++ b/tests/testsuite/cargo_add/git_registry/mod.rs
@@ -46,7 +46,6 @@ fn case() {
         ])
         .current_dir(cwd)
         .assert()
-        .failure()
         .stdout_eq(str![""])
         .stderr_eq(file!["stderr.term.svg"]);
 

--- a/tests/testsuite/cargo_add/git_registry/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_registry/stderr.term.svg
@@ -1,9 +1,8 @@
-<svg width="902px" height="146px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1314px" height="110px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-green { fill: #55FF55 }
-    .fg-bright-red { fill: #FF5555 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -23,15 +22,11 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> versioned-package (git) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-red bold">error</tspan><tspan>: failed to parse manifest at `[ROOT]/case/Cargo.toml`</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/versioned-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px">
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Caused by:</tspan>
-</tspan>
-    <tspan x="10px" y="118px"><tspan>  dependency (versioned-package) specification is ambiguous. Only one of `git` or `registry` is allowed.</tspan>
-</tspan>
-    <tspan x="10px" y="136px">
+    <tspan x="10px" y="100px">
 </tspan>
   </text>
 


### PR DESCRIPTION
### What does this PR try to resolve?

Removes the restriction that prevented combining `git` with `registry` (or `registry-index`), bringing alternate registries to parity with crates.io for the [multiple locations feature](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations).

Previously, any combination of `git + registry` was rejected. Now:
- `git + path` is still always rejected
- `registry + registry_index` together is still rejected
- `git + registry` is allowed: the git arm `(Some(git), None, _, _)` handles it

At publishing time, it already stripped all `git` fields, leaving only `registry`, so it required no changes.

Fixes #10875

### How to test and review this PR?

Run tests:
- `registry_and_git_dep_works` 
- `publish_with_git_and_registry_dep`

in `alt_registry` test suite, and:

- `git_registry`

in `cargo_add` test suite.