### PR TITLE
docs(ref): Better highlight 'package --list' for include/exclude

### DIFF
--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -372,8 +372,6 @@ and certain kinds of change tracking (described below).
 The patterns specified in the `exclude` field identify a set of files that are
 not included, and the patterns in `include` specify files that are explicitly
 included.
-You may run [`cargo package --list`][`cargo package`] to verify which files will
-be included in the package.
 
 ```toml
 [package]
@@ -386,6 +384,9 @@ exclude = ["/ci", "images/", ".*"]
 # ...
 include = ["/src", "COPYRIGHT", "/examples", "!/examples/big_example"]
 ```
+
+> **Note:** Run [`cargo package --list`][`cargo package`]
+> to verify which files will be included in the package.
 
 The default if neither field is specified is to include all files from the
 root of the package, except for the exclusions listed below.


### PR DESCRIPTION
### What does this PR try to resolve?

With the suggestion of `cargo package --list` at the end of a paragraph, it could be easy to miss.  Moving it into a note in case it helps encourage its use.

### How to test and review this PR?
