### PR TITLE
test(git): add regression test for full-hash GitHub fast path

### DIFF
--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -1656,7 +1656,22 @@ fn is_short_hash_of(rev: &str, oid: Oid) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::absolute_submodule_url;
+    use super::*;
+
+    #[test]
+    fn github_fast_path_full_hash_returns_needs_fetch() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let mut repo = git2::Repository::init_bare(temp_dir.path()).unwrap();
+        let full_hash = "c9040898c9183ddbb9402dcbf749ed06d6ea90ad";
+        let reference = GitReference::Rev(full_hash.to_string());
+        let gctx = GlobalContext::default().unwrap();
+        let expected_oid = rev_to_oid(full_hash).unwrap();
+
+        let result =
+            github_fast_path(&mut repo, "https://github.com/user/repo", &reference, &gctx).unwrap();
+
+        assert!(matches!(result, FastPathRev::NeedsFetch(oid) if oid == expected_oid));
+    }
 
     #[test]
     fn test_absolute_submodule_url() {


### PR DESCRIPTION
### What does this PR try to resolve?

Follow-up coverage for #13946, which fixed #13555

That fix restored the early return in `github_fast_path` for full commit hashes, but it did not add a direct test for this path. If this guard gets removed in a later refactor, CI would not catch it very directly.

I first looked at adding this in the testsuite, but the existing GitHub fast-path coverage uses the public network, and the GitHub API URL is built directly in the code. So i went with a small unit test for the early-return path instead.

### How to test and review this PR?

```bash
cargo +1.95 test --lib github_fast_path_full_hash_returns_needs_fetch
cargo +1.95 fmt --check --all
```