### PR TITLE
fix: Typo in target.<cfg>.linker

### DIFF
--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -1345,9 +1345,9 @@ Specifies the linker which is passed to `rustc` (via [`-C linker`]) when the
 
 #### `target.<cfg>.linker`
 This is similar to the [target linker](#targettriplelinker), but using
-a [`cfg()` expression]. If both a [`<triple>`] and `<cfg>` runner match,
+a [`cfg()` expression]. If both a [`<triple>`] and `<cfg>` linker match,
 the `<triple>` will take precedence. It is an error if more than one
-`<cfg>` runner matches the current target.
+`<cfg>` linker matches the current target.
 
 #### `target.<triple>.runner`
 * Type: string or array of strings ([program path with args])


### PR DESCRIPTION
Mistaken use of "runner" instead of "linker"

### What does this PR try to resolve?

Fixes a typo.