### PR TITLE
fix: cargo publish: false-positive uncommitted error for .gitignored files when package.include is specified

### DIFF
--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -22,7 +22,7 @@ use filetime::FileTime;
 use gix::bstr::{BString, ByteVec};
 use gix::dir::entry::Status;
 use gix::index::entry::Stage;
-use ignore::gitignore::GitignoreBuilder;
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use tracing::{debug, info, trace, warn};
 use walkdir::WalkDir;
 
@@ -577,6 +577,34 @@ pub fn list_files(pkg: &Package, gctx: &GlobalContext) -> CargoResult<Vec<PathEn
         )
     })
 }
+fn build_gitignore_for_include(root: &Path) -> CargoResult<Option<Gitignore>> {
+    let repo_workdir =
+        discover_gix_repo(root)?.and_then(|repo| repo.workdir().map(|p| p.to_path_buf()));
+    let ignore_root = repo_workdir.as_deref().unwrap_or(root);
+
+    let mut builder = GitignoreBuilder::new(ignore_root);
+    let mut has_rules = false;
+
+    let repo_gitignore = ignore_root.join(".gitignore");
+    if repo_gitignore.exists() {
+        builder.add(&repo_gitignore);
+        has_rules = true;
+    }
+
+    if ignore_root != root {
+        let pkg_gitignore = root.join(".gitignore");
+        if pkg_gitignore.exists() {
+            builder.add(&pkg_gitignore);
+            has_rules = true;
+        }
+    }
+
+    if has_rules {
+        Ok(Some(builder.build()?))
+    } else {
+        Ok(None)
+    }
+}
 
 /// See [`PathSource::list_files`].
 fn _list_files(pkg: &Package, gctx: &GlobalContext) -> CargoResult<Vec<PathEntry>> {
@@ -604,6 +632,19 @@ fn _list_files(pkg: &Package, gctx: &GlobalContext) -> CargoResult<Vec<PathEntry
     }
     let ignore_include = include_builder.build()?;
 
+    let gitignore_for_include = if !no_include_option {
+        build_gitignore_for_include(root)?
+    } else {
+        None
+    };
+
+    let include_rules: Vec<String> = pkg
+        .manifest()
+        .include()
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
     let ignore_should_package = |relative_path: &Path, is_dir: bool| {
         // "Include" and "exclude" options are mutually exclusive.
         if no_include_option {
@@ -612,6 +653,24 @@ fn _list_files(pkg: &Package, gctx: &GlobalContext) -> CargoResult<Vec<PathEntry
                 .is_ignore()
         } else {
             if is_dir {
+                if let Some(ref gitignore) = gitignore_for_include {
+                    if gitignore
+                        .matched_path_or_any_parents(relative_path, is_dir)
+                        .is_ignore()
+                    {
+                        let dominated_by_include = ignore_include
+                            .matched_path_or_any_parents(relative_path, is_dir)
+                            .is_ignore();
+                        let normalized = relative_path.to_string_lossy().replace('\\', "/");
+                        let prefix = format!("{}/", normalized);
+                        let include_references_inside = include_rules.iter().any(|rule| {
+                            rule.starts_with(&prefix) || rule.starts_with(&format!("/{}", prefix))
+                        });
+                        if !dominated_by_include && !include_references_inside {
+                            return false;
+                        }
+                    }
+                }
                 // Generally, include directives don't list every
                 // directory (nor should they!). Just skip all directory
                 // checks, and only check files.

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1229,6 +1229,43 @@ src/lib.rs
 }
 
 #[cargo_test]
+fn include_overrides_gitignore() {
+    // Verifies that a file ignored by `.gitignore` is still packaged
+    // if it is explicitly specified in `package.include`.
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                edition = "2024"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                include = ["src/main.rs", "ignored_dir/included_file.rs"]
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file(".gitignore", "ignored_dir/\n")
+        .file("ignored_dir/included_file.rs", "")
+        .file("ignored_dir/ignored_file.rs", "")
+        .build();
+
+    p.cargo("package --list --allow-dirty")
+        .with_stdout_data(str![[r#"
+Cargo.lock
+Cargo.toml
+Cargo.toml.orig
+ignored_dir/included_file.rs
+src/main.rs
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn vcs_status_check_for_each_workspace_member() {
     // Cargo checks VCS status separately for each workspace member.
     // This ensure one file changed in a package won't affect the other.

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1207,25 +1207,23 @@ fn include_does_not_pick_up_gitignored_files() {
                 include = ["src/**/*", "Cargo.toml", "LICENSE"]
             "#,
         )
-            .file("src/lib.rs", "")
-            .file("LICENSE", "license text")
-            .file(".gitignore", ".venv/")
+        .file("src/lib.rs", "")
+        .file("LICENSE", "license text")
+        .file(".gitignore", ".venv/")
     });
 
     p.change_file(".venv/some-package/LICENSE", "other license");
 
-    // TODO: not expected behavior
     p.cargo("package --list")
-        .with_status(101)
-        .with_stderr_data(str![[r#"
-[ERROR] 1 files in the working directory contain changes that were not yet committed into git:
-
-.venv/some-package/LICENSE
-
-to proceed despite this and include the uncommitted changes, pass the `--allow-dirty` flag
-
-"#]])
+        .with_stderr_data("")
         .with_stdout_data(str![[r#"
+.cargo_vcs_info.json
+Cargo.lock
+Cargo.toml
+Cargo.toml.orig
+LICENSE
+src/lib.rs
+
 "#]])
         .run();
 }

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1191,6 +1191,46 @@ src/lib.rs
 }
 
 #[cargo_test]
+fn include_does_not_pick_up_gitignored_files() {
+    // Ensures `include` directives do not traverse into `.gitignore`d directories.
+    let (p, _repo) = git::new_repo("foo", |p| {
+        p.file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2024"
+                description = "foo"
+                license = "MIT"
+                documentation = "foo"
+                include = ["src/**/*", "Cargo.toml", "LICENSE"]
+            "#,
+        )
+            .file("src/lib.rs", "")
+            .file("LICENSE", "license text")
+            .file(".gitignore", ".venv/")
+    });
+
+    p.change_file(".venv/some-package/LICENSE", "other license");
+
+    // TODO: not expected behavior
+    p.cargo("package --list")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] 1 files in the working directory contain changes that were not yet committed into git:
+
+.venv/some-package/LICENSE
+
+to proceed despite this and include the uncommitted changes, pass the `--allow-dirty` flag
+
+"#]])
+        .with_stdout_data(str![[r#"
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn vcs_status_check_for_each_workspace_member() {
     // Cargo checks VCS status separately for each workspace member.
     // This ensure one file changed in a package won't affect the other.


### PR DESCRIPTION
fixes #16872

### What does this PR try to resolve?

When `package.include` is specified in `Cargo.toml`, `cargo publish` incorrectly reports files inside `.gitignore`d directories as uncommitted changes.

### How to test and review this PR?

Two tests are added:

* A reproduction test asserting that files inside `.gitignore`d directories are not reported as uncommitted changes when `package.include` is specified.
* A regression test asserting that files explicitly listed in `package.include` are correctly included in the package even if their parent directory is `.gitignore`d.