### PR TITLE
Fix flaky test: proc_macro_in_artifact_dep

### DIFF
--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -1802,7 +1802,7 @@ fn proc_macro_in_artifact_dep() {
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
-[DOWNLOADED] bin-uses-pm v1.0.0 (registry `dummy-registry`)
+...
 [ERROR] failed to download from `[ROOTURL]/dl/pm/1.0.0/download`
 
 Caused by:


### PR DESCRIPTION
Sometimes cargo will attempt to download `pm` before `bin-uses-pm`, which causes the expected error to occur before the `[DOWNLOADED]` message is printed.

Since the test doesn't care about downloading `pm`, we can exclude this case by matching `...`.