### PR TITLE
chore(ci): Use `actions/deploy-pages` for Cargo Contributor Guide deployment

### DIFF
--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -15,41 +15,45 @@ env:
   MDBOOK_VERSION: 0.5.1
 
 jobs:
-  deploy:
-    permissions:
-      contents: write  # for Git to git push
+  build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      with:
-        fetch-depth: 0
     - name: Install mdbook
       run: |
         mkdir mdbook
         curl -Lf https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
         echo `pwd`/mdbook >> $GITHUB_PATH
-    - name: Deploy docs
+    - name: Build
       run: |
         GENERATE_PY="$(pwd)/ci/generate.py"
 
         cd src/doc/contrib
         mdbook build
 
-        # Override previous ref to avoid keeping history.
-        git worktree add --orphan -B gh-pages gh-pages
-        git config user.name "Deploy from CI"
-        git config user.email ""
+        mkdir gh-pages
         cd gh-pages
         mv ../book contrib
-        git add contrib
 
         # Generate HTML for link redirections.
         python3 "$GENERATE_PY"
-        git add *.html
-        # WARN: The CNAME file is for GitHub to redirect requests to the custom domain.
-        # Missing this may entail security hazard and domain takeover.
-        # See <https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#securing-your-custom-domain>
-        git add CNAME
+    - name: Upload Artifact
+      uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
+      with:
+        path: src/doc/contrib/gh-pages
 
-        git commit -m "Deploy $GITHUB_SHA to gh-pages"
-        git push origin +gh-pages
+  deploy:
+    needs: build
+
+    permissions:
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0

--- a/ci/generate.py
+++ b/ci/generate.py
@@ -39,11 +39,5 @@ def main():
                 mapped = "https://doc.rust-lang.org/cargo/reference/{}".format(name)
             f.write(TEMPLATE.format(name=name, mapped=mapped))
 
-    # WARN: The CNAME file is for GitHub to redirect requests to the custom domain.
-    # Missing this may entail security hazard and domain takeover.
-    # See <https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#securing-your-custom-domain>
-    with open('CNAME', 'w') as f:
-        f.write('doc.crates.io')
-
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This replaces the `gh-pages` git branch deployment with the official `actions/upload-pages-artifact` and `actions/deploy-pages` actions.

It requires changing the repository's Pages settings from "Deploy from a branch" to "GitHub Actions" as described also in https://github.com/rust-lang/rfcs/pull/3419, which has used a similar setup for a while now.

I've tested the `build` job in my forked repo and verified that the artifact contents match the current content of the `gh-pages` branch. I did not test the `deploy` job with my fork repo, but since it is the same as in e.g. the `rfcs` repo I don't expect any issues from that.
