### PR TITLE
docs(semver-check): update diagnostics to Rust 1.95

### DIFF
--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -1341,7 +1341,7 @@ struct Foo;
 impl Trait for Foo {}
 
 fn main() {
-    let obj: Box<dyn Trait> = Box::new(Foo); // Error: the trait `Trait` is not dyn compatible
+    let obj: Box<dyn Trait> = Box::new(Foo); // Error: the trait `updated_crate::Trait` is not dyn compatible
 }
 ```
 


### PR DESCRIPTION
See https://github.com/rust-lang/cargo/actions/runs/24515552632/job/71658352382?pr=16892

```
error: test failed for example starting on line 1322: expected error message not found in compiler output
Expected: the trait `Trait` is not dyn compatible
Got:
error[E0038]: the trait `updated_crate::Trait` is not dyn compatible
  --> /tmp/.tmp0LpIwx/example.rs:10:22
   |
10 |     let obj: Box<dyn Trait> = Box::new(Foo);
   |                      ^^^^^ `updated_crate::Trait` is not dyn compatible
   |
note: for a trait to be dyn compatible it needs to allow building a vtable
      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
  --> /tmp/.tmp0LpIwx/after.rs:6:11
   |
 6 |     const CONST: i32 = 123;
   |           ^^^^^ the trait is not dyn compatible because it contains associated const `CONST`
   = help: only type `Foo` implements `updated_crate::Trait`; consider using it directly instead.

error: aborting due to 1 previous error
```
