### PR TITLE
docs(unstable): List the minimum required MSRV for 'public' field

### DIFF
--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -358,6 +358,7 @@ private_dep = "2.0.0" # Will be 'private' by default
 
 Documentation updates:
 - For workspace's "The `dependencies` table" section, include `public` as an unsupported field for `workspace.dependencies`
+- Required MSRV for use of `public` is 1.83 (see [#14507](https://github.com/rust-lang/cargo/pull/14507))
 
 ## msrv-policy
 - [RFC: MSRV-aware Resolver](https://rust-lang.github.io/rfcs/3537-msrv-resolver.html)


### PR DESCRIPTION
### What does this PR try to resolve?

- We'll eventually need to cover this when we write more documentation and would best not to forget that `public` couldn't always be used on stable
- I occasionally find myself interested in this for one reason or the other and don't want to look up the PR every time to know the answer (e.g. "is my MSRV old enough to start using this?)

### How to test and review this PR?

