### PR TITLE
Revert "feat(lints): Add unused deps ignore list"

### DIFF
--- a/src/cargo/core/compiler/unused_deps.rs
+++ b/src/cargo/core/compiler/unused_deps.rs
@@ -173,23 +173,6 @@ impl UnusedDepState {
                 continue;
             }
 
-            let mut ignore = Vec::new();
-            if let Some(unused_dependencies) = cargo_lints.get("unused_dependencies") {
-                if let Some(config) = unused_dependencies.config() {
-                    if let Some(config_ignore) = config.get("ignore") {
-                        if let Ok(config_ignore) =
-                            toml::Value::try_into::<Vec<InternedString>>(config_ignore.clone())
-                        {
-                            ignore = config_ignore
-                        } else {
-                            anyhow::bail!(
-                                "`lints.cargo.unused_dependencies.ignore` must be a list of string"
-                            );
-                        }
-                    }
-                }
-            }
-
             let manifest_path = rel_cwd_manifest_path(pkg.manifest_path(), build_runner.bcx.gctx);
             let mut lint_count = 0;
             for (dep_kind, state) in states.iter() {
@@ -249,15 +232,6 @@ impl UnusedDepState {
                         continue;
                     };
                     for dependency in dependency {
-                        if ignore.contains(&dependency.name_in_toml()) {
-                            debug!(
-                                "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, requested in manifest",
-                                pkg_id.name(),
-                                pkg_id.version(),
-                            );
-                            continue;
-                        }
-
                         let manifest = pkg.manifest();
                         let document = manifest.document();
                         let contents = manifest.contents();

--- a/src/cargo/lints/rules/unused_dependencies.rs
+++ b/src/cargo/lints/rules/unused_dependencies.rs
@@ -71,10 +71,6 @@ Should be written as:
 [package]
 name = "foo"
 ```
-
-### Configuration
-
-- `ignore`: a list of dependency names to allow the lint on
 "#,
     ),
 };
@@ -115,23 +111,6 @@ pub fn unused_build_dependencies_no_build_rs(
     let document = manifest.document();
     let contents = manifest.contents();
 
-    let mut ignore = Vec::new();
-    if let Some(unused_dependencies) = cargo_lints.get("unused_dependencies") {
-        if let Some(config) = unused_dependencies.config() {
-            if let Some(config_ignore) = config.get("ignore") {
-                if let Ok(config_ignore) =
-                    toml::Value::try_into::<Vec<String>>(config_ignore.clone())
-                {
-                    ignore = config_ignore
-                } else {
-                    anyhow::bail!(
-                        "`lints.cargo.unused_dependencies.ignore` must be a list of string"
-                    );
-                }
-            }
-        }
-    }
-
     for (i, dep_name) in manifest
         .normalized_toml()
         .build_dependencies()
@@ -139,10 +118,6 @@ pub fn unused_build_dependencies_no_build_rs(
         .flat_map(|m| m.keys())
         .enumerate()
     {
-        if ignore.contains(&dep_name) {
-            continue;
-        }
-
         let level = lint_level.to_diagnostic_level();
         let emitted_source = LINT.emitted_source(lint_level, reason);
 

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -2734,7 +2734,6 @@ supported tools: {}",
 }
 
 static EXPECTED_LINT_CONFIG: &[(&str, &str, &str)] = &[
-    ("cargo", "unused_dependencies", "ignore"),
     // forwarded to rustc/rustdoc
     ("rust", "unexpected_cfgs", "check-cfg"),
 ];

--- a/src/doc/src/reference/lints.md
+++ b/src/doc/src/reference/lints.md
@@ -470,10 +470,6 @@ Should be written as:
 name = "foo"
 ```
 
-### Configuration
-
-- `ignore`: a list of dependency names to allow the lint on
-
 
 ## `unused_workspace_dependencies`
 Group: `suspicious`

--- a/tests/testsuite/lints/unused_dependencies.rs
+++ b/tests/testsuite/lints/unused_dependencies.rs
@@ -1329,58 +1329,6 @@ pub fn fun() -> &'static str {
 }
 
 #[cargo_test]
-fn config_ignore() {
-    // The most basic case where there is an unused dependency
-    Package::new("unused_build", "0.1.0").publish();
-    Package::new("unused", "0.1.0").publish();
-    let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-            edition = "2018"
-
-            [build-dependencies]
-            unused_build = "0.1.0"
-
-            [dependencies]
-            unused_renamed = { package = "unused", version = "0.1.0" }
-
-            [lints.cargo]
-            unused_dependencies = { level = "warn", ignore = ["unused_build", "unused_renamed"] }
-        "#,
-        )
-        .file(
-            "src/main.rs",
-            r#"
-            fn main() {}
-            "#,
-        )
-        .build();
-
-    p.cargo("check -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
-        .with_stderr_data(
-            str![[r#"
-[UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
-[DOWNLOADING] crates ...
-[DOWNLOADED] unused_build v0.1.0 (registry `dummy-registry`)
-[DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
-[CHECKING] unused v0.1.0
-[CHECKING] foo v0.1.0 ([ROOT]/foo)
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-
-"#]]
-            .unordered(),
-        )
-        .run();
-}
-
-#[cargo_test]
 fn allow_rustflags() {
     // The most basic case where there is an unused dependency
     Package::new("unused", "0.1.0").publish();


### PR DESCRIPTION
### What does this PR try to resolve?

This is a follow up to #16935 where we take a different direction for false positives.
We are now ignoring unused direct deps that are also transitive deps (technically still used somewhere). This leaves workflows like `curl` where the `build.rs` dynamically decides what deps to use but that seems like enough of an exception case to not worry about direct integration for.
This means we can punt on having an allowlist to decide what approach we want take from among rust-lang/rfcs#3920


### How to test and review this PR?

This reverts commit b276acc529dad2938c56a7f3db90723344909ab1.