### PR TITLE
Never include use extra-filename in build scripts

### DIFF
--- a/src/cargo/core/compiler/build_runner/compilation_files.rs
+++ b/src/cargo/core/compiler/build_runner/compilation_files.rs
@@ -914,9 +914,14 @@ fn use_extra_filename(bcx: &BuildContext<'_, '_>, unit: &Unit) -> bool {
             // These always use metadata.
             return true;
         }
+
+        if unit.target.is_custom_build() {
+            // Build scripts never use metadata
+            return false;
+        }
         // No metadata in these cases:
         //
-        // - dylib, cdylib, executable, build-scripts: `pkg_dir` avoids collisions for us and rustc isn't
+        // - dylib, cdylib, executable: `pkg_dir` avoids collisions for us and rustc isn't
         // looking these up by `-Cextra-filename`
         //
         // The __CARGO_DEFAULT_LIB_METADATA env var is used to override this to
@@ -926,10 +931,7 @@ fn use_extra_filename(bcx: &BuildContext<'_, '_>, unit: &Unit) -> bool {
         // installs. In addition it prevents accidentally loading a libstd of a
         // different compiler at runtime.
         // See https://github.com/rust-lang/cargo/issues/3005
-        if (unit.target.is_dylib()
-            || unit.target.is_cdylib()
-            || unit.target.is_executable()
-            || unit.target.is_custom_build())
+        if (unit.target.is_dylib() || unit.target.is_cdylib() || unit.target.is_executable())
             && bcx.gctx.get_env("__CARGO_DEFAULT_LIB_METADATA").is_err()
         {
             return false;

--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -1240,19 +1240,38 @@ fn should_work_with_cargo_default_lib_metadata() {
         .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .env("__CARGO_DEFAULT_LIB_METADATA", "true")
         .enable_mac_dsym()
-        .with_status(101)
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[ERROR] failed to run custom build command for `foo v0.0.1 ([ROOT]/foo)`
-
-Caused by:
-  could not execute process `[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/build_script_build[EXE]` (never executed)
-
-Caused by:
-  [NOT_FOUND]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
         .run();
+
+    // NOTE: build_script_build[EXE] does not contain a hash in the filename
+    p.root().join("build-dir").assert_build_dir_layout(str![[r#"
+[ROOT]/foo/build-dir/.rustc_info.json
+[ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/debug/.cargo-build-lock
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/run-build-script-build-script-build
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/run-build-script-build-script-build.json
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/run/invoked.timestamp
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/run/root-output
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/run/stderr
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/run/stdout
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/build-script-build-script-build
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/build-script-build-script-build.json
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-build-script-build-script-build
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/build_script_build[EXE]
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/build_script_build.d
+
+"#]]);
 }
 
 fn parse_workspace_manifest_path_hash(hash_dir: &PathBuf) -> PathBuf {


### PR DESCRIPTION

### What does this PR try to resolve?

See: #16854

This is that in #16812 we stopped adding the metadata hash to build script names and just call them `build_script_build[EXE]` since they are already contained within a directory with the hash.

However, I didn't take into consideration `__CARGO_DEFAULT_LIB_METADATA`, so if it is passed with a build script in the build graph it will get the wrong path (`build_script_build-[HASH][EXE]`) when it tries to execute and fail.

Looking at [the comments](https://github.com/rust-lang/cargo/blob/master/src/cargo/core/compiler/build_runner/compilation_files.rs#L922) about `__CARGO_DEFAULT_LIB_METADATA` I get the impression there is no usecase for using it with a build script.
So I modified the logic to never include the meta in the build script file names even when `__CARGO_DEFAULT_LIB_METADATA`.
Let me know if this is a bad assumption.

closes #16854

### How to test and review this PR?

See the included test.

Also double checked on https://github.com/RalfJung/rustc-build-sysroot/ and this change fixes the issue for me

cc: @RalfJung 

r? @epage 