### PR TITLE
chore: Remove unused deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,8 +527,6 @@ version = "0.4.12"
 name = "cargo-test-support"
 version = "0.11.3"
 dependencies = [
- "anstream",
- "anstyle",
  "anyhow",
  "cargo-test-macro",
  "cargo-util",
@@ -4314,8 +4312,6 @@ dependencies = [
  "snapbox",
  "tempfile",
  "thiserror 2.0.18",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -5927,7 +5923,6 @@ name = "xtask-spellcheck"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "cargo-util",
  "cargo_metadata",
  "clap",
  "semver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4303,7 +4303,7 @@ checksum = "781442f29170c5c93b7185ad559492601acdc71d5bb0706f5868094f45cfcd08"
 
 [[package]]
 name = "rustfix"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "anyhow",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ regex = "1.12.3"
 rusqlite = { version = "0.39.0", features = ["bundled"] }
 rustc-hash = "2.1.2"
 rustc-stable-hash = "0.1.2"
-rustfix = { version = "0.9.6", path = "crates/rustfix" }
+rustfix = { version = "0.9.7", path = "crates/rustfix" }
 same-file = "1.0.6"
 schemars = "1.2.1"
 security-framework = "3.7.0"

--- a/benches/benchsuite/Cargo.toml
+++ b/benches/benchsuite/Cargo.toml
@@ -11,11 +11,13 @@ publish = false
 cargo.workspace = true
 cargo-util.workspace = true
 cargo-util-terminal.workspace = true
-criterion.workspace = true
 flate2.workspace = true
 rand.workspace = true
 tar.workspace = true
 url.workspace = true
+
+[dev-dependencies]
+criterion.workspace = true
 
 [lib]
 bench = false

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -8,8 +8,6 @@ repository.workspace = true
 description = "Testing framework for Cargo's testsuite."
 
 [dependencies]
-anstream.workspace = true
-anstyle.workspace = true
 anyhow.workspace = true
 cargo-test-macro.workspace = true
 cargo-util.workspace = true

--- a/crates/resolver-tests/Cargo.toml
+++ b/crates/resolver-tests/Cargo.toml
@@ -10,8 +10,10 @@ cargo-platform.workspace = true
 cargo-util-schemas.workspace = true
 cargo-util.workspace = true
 proptest.workspace = true
-snapbox.workspace = true
 varisat.workspace = true
+
+[dev-dependencies]
+snapbox.workspace = true
 
 [lints]
 workspace = true

--- a/crates/rustfix/Cargo.toml
+++ b/crates/rustfix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustfix"
-version = "0.9.6"
+version = "0.9.7"
 authors = [
     "Pascal Hertleif <killercup@gmail.com>",
     "Oliver Schneider <oli-obk@users.noreply.github.com>",

--- a/crates/rustfix/Cargo.toml
+++ b/crates/rustfix/Cargo.toml
@@ -20,13 +20,11 @@ exclude = [
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
-tracing.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true
 proptest.workspace = true
 tempfile.workspace = true
-tracing-subscriber.workspace = true
 snapbox.workspace = true
 
 [lints]

--- a/crates/xtask-spellcheck/Cargo.toml
+++ b/crates/xtask-spellcheck/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 [dependencies]
 anyhow.workspace = true
 cargo_metadata.workspace = true
-cargo-util.workspace = true
 clap.workspace = true
 semver.workspace = true
 


### PR DESCRIPTION
### What does this PR try to resolve?

Likely won't make an impact to build times since these dependencies are still used somewhere but they at least make things clearer.  Maybe people using these crates as libraries can benefit.

### How to test and review this PR?

As found by
```
CARGO_LOG=cargo::core::compiler::unused_deps=debug nargo check --workspace
```
