### PR TITLE
Fix test fetch_all_platform_dependencies_when_no_target_is_given

### DIFF
--- a/tests/testsuite/fetch.rs
+++ b/tests/testsuite/fetch.rs
@@ -59,11 +59,15 @@ fn fetch_all_platform_dependencies_when_no_target_is_given() {
         .build();
 
     p.cargo("fetch")
-        .with_stderr_data(str![[r#"
+        .with_stderr_data(
+            str![[r#"
 ...
+[DOWNLOADED] d2 v0.1.2 (registry `dummy-registry`)
 [DOWNLOADED] d1 v1.2.3 (registry `dummy-registry`)
-
-"#]])
+...
+"#]]
+            .unordered(),
+        )
         .run();
 }
 


### PR DESCRIPTION
This test was randomly failing because the order that cargo prints the completion of `d1` and `d2` is not deterministic.

I suspect this is a result of
https://github.com/rust-lang/cargo/pull/16898 which can cause the parallel fetches to finish in different orders.

This is fixed with `.unordered()` because the order these are printed isn't important.
