### PR TITLE
fix(tests): flaky test local_poll_adapter deferred_success

### DIFF
--- a/src/cargo/util/local_poll_adapter.rs
+++ b/src/cargo/util/local_poll_adapter.rs
@@ -103,7 +103,22 @@ where
 #[cfg(test)]
 mod tests {
     use super::LocalPollAdapter;
-    use std::{rc::Rc, task::Poll, time::Duration};
+    use std::{rc::Rc, task::Poll};
+
+    /// Future that yields once.
+    fn yield_once() -> impl std::future::Future<Output = ()> {
+        let mut yielded = false;
+
+        std::future::poll_fn(move |cx| {
+            if yielded {
+                Poll::Ready(())
+            } else {
+                yielded = true;
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+        })
+    }
 
     struct Thing {}
 
@@ -111,7 +126,7 @@ mod tests {
         async fn widen(&self, i: &i32) -> Result<i64, ()> {
             if *i > 10 {
                 // Big numbers take longer to process (need to test futures that yield).
-                futures_timer::Delay::new(Duration::from_millis(1)).await
+                yield_once().await;
             }
             if *i % 2 != 0 {
                 // Odd numbers are not supported (need to test errors).


### PR DESCRIPTION
The deferred_success test used a timer to create a task future that would yield. Sometimes the timer was short enough that it had elapsed by the time it was supposed to yield, so the task didn't yield as the test expected.

This change replaces the timer with a future that always yields exactly once.

Fixes #16907