### PR TITLE
fix(install): Ignore resolver.lockfile-path

### DIFF
--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -219,23 +219,11 @@ impl<'gctx> InstallablePackage<'gctx> {
 
         let (ws, rustc, target) =
             make_ws_rustc_target(gctx, &original_opts, &source_id, pkg.clone())?;
-
-        if !gctx.lock_update_allowed() {
-            // When --lockfile-path is set, check that passed lock file exists
-            // (unlike the usual flag behavior, lockfile won't be created as we imply --locked)
-            if let Some(requested_lockfile_path) = ws.requested_lockfile_path() {
-                if !requested_lockfile_path.is_file() {
-                    bail!(
-                        "no Cargo.lock file found in the requested path {}",
-                        requested_lockfile_path.display()
-                    );
-                }
-            // If we're installing in --locked mode and there's no `Cargo.lock` published
-            // ie. the bin was published before https://github.com/rust-lang/cargo/pull/7026
-            } else if !ws.root().join("Cargo.lock").exists() {
-                gctx.shell()
-                    .warn(format!("no Cargo.lock file published in {}", pkg))?;
-            }
+        // If we're installing in --locked mode and there's no `Cargo.lock` published
+        // ie. the bin was published before https://github.com/rust-lang/cargo/pull/7026
+        if !gctx.lock_update_allowed() && !ws.root().join("Cargo.lock").exists() {
+            gctx.shell()
+                .warn(format!("no Cargo.lock file published in {}", pkg))?;
         }
         let pkg = if source_id.is_git() {
             // Don't use ws.current() in order to keep the package source as a git source so that
@@ -941,6 +929,7 @@ fn make_ws_rustc_target<'gctx>(
     };
     ws.set_resolve_feature_unification(FeatureUnification::Selected);
     ws.set_ignore_lock(gctx.lock_update_allowed());
+    ws.set_requested_lockfile_path(None);
     ws.set_require_optional_deps(false);
 
     let rustc = gctx.load_global_rustc(Some(&ws))?;

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1786,6 +1786,10 @@ lockfiles should be stored in different directories.
 
 *as a new `resolver.lockfile-path` entry in config.md*
 
+*Keep in mind, the `[resolver]` section has this clarification:*
+
+> *The `[resolver]` table overrides dependency resolution behavior for local development (e.g. excludes `cargo install`).*
+
 #### `resolver.lockfile-path`
 
 * Type: string (path)

--- a/tests/testsuite/lockfile_path.rs
+++ b/tests/testsuite/lockfile_path.rs
@@ -352,13 +352,12 @@ bar = "0.1.0"
 }
 
 #[cargo_test]
-fn config_install_respects_lock_file_path() {
-    // `cargo install` will imply --locked when lockfile path is provided
-    Package::new("bar", "0.1.0").publish();
-    Package::new("bar", "0.1.1")
+fn config_install_ignores_lock_file_path() {
+    Package::new("bar", "0.1.0")
         .file("src/lib.rs", "not rust")
         .publish();
-    // Publish with lockfile containing bad version of `bar` (0.1.1)
+    Package::new("bar", "0.1.1").publish();
+    // Publish with lockfile containing good version of `bar` (0.1.1)
     Package::new("foo", "0.1.0")
         .dep("bar", "0.1")
         .file("src/lib.rs", "")
@@ -386,16 +385,9 @@ dependencies = [
 
     let p = project().at("install").build();
 
-    p.cargo("install foo --locked")
-        .with_stderr_data(str![[r#"
-...
-[..]not rust[..]
-...
-"#]])
-        .with_status(101)
-        .run();
+    p.cargo("install foo --locked").run();
 
-    // Create lockfile with the good `bar` version (0.1.0) and use it for install
+    // Create lockfile with the bad `bar` version (0.1.0) and see it ignored for install
     project()
         .file(
             "Cargo.lock",
@@ -422,34 +414,6 @@ dependencies = [
 
     assert!(paths::root().join("foo/Cargo.lock").is_file());
     assert_has_installed_exe(paths::cargo_home(), "foo");
-}
-
-#[cargo_test]
-fn config_install_lock_file_path_must_present() {
-    // `cargo install` will imply --locked when lockfile path is provided
-    Package::new("bar", "0.1.0").publish();
-    Package::new("foo", "0.1.0")
-        .dep("bar", "0.1")
-        .file("src/lib.rs", "")
-        .file(
-            "src/main.rs",
-            "extern crate foo; extern crate bar; fn main() {}",
-        )
-        .publish();
-
-    let p = project().at("install").build();
-
-    p.cargo("install foo --locked -Zlockfile-path")
-        .masquerade_as_nightly_cargo(&["lockfile-path"])
-        .arg("--config")
-        .arg("resolver.lockfile-path='../lockfile_dir/Cargo.lock'")
-        .with_stderr_data(str![[r#"
-...
-[ERROR] no Cargo.lock file found in the requested path [ROOT]/install/../lockfile_dir/Cargo.lock
-...
-"#]])
-        .with_status(101)
-        .run();
 }
 
 #[cargo_test(nightly, reason = "-Zscript is unstable")]


### PR DESCRIPTION
### What does this PR try to resolve?

`[resolver]` was designed to not apply to `cargo install`, so `resolver.lockfile-path` shouldn't apply to `cargo install` also.

### How to test and review this PR?

This basically reverts the last of bf37cf7f325d35665bac4b7216871c297f0b3d3e
