### PR TITLE
fix(toml): Force script edition warnings on quiet 

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -636,7 +636,7 @@ fn normalize_package_toml<'a>(
                 let report = [Group::with_title(Level::WARNING.secondary_title(format!(
                     "`package.edition` is unspecified, defaulting to the latest edition (currently `{DEFAULT_EDITION}`)"
                 )))];
-                let _ = gctx.shell().print_report(&report, false);
+                let _ = gctx.shell().print_report(&report, true);
                 Some(manifest::InheritableField::Value(
                     DEFAULT_EDITION.to_string(),
                 ))

--- a/tests/testsuite/script/cargo.rs
+++ b/tests/testsuite/script/cargo.rs
@@ -414,6 +414,7 @@ rustc = "non-existent-rustc"
         .masquerade_as_nightly_cargo(&["script"])
         .with_status(101)
         .with_stderr_data(str![[r#"
+[WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `2024`)
 [ERROR] could not execute process `non-existent-rustc -vV` (never executed)
 
 Caused by:
@@ -449,7 +450,10 @@ arg0: [..]
 args: ["-NotAnArg"]
 
 "#]])
-        .with_stderr_data("")
+        .with_stderr_data(str![[r#"
+[WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+
+"#]])
         .run();
 }
 
@@ -468,7 +472,10 @@ arg0: [..]
 args: ["-NotAnArg"]
 
 "#]])
-        .with_stderr_data("")
+        .with_stderr_data(str![[r#"
+[WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+
+"#]])
         .run();
 }
 


### PR DESCRIPTION
### What does this PR try to resolve?

With closing of #16598, we were stating that "unpinned edition"
message should not be silenced.
However, by default all warnings are silenced with `--quiet`.
This also extends to `cargo foo.rs 2>&1 output.txt` because that implies
`--quiet` for now until we are better able to limit the output of Cargo
(see #8889).
This tty-dependent verbosity  was not necessarily intended to silence
this specific warning.

This changes the edition warning so it is "forced" to always be
displayed, regardless of verbosity, closing that hole for silencing it.

### How to test and review this PR?

