### PR TITLE
fix(path): clarify error message when path dependency has wrong package

### DIFF
--- a/src/resolver/errors.rs
+++ b/src/resolver/errors.rs
@@ -1,7 +1,9 @@
 use std::fmt;
 use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
 
 use crate::sources::IndexSummary;
+use crate::sources::path::RecursivePathSource;
 use crate::sources::source::QueryKind;
 use crate::util::edit_distance::{closest, edit_distance};
 use crate::util::errors::CargoResult;
@@ -375,6 +377,51 @@ pub(super) fn activation_error(
                 "\nnote: perhaps a crate was updated and forgotten to be re-vendored?"
             );
         }
+    } else if let Some(packages) = alt_paths(dep, gctx) {
+        let path = dep.source_id().url().to_file_path().unwrap();
+        let _ = writeln!(
+            &mut msg,
+            "no matching package named `{}` found",
+            dep.package_name()
+        );
+
+        let mut exact_match: Option<PathBuf> = None;
+        let mut found_dir: Option<String> = None;
+        let mut names_found: Vec<(String, PathBuf)> = vec![];
+
+        for pkg in &packages {
+            let manifest_dir = pkg.manifest_path().parent().unwrap();
+            let p_name = pkg.name().as_str();
+            if p_name == dep.package_name().as_str() {
+                exact_match = Some(manifest_dir.to_path_buf());
+                break;
+            } else if manifest_dir == path {
+                found_dir = Some(p_name.to_string());
+            } else {
+                names_found.push((p_name.to_string(), manifest_dir.to_path_buf()));
+            }
+        }
+
+        let mut add_hint = |name: &str, p: &Path| {
+            let _ = writeln!(&mut hints);
+            let _ = write!(
+                &mut hints,
+                "help: package `{}` exists at `{}`",
+                name,
+                p.display()
+            );
+        };
+
+        if let Some(dir) = exact_match {
+            add_hint(dep.package_name().as_str(), &dir);
+        } else if let Some(dir_pkg) = found_dir {
+            add_hint(&dir_pkg, &path);
+        } else {
+            names_found.sort_by(|a, b| a.0.cmp(&b.0));
+            for (name, p) in names_found.iter() {
+                add_hint(name, p);
+            }
+        }
     } else if let Some(name_candidates) = alt_names(registry, dep) {
         let name_candidates = match name_candidates {
             Ok(c) => c,
@@ -545,6 +592,31 @@ fn alt_names(
         None
     } else {
         Some(Ok(name_candidates))
+    }
+}
+
+/// For path dependencies, scan the dependency directory for any packages
+/// that exist in subdirectories. This helps when the user points to a
+/// directory without a Cargo.toml or with the wrong package name.
+fn alt_paths(
+    dep: &Dependency,
+    gctx: Option<&GlobalContext>,
+) -> Option<Vec<crate::workspace::Package>> {
+    let gctx = gctx?;
+    if !dep.source_id().is_path() {
+        return None;
+    }
+    let path = dep.source_id().url().to_file_path().ok()?;
+    if !path.is_dir() {
+        return None;
+    }
+    let source_id = dep.source_id();
+    let mut source = RecursivePathSource::new(&path, source_id, gctx);
+    let packages = source.read_packages().ok()?;
+    if packages.is_empty() {
+        None
+    } else {
+        Some(packages)
     }
 }
 

--- a/src/sources/path.rs
+++ b/src/sources/path.rs
@@ -36,8 +36,8 @@ pub struct PathSource<'gctx> {
     source_id: SourceId,
     /// The root path of this source.
     path: PathBuf,
-    /// Packages that this sources has discovered.
-    package: RefCell<Option<Package>>,
+    /// The package discovered in this source, if any.
+    package: RefCell<Option<Option<Package>>>,
     gctx: &'gctx GlobalContext,
 }
 
@@ -63,23 +63,23 @@ impl<'gctx> PathSource<'gctx> {
         Self {
             source_id,
             path,
-            package: RefCell::new(Some(pkg)),
+            package: RefCell::new(Some(Some(pkg))),
             gctx,
         }
     }
 
-    /// Gets the package on the root path.
+    /// Returns the root package, or an error if it is missing or failed to load.
     pub fn root_package(&mut self) -> CargoResult<Package> {
         trace!("root_package; source={:?}", self);
 
         self.load()?;
 
         match &*self.package.borrow() {
-            Some(pkg) => Ok(pkg.clone()),
-            None => Err(internal(format!(
-                "no package found in source {:?}",
-                self.path
-            ))),
+            Some(Some(pkg)) => Ok(pkg.clone()),
+            Some(None) | None => Err(anyhow::format_err!(
+                "failed to read `{}`",
+                self.path.join("Cargo.toml").display()
+            )),
         }
     }
 
@@ -124,10 +124,14 @@ impl<'gctx> PathSource<'gctx> {
         Ok(())
     }
 
-    fn read_package(&self) -> CargoResult<Package> {
+    /// Reads the manifest. Returning `Ok(None)` if missing allows the resolver
+    /// to handle it as "not found" instead of an early IO error.
+    fn read_package(&self) -> CargoResult<Option<Package>> {
         let path = self.path.join("Cargo.toml");
-        let pkg = ops::read_package(&path, self.source_id, self.gctx)?;
-        Ok(pkg)
+        if !path.exists() {
+            return Ok(None);
+        }
+        Ok(Some(ops::read_package(&path, self.source_id, self.gctx)?))
     }
 }
 
@@ -146,7 +150,8 @@ impl<'gctx> Source for PathSource<'gctx> {
         f: &mut dyn FnMut(IndexSummary),
     ) -> CargoResult<()> {
         self.load()?;
-        if let Some(s) = self.package.borrow().as_ref().map(|p| p.summary()) {
+        if let Some(Some(p)) = &*self.package.borrow() {
+            let s = p.summary();
             let matched = match kind {
                 QueryKind::Exact | QueryKind::RejectedVersions => dep.matches(s),
                 QueryKind::AlternativeNames => true,
@@ -175,7 +180,10 @@ impl<'gctx> Source for PathSource<'gctx> {
         trace!("getting packages; id={}", id);
         self.load()?;
         let pkg = self.package.borrow();
-        let pkg = pkg.iter().find(|pkg| pkg.package_id() == id);
+        let pkg = pkg
+            .as_ref()
+            .and_then(|p| p.as_ref())
+            .filter(|pkg| pkg.package_id() == id);
         pkg.cloned()
             .map(MaybePackage::Ready)
             .ok_or_else(|| internal(format!("failed to find {} in path source", id)))

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -1308,6 +1308,7 @@ fn cargo_compile_with_dep_name_mismatch() {
 [ERROR] no matching package named `notquitebar` found
 location searched: [ROOT]/foo/bar
 required by package `foo v0.0.1 ([ROOT]/foo)`
+[HELP] package `bar` exists at `[ROOT]/foo/bar`
 
 "#]])
         .run();

--- a/tests/testsuite/cargo_add/invalid_path/stderr.term.svg
+++ b/tests/testsuite/cargo_add/invalid_path/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="1188px" height="218px" xmlns="http://www.w3.org/2000/svg">
+<svg width="2238px" height="56px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -18,27 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: failed to load source for dependency `cargo-list-test-fixture`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: the crate `cargo-list-test-fixture@[ROOT]/case/tests/fixtures/local` could not be found at `[ROOT]/case/tests/fixtures/local`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
-</tspan>
-    <tspan x="10px" y="64px"><tspan>Caused by:</tspan>
-</tspan>
-    <tspan x="10px" y="82px"><tspan>  unable to update [ROOT]/case/tests/fixtures/local</tspan>
-</tspan>
-    <tspan x="10px" y="100px">
-</tspan>
-    <tspan x="10px" y="118px"><tspan>Caused by:</tspan>
-</tspan>
-    <tspan x="10px" y="136px"><tspan>  failed to read `[ROOT]/case/tests/fixtures/local/Cargo.toml`</tspan>
-</tspan>
-    <tspan x="10px" y="154px">
-</tspan>
-    <tspan x="10px" y="172px"><tspan>Caused by:</tspan>
-</tspan>
-    <tspan x="10px" y="190px"><tspan>  [..]</tspan>
-</tspan>
-    <tspan x="10px" y="208px">
 </tspan>
   </text>
 

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -1447,9 +1447,6 @@ fn uninstall_cwd_no_project() {
         .with_stderr_data(str![[r#"
 [ERROR] failed to read `[ROOT]/Cargo.toml`
 
-Caused by:
-  [NOT_FOUND]
-
 "#]])
         .run();
 }

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -571,19 +571,9 @@ fn error_message_for_missing_manifest() {
     p.cargo("check")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to get `bar` as a dependency of package `foo v0.5.0 ([ROOT]/foo)`
-
-Caused by:
-  failed to load source for dependency `bar`
-
-Caused by:
-  unable to update [ROOT]/foo/src/bar
-
-Caused by:
-  failed to read `[ROOT]/foo/src/bar/Cargo.toml`
-
-Caused by:
-  [NOT_FOUND]
+[ERROR] no matching package named `bar` found
+location searched: [ROOT]/foo/src/bar
+required by package `foo v0.5.0 ([ROOT]/foo)`
 
 "#]])
         .run();
@@ -1140,19 +1130,9 @@ fn invalid_path_with_base() {
         .masquerade_as_nightly_cargo(&["path-bases"])
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to get `bar` as a dependency of package `foo v0.5.0 ([ROOT]/foo)`
-
-Caused by:
-  failed to load source for dependency `bar`
-
-Caused by:
-  unable to update [ROOT]/foo/shared_proj/"
-
-Caused by:
-  failed to read `[ROOT]/foo/shared_proj/"/Cargo.toml`
-
-Caused by:
-  [NOT_FOUND]
+[ERROR] no matching package named `bar` found
+location searched: [ROOT]/foo/shared_proj/"
+required by package `foo v0.5.0 ([ROOT]/foo)`
 
 "#]])
         .run();
@@ -1753,21 +1733,11 @@ fn deep_path_error() {
     p.cargo("check")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to get `c` as a dependency of package `b v0.1.0 ([ROOT]/foo/b)`
+[ERROR] no matching package named `c` found
+location searched: [ROOT]/foo/c
+required by package `b v0.1.0 ([ROOT]/foo/b)`
     ... which satisfies path dependency `b` of package `a v0.1.0 ([ROOT]/foo/a)`
     ... which satisfies path dependency `a` of package `foo v0.1.0 ([ROOT]/foo)`
-
-Caused by:
-  failed to load source for dependency `c`
-
-Caused by:
-  unable to update [ROOT]/foo/c
-
-Caused by:
-  failed to read `[ROOT]/foo/c/Cargo.toml`
-
-Caused by:
-  [NOT_FOUND]
 
 "#]])
         .run();
@@ -1989,19 +1959,9 @@ fn path_dep_package_in_subdirectory() {
         .with_status(101)
         .with_stderr_data(
             "\
-[ERROR] failed to get `definitely_not_bar` as a dependency of package `foo v0.1.0 ([ROOT]/foo)`
-
-Caused by:
-  failed to load source for dependency `definitely_not_bar`
-
-Caused by:
-  unable to update [ROOT]/foo/bar
-
-Caused by:
-  failed to read `[ROOT]/foo/bar/Cargo.toml`
-
-Caused by:
-  [NOT_FOUND]
+[ERROR] no matching package named `definitely_not_bar` found
+location searched: [ROOT]/foo/bar
+required by package `foo v0.1.0 ([ROOT]/foo)`
 ",
         )
         .run();
@@ -2048,19 +2008,9 @@ fn path_dep_other_packages_nearby() {
         .with_status(101)
         .with_stderr_data(
             "\
-[ERROR] failed to get `definitely_not_bar` as a dependency of package `foo v0.1.0 ([ROOT]/foo)`
-
-Caused by:
-  failed to load source for dependency `definitely_not_bar`
-
-Caused by:
-  unable to update [ROOT]/foo/bar
-
-Caused by:
-  failed to read `[ROOT]/foo/bar/Cargo.toml`
-
-Caused by:
-  [NOT_FOUND]
+[ERROR] no matching package named `definitely_not_bar` found
+location searched: [ROOT]/foo/bar
+required by package `foo v0.1.0 ([ROOT]/foo)`
 ",
         )
         .run();

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -1918,3 +1918,150 @@ foo v1.0.0 ([ROOT]/foo)
 "#]])
         .run();
 }
+
+#[cargo_test]
+fn path_dep_wrong_package_name() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            edition = "2024"
+            [dependencies]
+            definitely_not_bar = { path = "bar" }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file(
+            "bar/Cargo.toml",
+            r#"
+            [package]
+            name = "bar"
+            version = "0.1.0"
+            edition = "2024"
+            "#,
+        )
+        .file("bar/src/lib.rs", "")
+        .build();
+
+    p.cargo("check")
+        .with_status(101)
+        .with_stderr_data(
+            "\
+[ERROR] no matching package named `definitely_not_bar` found
+location searched: [ROOT]/foo/bar
+required by package `foo v0.1.0 ([ROOT]/foo)`
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn path_dep_package_in_subdirectory() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            edition = "2024"
+            [dependencies]
+            definitely_not_bar = { path = "bar" }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file(
+            "bar/definitely_not_bar/Cargo.toml",
+            r#"
+            [package]
+            name = "definitely_not_bar"
+            version = "0.1.0"
+            edition = "2024"
+            "#,
+        )
+        .file("bar/definitely_not_bar/src/lib.rs", "")
+        .build();
+
+    p.cargo("check")
+        .with_status(101)
+        .with_stderr_data(
+            "\
+[ERROR] failed to get `definitely_not_bar` as a dependency of package `foo v0.1.0 ([ROOT]/foo)`
+
+Caused by:
+  failed to load source for dependency `definitely_not_bar`
+
+Caused by:
+  unable to update [ROOT]/foo/bar
+
+Caused by:
+  failed to read `[ROOT]/foo/bar/Cargo.toml`
+
+Caused by:
+  [NOT_FOUND]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn path_dep_other_packages_nearby() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            edition = "2024"
+            [dependencies]
+            definitely_not_bar = { path = "bar" }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file(
+            "bar/alice/Cargo.toml",
+            r#"
+            [package]
+            name = "alice"
+            version = "0.1.0"
+            edition = "2024"
+            "#,
+        )
+        .file("bar/alice/src/lib.rs", "")
+        .file(
+            "bar/bob/Cargo.toml",
+            r#"
+            [package]
+            name = "bob"
+            version = "0.1.0"
+            edition = "2024"
+            "#,
+        )
+        .file("bar/bob/src/lib.rs", "")
+        .build();
+
+    p.cargo("check")
+        .with_status(101)
+        .with_stderr_data(
+            "\
+[ERROR] failed to get `definitely_not_bar` as a dependency of package `foo v0.1.0 ([ROOT]/foo)`
+
+Caused by:
+  failed to load source for dependency `definitely_not_bar`
+
+Caused by:
+  unable to update [ROOT]/foo/bar
+
+Caused by:
+  failed to read `[ROOT]/foo/bar/Cargo.toml`
+
+Caused by:
+  [NOT_FOUND]
+",
+        )
+        .run();
+}

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -1652,8 +1652,7 @@ fn invalid_path_dep_in_workspace_with_lockfile() {
 [ERROR] no matching package named `bar` found
 location searched: [ROOT]/foo/foo
 required by package `foo v0.5.0 ([ROOT]/foo/foo)`
-[HELP] packages with similar names: foo
-
+[HELP] package `foo` exists at `[ROOT]/foo/foo`
 
 "#]])
         .run();
@@ -1923,6 +1922,7 @@ fn path_dep_wrong_package_name() {
 [ERROR] no matching package named `definitely_not_bar` found
 location searched: [ROOT]/foo/bar
 required by package `foo v0.1.0 ([ROOT]/foo)`
+[HELP] package `bar` exists at `[ROOT]/foo/bar`
 ",
         )
         .run();
@@ -1962,6 +1962,7 @@ fn path_dep_package_in_subdirectory() {
 [ERROR] no matching package named `definitely_not_bar` found
 location searched: [ROOT]/foo/bar
 required by package `foo v0.1.0 ([ROOT]/foo)`
+[HELP] package `definitely_not_bar` exists at `[ROOT]/foo/bar/definitely_not_bar`
 ",
         )
         .run();
@@ -2011,6 +2012,8 @@ fn path_dep_other_packages_nearby() {
 [ERROR] no matching package named `definitely_not_bar` found
 location searched: [ROOT]/foo/bar
 required by package `foo v0.1.0 ([ROOT]/foo)`
+[HELP] package `alice` exists at `[ROOT]/foo/bar/alice`
+[HELP] package `bob` exists at `[ROOT]/foo/bar/bob`
 ",
         )
         .run();

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -2479,19 +2479,9 @@ fn invalid_missing() {
     p.cargo("check -q")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to get `x` as a dependency of package `foo v0.1.0 ([ROOT]/foo)`
-
-Caused by:
-  failed to load source for dependency `x`
-
-Caused by:
-  unable to update [ROOT]/foo/x
-
-Caused by:
-  failed to read `[ROOT]/foo/x/Cargo.toml`
-
-Caused by:
-  [NOT_FOUND]
+[ERROR] no matching package named `x` found
+location searched: [ROOT]/foo/x
+required by package `foo v0.1.0 ([ROOT]/foo)`
 
 "#]])
         .run();


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/cargo/pull/16927)*

Fixes #15296

When a path dependency points to a directory with a wrong or missing package, Cargo now scans subdirectories and shows helpful hints about what packages exist nearby.