### PR TITLE
fix(toml): Teach users how to pin edition

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -633,9 +633,14 @@ fn normalize_package_toml<'a>(
             if is_embedded {
                 const DEFAULT_EDITION: crate::core::features::Edition =
                     crate::core::features::Edition::LATEST_STABLE;
-                let report = [Group::with_title(Level::WARNING.secondary_title(format!(
+                let mut report = vec![Group::with_title(Level::WARNING.secondary_title(format!(
                     "`package.edition` is unspecified, defaulting to the latest edition (currently `{DEFAULT_EDITION}`)"
                 )))];
+                if !matches!(gctx.shell().verbosity(), cargo_util_terminal::Verbosity::Quiet) {
+                    report.push(Group::with_title(Level::HELP.secondary_title(format!(
+                        "to pin the edition, run `cargo fix --manifest-path {}`", manifest_file.display()
+                    ))));
+                }
                 let _ = gctx.shell().print_report(&report, true);
                 Some(manifest::InheritableField::Value(
                     DEFAULT_EDITION.to_string(),

--- a/tests/testsuite/cargo_add/script_bare/stderr.term.svg
+++ b/tests/testsuite/cargo_add/script_bare/stderr.term.svg
@@ -1,7 +1,8 @@
-<svg width="810px" height="128px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1465px" height="164px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
     .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
@@ -21,15 +22,19 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-cyan bold">help</tspan><tspan>: to pin the edition, run `cargo fix --manifest-path [ROOT]/case/cargo-test-fixture.rs`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)</tspan>
 </tspan>
-    <tspan x="10px" y="118px">
+    <tspan x="10px" y="118px"><tspan class="fg-bright-cyan bold">help</tspan><tspan>: to pin the edition, run `cargo fix --manifest-path [ROOT]/case/cargo-test-fixture.rs`</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
+</tspan>
+    <tspan x="10px" y="154px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_add/script_frontmatter_empty/stderr.term.svg
+++ b/tests/testsuite/cargo_add/script_frontmatter_empty/stderr.term.svg
@@ -1,7 +1,8 @@
-<svg width="810px" height="128px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1574px" height="164px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
     .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
@@ -21,15 +22,19 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-cyan bold">help</tspan><tspan>: to pin the edition, run `cargo fix --manifest-path [ROOT]/case/cargo-test-fixture.rs`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)</tspan>
 </tspan>
-    <tspan x="10px" y="118px">
+    <tspan x="10px" y="118px"><tspan class="fg-bright-cyan bold">help</tspan><tspan>: to pin the edition, run `cargo fix --manifest-path [ROOT]/case/cargo-test-fixture.rs`</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
+</tspan>
+    <tspan x="10px" y="154px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_add/script_shebang/stderr.term.svg
+++ b/tests/testsuite/cargo_add/script_shebang/stderr.term.svg
@@ -1,7 +1,8 @@
-<svg width="810px" height="128px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1490px" height="164px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
     .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
@@ -21,15 +22,19 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-cyan bold">help</tspan><tspan>: to pin the edition, run `cargo fix --manifest-path [ROOT]/case/cargo-test-fixture.rs`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)</tspan>
 </tspan>
-    <tspan x="10px" y="118px">
+    <tspan x="10px" y="118px"><tspan class="fg-bright-cyan bold">help</tspan><tspan>: to pin the edition, run `cargo fix --manifest-path [ROOT]/case/cargo-test-fixture.rs`</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
+</tspan>
+    <tspan x="10px" y="154px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_remove/script/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/script/stderr.term.svg
@@ -1,7 +1,8 @@
-<svg width="810px" height="92px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1507px" height="128px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
     .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
@@ -21,11 +22,15 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> docopt from dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-cyan bold">help</tspan><tspan>: to pin the edition, run `cargo fix --manifest-path [ROOT]/case/cargo-remove-test-fixture.rs`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> docopt from dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px">
+    <tspan x="10px" y="82px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-cyan bold">help</tspan><tspan>: to pin the edition, run `cargo fix --manifest-path [ROOT]/case/cargo-remove-test-fixture.rs`</tspan>
+</tspan>
+    <tspan x="10px" y="118px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_remove/script_last/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/script_last/stderr.term.svg
@@ -1,7 +1,8 @@
-<svg width="810px" height="92px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1549px" height="128px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
     .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
     .container {
@@ -21,11 +22,15 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> docopt from dependencies</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-cyan bold">help</tspan><tspan>: to pin the edition, run `cargo fix --manifest-path [ROOT]/case/cargo-remove-test-fixture.rs`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> docopt from dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px">
+    <tspan x="10px" y="82px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-cyan bold">help</tspan><tspan>: to pin the edition, run `cargo fix --manifest-path [ROOT]/case/cargo-remove-test-fixture.rs`</tspan>
+</tspan>
+    <tspan x="10px" y="118px">
 </tspan>
   </text>
 

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -3091,6 +3091,7 @@ fn script_without_frontmatter() {
         .with_stdout_data(str![""])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/echo.rs`
 [FIXED] echo.rs (1 fix)
 [CHECKING] echo v0.0.0 ([ROOT]/foo/echo.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -3129,6 +3130,7 @@ fn main() {}",
         .with_stdout_data(str![""])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/echo.rs`
 [FIXED] echo.rs (1 fix)
 [CHECKING] echo v0.0.0 ([ROOT]/foo/echo.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -3169,6 +3171,7 @@ fn main() {}"#,
         .with_stdout_data(str![""])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/echo.rs`
 [FIXED] echo.rs (1 fix)
 [CHECKING] foo v0.0.0 ([ROOT]/foo/echo.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -3208,6 +3211,7 @@ fn main() {}"#,
         .with_stdout_data(str![""])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/echo.rs`
 [FIXED] echo.rs (1 fix)
 [CHECKING] foo v0.0.0 ([ROOT]/foo/echo.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/lints/non_kebab_case_bins.rs
+++ b/tests/testsuite/lints/non_kebab_case_bins.rs
@@ -154,6 +154,7 @@ fn main() {}"#,
         .masquerade_as_nightly_cargo(&["cargo-lints", "script"])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/foo_bar`
 [WARNING] binaries should have a kebab-case name
   |
 1 | [ROOT]/home/.cargo/build/[HASH]/target/.../foo_bar[EXE]

--- a/tests/testsuite/lints/non_kebab_case_packages.rs
+++ b/tests/testsuite/lints/non_kebab_case_packages.rs
@@ -61,6 +61,7 @@ fn main() {}"#,
         .masquerade_as_nightly_cargo(&["cargo-lints", "script"])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/foo_bar`
 [WARNING] packages should have a kebab-case name
  --> foo_bar
   = [NOTE] `cargo::non_kebab_case_packages` is set to `warn` in `[lints]`

--- a/tests/testsuite/lints/non_snake_case_packages.rs
+++ b/tests/testsuite/lints/non_snake_case_packages.rs
@@ -61,6 +61,7 @@ fn main() {}"#,
         .masquerade_as_nightly_cargo(&["cargo-lints", "script"])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/foo-bar`
 [WARNING] packages should have a snake-case name
  --> foo-bar
   = [NOTE] `cargo::non_snake_case_packages` is set to `warn` in `[lints]`

--- a/tests/testsuite/lockfile_path.rs
+++ b/tests/testsuite/lockfile_path.rs
@@ -447,6 +447,7 @@ fn config_run_embed() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/src/main.rs`
 [ERROR] failed to parse lock file at: [ROOT]/foo/Cargo.lock
 ...
 "#]])

--- a/tests/testsuite/script/cargo.rs
+++ b/tests/testsuite/script/cargo.rs
@@ -40,6 +40,7 @@ args: []
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/echo.rs`
 [COMPILING] echo v0.0.0 ([ROOT]/foo/echo.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/echo[EXE]`
@@ -65,6 +66,7 @@ args: []
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/echo.rs`
 [COMPILING] echo v0.0.0 ([ROOT]/foo/echo.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/echo[EXE]`
@@ -90,6 +92,7 @@ args: []
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/echo.rs`
 [COMPILING] echo v0.0.0 ([ROOT]/foo/echo.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/echo[EXE]`
@@ -114,6 +117,7 @@ args: []
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/echo`
 [COMPILING] echo v0.0.0 ([ROOT]/foo/echo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/echo[EXE]`
@@ -169,6 +173,7 @@ args: []
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/echo.rs`
 [COMPILING] echo v0.0.0 ([ROOT]/foo/echo.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/echo[EXE]`
@@ -322,6 +327,7 @@ Hello world!
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 [COMPILING] script v0.0.0 ([ROOT]/foo/script.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/script[EXE]`
@@ -350,6 +356,7 @@ msg = undefined
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 [COMPILING] script v0.0.0 ([ROOT]/foo/script.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/script[EXE]`
@@ -366,6 +373,7 @@ msg = undefined
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/script[EXE]`
 
@@ -382,6 +390,7 @@ msg = hello
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 [COMPILING] script v0.0.0 ([ROOT]/foo/script.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/script[EXE]`
@@ -499,6 +508,7 @@ line: 4
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 [COMPILING] script v0.0.0 ([ROOT]/foo/script.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/script[EXE]`
@@ -524,6 +534,7 @@ args: ["-NotAnArg"]
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 [COMPILING] script v0.0.0 ([ROOT]/foo/script.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/script[EXE] -NotAnArg`
@@ -549,6 +560,7 @@ args: ["-NotAnArg"]
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 [COMPILING] script v0.0.0 ([ROOT]/foo/script.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/script[EXE] -NotAnArg`
@@ -574,6 +586,7 @@ args: ["--help"]
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 [COMPILING] script v0.0.0 ([ROOT]/foo/script.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/script[EXE] --help`
@@ -599,6 +612,7 @@ args: []
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/s-h.w§c!.rs`
 [COMPILING] s-h-w-c- v0.0.0 ([ROOT]/foo/s-h.w§c!.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/s-h-w-c-[EXE]`
@@ -624,6 +638,7 @@ args: []
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/42answer.rs`
 [COMPILING] answer v0.0.0 ([ROOT]/foo/42answer.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/answer[EXE]`
@@ -647,6 +662,7 @@ args: []
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/42.rs`
 [COMPILING] package v0.0.0 ([ROOT]/foo/42.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/package[EXE]`
@@ -671,6 +687,7 @@ args: []
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/con`
 [COMPILING] con v0.0.0 ([ROOT]/foo/con)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/con[EXE]`
@@ -694,6 +711,7 @@ args: []
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/test`
 [COMPILING] test v0.0.0 ([ROOT]/foo/test)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/test[EXE]`
@@ -717,6 +735,7 @@ args: []
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/self`
 [COMPILING] self v0.0.0 ([ROOT]/foo/self)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/self[EXE]`
@@ -738,6 +757,7 @@ fn test_name_is_deps_dir_implicit() {
         .with_stdout_data(str![""])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/deps.rs`
 [ERROR] failed to parse manifest at `[ROOT]/foo/deps.rs`
 
 Caused by:
@@ -777,6 +797,7 @@ fn test () {}
         .with_stdout_data(str![""])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/deps.rs`
 [ERROR] failed to parse manifest at `[ROOT]/foo/deps.rs`
 
 Caused by:
@@ -923,6 +944,7 @@ Hello world!
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest Rust [..] compatible version
 [DOWNLOADING] crates ...
@@ -962,6 +984,7 @@ Hello world!
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 [LOCKING] 1 package to latest Rust [..] compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [COMPILING] script v0.0.0 ([ROOT]/foo/script.rs)
@@ -992,6 +1015,7 @@ Hello world!
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 [COMPILING] script v0.0.0 ([ROOT]/foo/script.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/script[EXE] --help`
@@ -1020,6 +1044,7 @@ Hello world!
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 [COMPILING] script v0.0.0 ([ROOT]/foo/script.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/script[EXE] --help`
@@ -1048,6 +1073,7 @@ Hello world!
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 [COMPILING] script v0.0.0 ([ROOT]/foo/script.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/script[EXE] --help`
@@ -1576,6 +1602,7 @@ args: []
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 [COMPILING] script v0.0.0 ([ROOT]/foo/script.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/script[EXE]`
@@ -1604,6 +1631,7 @@ args: []
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 [COMPILING] script v0.0.0 ([ROOT]/foo/script.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/script[EXE]`
@@ -1661,6 +1689,7 @@ fn cmd_check_with_embedded() {
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 [CHECKING] script v0.0.0 ([ROOT]/foo/script.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1710,6 +1739,7 @@ fn cmd_build_with_embedded() {
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 [COMPILING] script v0.0.0 ([ROOT]/foo/script.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1737,6 +1767,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 [COMPILING] script v0.0.0 ([ROOT]/foo/script.rs)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] unittests script.rs ([ROOT]/home/.cargo/build/[HASH]/debug/deps/script-[HASH][EXE])
@@ -1762,6 +1793,7 @@ fn cmd_clean_with_embedded() {
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
 "#]])
@@ -1780,6 +1812,7 @@ fn cmd_generate_lockfile_with_embedded() {
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 
 "#]])
         .run();
@@ -1868,6 +1901,7 @@ fn cmd_metadata_with_embedded() {
         )
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 
 "#]])
         .run();
@@ -1930,6 +1964,7 @@ fn cmd_read_manifest_with_embedded() {
         )
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 
 "#]])
         .run();
@@ -1951,6 +1986,7 @@ args: []
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 [COMPILING] script v0.0.0 ([ROOT]/foo/script.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/script[EXE]`
@@ -1973,6 +2009,7 @@ script v0.0.0 ([ROOT]/foo/script.rs)
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 
 "#]])
         .run();
@@ -1989,6 +2026,7 @@ fn cmd_update_with_embedded() {
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 
 "#]])
         .run();
@@ -2012,6 +2050,7 @@ fn cmd_verify_project_with_embedded() {
         )
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 
 "#]])
         .run();
@@ -2035,6 +2074,7 @@ path+[ROOTURL]/foo/script.rs#script@0.0.0
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 
 "#]])
         .run();
@@ -2051,6 +2091,7 @@ fn cmd_pkgid_with_embedded_no_lock_file() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 [ERROR] a Cargo.lock must exist for this command
 
 "#]])
@@ -2085,6 +2126,7 @@ registry+https://github.com/rust-lang/crates.io-index#dep@1.0.0
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 
 "#]])
         .run();
@@ -2155,6 +2197,7 @@ fn cmd_package_with_embedded() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 [ERROR] [ROOT]/foo/script.rs is unsupported by `cargo package`
 
 "#]])
@@ -2172,6 +2215,7 @@ fn cmd_publish_with_embedded() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 [ERROR] [ROOT]/foo/script.rs is unsupported by `cargo publish`
 
 "#]])
@@ -2200,6 +2244,7 @@ CARGO_MANIFEST_PATH: [ROOT]/foo/script.rs
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 [COMPILING] script v0.0.0 ([ROOT]/foo/script.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/script[EXE]`
@@ -2252,6 +2297,7 @@ args: []
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script/echo.rs`
 [COMPILING] echo v0.0.0 ([ROOT]/foo/script/echo.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/echo[EXE]`
@@ -2290,6 +2336,7 @@ args: []
 "#]])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
+[HELP] to pin the edition, run `cargo fix --manifest-path /proc/self/fd/[..]`
 [COMPILING] package v0.0.0 (/proc/self/fd/[..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/package`


### PR DESCRIPTION
### What does this PR try to resolve?

Only when not `--quiet` (note: piped stderr implies `--quiet`)

This tries to strike a balance between
- Helping users know how to react to the warning
- Good noise that encourages users to pin the edition
- Bad noise that overwhelms the throwaway scripts

### How to test and review this PR
