### PR TITLE
Simplified build script bin names in new layout

### DIFF
--- a/src/cargo/core/compiler/build_runner/compilation_files.rs
+++ b/src/cargo/core/compiler/build_runner/compilation_files.rs
@@ -449,7 +449,13 @@ impl<'a, 'gctx: 'a> CompilationFiles<'a, 'gctx> {
     ///
     /// Returns `None` if the unit shouldn't be uplifted (for example, a
     /// dependent rlib).
-    fn uplift_to(&self, unit: &Unit, file_type: &FileType, from_path: &Path) -> Option<PathBuf> {
+    fn uplift_to(
+        &self,
+        unit: &Unit,
+        file_type: &FileType,
+        from_path: &Path,
+        bcx: &BuildContext<'_, '_>,
+    ) -> Option<PathBuf> {
         // Tests, check, doc, etc. should not be uplifted.
         if unit.mode != CompileMode::Build || file_type.flavor == FileFlavor::Rmeta {
             return None;
@@ -457,6 +463,11 @@ impl<'a, 'gctx: 'a> CompilationFiles<'a, 'gctx> {
 
         // Artifact dependencies are never uplifted.
         if unit.artifact.is_true() {
+            return None;
+        }
+
+        // Build script bins are never uplifted.
+        if bcx.gctx.cli_unstable().build_dir_new_layout && unit.target.is_custom_build() {
             return None;
         }
 
@@ -645,7 +656,7 @@ impl<'a, 'gctx: 'a> CompilationFiles<'a, 'gctx> {
 
             // If, the `different_binary_name` feature is enabled, the name of the hardlink will
             // be the name of the binary provided by the user in `Cargo.toml`.
-            let hardlink = self.uplift_to(unit, &file_type, &path);
+            let hardlink = self.uplift_to(unit, &file_type, &path, bcx);
             let export_path = if unit.target.is_custom_build() {
                 None
             } else {

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -349,7 +349,12 @@ fn build_work(build_runner: &mut BuildRunner<'_, '_>, unit: &Unit) -> CargoResul
     }
 
     // Building the command to execute
-    let to_exec = script_dir.join(unit.target.name());
+    let bin_name = if bcx.gctx.cli_unstable().build_dir_new_layout {
+        unit.target.crate_name()
+    } else {
+        unit.target.name().to_string()
+    };
+    let to_exec = script_dir.join(bin_name);
 
     // Start preparing the process to execute, starting out with some
     // environment variables. Note that the profile-related environment

--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -283,7 +283,6 @@ fn build_script_should_output_to_build_dir() {
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo.txt
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/build_script_build.d
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/build_script_build[EXE]
-[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/build-script-build[EXE]
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp

--- a/tests/testsuite/clean_new_layout.rs
+++ b/tests/testsuite/clean_new_layout.rs
@@ -401,7 +401,7 @@ fn build_script() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc [..] build.rs [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc [..] src/main.rs [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 


### PR DESCRIPTION
### What does this PR try to resolve?

This PR spawned out of a [comment](https://github.com/rust-lang/cargo/pull/16807#discussion_r3010589089) from @epage raising that we didn't remove the hashes for some bins. However we did remove the hashes from "regular" bins in https://github.com/rust-lang/cargo/pull/16351

This PR 
* Removes the use of `-Cextra-filename` for build scripts when `-Zbuild-dir-new-layout` is enabled.
* Does not uplift build-scripts in the `build-dir` internally. (its not really uplifting, its more of a rename via hardlink)

Previously, we had a directory like 
```
build/<pkg>/<hash>/out/
    build_script_build-[HASH].d
    build_script_build-[HASH][EXE]
    build-script-build[EXE]
```

After this change
```
build/<pkg>/<hash>/out/
    build_script_build.d
    build_script_build[EXE]
```

Part of: https://github.com/rust-lang/cargo/issues/15010

### How to test and review this PR?

See the test updates in each commit.
I could split into 2 PRs if needed but I felt the changes were related and small enough to go together.