### PR TITLE
docs: fix typo in traverse_and_share comment

### DIFF
--- a/src/cargo/ops/cargo_compile/mod.rs
+++ b/src/cargo/ops/cargo_compile/mod.rs
@@ -890,8 +890,8 @@ fn traverse_and_share(
     let mut dep_hash = StableHasher::new();
     let skip_non_compile_time_deps = compile_time_deps_only
         && (!unit.target.is_compile_time_dependency() ||
-            // Root unit is not a dependency unless other units are dependant
-            // to it.
+            // Root unit is not a dependency unless other units are dependent
+            // on it.
             unit_is_root);
     let new_deps: Vec<_> = unit_graph[unit]
         .iter()


### PR DESCRIPTION

**Repo:** rust-lang/cargo (⭐ 12000)
**Type:** docs
**Files changed:** 1
**Lines:** +2/-2

## What
Fixes a small grammatical typo in a code comment in `src/cargo/ops/cargo_compile/mod.rs`. Changes "other units are dependant to it" to "other units are dependent on it" — both correcting the misspelling ("dependant" → "dependent") and the preposition ("to" → "on").

## Why
Improves readability of the comment for future maintainers. "Dependant" is a noun in British English; the adjective is "dependent". The preposition "on" is also the standard collocation. Trivial cleanup, no behavioural change.

## Testing
Comment-only change inside an existing function — no compilation or behavioural impact. `cargo check` would still pass.

## Risk
Low — comment-only edit.
