### PR TITLE
Support target.'cfg(..)'.rustdocflags analogously to rustflags

### DIFF
--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -870,15 +870,15 @@ fn rustflags_from_target(
     if let Some(target_cfg) = target_cfg {
         gctx.target_cfgs()?
             .iter()
-            .filter_map(|(key, cfg)| {
-                match flag {
-                    Flags::Rust => cfg
-                        .rustflags
-                        .as_ref()
-                        .map(|rustflags| (key, &rustflags.val)),
-                    // `target.cfg(…).rustdocflags` is currently not supported.
-                    Flags::Rustdoc => None,
-                }
+            .filter_map(|(key, cfg)| match flag {
+                Flags::Rust => cfg
+                    .rustflags
+                    .as_ref()
+                    .map(|rustflags| (key, &rustflags.val)),
+                Flags::Rustdoc => cfg
+                    .rustdocflags
+                    .as_ref()
+                    .map(|rustdocflags| (key, &rustdocflags.val)),
             })
             .filter(|(key, _rustflags)| CfgExpr::matches_key(key, target_cfg))
             .for_each(|(_key, cfg_rustflags)| {

--- a/src/cargo/util/context/target.rs
+++ b/src/cargo/util/context/target.rs
@@ -13,6 +13,7 @@ use std::rc::Rc;
 pub struct TargetCfgConfig {
     pub runner: OptValue<PathAndArgs>,
     pub rustflags: OptValue<StringList>,
+    pub rustdocflags: OptValue<StringList>,
     pub linker: OptValue<ConfigRelativePath>,
     // This is here just to ignore fields from normal `TargetConfig` because
     // all `[target]` tables are getting deserialized, whether they start with

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -605,7 +605,8 @@ order, with the first one being used:
 
 1. `CARGO_ENCODED_RUSTDOCFLAGS` environment variable.
 2. `RUSTDOCFLAGS` environment variable.
-3. All matching `target.<triple>.rustdocflags` config entries joined together.
+3. All matching `target.<triple>.rustdocflags` and `target.<cfg>.rustdocflags`
+  config entries joined together.
 4. `build.rustdocflags` config value.
 
 Additional flags may also be passed with the [`cargo rustdoc`] command.
@@ -1393,6 +1394,12 @@ The value may be an array of strings or a space-separated string.
 
 See [`build.rustdocflags`](#buildrustdocflags) for more details on the different
 ways to specific extra flags.
+
+#### `target.<cfg>.rustdocflags`
+
+This is similar to the [target rustdocflags](#targettriplerustdocflags), but
+using a [`cfg()` expression]. If several `<cfg>` and [`<triple>`] entries
+match the current target, the flags are joined together.
 
 #### `target.<triple>.<links>`
 

--- a/tests/testsuite/rustdocflags.rs
+++ b/tests/testsuite/rustdocflags.rs
@@ -194,7 +194,7 @@ fn not_affected_by_target_rustflags() {
 }
 
 #[cargo_test]
-fn target_cfg_rustdocflags_is_ignored() {
+fn target_cfg_rustdocflags_works() {
     let p = project()
         .file("src/lib.rs", "")
         .file(
@@ -211,22 +211,21 @@ fn target_cfg_rustdocflags_is_ignored() {
 
     p.cargo("doc -v")
         .with_stderr_data(str![[r#"
-[WARNING] unused key `rustdocflags` in [target] config table `cfg(true)`
 ...
-[RUNNING] `rustdoc [..] --cfg from_build[..]`
+[RUNNING] `rustdoc [..] --cfg from_target_cfg[..]`
 ...
 "#]])
         .run();
 }
 
 #[cargo_test]
-fn target_cfg_rustdocflags_is_ignored_through_cargo_test() {
+fn target_cfg_rustdocflags_works_through_cargo_test() {
     let p = project()
         .file(
             "src/lib.rs",
             r#"
                 //! ```
-                //! assert!(cfg!(from_build));
+                //! assert!(cfg!(from_target_cfg));
                 //! ```
             "#,
         )
@@ -244,9 +243,9 @@ fn target_cfg_rustdocflags_is_ignored_through_cargo_test() {
 
     p.cargo("test --doc -v")
         .with_stderr_data(str![[r#"
-[WARNING] unused key `rustdocflags` in [target] config table `cfg(true)`
 ...
-[RUNNING] `rustdoc[..]--test[..]--cfg[..]from_build[..]`
+[RUNNING] `rustdoc[..]--test[..]--cfg[..]from_target_cfg[..]`
+
 "#]])
         .with_stdout_data(str![[r#"
 


### PR DESCRIPTION
### What does this PR try to resolve?

Resolves #16761 by supporting `target.'cfg(..)'.rustdocflags` with behavior analogous to `target.'cfg(..)'.rustflags`.

Before this change, `target.'cfg(..)'.rustdocflags` was ignored and warned as an unused key. This PR brings cfg-based `rustdocflags` support to parity with existing cfg-based `rustflags` behavior.

This PR is intentionally split into two atomic commits:

- `test: cover ignored target cfg rustdocflags behavior`
  - Adds tests that document the prior behavior first (C-TEST).
- `fix: support target cfg rustdocflags`
  - Implements cfg-based `rustdocflags` support.
  - Updates the new tests to the new expected behavior.
  - Updates config reference docs for precedence and `target.<cfg>.rustdocflags`.

### How to test and review this PR?

Suggested review order by commit:

1. `test: cover ignored target cfg rustdocflags behavior`
2. `fix: support target cfg rustdocflags`

Focused tests:

```bash
cargo test -p cargo --test testsuite -- rustdocflags::target_cfg_rustdocflags -- --test-threads=1
```

Full rustdocflags module:

```bash
cargo test -p cargo --test testsuite -- rustdocflags:: -- --test-threads=1
```

Local validation run for this branch included:

- `cargo build`
- `cargo clippy -- -D warnings`
- `cargo test -p cargo --test testsuite -- rustdocflags:: -- --test-threads=1`