### PR TITLE
Make crate downloads process as a queue rather than a stack

### DIFF
--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -1,7 +1,7 @@
 use std::cell::OnceCell;
 use std::cell::{Cell, Ref, RefCell};
 use std::cmp::Ordering;
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::fmt;
 use std::hash;
 use std::mem;
@@ -313,7 +313,7 @@ pub struct Downloads<'a, 'gctx> {
     /// temporary holding area, needed because curl can report multiple
     /// downloads at once, but the main loop (`wait`) is written to only
     /// handle one at a time.
-    results: Vec<(usize, Result<(), curl::Error>)>,
+    results: VecDeque<(usize, Result<(), curl::Error>)>,
     /// The next ID to use for creating a token (see `Download::token`).
     next: usize,
     /// Progress bar.
@@ -436,7 +436,7 @@ impl<'gctx> PackageSet<'gctx> {
             pending: HashMap::new(),
             pending_ids: HashSet::new(),
             sleeping: SleepTracker::new(),
-            results: Vec::new(),
+            results: VecDeque::new(),
             progress: RefCell::new(Some(Progress::with_style(
                 "Downloading",
                 ProgressStyle::Ratio,
@@ -989,13 +989,13 @@ impl<'a, 'gctx> Downloads<'a, 'gctx> {
                 let token = msg.token().expect("failed to read token");
                 let handle = &pending[&token].1;
                 if let Some(result) = msg.result_for(handle) {
-                    results.push((token, result));
+                    results.push_back((token, result));
                 } else {
                     debug!(target: "network", "message without a result (?)");
                 }
             });
 
-            if let Some(pair) = results.pop() {
+            if let Some(pair) = results.pop_front() {
                 break Ok(pair);
             }
             assert_ne!(self.remaining(), 0);

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -91,8 +91,8 @@ fn depend_on_alt_registry_depends_on_same_registry_no_index() {
 [UPDATING] `alternative` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
-[DOWNLOADED] baz v0.0.1 (registry `alternative`)
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
+[DOWNLOADED] baz v0.0.1 (registry `alternative`)
 [CHECKING] baz v0.0.1 (registry `alternative`)
 [CHECKING] bar v0.0.1 (registry `alternative`)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -134,8 +134,8 @@ fn depend_on_alt_registry_depends_on_same_registry() {
 [UPDATING] `alternative` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
-[DOWNLOADED] baz v0.0.1 (registry `alternative`)
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
+[DOWNLOADED] baz v0.0.1 (registry `alternative`)
 [CHECKING] baz v0.0.1 (registry `alternative`)
 [CHECKING] bar v0.0.1 (registry `alternative`)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -1797,17 +1797,18 @@ fn proc_macro_in_artifact_dep() {
 
     p.cargo("check -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
-        .with_stderr_data(
-            r#"...
+        .with_stderr_data(str![[r#"
+...
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
+[DOWNLOADED] bin-uses-pm v1.0.0 (registry `dummy-registry`)
 [ERROR] failed to download from `[ROOTURL]/dl/pm/1.0.0/download`
 
 Caused by:
   [37] Could[..]t read a file:// file (Could[..]t open file [ROOT]/dl/pm/1.0.0/download)
-"#,
-        )
+
+"#]])
         .with_status(101)
         .run();
 }

--- a/tests/testsuite/cargo_tree/deps.rs
+++ b/tests/testsuite/cargo_tree/deps.rs
@@ -1682,9 +1682,9 @@ fn ambiguous_name() {
 [LOCKING] 3 packages to latest compatible versions
 [ADDING] dep v1.0.0 (available: v2.0.0)
 [DOWNLOADING] crates ...
-[DOWNLOADED] dep v2.0.0 (registry `dummy-registry`)
-[DOWNLOADED] dep v1.0.0 (registry `dummy-registry`)
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
+[DOWNLOADED] dep v1.0.0 (registry `dummy-registry`)
+[DOWNLOADED] dep v2.0.0 (registry `dummy-registry`)
 [ERROR] specification `dep` is ambiguous
 [HELP] re-run this command with one of the following specifications
   dep@1.0.0

--- a/tests/testsuite/cargo_tree/dupe/stderr.term.svg
+++ b/tests/testsuite/cargo_tree/dupe/stderr.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="146px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
@@ -24,11 +24,11 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold"> Downloading</tspan><tspan> crates ...</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> c v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> a v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> b v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> a v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> c v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_tree/edge_kind/stderr.term.svg
+++ b/tests/testsuite/cargo_tree/edge_kind/stderr.term.svg
@@ -1,7 +1,7 @@
 <svg width="740px" height="416px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
@@ -24,41 +24,41 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold"> Downloading</tspan><tspan> crates ...</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> normal_d v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> build_a v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> normal_c v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> build_b v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> normal_b_build_a_normal_a v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> build_b_build_a v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> normal_b_build_a v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> build_b_build_a_normal_a v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> normal_b v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> build_c v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> normal_a v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> build_d v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> dev_d v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="190px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> dev_a v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> dev_c v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="208px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> dev_b v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> dev_b_build_a_normal_a v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="226px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> dev_b_build_a v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> dev_b_build_a v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="244px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> dev_b_build_a_normal_a v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> dev_b v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="262px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> dev_c v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> dev_a v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="280px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> dev_d v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> build_d v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="298px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> normal_a v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> build_c v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="316px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> normal_b v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> build_b_build_a_normal_a v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="334px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> normal_b_build_a v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> build_b_build_a v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="352px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> normal_b_build_a_normal_a v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> build_b v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="370px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> normal_c v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> build_a v1.0.0 (registry `dummy-registry`)</tspan>
+    <tspan x="10px" y="388px"><tspan class="fg-bright-green bold">  Downloaded</tspan><tspan> normal_d v1.0.0 (registry `dummy-registry`)</tspan>
 </tspan>
     <tspan x="10px" y="406px">
 </tspan>

--- a/tests/testsuite/cfg.rs
+++ b/tests/testsuite/cfg.rs
@@ -97,8 +97,8 @@ fn works_through_the_registry() {
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
-[DOWNLOADED] baz v0.1.0 (registry `dummy-registry`)
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
+[DOWNLOADED] baz v0.1.0 (registry `dummy-registry`)
 [CHECKING] baz v0.1.0
 [CHECKING] bar v0.1.0
 [CHECKING] foo v0.0.1 ([ROOT]/foo)

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -3951,8 +3951,8 @@ fn mergeable_info_dep_collision() {
 [LOCKING] 2 packages to latest compatible versions
 [ADDING] dep v0.1.0 (available: v0.2.0)
 [DOWNLOADING] crates ...
-[DOWNLOADED] dep v0.2.0 (registry `dummy-registry`)
 [DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)
+[DOWNLOADED] dep v0.2.0 (registry `dummy-registry`)
 [DOCUMENTING] dep v0.1.0
 [RUNNING] `rustdoc [..]--crate-name dep [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/out [..]--crate-version 0.1.0`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -2267,8 +2267,8 @@ fn registry_summary_order_doesnt_matter() {
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
-[DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
+[DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)
 [COMPILING] dep v0.1.0
 [COMPILING] bar v0.1.0
 [COMPILING] foo v0.1.0 ([ROOT]/foo)

--- a/tests/testsuite/features_namespaced.rs
+++ b/tests/testsuite/features_namespaced.rs
@@ -36,8 +36,8 @@ fn dependency_with_crate_syntax() {
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
-[DOWNLOADED] baz v1.0.0 (registry `dummy-registry`)
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
+[DOWNLOADED] baz v1.0.0 (registry `dummy-registry`)
 [CHECKING] baz v1.0.0
 [CHECKING] bar v1.0.0
 [CHECKING] foo v0.1.0 ([ROOT]/foo)

--- a/tests/testsuite/fetch.rs
+++ b/tests/testsuite/fetch.rs
@@ -62,8 +62,7 @@ fn fetch_all_platform_dependencies_when_no_target_is_given() {
         .with_stderr_data(str![[r#"
 ...
 [DOWNLOADED] d1 v1.2.3 (registry `dummy-registry`)
-[DOWNLOADED] d2 v0.1.2 (registry `dummy-registry`)
-...
+
 "#]])
         .run();
 }

--- a/tests/testsuite/future_incompat_report.rs
+++ b/tests/testsuite/future_incompat_report.rs
@@ -580,9 +580,9 @@ fn suggestions_for_updates() {
         .env("RUSTFLAGS", "-Zfuture-incompat-test")
         .with_stderr_data(str![[r#"
 [DOWNLOADING] crates ...
-[DOWNLOADED] without_updates v1.0.0 (registry `dummy-registry`)
-[DOWNLOADED] with_updates v1.0.0 (registry `dummy-registry`)
 [DOWNLOADED] big_update v1.0.0 (registry `dummy-registry`)
+[DOWNLOADED] with_updates v1.0.0 (registry `dummy-registry`)
+[DOWNLOADED] without_updates v1.0.0 (registry `dummy-registry`)
 [CHECKING] with_updates v1.0.0
 [CHECKING] big_update v1.0.0
 [CHECKING] without_updates v1.0.0

--- a/tests/testsuite/inheritable_workspace_fields.rs
+++ b/tests/testsuite/inheritable_workspace_fields.rs
@@ -1171,8 +1171,8 @@ fn inherit_dependency_features() {
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
-[DOWNLOADED] fancy_dep v0.2.4 (registry `dummy-registry`)
 [DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)
+[DOWNLOADED] fancy_dep v0.2.4 (registry `dummy-registry`)
 [CHECKING] fancy_dep v0.2.4
 [CHECKING] dep v0.1.0
 [CHECKING] bar v0.2.0 ([ROOT]/foo)
@@ -1539,8 +1539,8 @@ fn warn_inherit_def_feat_true_member_def_feat_false() {
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
-[DOWNLOADED] fancy_dep v0.2.4 (registry `dummy-registry`)
 [DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)
+[DOWNLOADED] fancy_dep v0.2.4 (registry `dummy-registry`)
 [CHECKING] fancy_dep v0.2.4
 [CHECKING] dep v0.1.0
 [CHECKING] bar v0.2.0 ([ROOT]/foo)
@@ -1631,8 +1631,8 @@ fn warn_inherit_simple_member_def_feat_false() {
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
-[DOWNLOADED] fancy_dep v0.2.4 (registry `dummy-registry`)
 [DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)
+[DOWNLOADED] fancy_dep v0.2.4 (registry `dummy-registry`)
 [CHECKING] fancy_dep v0.2.4
 [CHECKING] dep v0.1.0
 [CHECKING] bar v0.2.0 ([ROOT]/foo)
@@ -1723,8 +1723,8 @@ fn inherit_def_feat_false_member_def_feat_true() {
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
-[DOWNLOADED] fancy_dep v0.2.4 (registry `dummy-registry`)
 [DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)
+[DOWNLOADED] fancy_dep v0.2.4 (registry `dummy-registry`)
 [CHECKING] fancy_dep v0.2.4
 [CHECKING] dep v0.1.0
 [CHECKING] bar v0.2.0 ([ROOT]/foo)

--- a/tests/testsuite/lints/unused_dependencies.rs
+++ b/tests/testsuite/lints/unused_dependencies.rs
@@ -1234,8 +1234,8 @@ fn pinned_transitive_dep() {
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
-[DOWNLOADED] transitive v0.1.1 (registry `dummy-registry`)
 [DOWNLOADED] intermediate v0.1.0 (registry `dummy-registry`)
+[DOWNLOADED] transitive v0.1.1 (registry `dummy-registry`)
 [CHECKING] transitive v0.1.1
 [CHECKING] intermediate v0.1.0
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
@@ -1305,8 +1305,8 @@ pub fn fun() -> &'static str {
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
-[DOWNLOADED] transitive v0.1.1 (registry `dummy-registry`)
 [DOWNLOADED] intermediate v0.1.0 (registry `dummy-registry`)
+[DOWNLOADED] transitive v0.1.1 (registry `dummy-registry`)
 [CHECKING] transitive v0.1.1
 [CHECKING] intermediate v0.1.0
 [CHECKING] foo v0.1.0 ([ROOT]/foo)

--- a/tests/testsuite/offline.rs
+++ b/tests/testsuite/offline.rs
@@ -360,7 +360,7 @@ Caused by:
     p.cargo("check --offline")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to download `bar v0.1.0`
+[ERROR] failed to download `baz v1.0.0`
 
 Caused by:
   attempting to make an HTTP request, but --offline was specified

--- a/tests/testsuite/progress.rs
+++ b/tests/testsuite/progress.rs
@@ -105,8 +105,6 @@ fn always_shows_progress() {
     p.cargo("check")
         .with_stderr_data(
             str![[r#"
-[DOWNLOADING] [..] crate [..]
-[DOWNLOADED] 3 crates ([..]) in [..]s
 [BUILDING] [..] [..]/4: [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 ...

--- a/tests/testsuite/pub_priv.rs
+++ b/tests/testsuite/pub_priv.rs
@@ -568,8 +568,8 @@ fn publish_package_with_public_dependency() {
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
-[DOWNLOADED] pub_bar v0.1.0 (registry `dummy-registry`)
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
+[DOWNLOADED] pub_bar v0.1.0 (registry `dummy-registry`)
 [CHECKING] pub_bar v0.1.0
 [CHECKING] bar v0.1.0
 [CHECKING] foo v0.0.1 ([ROOT]/foo)

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -166,9 +166,9 @@ fn lint_dep_incompatible_with_rust_version() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [DOWNLOADING] crates ...
-[DOWNLOADED] too_new_parent v0.0.1 (registry `dummy-registry`)
-[DOWNLOADED] too_new_child v0.0.1 (registry `dummy-registry`)
 [DOWNLOADED] rustc_compatible v0.0.1 (registry `dummy-registry`)
+[DOWNLOADED] too_new_child v0.0.1 (registry `dummy-registry`)
+[DOWNLOADED] too_new_parent v0.0.1 (registry `dummy-registry`)
 [ERROR] rustc [..] is not supported by the following packages:
   too_new_child@0.0.1 requires rustc 1.2345.0
   too_new_parent@0.0.1 requires rustc 1.2345.0

--- a/tests/testsuite/weak_dep_features.rs
+++ b/tests/testsuite/weak_dep_features.rs
@@ -110,9 +110,9 @@ fn deferred() {
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
-[DOWNLOADED] dep v1.0.0 (registry `dummy-registry`)
-[DOWNLOADED] bar_activator v1.0.0 (registry `dummy-registry`)
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
+[DOWNLOADED] bar_activator v1.0.0 (registry `dummy-registry`)
+[DOWNLOADED] dep v1.0.0 (registry `dummy-registry`)
 [CHECKING] bar v1.0.0
 [CHECKING] dep v1.0.0
 [CHECKING] bar_activator v1.0.0
@@ -355,9 +355,9 @@ fn weak_with_host_decouple() {
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
-[DOWNLOADED] common v1.0.0 (registry `dummy-registry`)
-[DOWNLOADED] bar_activator v1.0.0 (registry `dummy-registry`)
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
+[DOWNLOADED] bar_activator v1.0.0 (registry `dummy-registry`)
+[DOWNLOADED] common v1.0.0 (registry `dummy-registry`)
 [COMPILING] bar v1.0.0
 [COMPILING] common v1.0.0
 [COMPILING] bar_activator v1.0.0


### PR DESCRIPTION
The existing crate downloader pops the most recently completed download off when processing completed download. This results in the downloads finishing backwards to the order they were started.

In practice, this only impacts when multiple crates finish at the same time, such as when downloading from `file:///` URLs in the tests. Otherwise, the crates are processed in the order they finish downloading.

Emulating this behavior when converting to `http_async` is difficult, hence this change.

cc #16845