### PR TITLE
tests: cover invalid build.warnings value in config file

### DIFF
--- a/tests/testsuite/warning_override.rs
+++ b/tests/testsuite/warning_override.rs
@@ -148,6 +148,42 @@ Caused by:
 }
 
 #[cargo_test]
+fn unknown_value_in_config_file() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                edition = "2021"
+            "#,
+        )
+        .file("src/main.rs", "fn main() { let x = 3; }")
+        .file(
+            ".cargo/config.toml",
+            r#"
+                [build]
+                warnings = "forbid"
+            "#,
+        )
+        .build();
+
+    p.cargo("check")
+        .masquerade_as_nightly_cargo(&["warnings"])
+        .arg("-Zwarnings")
+        .with_stderr_data(str![[r#"
+[ERROR] error in [ROOT]/foo/.cargo/config.toml: could not load config key `build.warnings`
+
+Caused by:
+  unknown variant `forbid`, expected one of `warn`, `allow`, `deny`
+
+"#]])
+        .with_status(101)
+        .run();
+}
+
+#[cargo_test]
 fn keep_going() {
     let p = project()
         .file(


### PR DESCRIPTION
### What does this PR try to resolve?

Adds config coverage for the `build.warnings` field when it is set in `.cargo/config.toml`.

This introduces a focused testsuite case, `warning_override::unknown_value_in_config_file`, that checks an invalid value (`forbid`) and verifies Cargo reports the expected config-key parse error for `build.warnings`.

### How to test and review this PR?

Run:

- cargo fmt --check
- cargo test -p cargo --test testsuite -- warning_override --nocapture

The added case is:

- warning_override::unknown_value_in_config_file