### PR TITLE
Send Content-Type header with cargo publish requests

### DIFF
--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -244,7 +244,7 @@ impl Registry {
 
     pub fn add_owners(&mut self, krate: &str, owners: &[&str]) -> Result<String> {
         let body = serde_json::to_string(&OwnersReq { users: owners })?;
-        let body = self.put(&format!("/crates/{}/owners", krate), body.as_bytes())?;
+        let body = self.put(&format!("/crates/{}/owners", krate), Some(body.as_bytes()))?;
         assert!(serde_json::from_str::<OwnerResponse>(&body)?.ok);
         Ok(serde_json::from_str::<OwnerResponse>(&body)?.msg)
     }
@@ -365,14 +365,14 @@ impl Registry {
     }
 
     pub fn unyank(&mut self, krate: &str, version: &str) -> Result<()> {
-        let body = self.put(&format!("/crates/{}/{}/unyank", krate, version), &[])?;
+        let body = self.put(&format!("/crates/{}/{}/unyank", krate, version), None)?;
         assert!(serde_json::from_str::<R>(&body)?.ok);
         Ok(())
     }
 
-    fn put(&mut self, path: &str, b: &[u8]) -> Result<String> {
+    fn put(&mut self, path: &str, b: Option<&[u8]>) -> Result<String> {
         self.handle.put(true)?;
-        self.req(path, Some(b), Auth::Authorized)
+        self.req(path, b, Auth::Authorized)
     }
 
     fn get(&mut self, path: &str) -> Result<String> {

--- a/src/doc/src/reference/registry-web-api.md
+++ b/src/doc/src/reference/registry-web-api.md
@@ -212,9 +212,8 @@ A successful response includes the JSON object:
 - Method: PUT
 - Authorization: Included
 - Headers:
-    - `Content-Type`: `application/json`
     - `Accept`: `application/json`
-- Body: ""
+- Body: None
 
 The unyank endpoint will set the `yank` field of the given version of a crate
 to `false` in the index.


### PR DESCRIPTION
### What does this PR try to resolve?

Sends an appropriate `Content-Type` header with `cargo publish` requests.

Resolves:

https://github.com/rust-lang/cargo/issues/16830

### How to test and review this PR?

If necessary, find a way to log the request headers / metadata - I tested this against my in-progress registry implementation.  Maybe there is logging mode which can skip that step, I'm not sure.