### PR TITLE
fix: Update `bash` and `zsh` Autocompletion Documents to add `-m`

### DIFF
--- a/src/etc/_cargo
+++ b/src/etc/_cargo
@@ -61,10 +61,13 @@ _cargo() {
         "--no-default-features[don't build the default features]"
     )
 
+    manifest=(
+        '(-m --manifest-path)'{-m+,--manifest-path=}'[specify path to manifest]:path:_directories'
+    )
+
     msgfmt='--message-format=[specify error format]:error format [human]:(human json short)'
     triple='--target=[specify target triple]:target triple:_cargo_target_triple'
     target='--target-dir=[specify directory for all generated artifacts]:directory:_directories'
-    manifest='--manifest-path=[specify path to manifest]:path:_directories'
     registry='--registry=[specify registry to use]:registry'
 
     case $state in

--- a/src/etc/cargo.bashcomp.sh
+++ b/src/etc/cargo.bashcomp.sh
@@ -48,7 +48,7 @@ _cargo()
 	local opt_pkg_spec='-p --package --all --exclude --workspace'
 	local opt_pkg='-p --package'
 	local opt_feat='-F --features --all-features --no-default-features'
-	local opt_mani='--manifest-path'
+	local opt_mani='-m --manifest-path'
 	local opt_jobs='-j --jobs'
 	local opt_parallel="$opt_jobs --keep-going"
 	local opt_force='-f --force'


### PR DESCRIPTION
### What does this PR try to resolve?

- Act on [this request](https://github.com/rust-lang/cargo/pull/16858#issuecomment-4248392904) in #16858
- `-m` is short for `--manifest-path`, and must be added in places where `--manifest-path` could be accepted.

### How to test and review this PR?

- Use `zsh`, `bash`, or any other shell where Cargo provides autocomplete support, and ensure `-m` has identical behaviour to `--manifest-path`

### Notes

- I've never worked on these autocomplete documents before, so I'm assuming the modifications I've made are correct based on existing instances of shorthand (e.g., `-F`)
- ~~Creating as a draft until #16858 is merged (which should be very soon).~~
- No AI tooling of any kind was used during the creation of this PR.
