### PR TITLE
fix: set CARGO env var during rustc -vV probe

### DIFF
--- a/src/cargo/util/rustc.rs
+++ b/src/cargo/util/rustc.rs
@@ -63,6 +63,7 @@ impl Rustc {
             .wrapped(workspace_wrapper.as_ref())
             .wrapped(wrapper.as_deref());
         apply_env_config(gctx, &mut cmd)?;
+        cmd.env(crate::CARGO_ENV, gctx.cargo_exe()?);
         cmd.arg("-vV");
         let verbose_version = cache.cached_output(&cmd, 0)?.0;
 

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -4581,8 +4581,8 @@ fn rustc_wrapper_vv_probe_has_cargo_env() {
 
     let result = std::fs::read_to_string(marker_dir.join("cargo_env_in_vv")).unwrap();
     assert_eq!(
-        result, "false",
-        "CARGO env var should not be set during -vV probe without the fix"
+        result, "true",
+        "CARGO env var should be set during -vV probe for wrapper compatibility"
     );
 }
 


### PR DESCRIPTION
## Summary

Set the `CARGO` environment variable when running the `rustc -vV` version probe, consistent with how `Compilation::fill_env()` sets it for all compilation invocations.

## Problem

Since #13659, the `-vV` probe goes through `RUSTC_WRAPPER` and `RUSTC_WORKSPACE_WRAPPER`. However, the `CARGO` env var is not set during this probe. Tools like sccache depend on `CARGO` to detect the workspace wrapper pattern in their compiler detection logic ([mozilla/sccache#1280](https://github.com/mozilla/sccache/pull/1280)), causing `sccache` to fail with "Compiler not supported" when a `RUSTC_WORKSPACE_WRAPPER` is present.

## Solution

Add `cmd.env(crate::CARGO_ENV, gctx.cargo_exe()?)` before the `-vV` invocation in `Rustc::new()`.

## Test plan

- [x] Existing `rustc_wrapper` tests pass (8/8)
- Manually verified: `CARGO=$(which cargo)` as a workaround resolves the issue

Closes #16805