### PR TITLE
fix(help): add `.1` extension to man page temp file

### DIFF
--- a/src/bin/cargo/commands/help.rs
+++ b/src/bin/cargo/commands/help.rs
@@ -171,7 +171,11 @@ fn extract_man(subcommand: &str, extension: &str) -> Option<Vec<u8>> {
 /// display it.
 fn write_and_spawn(name: &str, contents: &[u8], command: &str) -> CargoResult<()> {
     let prefix = format!("cargo-{}.", name);
-    let mut tmp = tempfile::Builder::new().prefix(&prefix).tempfile()?;
+    let suffix = if command == "man" { ".1" } else { "" };
+    let mut tmp = tempfile::Builder::new()
+        .prefix(&prefix)
+        .suffix(suffix)
+        .tempfile()?;
     let f = tmp.as_file_mut();
     f.write_all(contents)?;
     f.flush()?;

--- a/tests/testsuite/help.rs
+++ b/tests/testsuite/help.rs
@@ -142,7 +142,7 @@ fn help_man_temp_file_extension() {
     cargo_process("help build")
         .env("PATH", &p.target_debug_dir())
         .with_stdout_data(str![[r#"
-no .1 extension
+has .1 extension
 
 "#]])
         .run();

--- a/tests/testsuite/help.rs
+++ b/tests/testsuite/help.rs
@@ -119,6 +119,36 @@ fn help_man() {
 }
 
 #[cargo_test]
+fn help_man_temp_file_extension() {
+    let p = project()
+        .at("man")
+        .file("Cargo.toml", &basic_manifest("man", "1.0.0"))
+        .file(
+            "src/main.rs",
+            r#"
+                fn main() {
+                    let path = std::env::args().nth(1).unwrap();
+                    if path.ends_with(".1") {
+                        println!("has .1 extension");
+                    } else {
+                        println!("no .1 extension");
+                    }
+                }
+            "#,
+        )
+        .build();
+    p.cargo("build").run();
+
+    cargo_process("help build")
+        .env("PATH", &p.target_debug_dir())
+        .with_stdout_data(str![[r#"
+no .1 extension
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn help_alias() {
     // Check that `help some_alias` will resolve.
     help_with_man_and_path("", "b", "build", Path::new(""));


### PR DESCRIPTION
Fixes #16910

Add `.1` suffix to the temp file when spawning `man` so platforms like 
NetBSD recognize it as a man page.