### PR TITLE
fix(core): use `closest_msg` to suggest similar member name for mistyped `-p`

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -47,8 +47,8 @@ use crate::util::errors::{CargoResult, ManifestError};
 use crate::util::interning::InternedString;
 use crate::util::toml::{InheritableFields, read_manifest};
 use crate::util::{
-    Filesystem, GlobalContext, IntoUrl, context::CargoResolverConfig, context::ConfigRelativePath,
-    context::IncompatibleRustVersions,
+    Filesystem, GlobalContext, IntoUrl, closest_msg, context::CargoResolverConfig,
+    context::ConfigRelativePath, context::IncompatibleRustVersions,
 };
 
 use cargo_util::paths;
@@ -1890,7 +1890,19 @@ impl<'gctx> Workspace<'gctx> {
                 && !cli_features.all_features
                 && cli_features.uses_default_features)
             {
-                bail!("cannot specify features for packages outside of workspace");
+                let hint = specs
+                    .iter()
+                    .map(|spec| {
+                        closest_msg(
+                            spec.name(),
+                            self.members(),
+                            |m| m.name().as_str(),
+                            "workspace member",
+                        )
+                    })
+                    .find(|msg| !msg.is_empty())
+                    .unwrap_or_default();
+                bail!("cannot specify features for packages outside of workspace{hint}");
             }
             // Add all members from the workspace so we can ensure `-p nonmember`
             // is in the resolve graph.

--- a/tests/testsuite/package_features.rs
+++ b/tests/testsuite/package_features.rs
@@ -780,6 +780,32 @@ fn non_member() {
 }
 
 #[cargo_test]
+fn non_member_typo() {
+    // -p with a mistyped package name currently shows a misleading error
+    // without any hint about similar workspace member names.
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["bar"]
+            resolver = "2"
+            "#,
+        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "1.0.0"))
+        .file("bar/src/lib.rs", "")
+        .build();
+
+    p.cargo("build -p barr --all-features")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] cannot specify features for packages outside of workspace
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn resolver1_member_features() {
     // --features member-name/feature-name with resolver="1"
     let p = project()

--- a/tests/testsuite/package_features.rs
+++ b/tests/testsuite/package_features.rs
@@ -747,6 +747,8 @@ fn non_member() {
         .with_stderr_data(str![[r#"
 [ERROR] cannot specify features for packages outside of workspace
 
+[HELP] a workspace member with a similar name exists: `foo`
+
 "#]])
         .run();
 
@@ -755,6 +757,8 @@ fn non_member() {
         .with_stderr_data(str![[r#"
 [ERROR] cannot specify features for packages outside of workspace
 
+[HELP] a workspace member with a similar name exists: `foo`
+
 "#]])
         .run();
 
@@ -762,6 +766,8 @@ fn non_member() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] cannot specify features for packages outside of workspace
+
+[HELP] a workspace member with a similar name exists: `foo`
 
 "#]])
         .run();
@@ -781,8 +787,8 @@ fn non_member() {
 
 #[cargo_test]
 fn non_member_typo() {
-    // -p with a mistyped package name currently shows a misleading error
-    // without any hint about similar workspace member names.
+    // -p with a mistyped package name shows a helpful error hint
+    // about similarly named workspace members.
     let p = project()
         .file(
             "Cargo.toml",
@@ -800,6 +806,8 @@ fn non_member_typo() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] cannot specify features for packages outside of workspace
+
+[HELP] a workspace member with a similar name exists: `bar`
 
 "#]])
         .run();
@@ -988,6 +996,8 @@ fn non_member_feature() {
         .with_stderr_data(str![[r#"
 [ERROR] cannot specify features for packages outside of workspace
 
+[HELP] a workspace member with a similar name exists: `foo`
+
 "#]])
         .run();
 
@@ -1009,6 +1019,8 @@ fn non_member_feature() {
         .with_stderr_data(str![[r#"
 [ERROR] cannot specify features for packages outside of workspace
 
+[HELP] a workspace member with a similar name exists: `foo`
+
 "#]])
         .run();
     p.cargo("check -p bar --features bar/jazz")
@@ -1016,12 +1028,16 @@ fn non_member_feature() {
         .with_stderr_data(str![[r#"
 [ERROR] cannot specify features for packages outside of workspace
 
+[HELP] a workspace member with a similar name exists: `foo`
+
 "#]])
         .run();
     p.cargo("check -p bar --features foo/bar")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] cannot specify features for packages outside of workspace
+
+[HELP] a workspace member with a similar name exists: `foo`
 
 "#]])
         .run();


### PR DESCRIPTION
Fixes: #15561 

Use `closest_msg` to suggest similar workspace member name when `-p <typo>` triggers the outside-of-workspace features error.