### PR TITLE
Update rustls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4333,9 +4333,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -4355,9 +4355,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
This updates:

Updating rustls v0.23.37 -> v0.23.39
Updating rustls-webpki v0.103.10 -> v0.103.13

There were several security fixes in rustls-webki. I don't know if any of them are important. I don't remember if gix is even using rustls.

- https://github.com/rustls/rustls/releases/tag/v%2F0.23.38 
- https://github.com/rustls/rustls/releases/tag/v%2F0.23.39
- https://github.com/rustls/webpki/releases/tag/v%2F0.103.11 
- https://github.com/rustls/webpki/releases/tag/v%2F0.103.12 
- https://github.com/rustls/webpki/releases/tag/v%2F0.103.13
