### PR TITLE
fix: pass --extern-html-root-takes-precedence in addition to --extern-html-root-url on rustdoc invocation

### DIFF
--- a/src/cargo/core/compiler/rustdoc.rs
+++ b/src/cargo/core/compiler/rustdoc.rs
@@ -228,6 +228,16 @@ pub fn add_root_urls(
         }
         Some(RustdocExternMode::Url(s)) => Some(s.to_string()),
     };
+
+    if matches!(std_url, Some(_))
+        || map
+            .registries
+            .iter()
+            .any(|(registry, _)| registry != CRATES_IO_REGISTRY)
+    {
+        rustdoc.arg("--extern-html-root-takes-precedence");
+    }
+
     if let Some(url) = std_url {
         for name in &["std", "core", "alloc", "proc_macro"] {
             rustdoc.arg("--extern-html-root-url");

--- a/tests/testsuite/rustdoc_extern_html.rs
+++ b/tests/testsuite/rustdoc_extern_html.rs
@@ -60,9 +60,7 @@ fn simple() {
     assert!(myfun.contains(r#"href="https://docs.rs/bar/1.0.0/bar/struct.Straw.html""#));
 }
 
-#[ignore = "Broken, temporarily disabled until https://github.com/rust-lang/rust/pull/82776 is resolved."]
-#[cargo_test]
-// #[cargo_test(nightly, reason = "--extern-html-root-url is unstable")]
+#[cargo_test(nightly, reason = "--extern-html-root-url is unstable")]
 fn std_docs() {
     // Mapping std docs somewhere else.
     // For local developers, skip this test if docs aren't installed.


### PR DESCRIPTION
The fix mentioned in tests (https://github.com/rust-lang/rust/pull/82776) is already merged upstream, so I believe this works now.