### PR TITLE
fix: sparse registry fetch progress reporting

### DIFF
--- a/src/cargo/sources/registry/http_remote.rs
+++ b/src/cargo/sources/registry/http_remote.rs
@@ -476,11 +476,6 @@ impl<'gctx> HttpBackend<'gctx> {
         if self.offline() {
             return Ok(LoadResponse::NotFound);
         }
-
-        if !self.fresh.borrow_mut().insert(path.to_string()) {
-            warn!("downloaded the index file `{path}` twice");
-        }
-
         let mut r = Retry::new(self.gctx)?;
         self.pending.update(|v| v + 1);
         let response = loop {
@@ -494,6 +489,9 @@ impl<'gctx> HttpBackend<'gctx> {
             }
         };
         self.pending.update(|v| v - 1);
+        if !self.fresh.borrow_mut().insert(path.to_string()) {
+            warn!("downloaded the index file `{path}` twice");
+        }
         response
     }
 


### PR DESCRIPTION
### What does this PR try to resolve?

This makes the sparse progress update work a little better. Previously it would display `N completed; M pending`, when all of `N` had not actually finished yet. This is a regression in the new `async_http` sparse remote. With this change, N now ticks up as M ticks down.

For example:
Before
```
4 completed; 3 pending
4 completed; 2 pending
4 completed; 1 pending
```
After
```
1 completed; 3 pending
2 completed; 2 pending
3 completed; 1 pending
```

### How to test and review this PR?
There are no tests for this interactive progress reporting. To validate it yourself, I suggest `cargo update --dry-run`.

cc #16845