### PR TITLE
chore: downgrade to libz-sys@1.1.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3173,9 +3173,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.25"
+version = "1.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
+checksum = "4735e9cbde5aac84a5ce588f6b23a90b9b0b528f6c5a8db8a4aff300463a0839"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
### What does this PR try to resolve?

libz-sys@1.1.25 doesn't compile on FreeBSD.

See

* https://github.com/rust-lang/libz-sys/pull/264
* [#t-libs/crates > libz-sys failed to build on FreeBSD](https://rust-lang.zulipchat.com/#narrow/channel/351149-t-libs.2Fcrates/topic/libz-sys.20failed.20to.20build.20on.20FreeBSD/with/583479437)

Alternatively, we could wait for new release of libz-sys, but I'd like to maximize test window of the gigantic async refactor rust-lang/cargo#16745

