### PR TITLE
fix: Prefer defined lint levels over default

### DIFF
--- a/src/cargo/lints/mod.rs
+++ b/src/cargo/lints/mod.rs
@@ -44,7 +44,7 @@ pub enum ManifestFor<'a> {
 }
 
 impl ManifestFor<'_> {
-    fn lint_level(&self, pkg_lints: &TomlToolLints, lint: &Lint) -> (LintLevel, LintLevelReason) {
+    fn lint_level(&self, pkg_lints: &TomlToolLints, lint: &Lint) -> (LintLevel, LintLevelSource) {
         lint.level(pkg_lints, self.rust_version(), self.unstable_features())
     }
 
@@ -111,10 +111,10 @@ pub fn analyze_cargo_lints_table(
             continue;
         };
 
-        let (_, reason, _) = level_priority(name, *default_level, cargo_lints);
+        let (_, source, _) = level_priority(name, *default_level, cargo_lints);
 
         // Only run analysis on user-specified lints
-        if !reason.is_user_specified() {
+        if !source.is_user_specified() {
             continue;
         }
 
@@ -423,20 +423,20 @@ impl Lint {
         pkg_lints: &TomlToolLints,
         pkg_rust_version: Option<&RustVersion>,
         unstable_features: &Features,
-    ) -> (LintLevel, LintLevelReason) {
+    ) -> (LintLevel, LintLevelSource) {
         // We should return `Allow` if a lint is behind a feature, but it is
         // not enabled, that way the lint does not run.
         if self
             .feature_gate
             .is_some_and(|f| !unstable_features.is_enabled(f))
         {
-            return (LintLevel::Allow, LintLevelReason::Default);
+            return (LintLevel::Allow, LintLevelSource::Default);
         }
 
         if let (Some(msrv), Some(pkg_rust_version)) = (&self.msrv, pkg_rust_version) {
             let pkg_rust_version = pkg_rust_version.to_partial();
             if !msrv.is_compatible_with(&pkg_rust_version) {
-                return (LintLevel::Allow, LintLevelReason::Default);
+                return (LintLevel::Allow, LintLevelSource::Default);
             }
         }
 
@@ -449,16 +449,16 @@ impl Lint {
             pkg_lints,
         );
 
-        let (_, (l, r, _)) = max_by_key(
+        let (_, (l, s, _)) = max_by_key(
             (self.name, lint_level_priority),
             (self.primary_group.name, group_level_priority),
             |(n, (l, _, p))| (l == &LintLevel::Forbid, *p, Reverse(*n)),
         );
-        (l, r)
+        (l, s)
     }
 
-    pub fn emitted_source(&self, lint_level: LintLevel, reason: LintLevelReason) -> String {
-        format!("`cargo::{}` is set to `{lint_level}` {reason}", self.name,)
+    pub fn emitted_source(&self, lint_level: LintLevel, source: LintLevelSource) -> String {
+        format!("`cargo::{}` is set to `{lint_level}` {source}", self.name,)
     }
 }
 
@@ -521,25 +521,25 @@ impl From<TomlLintLevel> for LintLevel {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum LintLevelReason {
+pub enum LintLevelSource {
     Default,
     Package,
 }
 
-impl Display for LintLevelReason {
+impl Display for LintLevelSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            LintLevelReason::Default => write!(f, "by default"),
-            LintLevelReason::Package => write!(f, "in `[lints]`"),
+            LintLevelSource::Default => write!(f, "by default"),
+            LintLevelSource::Package => write!(f, "in `[lints]`"),
         }
     }
 }
 
-impl LintLevelReason {
+impl LintLevelSource {
     fn is_user_specified(&self) -> bool {
         match self {
-            LintLevelReason::Default => false,
-            LintLevelReason::Package => true,
+            LintLevelSource::Default => false,
+            LintLevelSource::Package => true,
         }
     }
 }
@@ -548,15 +548,15 @@ fn level_priority(
     name: &str,
     default_level: LintLevel,
     pkg_lints: &TomlToolLints,
-) -> (LintLevel, LintLevelReason, i8) {
+) -> (LintLevel, LintLevelSource, i8) {
     if let Some(defined_level) = pkg_lints.get(name) {
         (
             defined_level.level().into(),
-            LintLevelReason::Package,
+            LintLevelSource::Package,
             defined_level.priority(),
         )
     } else {
-        (default_level, LintLevelReason::Default, 0)
+        (default_level, LintLevelSource::Default, 0)
     }
 }
 
@@ -590,9 +590,9 @@ mod tests {
         );
         let features = Features::default();
 
-        let (level, reason) = lint.level(&pkg_lints, None, &features);
+        let (level, source) = lint.level(&pkg_lints, None, &features);
         assert_eq!(level, LintLevel::Warn);
-        assert_eq!(reason, LintLevelReason::Default);
+        assert_eq!(source, LintLevelSource::Default);
     }
 
     #[test]
@@ -606,9 +606,9 @@ mod tests {
         );
         let features = Features::default();
 
-        let (level, reason) = lint.level(&pkg_lints, None, &features);
+        let (level, source) = lint.level(&pkg_lints, None, &features);
         assert_eq!(level, LintLevel::Warn);
-        assert_eq!(reason, LintLevelReason::Default);
+        assert_eq!(source, LintLevelSource::Default);
     }
 
     #[test]

--- a/src/cargo/lints/mod.rs
+++ b/src/cargo/lints/mod.rs
@@ -452,7 +452,14 @@ impl Lint {
         let (_, (l, s, _)) = max_by_key(
             (self.name, lint_level_priority),
             (self.primary_group.name, group_level_priority),
-            |(n, (l, _, p))| (l == &LintLevel::Forbid, *p, Reverse(*n)),
+            |(n, (l, s, p))| {
+                (
+                    l == &LintLevel::Forbid,
+                    *s != LintLevelSource::Default,
+                    *p,
+                    Reverse(*n),
+                )
+            },
         );
         (l, s)
     }
@@ -591,8 +598,8 @@ mod tests {
         let features = Features::default();
 
         let (level, source) = lint.level(&pkg_lints, None, &features);
-        assert_eq!(level, LintLevel::Warn);
-        assert_eq!(source, LintLevelSource::Default);
+        assert_eq!(level, LintLevel::Deny);
+        assert_eq!(source, LintLevelSource::Package);
     }
 
     #[test]
@@ -607,8 +614,8 @@ mod tests {
         let features = Features::default();
 
         let (level, source) = lint.level(&pkg_lints, None, &features);
-        assert_eq!(level, LintLevel::Warn);
-        assert_eq!(source, LintLevelSource::Default);
+        assert_eq!(level, LintLevel::Deny);
+        assert_eq!(source, LintLevelSource::Package);
     }
 
     #[test]

--- a/src/cargo/lints/mod.rs
+++ b/src/cargo/lints/mod.rs
@@ -566,6 +566,51 @@ mod tests {
     use snapbox::ToDebug;
     use std::collections::HashSet;
 
+    use super::*;
+
+    fn test_lint(name: &'static str, group: &'static LintGroup) -> Lint {
+        Lint {
+            name,
+            desc: "test lint",
+            primary_group: group,
+            msrv: None,
+            feature_gate: None,
+            docs: None,
+        }
+    }
+
+    #[test]
+    fn lint_level_prefers_user_specified_over_default() {
+        let lint = test_lint("unused_dependencies", &STYLE);
+
+        let mut pkg_lints = TomlToolLints::new();
+        pkg_lints.insert(
+            "unused_dependencies".to_string(),
+            cargo_util_schemas::manifest::TomlLint::Level(TomlLintLevel::Deny),
+        );
+        let features = Features::default();
+
+        let (level, reason) = lint.level(&pkg_lints, None, &features);
+        assert_eq!(level, LintLevel::Warn);
+        assert_eq!(reason, LintLevelReason::Default);
+    }
+
+    #[test]
+    fn lint_level_group_overrides_default() {
+        let lint = test_lint("non_kebab_case_bins", &STYLE);
+
+        let mut pkg_lints = TomlToolLints::new();
+        pkg_lints.insert(
+            "style".to_string(),
+            cargo_util_schemas::manifest::TomlLint::Level(TomlLintLevel::Deny),
+        );
+        let features = Features::default();
+
+        let (level, reason) = lint.level(&pkg_lints, None, &features);
+        assert_eq!(level, LintLevel::Warn);
+        assert_eq!(reason, LintLevelReason::Default);
+    }
+
     #[test]
     fn ensure_lint_groups_do_not_default_to_forbid() {
         let forbid_groups = super::LINT_GROUPS

--- a/src/cargo/lints/rules/blanket_hint_mostly_unused.rs
+++ b/src/cargo/lints/rules/blanket_hint_mostly_unused.rs
@@ -62,7 +62,7 @@ pub fn blanket_hint_mostly_unused(
     error_count: &mut usize,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
-    let (lint_level, reason) = LINT.level(
+    let (lint_level, source) = LINT.level(
         pkg_lints,
         ws.lowest_rust_version(),
         maybe_pkg.unstable_features(),
@@ -169,7 +169,7 @@ pub fn blanket_hint_mostly_unused(
 
         if i == 0 {
             primary_group =
-                primary_group.element(Level::NOTE.message(LINT.emitted_source(lint_level, reason)));
+                primary_group.element(Level::NOTE.message(LINT.emitted_source(lint_level, source)));
         }
 
         // The primary group should always be first

--- a/src/cargo/lints/rules/im_a_teapot.rs
+++ b/src/cargo/lints/rules/im_a_teapot.rs
@@ -35,7 +35,7 @@ pub fn check_im_a_teapot(
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let manifest = pkg.manifest();
-    let (lint_level, reason) =
+    let (lint_level, source) =
         LINT.level(pkg_lints, pkg.rust_version(), manifest.unstable_features());
 
     if lint_level == LintLevel::Allow {
@@ -52,7 +52,7 @@ pub fn check_im_a_teapot(
         }
         let level = lint_level.to_diagnostic_level();
         let manifest_path = rel_cwd_manifest_path(path, gctx);
-        let emitted_reason = LINT.emitted_source(lint_level, reason);
+        let emitted_source = LINT.emitted_source(lint_level, source);
 
         let mut desc = Group::with_title(level.primary_title(LINT.desc));
 
@@ -70,7 +70,7 @@ pub fn check_im_a_teapot(
             desc = desc.element(Origin::path(&manifest_path));
         }
 
-        let report = &[desc.element(Level::NOTE.message(&emitted_reason))];
+        let report = &[desc.element(Level::NOTE.message(&emitted_source))];
 
         gctx.shell().print_report(report, lint_level.force())?;
     }

--- a/src/cargo/lints/rules/implicit_minimum_version_req.rs
+++ b/src/cargo/lints/rules/implicit_minimum_version_req.rs
@@ -20,7 +20,7 @@ use crate::core::Package;
 use crate::core::Workspace;
 use crate::lints::Lint;
 use crate::lints::LintLevel;
-use crate::lints::LintLevelReason;
+use crate::lints::LintLevelSource;
 use crate::lints::PEDANTIC;
 use crate::lints::get_key_value;
 use crate::lints::rel_cwd_manifest_path;
@@ -89,7 +89,7 @@ pub fn implicit_minimum_version_req_pkg(
     error_count: &mut usize,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
-    let (lint_level, reason) = LINT.level(
+    let (lint_level, source) = LINT.level(
         cargo_lints,
         pkg.rust_version(),
         pkg.manifest().unstable_features(),
@@ -124,7 +124,7 @@ pub fn implicit_minimum_version_req_pkg(
 
         let Some(report) = report(
             lint_level,
-            reason,
+            source,
             contents,
             document,
             key_path,
@@ -156,7 +156,7 @@ pub fn implicit_minimum_version_req_ws(
     error_count: &mut usize,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
-    let (lint_level, reason) = LINT.level(
+    let (lint_level, source) = LINT.level(
         cargo_lints,
         ws.lowest_rust_version(),
         maybe_pkg.unstable_features(),
@@ -207,7 +207,7 @@ pub fn implicit_minimum_version_req_ws(
 
         let Some(report) = report(
             lint_level,
-            reason,
+            source,
             contents,
             document,
             &key_path,
@@ -255,7 +255,7 @@ pub fn span_of_version_req<'doc>(
 
 fn report<'a>(
     lint_level: LintLevel,
-    reason: LintLevelReason,
+    source: LintLevelSource,
     contents: Option<&'a str>,
     document: Option<&toml::Spanned<toml::de::DeTable<'static>>>,
     key_path: &[&str],
@@ -264,7 +264,7 @@ fn report<'a>(
     emit_source: bool,
 ) -> Option<[Group<'a>; 2]> {
     let level = lint_level.to_diagnostic_level();
-    let emitted_source = LINT.emitted_source(lint_level, reason);
+    let emitted_source = LINT.emitted_source(lint_level, source);
     let replacement = format!(r#""{suggested_req}""#);
     let label = "missing full version components";
     let secondary_title = "consider specifying full `major.minor.patch` version components";

--- a/src/cargo/lints/rules/missing_lints_inheritance.rs
+++ b/src/cargo/lints/rules/missing_lints_inheritance.rs
@@ -60,7 +60,7 @@ pub fn missing_lints_inheritance(
     error_count: &mut usize,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
-    let (lint_level, reason) = LINT.level(
+    let (lint_level, source) = LINT.level(
         cargo_lints,
         pkg.rust_version(),
         pkg.manifest().unstable_features(),
@@ -89,7 +89,7 @@ pub fn missing_lints_inheritance(
     let manifest = pkg.manifest();
     let contents = manifest.contents();
     let level = lint_level.to_diagnostic_level();
-    let emitted_source = LINT.emitted_source(lint_level, reason);
+    let emitted_source = LINT.emitted_source(lint_level, source);
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
 
     let mut primary = Group::with_title(level.primary_title(LINT.desc));

--- a/src/cargo/lints/rules/non_kebab_case_bins.rs
+++ b/src/cargo/lints/rules/non_kebab_case_bins.rs
@@ -15,7 +15,7 @@ use crate::core::Workspace;
 use crate::lints::AsIndex;
 use crate::lints::Lint;
 use crate::lints::LintLevel;
-use crate::lints::LintLevelReason;
+use crate::lints::LintLevelSource;
 use crate::lints::STYLE;
 use crate::lints::get_key_value_span;
 use crate::lints::rel_cwd_manifest_path;
@@ -69,7 +69,7 @@ pub fn non_kebab_case_bins(
     error_count: &mut usize,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
-    let (lint_level, reason) = LINT.level(
+    let (lint_level, source) = LINT.level(
         cargo_lints,
         pkg.rust_version(),
         pkg.manifest().unstable_features(),
@@ -86,7 +86,7 @@ pub fn non_kebab_case_bins(
         pkg,
         &manifest_path,
         lint_level,
-        reason,
+        source,
         error_count,
         gctx,
     )
@@ -97,7 +97,7 @@ pub fn lint_package(
     pkg: &Package,
     manifest_path: &str,
     lint_level: LintLevel,
-    reason: LintLevelReason,
+    source: LintLevelSource,
     error_count: &mut usize,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
@@ -115,7 +115,7 @@ pub fn lint_package(
         let document = manifest.document();
         let contents = manifest.contents();
         let level = lint_level.to_diagnostic_level();
-        let emitted_source = LINT.emitted_source(lint_level, reason);
+        let emitted_source = LINT.emitted_source(lint_level, source);
 
         let mut primary_source = ws.target_dir().as_path_unlocked().to_owned();
         // Elide profile/platform as we don't have that context

--- a/src/cargo/lints/rules/non_kebab_case_features.rs
+++ b/src/cargo/lints/rules/non_kebab_case_features.rs
@@ -13,7 +13,7 @@ use crate::GlobalContext;
 use crate::core::Package;
 use crate::lints::Lint;
 use crate::lints::LintLevel;
-use crate::lints::LintLevelReason;
+use crate::lints::LintLevelSource;
 use crate::lints::RESTRICTION;
 use crate::lints::get_key_value_span;
 use crate::lints::rel_cwd_manifest_path;
@@ -62,7 +62,7 @@ pub fn non_kebab_case_features(
     error_count: &mut usize,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
-    let (lint_level, reason) = LINT.level(
+    let (lint_level, source) = LINT.level(
         cargo_lints,
         pkg.rust_version(),
         pkg.manifest().unstable_features(),
@@ -74,14 +74,14 @@ pub fn non_kebab_case_features(
 
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
 
-    lint_package(pkg, &manifest_path, lint_level, reason, error_count, gctx)
+    lint_package(pkg, &manifest_path, lint_level, source, error_count, gctx)
 }
 
 pub fn lint_package(
     pkg: &Package,
     manifest_path: &str,
     lint_level: LintLevel,
-    reason: LintLevelReason,
+    source: LintLevelSource,
     error_count: &mut usize,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
@@ -96,7 +96,7 @@ pub fn lint_package(
         let document = manifest.document();
         let contents = manifest.contents();
         let level = lint_level.to_diagnostic_level();
-        let emitted_source = LINT.emitted_source(lint_level, reason);
+        let emitted_source = LINT.emitted_source(lint_level, source);
 
         let mut primary = Group::with_title(level.primary_title(LINT.desc));
         if let Some(document) = document

--- a/src/cargo/lints/rules/non_kebab_case_packages.rs
+++ b/src/cargo/lints/rules/non_kebab_case_packages.rs
@@ -13,7 +13,7 @@ use crate::GlobalContext;
 use crate::core::Package;
 use crate::lints::Lint;
 use crate::lints::LintLevel;
-use crate::lints::LintLevelReason;
+use crate::lints::LintLevelSource;
 use crate::lints::RESTRICTION;
 use crate::lints::get_key_value_span;
 use crate::lints::rel_cwd_manifest_path;
@@ -62,7 +62,7 @@ pub fn non_kebab_case_packages(
     error_count: &mut usize,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
-    let (lint_level, reason) = LINT.level(
+    let (lint_level, source) = LINT.level(
         cargo_lints,
         pkg.rust_version(),
         pkg.manifest().unstable_features(),
@@ -74,14 +74,14 @@ pub fn non_kebab_case_packages(
 
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
 
-    lint_package(pkg, &manifest_path, lint_level, reason, error_count, gctx)
+    lint_package(pkg, &manifest_path, lint_level, source, error_count, gctx)
 }
 
 pub fn lint_package(
     pkg: &Package,
     manifest_path: &str,
     lint_level: LintLevel,
-    reason: LintLevelReason,
+    source: LintLevelSource,
     error_count: &mut usize,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
@@ -96,7 +96,7 @@ pub fn lint_package(
     let document = manifest.document();
     let contents = manifest.contents();
     let level = lint_level.to_diagnostic_level();
-    let emitted_source = LINT.emitted_source(lint_level, reason);
+    let emitted_source = LINT.emitted_source(lint_level, source);
 
     let mut primary = Group::with_title(level.primary_title(LINT.desc));
     if let Some(document) = document

--- a/src/cargo/lints/rules/non_snake_case_features.rs
+++ b/src/cargo/lints/rules/non_snake_case_features.rs
@@ -13,7 +13,7 @@ use crate::GlobalContext;
 use crate::core::Package;
 use crate::lints::Lint;
 use crate::lints::LintLevel;
-use crate::lints::LintLevelReason;
+use crate::lints::LintLevelSource;
 use crate::lints::RESTRICTION;
 use crate::lints::get_key_value_span;
 use crate::lints::rel_cwd_manifest_path;
@@ -62,7 +62,7 @@ pub fn non_snake_case_features(
     error_count: &mut usize,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
-    let (lint_level, reason) = LINT.level(
+    let (lint_level, source) = LINT.level(
         cargo_lints,
         pkg.rust_version(),
         pkg.manifest().unstable_features(),
@@ -74,14 +74,14 @@ pub fn non_snake_case_features(
 
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
 
-    lint_package(pkg, &manifest_path, lint_level, reason, error_count, gctx)
+    lint_package(pkg, &manifest_path, lint_level, source, error_count, gctx)
 }
 
 pub fn lint_package(
     pkg: &Package,
     manifest_path: &str,
     lint_level: LintLevel,
-    reason: LintLevelReason,
+    source: LintLevelSource,
     error_count: &mut usize,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
@@ -96,7 +96,7 @@ pub fn lint_package(
         let document = manifest.document();
         let contents = manifest.contents();
         let level = lint_level.to_diagnostic_level();
-        let emitted_source = LINT.emitted_source(lint_level, reason);
+        let emitted_source = LINT.emitted_source(lint_level, source);
 
         let mut primary = Group::with_title(level.primary_title(LINT.desc));
         if let Some(document) = document

--- a/src/cargo/lints/rules/non_snake_case_packages.rs
+++ b/src/cargo/lints/rules/non_snake_case_packages.rs
@@ -13,7 +13,7 @@ use crate::GlobalContext;
 use crate::core::Package;
 use crate::lints::Lint;
 use crate::lints::LintLevel;
-use crate::lints::LintLevelReason;
+use crate::lints::LintLevelSource;
 use crate::lints::RESTRICTION;
 use crate::lints::get_key_value_span;
 use crate::lints::rel_cwd_manifest_path;
@@ -62,7 +62,7 @@ pub fn non_snake_case_packages(
     error_count: &mut usize,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
-    let (lint_level, reason) = LINT.level(
+    let (lint_level, source) = LINT.level(
         cargo_lints,
         pkg.rust_version(),
         pkg.manifest().unstable_features(),
@@ -74,14 +74,14 @@ pub fn non_snake_case_packages(
 
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
 
-    lint_package(pkg, &manifest_path, lint_level, reason, error_count, gctx)
+    lint_package(pkg, &manifest_path, lint_level, source, error_count, gctx)
 }
 
 pub fn lint_package(
     pkg: &Package,
     manifest_path: &str,
     lint_level: LintLevel,
-    reason: LintLevelReason,
+    source: LintLevelSource,
     error_count: &mut usize,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
@@ -96,7 +96,7 @@ pub fn lint_package(
     let document = manifest.document();
     let contents = manifest.contents();
     let level = lint_level.to_diagnostic_level();
-    let emitted_source = LINT.emitted_source(lint_level, reason);
+    let emitted_source = LINT.emitted_source(lint_level, source);
 
     let mut primary = Group::with_title(level.primary_title(LINT.desc));
     if let Some(document) = document

--- a/src/cargo/lints/rules/redundant_homepage.rs
+++ b/src/cargo/lints/rules/redundant_homepage.rs
@@ -14,7 +14,7 @@ use crate::GlobalContext;
 use crate::core::Package;
 use crate::lints::Lint;
 use crate::lints::LintLevel;
-use crate::lints::LintLevelReason;
+use crate::lints::LintLevelSource;
 use crate::lints::STYLE;
 use crate::lints::get_key_value_span;
 use crate::lints::rel_cwd_manifest_path;
@@ -66,7 +66,7 @@ pub fn redundant_homepage(
     error_count: &mut usize,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
-    let (lint_level, reason) = LINT.level(
+    let (lint_level, source) = LINT.level(
         cargo_lints,
         pkg.rust_version(),
         pkg.manifest().unstable_features(),
@@ -78,14 +78,14 @@ pub fn redundant_homepage(
 
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
 
-    lint_package(pkg, &manifest_path, lint_level, reason, error_count, gctx)
+    lint_package(pkg, &manifest_path, lint_level, source, error_count, gctx)
 }
 
 pub fn lint_package(
     pkg: &Package,
     manifest_path: &str,
     lint_level: LintLevel,
-    reason: LintLevelReason,
+    source: LintLevelSource,
     error_count: &mut usize,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
@@ -113,7 +113,7 @@ pub fn lint_package(
     let document = manifest.document();
     let contents = manifest.contents();
     let level = lint_level.to_diagnostic_level();
-    let emitted_source = LINT.emitted_source(lint_level, reason);
+    let emitted_source = LINT.emitted_source(lint_level, source);
 
     let mut primary = Group::with_title(level.primary_title(LINT.desc));
     if let Some(document) = document

--- a/src/cargo/lints/rules/redundant_readme.rs
+++ b/src/cargo/lints/rules/redundant_readme.rs
@@ -15,7 +15,7 @@ use crate::GlobalContext;
 use crate::core::Package;
 use crate::lints::Lint;
 use crate::lints::LintLevel;
-use crate::lints::LintLevelReason;
+use crate::lints::LintLevelSource;
 use crate::lints::STYLE;
 use crate::lints::get_key_value_span;
 use crate::lints::rel_cwd_manifest_path;
@@ -68,7 +68,7 @@ pub fn redundant_readme(
     error_count: &mut usize,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
-    let (lint_level, reason) = LINT.level(
+    let (lint_level, source) = LINT.level(
         cargo_lints,
         pkg.rust_version(),
         pkg.manifest().unstable_features(),
@@ -80,14 +80,14 @@ pub fn redundant_readme(
 
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
 
-    lint_package(pkg, &manifest_path, lint_level, reason, error_count, gctx)
+    lint_package(pkg, &manifest_path, lint_level, source, error_count, gctx)
 }
 
 pub fn lint_package(
     pkg: &Package,
     manifest_path: &str,
     lint_level: LintLevel,
-    reason: LintLevelReason,
+    source: LintLevelSource,
     error_count: &mut usize,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
@@ -117,7 +117,7 @@ pub fn lint_package(
     let document = manifest.document();
     let contents = manifest.contents();
     let level = lint_level.to_diagnostic_level();
-    let emitted_source = LINT.emitted_source(lint_level, reason);
+    let emitted_source = LINT.emitted_source(lint_level, source);
 
     let mut primary = Group::with_title(level.primary_title(LINT.desc));
     if let Some(document) = document

--- a/src/cargo/lints/rules/unknown_lints.rs
+++ b/src/cargo/lints/rules/unknown_lints.rs
@@ -49,7 +49,7 @@ pub fn output_unknown_lints(
     error_count: &mut usize,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
-    let (lint_level, reason) = manifest.lint_level(cargo_lints, LINT);
+    let (lint_level, source) = manifest.lint_level(cargo_lints, LINT);
     if lint_level == LintLevel::Allow {
         return Ok(());
     }
@@ -97,7 +97,7 @@ pub fn output_unknown_lints(
         }
 
         if emitted_source.is_none() {
-            emitted_source = Some(LINT.emitted_source(lint_level, reason));
+            emitted_source = Some(LINT.emitted_source(lint_level, source));
             group = group.element(Level::NOTE.message(emitted_source.as_ref().unwrap()));
         }
         if let Some(help) = help.as_ref() {

--- a/src/cargo/lints/rules/unused_workspace_dependencies.rs
+++ b/src/cargo/lints/rules/unused_workspace_dependencies.rs
@@ -53,7 +53,7 @@ pub fn unused_workspace_dependencies(
     error_count: &mut usize,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
-    let (lint_level, reason) = LINT.level(
+    let (lint_level, source) = LINT.level(
         cargo_lints,
         ws.lowest_rust_version(),
         maybe_pkg.unstable_features(),
@@ -132,7 +132,7 @@ pub fn unused_workspace_dependencies(
         let contents = maybe_pkg.contents();
         let level = lint_level.to_diagnostic_level();
         let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
-        let emitted_source = LINT.emitted_source(lint_level, reason);
+        let emitted_source = LINT.emitted_source(lint_level, source);
 
         let mut primary = Group::with_title(level.primary_title(LINT.desc));
         if let Some(document) = document

--- a/src/cargo/lints/rules/unused_workspace_package_fields.rs
+++ b/src/cargo/lints/rules/unused_workspace_package_fields.rs
@@ -53,7 +53,7 @@ pub fn unused_workspace_package_fields(
     error_count: &mut usize,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
-    let (lint_level, reason) = LINT.level(
+    let (lint_level, source) = LINT.level(
         cargo_lints,
         ws.lowest_rust_version(),
         maybe_pkg.unstable_features(),
@@ -101,7 +101,7 @@ pub fn unused_workspace_package_fields(
         let contents = maybe_pkg.contents();
         let level = lint_level.to_diagnostic_level();
         let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
-        let emitted_source = LINT.emitted_source(lint_level, reason);
+        let emitted_source = LINT.emitted_source(lint_level, source);
 
         let mut primary = Group::with_title(level.primary_title(LINT.desc));
         if let Some(document) = document

--- a/tests/testsuite/lints/mod.rs
+++ b/tests/testsuite/lints/mod.rs
@@ -489,6 +489,7 @@ fn explicit_lint_level_overrides_default() {
 
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
@@ -496,18 +497,17 @@ fn explicit_lint_level_overrides_default() {
 [DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
 [CHECKING] unused v0.1.0
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
-[WARNING] unused dependency
+[ERROR] unused dependency
  --> Cargo.toml:9:13
   |
 9 |             unused = "0.1.0"
   |             ^^^^^^^^^^^^^^^^
   |
-  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+  = [NOTE] `cargo::unused_dependencies` is set to `deny` in `[lints]`
 [HELP] remove the dependency
   |
 9 -             unused = "0.1.0"
   |
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
         .run();

--- a/tests/testsuite/lints/mod.rs
+++ b/tests/testsuite/lints/mod.rs
@@ -458,3 +458,57 @@ im_a_teapot = { level = "warn", priority = 10 }
 "#]])
         .run();
 }
+
+#[cargo_test]
+fn explicit_lint_level_overrides_default() {
+    Package::new("unused", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dependencies]
+            unused = "0.1.0"
+
+            [lints.cargo]
+            unused_dependencies = "deny"
+        "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+            fn main() {}
+            "#,
+        )
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
+[LOCKING] 1 package to latest compatible version
+[DOWNLOADING] crates ...
+[DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
+[CHECKING] unused v0.1.0
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[WARNING] unused dependency
+ --> Cargo.toml:9:13
+  |
+9 |             unused = "0.1.0"
+  |             ^^^^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+[HELP] remove the dependency
+  |
+9 -             unused = "0.1.0"
+  |
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}

--- a/tests/testsuite/lints/unused_dependencies.rs
+++ b/tests/testsuite/lints/unused_dependencies.rs
@@ -48,7 +48,7 @@ fn unused_dep_normal() {
 9 |             unused = "0.1.0"
   |             ^^^^^^^^^^^^^^^^
   |
-  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] remove the dependency
   |
 9 -             unused = "0.1.0"
@@ -108,7 +108,7 @@ fn unused_dep_build() {
 9 |             unused = "0.1.0"
   |             ^^^^^^^^^^^^^^^^
   |
-  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] remove the dependency
   |
 9 -             unused = "0.1.0"
@@ -156,7 +156,7 @@ fn unused_dep_build_no_build_rs() {
 9 |             unused = "0.1.0"
   |             ^^^^^^^^^^^^^^^^
   |
-  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] remove the dependency
   |
 9 -             unused = "0.1.0"
@@ -241,7 +241,7 @@ fn unused_dep_lib_bins() {
 9 |             unused = "0.1.0"
   |             ^^^^^^^^^^^^^^^^
   |
-  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] remove the dependency
   |
 9 -             unused = "0.1.0"
@@ -332,7 +332,7 @@ fn unused_dep_build_with_used_dep_normal() {
 9 |             unused_build = "0.1.0"
   |             ^^^^^^^^^^^^^^^^^^^^^^
   |
-  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] remove the dependency
   |
 9 -             unused_build = "0.1.0"
@@ -395,7 +395,7 @@ fn unused_dep_normal_but_implicit_used_dep_dev() {
 9 |             used_dev = "0.1.0"
   |             ^^^^^^^^^^^^^^^^^^
   |
-  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] remove the dependency
   |
 9 -             used_dev = "0.1.0"
@@ -461,7 +461,7 @@ fn unused_dep_normal_but_explicit_used_dep_dev() {
 9 |             used_once = "0.1.0"
   |             ^^^^^^^^^^^^^^^^^^^
   |
-  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] remove the dependency
   |
 9 -             used_once = "0.1.0"
@@ -592,7 +592,7 @@ fn optional_dependency() {
 9 |             unused = { version = "0.1.0", optional = true }
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] remove the dependency
   |
 9 -             unused = { version = "0.1.0", optional = true }
@@ -655,7 +655,7 @@ fn unused_dep_renamed() {
 9 |             baz = { package = "bar", version = "0.1.0" }
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] remove the dependency
   |
 9 -             baz = { package = "bar", version = "0.1.0" }
@@ -711,7 +711,7 @@ fn warning_replay() {
 9 |             unused = "0.1.0"
   |             ^^^^^^^^^^^^^^^^
   |
-  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] remove the dependency
   |
 9 -             unused = "0.1.0"
@@ -730,7 +730,7 @@ fn warning_replay() {
 9 |             unused = "0.1.0"
   |             ^^^^^^^^^^^^^^^^
   |
-  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] remove the dependency
   |
 9 -             unused = "0.1.0"
@@ -795,7 +795,7 @@ fn unused_dep_target() {
 9 |             unused = "0.1.0"
   |             ^^^^^^^^^^^^^^^^
   |
-  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] remove the dependency
   |
 9 -             unused = "0.1.0"
@@ -1076,7 +1076,7 @@ fn package_selection() {
 9 |             unused = "0.1.0"
   |             ^^^^^^^^^^^^^^^^
   |
-  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] remove the dependency
   |
 9 -             unused = "0.1.0"
@@ -1087,7 +1087,7 @@ fn package_selection() {
 11 |             bar.path = "../bar"
    |             ^^^
    |
-   = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] remove the dependency
    |
 11 -             bar.path = "../bar"
@@ -1131,7 +1131,7 @@ fn package_selection() {
 11 |             bar.path = "../bar"
    |             ^^^
    |
-   = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] remove the dependency
    |
 11 -             bar.path = "../bar"
@@ -1175,7 +1175,7 @@ fn package_selection() {
 9 |             unused = "0.1.0"
   |             ^^^^^^^^^^^^^^^^
   |
-  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] remove the dependency
   |
 9 -             unused = "0.1.0"
@@ -1316,7 +1316,7 @@ pub fn fun() -> &'static str {
 10 |             transitive = { version = "0.1.1", features = ["a"] }
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] remove the dependency
    |
 10 -             transitive = { version = "0.1.1", features = ["a"] }
@@ -1424,7 +1424,7 @@ fn allow_rustflags() {
 9 |             unused = "0.1.0"
   |             ^^^^^^^^^^^^^^^^
   |
-  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] remove the dependency
   |
 9 -             unused = "0.1.0"
@@ -1480,7 +1480,7 @@ fn allow_attribute() {
 9 |             unused = "0.1.0"
   |             ^^^^^^^^^^^^^^^^
   |
-  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] remove the dependency
   |
 9 -             unused = "0.1.0"
@@ -1536,7 +1536,7 @@ fn deny_rustflags() {
 9 |             unused = "0.1.0"
   |             ^^^^^^^^^^^^^^^^
   |
-  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] remove the dependency
   |
 9 -             unused = "0.1.0"
@@ -1592,7 +1592,7 @@ fn deny_attribute() {
 9 |             unused = "0.1.0"
   |             ^^^^^^^^^^^^^^^^
   |
-  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] remove the dependency
   |
 9 -             unused = "0.1.0"
@@ -1648,7 +1648,7 @@ fn forbid_rustflags() {
 9 |             unused = "0.1.0"
   |             ^^^^^^^^^^^^^^^^
   |
-  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] remove the dependency
   |
 9 -             unused = "0.1.0"
@@ -1704,7 +1704,7 @@ fn forbid_attribute() {
 9 |             unused = "0.1.0"
   |             ^^^^^^^^^^^^^^^^
   |
-  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
+  = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] remove the dependency
   |
 9 -             unused = "0.1.0"

--- a/tests/testsuite/lints/unused_workspace_dependencies.rs
+++ b/tests/testsuite/lints/unused_workspace_dependencies.rs
@@ -84,7 +84,7 @@ workspace = true
 12 | not-inherited = "1"
    | ^^^^^^^^^^^^^
    |
-   = [NOTE] `cargo::unused_workspace_dependencies` is set to `warn` by default
+   = [NOTE] `cargo::unused_workspace_dependencies` is set to `warn` in `[lints]`
 [HELP] consider removing the unused dependency
    |
 12 - not-inherited = "1"

--- a/tests/testsuite/lints/unused_workspace_package_fields.rs
+++ b/tests/testsuite/lints/unused_workspace_package_fields.rs
@@ -56,7 +56,7 @@ workspace = true
 8 | rust-version = "1.0"
   | ^^^^^^^^^^^^
   |
-  = [NOTE] `cargo::unused_workspace_package_fields` is set to `warn` by default
+  = [NOTE] `cargo::unused_workspace_package_fields` is set to `warn` in `[lints]`
 [HELP] consider removing the unused field
   |
 8 - rust-version = "1.0"


### PR DESCRIPTION
The current logic for selecting a level for a lint does not prioritize defined lint levels over the default one. This led to cases where the wrong level, or `LintLevelReason`, was chosen. To address this, I did two things. The first was renaming `LintLevelReason` to `LintLevelSource`, this was done to better align the name with how it will be used, as well as to align with how [Rust](https://github.com/rust-lang/rust/blob/14196dbfa3eb7c30195251eac092b1b86c8a2d84/compiler/rustc_middle/src/lint.rs#L19) names its similar struct. The second thing is to add `LintLevelSource` to the `max_by_key` in `Lint::level`, as a way to prioritize defined lint levels over the default one.