### PR TITLE
docs: `include` doesnt apply gitignore from repo

### DIFF
--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -398,6 +398,9 @@ If `include` is not specified, then the following files will be excluded:
   [gitignore] rules of the repository and global git configuration will be
   skipped.
 
+If `include` is specified,
+gitignore rules of the repository and global git configuration are not applied.
+
 Regardless of whether `exclude` or `include` is specified, the following files
 are always excluded:
 


### PR DESCRIPTION
### What does this PR try to resolve?

This makes it more explicitly.

fixes https://github.com/rust-lang/cargo/issues/16889

### How to test and review this PR?

I didn't try adding more for the others. They are resolved or mentioned already:

> Files in gitignored directories may still be matched unexpectedly

This is more a concern in `cargo package`/`cargo publish`. The doc already encourages checking the result of `cargo package --list` before publishing. The addition in this PR also explicitly say gitignore from Git is not respected by `include`.

> The ! prefix can be used to explicitly exclude such paths

This is mentioned a few lines down.

https://github.com/rust-lang/cargo/blob/f4f977ff6fc657b3bcf3ac1addd4fd62387ddd46/src/doc/src/reference/manifest.md?plain=1#L417-L419



