### PR TITLE
feat(lints): Add deny-by-default text_direction_codepoint lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,6 +442,7 @@ dependencies = [
  "toml",
  "toml_edit",
  "toml_parser",
+ "toml_writer",
  "tracing",
  "tracing-chrome",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,6 +441,7 @@ dependencies = [
  "time",
  "toml",
  "toml_edit",
+ "toml_parser",
  "tracing",
  "tracing-chrome",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,7 @@ thiserror = "2.0.18"
 time = { version = "0.3.47", features = ["parsing", "formatting", "serde"] }
 toml = { version = "1.1.2", default-features = false }
 toml_edit = { version = "0.25.10", features = ["serde"] }
+toml_parser = "1.1.2"
 tracing = { version = "0.1.44", default-features = false, features = ["std"] } # be compatible with rustc_log: https://github.com/rust-lang/rust/blob/e51e98dde6a/compiler/rustc_log/Cargo.toml#L9
 tracing-chrome = "0.7.2"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
@@ -227,6 +228,7 @@ thiserror.workspace = true
 time.workspace = true
 toml = { workspace = true, features = ["std", "serde", "parse", "display", "preserve_order"] }
 toml_edit.workspace = true
+toml_parser.workspace = true
 tracing = { workspace = true, features = ["attributes"] }
 tracing-chrome.workspace = true
 tracing-subscriber.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ time = { version = "0.3.47", features = ["parsing", "formatting", "serde"] }
 toml = { version = "1.1.2", default-features = false }
 toml_edit = { version = "0.25.10", features = ["serde"] }
 toml_parser = "1.1.2"
+toml_writer = "1.1.1"
 tracing = { version = "0.1.44", default-features = false, features = ["std"] } # be compatible with rustc_log: https://github.com/rust-lang/rust/blob/e51e98dde6a/compiler/rustc_log/Cargo.toml#L9
 tracing-chrome = "0.7.2"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
@@ -229,6 +230,7 @@ time.workspace = true
 toml = { workspace = true, features = ["std", "serde", "parse", "display", "preserve_order"] }
 toml_edit.workspace = true
 toml_parser.workspace = true
+toml_writer.workspace = true
 tracing = { workspace = true, features = ["attributes"] }
 tracing-chrome.workspace = true
 tracing-subscriber.workspace = true

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -34,6 +34,7 @@ use crate::lints::rules::non_snake_case_features;
 use crate::lints::rules::non_snake_case_packages;
 use crate::lints::rules::redundant_homepage;
 use crate::lints::rules::redundant_readme;
+use crate::lints::rules::text_direction_codepoint_in_comment;
 use crate::lints::rules::unused_build_dependencies_no_build_rs;
 use crate::lints::rules::unused_workspace_dependencies;
 use crate::lints::rules::unused_workspace_package_fields;
@@ -1401,6 +1402,13 @@ impl<'gctx> Workspace<'gctx> {
                 &mut run_error_count,
                 self.gctx,
             )?;
+            text_direction_codepoint_in_comment(
+                pkg.into(),
+                &path,
+                &cargo_lints,
+                &mut run_error_count,
+                self.gctx,
+            )?;
 
             if run_error_count > 0 {
                 let plural = if run_error_count == 1 { "" } else { "s" };
@@ -1470,6 +1478,13 @@ impl<'gctx> Workspace<'gctx> {
             implicit_minimum_version_req_ws(
                 self,
                 self.root_maybe(),
+                self.root_manifest(),
+                &cargo_lints,
+                &mut run_error_count,
+                self.gctx,
+            )?;
+            text_direction_codepoint_in_comment(
+                (self, self.root_maybe()).into(),
                 self.root_manifest(),
                 &cargo_lints,
                 &mut run_error_count,

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -35,6 +35,7 @@ use crate::lints::rules::non_snake_case_packages;
 use crate::lints::rules::redundant_homepage;
 use crate::lints::rules::redundant_readme;
 use crate::lints::rules::text_direction_codepoint_in_comment;
+use crate::lints::rules::text_direction_codepoint_in_literal;
 use crate::lints::rules::unused_build_dependencies_no_build_rs;
 use crate::lints::rules::unused_workspace_dependencies;
 use crate::lints::rules::unused_workspace_package_fields;
@@ -1409,6 +1410,13 @@ impl<'gctx> Workspace<'gctx> {
                 &mut run_error_count,
                 self.gctx,
             )?;
+            text_direction_codepoint_in_literal(
+                pkg.into(),
+                &path,
+                &cargo_lints,
+                &mut run_error_count,
+                self.gctx,
+            )?;
 
             if run_error_count > 0 {
                 let plural = if run_error_count == 1 { "" } else { "s" };
@@ -1484,6 +1492,13 @@ impl<'gctx> Workspace<'gctx> {
                 self.gctx,
             )?;
             text_direction_codepoint_in_comment(
+                (self, self.root_maybe()).into(),
+                self.root_manifest(),
+                &cargo_lints,
+                &mut run_error_count,
+                self.gctx,
+            )?;
+            text_direction_codepoint_in_literal(
                 (self, self.root_maybe()).into(),
                 self.root_manifest(),
                 &cargo_lints,

--- a/src/cargo/lints/rules/mod.rs
+++ b/src/cargo/lints/rules/mod.rs
@@ -10,6 +10,7 @@ mod non_snake_case_packages;
 mod redundant_homepage;
 mod redundant_readme;
 mod text_direction_codepoint_in_comment;
+mod text_direction_codepoint_in_literal;
 mod unknown_lints;
 pub mod unused_dependencies;
 mod unused_workspace_dependencies;
@@ -28,6 +29,7 @@ pub use non_snake_case_packages::non_snake_case_packages;
 pub use redundant_homepage::redundant_homepage;
 pub use redundant_readme::redundant_readme;
 pub use text_direction_codepoint_in_comment::text_direction_codepoint_in_comment;
+pub use text_direction_codepoint_in_literal::text_direction_codepoint_in_literal;
 pub use unknown_lints::output_unknown_lints;
 pub use unused_dependencies::unused_build_dependencies_no_build_rs;
 pub use unused_workspace_dependencies::unused_workspace_dependencies;
@@ -46,6 +48,7 @@ pub static LINTS: &[&crate::lints::Lint] = &[
     redundant_homepage::LINT,
     redundant_readme::LINT,
     text_direction_codepoint_in_comment::LINT,
+    text_direction_codepoint_in_literal::LINT,
     unknown_lints::LINT,
     unused_dependencies::LINT,
     unused_workspace_dependencies::LINT,

--- a/src/cargo/lints/rules/mod.rs
+++ b/src/cargo/lints/rules/mod.rs
@@ -9,6 +9,7 @@ mod non_snake_case_features;
 mod non_snake_case_packages;
 mod redundant_homepage;
 mod redundant_readme;
+mod text_direction_codepoint_in_comment;
 mod unknown_lints;
 pub mod unused_dependencies;
 mod unused_workspace_dependencies;
@@ -26,6 +27,7 @@ pub use non_snake_case_features::non_snake_case_features;
 pub use non_snake_case_packages::non_snake_case_packages;
 pub use redundant_homepage::redundant_homepage;
 pub use redundant_readme::redundant_readme;
+pub use text_direction_codepoint_in_comment::text_direction_codepoint_in_comment;
 pub use unknown_lints::output_unknown_lints;
 pub use unused_dependencies::unused_build_dependencies_no_build_rs;
 pub use unused_workspace_dependencies::unused_workspace_dependencies;
@@ -43,6 +45,7 @@ pub static LINTS: &[&crate::lints::Lint] = &[
     non_snake_case_packages::LINT,
     redundant_homepage::LINT,
     redundant_readme::LINT,
+    text_direction_codepoint_in_comment::LINT,
     unknown_lints::LINT,
     unused_dependencies::LINT,
     unused_workspace_dependencies::LINT,

--- a/src/cargo/lints/rules/text_direction_codepoint_in_comment.rs
+++ b/src/cargo/lints/rules/text_direction_codepoint_in_comment.rs
@@ -1,0 +1,192 @@
+use std::path::Path;
+
+use cargo_util_schemas::manifest::TomlToolLints;
+use cargo_util_terminal::report::AnnotationKind;
+use cargo_util_terminal::report::Group;
+use cargo_util_terminal::report::Level;
+use cargo_util_terminal::report::Snippet;
+use toml_parser::Source;
+use toml_parser::Span;
+use toml_parser::decoder::Encoding;
+use toml_parser::parser::Event;
+use toml_parser::parser::EventKind;
+use toml_parser::parser::EventReceiver;
+
+use crate::CargoResult;
+use crate::GlobalContext;
+use crate::core::MaybePackage;
+use crate::lints::CORRECTNESS;
+use crate::lints::Lint;
+use crate::lints::LintLevel;
+use crate::lints::ManifestFor;
+use crate::lints::rel_cwd_manifest_path;
+
+pub static LINT: &Lint = &Lint {
+    name: "text_direction_codepoint_in_comment",
+    desc: "unicode codepoint changing visible direction of text present in comment",
+    primary_group: &CORRECTNESS,
+    msrv: Some(super::CARGO_LINTS_MSRV),
+    feature_gate: None,
+    docs: Some(
+        r#"
+### What it does
+Detects Unicode codepoints in manifest comments that change the visual representation of text on screen
+in a way that does not correspond to their on memory representation.
+
+### Why it is bad
+Unicode allows changing the visual flow of text on screen
+in order to support scripts that are written right-to-left,
+but a specially crafted comment can make code that will be compiled appear to be part of a comment,
+depending on the software used to read the code.
+To avoid potential problems or confusion,
+such as in CVE-2021-42574,
+by default we deny their use.
+"#,
+    ),
+};
+
+pub fn text_direction_codepoint_in_comment(
+    manifest: ManifestFor<'_>,
+    manifest_path: &Path,
+    cargo_lints: &TomlToolLints,
+    error_count: &mut usize,
+    gctx: &GlobalContext,
+) -> CargoResult<()> {
+    let (lint_level, source) = manifest.lint_level(cargo_lints, LINT);
+    if lint_level == LintLevel::Allow {
+        return Ok(());
+    }
+
+    if matches!(
+        &manifest,
+        ManifestFor::Workspace {
+            maybe_pkg: MaybePackage::Package { .. },
+            ..
+        }
+    ) {
+        // For real manifests, lint as a package, rather than a workspace
+        return Ok(());
+    }
+
+    let Some(contents) = manifest.contents() else {
+        return Ok(());
+    };
+
+    let bidi_spans = contents
+        .char_indices()
+        .filter(|(_i, c)| {
+            UNICODE_BIDI_CODEPOINTS
+                .iter()
+                .any(|(bidi, _name)| c == bidi)
+        })
+        .map(|(i, c)| (i, i + c.len_utf8()))
+        .collect::<Vec<_>>();
+    if bidi_spans.is_empty() {
+        return Ok(());
+    }
+
+    let events = bidi_events(contents, &bidi_spans);
+    let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
+    let mut emitted_source = None;
+    for event in events {
+        if lint_level.is_error() {
+            *error_count += 1;
+        }
+
+        let token_span = event.token.span();
+        let token_span = token_span.start()..token_span.end();
+        let mut snippet = Snippet::source(contents).path(&manifest_path).annotation(
+            AnnotationKind::Context
+                .span(token_span)
+                .label("this comment contains an invisible unicode text flow control codepoint"),
+        );
+        for bidi_span in event.bidi_spans {
+            let bidi_span = bidi_span.0..bidi_span.1;
+            let escaped = format!("{:?}", &contents[bidi_span.clone()]);
+            snippet = snippet.annotation(AnnotationKind::Primary.span(bidi_span).label(escaped));
+        }
+
+        let level = lint_level.to_diagnostic_level();
+        let mut primary = Group::with_title(level.primary_title(LINT.desc)).element(snippet);
+        if emitted_source.is_none() {
+            emitted_source = Some(LINT.emitted_source(lint_level, source));
+            primary = primary.element(Level::NOTE.message(emitted_source.as_ref().unwrap()));
+        }
+
+        let report = [primary];
+        gctx.shell().print_report(&report, lint_level.force())?;
+    }
+
+    Ok(())
+}
+
+const UNICODE_BIDI_CODEPOINTS: &[(char, &str)] = &[
+    ('\u{202A}', "LEFT-TO-RIGHT EMBEDDING"),
+    ('\u{202B}', "RIGHT-TO-LEFT EMBEDDING"),
+    ('\u{202C}', "POP DIRECTIONAL FORMATTING"),
+    ('\u{202D}', "LEFT-TO-RIGHT OVERRIDE"),
+    ('\u{202E}', "RIGHT-TO-LEFT OVERRIDE"),
+    ('\u{2066}', "LEFT-TO-RIGHT ISOLATE"),
+    ('\u{2067}', "RIGHT-TO-LEFT ISOLATE"),
+    ('\u{2068}', "FIRST STRONG ISOLATE"),
+    ('\u{2069}', "POP DIRECTIONAL ISOLATE"),
+];
+
+struct BiDiEvent {
+    token: Event,
+    bidi_spans: Vec<(usize, usize)>,
+}
+
+fn bidi_events(contents: &str, bidi_spans: &[(usize, usize)]) -> Vec<BiDiEvent> {
+    let mut bidi_spans = bidi_spans.iter();
+    let bidi_span = bidi_spans.next().copied();
+
+    let source = Source::new(contents);
+    let tokens = source.lex().into_vec();
+    let mut collector = BiDiCollector {
+        bidi_span,
+        bidi_spans,
+        events: Vec::new(),
+    };
+    let mut errors = ();
+    toml_parser::parser::parse_document(&tokens, &mut collector, &mut errors);
+
+    collector.events
+}
+
+struct BiDiCollector<'b> {
+    bidi_span: Option<(usize, usize)>,
+    bidi_spans: std::slice::Iter<'b, (usize, usize)>,
+    events: Vec<BiDiEvent>,
+}
+
+impl BiDiCollector<'_> {
+    fn process(&mut self, kind: EventKind, encoding: Option<Encoding>, span: Span) {
+        let mut event_bidi_spans = Vec::new();
+        while let Some(bidi_span) = self.bidi_span {
+            if bidi_span.0 < span.start() {
+                self.bidi_span = self.bidi_spans.next().copied();
+                continue;
+            } else if span.end() <= bidi_span.0 {
+                break;
+            }
+
+            event_bidi_spans.push(bidi_span);
+            self.bidi_span = self.bidi_spans.next().copied();
+        }
+
+        if !event_bidi_spans.is_empty() {
+            let token = Event::new_unchecked(kind, encoding, span);
+            self.events.push(BiDiEvent {
+                token,
+                bidi_spans: event_bidi_spans,
+            });
+        }
+    }
+}
+
+impl EventReceiver for BiDiCollector<'_> {
+    fn comment(&mut self, span: Span, _error: &mut dyn toml_parser::ErrorSink) {
+        self.process(EventKind::Comment, None, span)
+    }
+}

--- a/src/cargo/lints/rules/text_direction_codepoint_in_literal.rs
+++ b/src/cargo/lints/rules/text_direction_codepoint_in_literal.rs
@@ -1,0 +1,247 @@
+use std::path::Path;
+
+use cargo_util_schemas::manifest::TomlToolLints;
+use cargo_util_terminal::report::AnnotationKind;
+use cargo_util_terminal::report::Group;
+use cargo_util_terminal::report::Level;
+use cargo_util_terminal::report::Patch;
+use cargo_util_terminal::report::Snippet;
+use toml_parser::Source;
+use toml_parser::Span;
+use toml_parser::decoder::Encoding;
+use toml_parser::parser::Event;
+use toml_parser::parser::EventKind;
+use toml_parser::parser::EventReceiver;
+
+use crate::CargoResult;
+use crate::GlobalContext;
+use crate::core::MaybePackage;
+use crate::lints::CORRECTNESS;
+use crate::lints::Lint;
+use crate::lints::LintLevel;
+use crate::lints::ManifestFor;
+use crate::lints::rel_cwd_manifest_path;
+
+pub static LINT: &Lint = &Lint {
+    name: "text_direction_codepoint_in_literal",
+    desc: "unicode codepoint changing visible direction of text present in literal",
+    primary_group: &CORRECTNESS,
+    msrv: Some(super::CARGO_LINTS_MSRV),
+    feature_gate: None,
+    docs: Some(
+        r#"
+### What it does
+Detects Unicode codepoints in literals in manifests that change the visual representation of text on screen
+in a way that does not correspond to their on memory representation.
+
+### Why it is bad
+Unicode allows changing the visual flow of text on screen
+in order to support scripts that are written right-to-left,
+but a specially crafted literal can make code that will be compiled appear to be part of a literal,
+depending on the software used to read the code.
+To avoid potential problems or confusion,
+such as in CVE-2021-42574,
+by default we deny their use.
+"#,
+    ),
+};
+
+pub fn text_direction_codepoint_in_literal(
+    manifest: ManifestFor<'_>,
+    manifest_path: &Path,
+    cargo_lints: &TomlToolLints,
+    error_count: &mut usize,
+    gctx: &GlobalContext,
+) -> CargoResult<()> {
+    let (lint_level, source) = manifest.lint_level(cargo_lints, LINT);
+    if lint_level == LintLevel::Allow {
+        return Ok(());
+    }
+
+    if matches!(
+        &manifest,
+        ManifestFor::Workspace {
+            maybe_pkg: MaybePackage::Package { .. },
+            ..
+        }
+    ) {
+        // For real manifests, lint as a package, rather than a workspace
+        return Ok(());
+    }
+
+    let Some(contents) = manifest.contents() else {
+        return Ok(());
+    };
+
+    let bidi_spans = contents
+        .char_indices()
+        .filter(|(_i, c)| {
+            UNICODE_BIDI_CODEPOINTS
+                .iter()
+                .any(|(bidi, _, _name)| c == bidi)
+        })
+        .map(|(i, c)| (i, i + c.len_utf8()))
+        .collect::<Vec<_>>();
+    if bidi_spans.is_empty() {
+        return Ok(());
+    }
+
+    let toml_source = Source::new(contents);
+    let events = bidi_events(&toml_source, &bidi_spans);
+    let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
+    let mut emitted_source = None;
+    for event in events {
+        if lint_level.is_error() {
+            *error_count += 1;
+        }
+
+        let token_span = event.token.span();
+        let token_span = token_span.start()..token_span.end();
+        let mut snippet = Snippet::source(contents).path(&manifest_path).annotation(
+            AnnotationKind::Context
+                .span(token_span.clone())
+                .label("this literal contains an invisible unicode text flow control codepoint"),
+        );
+        for bidi_span in event.bidi_spans {
+            let bidi_span = bidi_span.0..bidi_span.1;
+            let escaped = format!("{:?}", &contents[bidi_span.clone()]);
+            snippet = snippet.annotation(AnnotationKind::Primary.span(bidi_span).label(escaped));
+        }
+        let mut help_snippet = Snippet::source(contents).path(&manifest_path);
+        if let Some(original_raw) = toml_source.get(&event.token) {
+            let mut decoded = String::new();
+            let replacement = match event.token.kind() {
+                toml_parser::parser::EventKind::SimpleKey => {
+                    use toml_writer::ToTomlKey as _;
+                    original_raw.decode_key(&mut decoded, &mut ());
+                    let builder = toml_writer::TomlKeyBuilder::new(&decoded);
+                    let replacement = builder.as_basic();
+                    Some(replacement.to_toml_key())
+                }
+                toml_parser::parser::EventKind::Scalar => {
+                    use toml_writer::ToTomlValue as _;
+                    let kind = original_raw.decode_scalar(&mut decoded, &mut ());
+                    if matches!(kind, toml_parser::decoder::ScalarKind::String) {
+                        let builder = toml_writer::TomlStringBuilder::new(&decoded);
+                        let replacement = match event.token.encoding() {
+                            Some(toml_parser::decoder::Encoding::BasicString)
+                            | Some(toml_parser::decoder::Encoding::LiteralString)
+                            | None => builder.as_basic(),
+                            Some(toml_parser::decoder::Encoding::MlBasicString)
+                            | Some(toml_parser::decoder::Encoding::MlLiteralString) => {
+                                builder.as_ml_basic()
+                            }
+                        };
+                        Some(replacement.to_toml_value())
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            };
+            if let Some(mut replacement) = replacement {
+                for (bidi, escaped, _) in UNICODE_BIDI_CODEPOINTS {
+                    replacement = replacement.replace(*bidi, escaped);
+                }
+                help_snippet = help_snippet.patch(Patch::new(token_span.clone(), replacement));
+            }
+        }
+
+        let level = lint_level.to_diagnostic_level();
+        let mut primary = Group::with_title(level.primary_title(LINT.desc)).element(snippet);
+        if emitted_source.is_none() {
+            emitted_source = Some(LINT.emitted_source(lint_level, source));
+            primary = primary.element(Level::NOTE.message(emitted_source.as_ref().unwrap()));
+        }
+
+        let help = Group::with_title(Level::HELP.secondary_title("if you want to keep them but make them visible in your source code, you can escape them")).element(help_snippet);
+
+        let report = [primary, help];
+        gctx.shell().print_report(&report, lint_level.force())?;
+    }
+
+    Ok(())
+}
+
+const UNICODE_BIDI_CODEPOINTS: &[(char, &str, &str)] = &[
+    ('\u{202A}', r"\u{202A}", "LEFT-TO-RIGHT EMBEDDING"),
+    ('\u{202B}', r"\u{202B}", "RIGHT-TO-LEFT EMBEDDING"),
+    ('\u{202C}', r"\u{202C}", "POP DIRECTIONAL FORMATTING"),
+    ('\u{202D}', r"\u{202D}", "LEFT-TO-RIGHT OVERRIDE"),
+    ('\u{202E}', r"\u{202E}", "RIGHT-TO-LEFT OVERRIDE"),
+    ('\u{2066}', r"\u{2066}", "LEFT-TO-RIGHT ISOLATE"),
+    ('\u{2067}', r"\u{2067}", "RIGHT-TO-LEFT ISOLATE"),
+    ('\u{2068}', r"\u{2068}", "FIRST STRONG ISOLATE"),
+    ('\u{2069}', r"\u{2069}", "POP DIRECTIONAL ISOLATE"),
+];
+
+struct BiDiEvent {
+    token: Event,
+    bidi_spans: Vec<(usize, usize)>,
+}
+
+fn bidi_events(source: &Source<'_>, bidi_spans: &[(usize, usize)]) -> Vec<BiDiEvent> {
+    let mut bidi_spans = bidi_spans.iter();
+    let bidi_span = bidi_spans.next().copied();
+
+    let tokens = source.lex().into_vec();
+    let mut collector = BiDiCollector {
+        bidi_span,
+        bidi_spans,
+        events: Vec::new(),
+    };
+    let mut errors = ();
+    toml_parser::parser::parse_document(&tokens, &mut collector, &mut errors);
+
+    collector.events
+}
+
+struct BiDiCollector<'b> {
+    bidi_span: Option<(usize, usize)>,
+    bidi_spans: std::slice::Iter<'b, (usize, usize)>,
+    events: Vec<BiDiEvent>,
+}
+
+impl BiDiCollector<'_> {
+    fn process(&mut self, kind: EventKind, encoding: Option<Encoding>, span: Span) {
+        let mut event_bidi_spans = Vec::new();
+        while let Some(bidi_span) = self.bidi_span {
+            if bidi_span.0 < span.start() {
+                self.bidi_span = self.bidi_spans.next().copied();
+                continue;
+            } else if span.end() <= bidi_span.0 {
+                break;
+            }
+
+            event_bidi_spans.push(bidi_span);
+            self.bidi_span = self.bidi_spans.next().copied();
+        }
+
+        if !event_bidi_spans.is_empty() {
+            let token = Event::new_unchecked(kind, encoding, span);
+            self.events.push(BiDiEvent {
+                token,
+                bidi_spans: event_bidi_spans,
+            });
+        }
+    }
+}
+
+impl EventReceiver for BiDiCollector<'_> {
+    fn simple_key(
+        &mut self,
+        span: Span,
+        encoding: Option<Encoding>,
+        _error: &mut dyn toml_parser::ErrorSink,
+    ) {
+        self.process(EventKind::SimpleKey, encoding, span)
+    }
+    fn scalar(
+        &mut self,
+        span: Span,
+        encoding: Option<Encoding>,
+        _error: &mut dyn toml_parser::ErrorSink,
+    ) {
+        self.process(EventKind::Scalar, encoding, span)
+    }
+}

--- a/src/doc/src/reference/lints.md
+++ b/src/doc/src/reference/lints.md
@@ -42,6 +42,7 @@ These lints are all set to the 'warn' level by default.
 
 These lints are all set to the 'deny' level by default.
 - [`text_direction_codepoint_in_comment`](#text_direction_codepoint_in_comment)
+- [`text_direction_codepoint_in_literal`](#text_direction_codepoint_in_literal)
 
 ## `blanket_hint_mostly_unused`
 Group: `suspicious`
@@ -414,6 +415,27 @@ in a way that does not correspond to their on memory representation.
 Unicode allows changing the visual flow of text on screen
 in order to support scripts that are written right-to-left,
 but a specially crafted comment can make code that will be compiled appear to be part of a comment,
+depending on the software used to read the code.
+To avoid potential problems or confusion,
+such as in CVE-2021-42574,
+by default we deny their use.
+
+
+## `text_direction_codepoint_in_literal`
+Group: `correctness`
+
+Level: `deny`
+
+MSRV: `1.79.0`
+
+### What it does
+Detects Unicode codepoints in literals in manifests that change the visual representation of text on screen
+in a way that does not correspond to their on memory representation.
+
+### Why it is bad
+Unicode allows changing the visual flow of text on screen
+in order to support scripts that are written right-to-left,
+but a specially crafted literal can make code that will be compiled appear to be part of a literal,
 depending on the software used to read the code.
 To avoid potential problems or confusion,
 such as in CVE-2021-42574,

--- a/src/doc/src/reference/lints.md
+++ b/src/doc/src/reference/lints.md
@@ -38,6 +38,11 @@ These lints are all set to the 'warn' level by default.
 - [`unused_workspace_dependencies`](#unused_workspace_dependencies)
 - [`unused_workspace_package_fields`](#unused_workspace_package_fields)
 
+## Deny-by-default
+
+These lints are all set to the 'deny' level by default.
+- [`text_direction_codepoint_in_comment`](#text_direction_codepoint_in_comment)
+
 ## `blanket_hint_mostly_unused`
 Group: `suspicious`
 
@@ -392,6 +397,27 @@ Should be written as:
 [package]
 name = "foo"
 ```
+
+
+## `text_direction_codepoint_in_comment`
+Group: `correctness`
+
+Level: `deny`
+
+MSRV: `1.79.0`
+
+### What it does
+Detects Unicode codepoints in manifest comments that change the visual representation of text on screen
+in a way that does not correspond to their on memory representation.
+
+### Why it is bad
+Unicode allows changing the visual flow of text on screen
+in order to support scripts that are written right-to-left,
+but a specially crafted comment can make code that will be compiled appear to be part of a comment,
+depending on the software used to read the code.
+To avoid potential problems or confusion,
+such as in CVE-2021-42574,
+by default we deny their use.
 
 
 ## `unknown_lints`

--- a/tests/testsuite/lints/mod.rs
+++ b/tests/testsuite/lints/mod.rs
@@ -15,6 +15,7 @@ mod non_snake_case_features;
 mod non_snake_case_packages;
 mod redundant_homepage;
 mod redundant_readme;
+mod text_direction_codepoint;
 mod unknown_lints;
 mod unused_dependencies;
 mod unused_workspace_dependencies;

--- a/tests/testsuite/lints/text_direction_codepoint.rs
+++ b/tests/testsuite/lints/text_direction_codepoint.rs
@@ -32,13 +32,6 @@ text_direction_codepoint_in_literal = \"allow\"
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `text_direction_codepoint_in_literal`
-  --> Cargo.toml:14:1
-   |
-14 | text_direction_codepoint_in_literal = "allow"
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [WARNING] unicode codepoint changing visible direction of text present in comment
  --> Cargo.toml:7:51
   |
@@ -95,13 +88,52 @@ text_direction_codepoint_in_literal = \"warn\"
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `text_direction_codepoint_in_literal`
-  --> Cargo.toml:14:1
-   |
-14 | text_direction_codepoint_in_literal = "warn"
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[WARNING] unicode codepoint changing visible direction of text present in literal
+ --> Cargo.toml:7:18
+  |
+7 | description = "a �description� here"  # this is a �tricky� comment
+  |               ---^-----------^------
+  |               |  |           |
+  |               |  |           "/u{202a}"
+  |               |  "/u{202e}"
+  |               this literal contains an invisible unicode text flow control codepoint
+  |
+  = [NOTE] `cargo::text_direction_codepoint_in_literal` is set to `warn` in `[lints]`
+[HELP] if you want to keep them but make them visible in your source code, you can escape them
+  |
+7 - description = "a �description� here"  # this is a �tricky� comment
+7 + description = "a /u{202E}description/u{202A} here"  # this is a �tricky� comment
+  |
+[WARNING] unicode codepoint changing visible direction of text present in literal
+ --> Cargo.toml:8:15
+  |
+8 | homepage = "a �homepage� there"  # this is a �tricky� comment
+  |            ---^--------^-------
+  |            |  |        |
+  |            |  |        "/u{202a}"
+  |            |  "/u{202e}"
+  |            this literal contains an invisible unicode text flow control codepoint
+  |
+[HELP] if you want to keep them but make them visible in your source code, you can escape them
+  |
+8 - homepage = "a �homepage� there"  # this is a �tricky� comment
+8 + homepage = "a /u{202E}homepage/u{202A} there"  # this is a �tricky� comment
+  |
+[WARNING] unicode codepoint changing visible direction of text present in literal
+ --> Cargo.toml:9:17
+  |
+9 | repository = "a �repository� everywhere"  # this is a �tricky� comment
+  |              ---^----------^------------
+  |              |  |          |
+  |              |  |          "/u{202a}"
+  |              |  "/u{202e}"
+  |              this literal contains an invisible unicode text flow control codepoint
+  |
+[HELP] if you want to keep them but make them visible in your source code, you can escape them
+  |
+9 - repository = "a �repository� everywhere"  # this is a �tricky� comment
+9 + repository = "a /u{202E}repository/u{202A} everywhere"  # this is a �tricky� comment
+  |
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -143,13 +175,6 @@ edition = \"2015\"
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `text_direction_codepoint_in_literal`
-  --> Cargo.toml:17:1
-   |
-17 | text_direction_codepoint_in_literal = "warn"
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [WARNING] unicode codepoint changing visible direction of text present in comment
   --> Cargo.toml:10:51
    |
@@ -179,6 +204,52 @@ edition = \"2015\"
    |                                           |           |      "/u{202c}"
    |                                           |           "/u{202b}"
    |                                           this comment contains an invisible unicode text flow control codepoint
+[WARNING] unicode codepoint changing visible direction of text present in literal
+  --> Cargo.toml:10:18
+   |
+10 | description = "a �description� here"  # this is a �tricky� comment
+   |               ---^-----------^------
+   |               |  |           |
+   |               |  |           "/u{202a}"
+   |               |  "/u{202e}"
+   |               this literal contains an invisible unicode text flow control codepoint
+   |
+   = [NOTE] `cargo::text_direction_codepoint_in_literal` is set to `warn` in `[lints]`
+[HELP] if you want to keep them but make them visible in your source code, you can escape them
+   |
+10 - description = "a �description� here"  # this is a �tricky� comment
+10 + description = "a /u{202E}description/u{202A} here"  # this is a �tricky� comment
+   |
+[WARNING] unicode codepoint changing visible direction of text present in literal
+  --> Cargo.toml:11:15
+   |
+11 | homepage = "a �homepage� there"  # this is a �tricky� comment
+   |            ---^--------^-------
+   |            |  |        |
+   |            |  |        "/u{202a}"
+   |            |  "/u{202e}"
+   |            this literal contains an invisible unicode text flow control codepoint
+   |
+[HELP] if you want to keep them but make them visible in your source code, you can escape them
+   |
+11 - homepage = "a �homepage� there"  # this is a �tricky� comment
+11 + homepage = "a /u{202E}homepage/u{202A} there"  # this is a �tricky� comment
+   |
+[WARNING] unicode codepoint changing visible direction of text present in literal
+  --> Cargo.toml:12:17
+   |
+12 | repository = "a �repository� everywhere"  # this is a �tricky� comment
+   |              ---^----------^------------
+   |              |  |          |
+   |              |  |          "/u{202a}"
+   |              |  "/u{202e}"
+   |              this literal contains an invisible unicode text flow control codepoint
+   |
+[HELP] if you want to keep them but make them visible in your source code, you can escape them
+   |
+12 - repository = "a �repository� everywhere"  # this is a �tricky� comment
+12 + repository = "a /u{202E}repository/u{202A} everywhere"  # this is a �tricky� comment
+   |
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -229,13 +300,6 @@ workspace = true
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `text_direction_codepoint_in_literal`
-  --> Cargo.toml:12:1
-   |
-12 | text_direction_codepoint_in_literal = "warn"
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [WARNING] unicode codepoint changing visible direction of text present in comment
  --> Cargo.toml:6:51
   |
@@ -265,6 +329,52 @@ workspace = true
   |                                           |           |      "/u{202c}"
   |                                           |           "/u{202b}"
   |                                           this comment contains an invisible unicode text flow control codepoint
+[WARNING] unicode codepoint changing visible direction of text present in literal
+ --> Cargo.toml:6:18
+  |
+6 | description = "a �description� here"  # this is a �tricky� comment
+  |               ---^-----------^------
+  |               |  |           |
+  |               |  |           "/u{202a}"
+  |               |  "/u{202e}"
+  |               this literal contains an invisible unicode text flow control codepoint
+  |
+  = [NOTE] `cargo::text_direction_codepoint_in_literal` is set to `warn` in `[lints]`
+[HELP] if you want to keep them but make them visible in your source code, you can escape them
+  |
+6 - description = "a �description� here"  # this is a �tricky� comment
+6 + description = "a /u{202E}description/u{202A} here"  # this is a �tricky� comment
+  |
+[WARNING] unicode codepoint changing visible direction of text present in literal
+ --> Cargo.toml:7:15
+  |
+7 | homepage = "a �homepage� there"  # this is a �tricky� comment
+  |            ---^--------^-------
+  |            |  |        |
+  |            |  |        "/u{202a}"
+  |            |  "/u{202e}"
+  |            this literal contains an invisible unicode text flow control codepoint
+  |
+[HELP] if you want to keep them but make them visible in your source code, you can escape them
+  |
+7 - homepage = "a �homepage� there"  # this is a �tricky� comment
+7 + homepage = "a /u{202E}homepage/u{202A} there"  # this is a �tricky� comment
+  |
+[WARNING] unicode codepoint changing visible direction of text present in literal
+ --> Cargo.toml:8:17
+  |
+8 | repository = "a �repository� everywhere"  # this is a �tricky� comment
+  |              ---^----------^------------
+  |              |  |          |
+  |              |  |          "/u{202a}"
+  |              |  "/u{202e}"
+  |              this literal contains an invisible unicode text flow control codepoint
+  |
+[HELP] if you want to keep them but make them visible in your source code, you can escape them
+  |
+8 - repository = "a �repository� everywhere"  # this is a �tricky� comment
+8 + repository = "a /u{202E}repository/u{202A} everywhere"  # this is a �tricky� comment
+  |
 [CHECKING] bar v0.0.1 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/lints/text_direction_codepoint.rs
+++ b/tests/testsuite/lints/text_direction_codepoint.rs
@@ -1,0 +1,206 @@
+use crate::prelude::*;
+use cargo_test_support::project;
+use cargo_test_support::str;
+
+const BIDI_MANIFEST: &str = "
+[package]
+name = \"foo\"
+version = \"0.0.1\"
+edition = \"2015\"
+description = \"a \u{202e}description\u{202a} here\"  # this is a \u{202b}tricky\u{202c} comment
+homepage = \"a \u{202e}homepage\u{202a} there\"  # this is a \u{202b}tricky\u{202c} comment
+repository = \"a \u{202e}repository\u{202a} everywhere\"  # this is a \u{202b}tricky\u{202c} comment
+";
+
+#[cargo_test]
+fn bidi_comments_warn() {
+    let manifest = format!(
+        "
+{BIDI_MANIFEST}
+
+[lints.cargo]
+text_direction_codepoint_in_comment = \"warn\"
+text_direction_codepoint_in_literal = \"allow\"
+"
+    );
+
+    let p = project()
+        .file("Cargo.toml", &manifest)
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] unknown lint: `text_direction_codepoint_in_comment`
+  --> Cargo.toml:13:1
+   |
+13 | text_direction_codepoint_in_comment = "warn"
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[WARNING] unknown lint: `text_direction_codepoint_in_literal`
+  --> Cargo.toml:14:1
+   |
+14 | text_direction_codepoint_in_literal = "allow"
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn bidi_literals_warn() {
+    let manifest = format!(
+        "
+{BIDI_MANIFEST}
+
+[lints.cargo]
+text_direction_codepoint_in_comment = \"allow\"
+text_direction_codepoint_in_literal = \"warn\"
+"
+    );
+
+    let p = project()
+        .file("Cargo.toml", &manifest)
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] unknown lint: `text_direction_codepoint_in_comment`
+  --> Cargo.toml:13:1
+   |
+13 | text_direction_codepoint_in_comment = "allow"
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[WARNING] unknown lint: `text_direction_codepoint_in_literal`
+  --> Cargo.toml:14:1
+   |
+14 | text_direction_codepoint_in_literal = "warn"
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn bidi_real_workspace() {
+    let workspace_manifest = format!(
+        "
+[workspace]
+members = [\"bar\"]
+
+{BIDI_MANIFEST}
+
+[lints.cargo]
+text_direction_codepoint_in_comment = \"warn\"
+text_direction_codepoint_in_literal = \"warn\"
+"
+    );
+
+    let member_manifest = format!(
+        "
+[package]
+name = \"bar\"
+version = \"0.0.1\"
+edition = \"2015\"
+"
+    );
+
+    let p = project()
+        .file("Cargo.toml", &workspace_manifest)
+        .file("src/lib.rs", "")
+        .file("bar/Cargo.toml", &member_manifest)
+        .file("bar/src/lib.rs", "")
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] unknown lint: `text_direction_codepoint_in_comment`
+  --> Cargo.toml:16:1
+   |
+16 | text_direction_codepoint_in_comment = "warn"
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[WARNING] unknown lint: `text_direction_codepoint_in_literal`
+  --> Cargo.toml:17:1
+   |
+17 | text_direction_codepoint_in_literal = "warn"
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn bidi_virtual_workspace() {
+    let workspace_manifest = format!(
+        "
+[workspace]
+members = [\"bar\"]
+
+[workspace.package]
+description = \"a \u{202e}description\u{202a} here\"  # this is a \u{202b}tricky\u{202c} comment
+homepage = \"a \u{202e}homepage\u{202a} there\"  # this is a \u{202b}tricky\u{202c} comment
+repository = \"a \u{202e}repository\u{202a} everywhere\"  # this is a \u{202b}tricky\u{202c} comment
+
+[workspace.lints.cargo]
+text_direction_codepoint_in_comment = \"warn\"
+text_direction_codepoint_in_literal = \"warn\"
+"
+    );
+
+    let member_manifest = format!(
+        "
+[package]
+name = \"bar\"
+version = \"0.0.1\"
+edition = \"2015\"
+description.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+"
+    );
+
+    let p = project()
+        .file("Cargo.toml", &workspace_manifest)
+        .file("src/lib.rs", "")
+        .file("bar/Cargo.toml", &member_manifest)
+        .file("bar/src/lib.rs", "")
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] unknown lint: `text_direction_codepoint_in_comment`
+  --> Cargo.toml:11:1
+   |
+11 | text_direction_codepoint_in_comment = "warn"
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[WARNING] unknown lint: `text_direction_codepoint_in_literal`
+  --> Cargo.toml:12:1
+   |
+12 | text_direction_codepoint_in_literal = "warn"
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[CHECKING] bar v0.0.1 ([ROOT]/foo/bar)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}

--- a/tests/testsuite/lints/text_direction_codepoint.rs
+++ b/tests/testsuite/lints/text_direction_codepoint.rs
@@ -32,18 +32,42 @@ text_direction_codepoint_in_literal = \"allow\"
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `text_direction_codepoint_in_comment`
-  --> Cargo.toml:13:1
-   |
-13 | text_direction_codepoint_in_comment = "warn"
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [WARNING] unknown lint: `text_direction_codepoint_in_literal`
   --> Cargo.toml:14:1
    |
 14 | text_direction_codepoint_in_literal = "allow"
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[WARNING] unicode codepoint changing visible direction of text present in comment
+ --> Cargo.toml:7:51
+  |
+7 | description = "a �description� here"  # this is a �tricky� comment
+  |                                       ------------^------^--------
+  |                                       |           |      |
+  |                                       |           |      "/u{202c}"
+  |                                       |           "/u{202b}"
+  |                                       this comment contains an invisible unicode text flow control codepoint
+  |
+  = [NOTE] `cargo::text_direction_codepoint_in_comment` is set to `warn` in `[lints]`
+[WARNING] unicode codepoint changing visible direction of text present in comment
+ --> Cargo.toml:8:46
+  |
+8 | homepage = "a �homepage� there"  # this is a �tricky� comment
+  |                                  ------------^------^--------
+  |                                  |           |      |
+  |                                  |           |      "/u{202c}"
+  |                                  |           "/u{202b}"
+  |                                  this comment contains an invisible unicode text flow control codepoint
+[WARNING] unicode codepoint changing visible direction of text present in comment
+ --> Cargo.toml:9:55
+  |
+9 | repository = "a �repository� everywhere"  # this is a �tricky� comment
+  |                                           ------------^------^--------
+  |                                           |           |      |
+  |                                           |           |      "/u{202c}"
+  |                                           |           "/u{202b}"
+  |                                           this comment contains an invisible unicode text flow control codepoint
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -71,18 +95,13 @@ text_direction_codepoint_in_literal = \"warn\"
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `text_direction_codepoint_in_comment`
-  --> Cargo.toml:13:1
-   |
-13 | text_direction_codepoint_in_comment = "allow"
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [WARNING] unknown lint: `text_direction_codepoint_in_literal`
   --> Cargo.toml:14:1
    |
 14 | text_direction_codepoint_in_literal = "warn"
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -124,18 +143,42 @@ edition = \"2015\"
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `text_direction_codepoint_in_comment`
-  --> Cargo.toml:16:1
-   |
-16 | text_direction_codepoint_in_comment = "warn"
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [WARNING] unknown lint: `text_direction_codepoint_in_literal`
   --> Cargo.toml:17:1
    |
 17 | text_direction_codepoint_in_literal = "warn"
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[WARNING] unicode codepoint changing visible direction of text present in comment
+  --> Cargo.toml:10:51
+   |
+10 | description = "a �description� here"  # this is a �tricky� comment
+   |                                       ------------^------^--------
+   |                                       |           |      |
+   |                                       |           |      "/u{202c}"
+   |                                       |           "/u{202b}"
+   |                                       this comment contains an invisible unicode text flow control codepoint
+   |
+   = [NOTE] `cargo::text_direction_codepoint_in_comment` is set to `warn` in `[lints]`
+[WARNING] unicode codepoint changing visible direction of text present in comment
+  --> Cargo.toml:11:46
+   |
+11 | homepage = "a �homepage� there"  # this is a �tricky� comment
+   |                                  ------------^------^--------
+   |                                  |           |      |
+   |                                  |           |      "/u{202c}"
+   |                                  |           "/u{202b}"
+   |                                  this comment contains an invisible unicode text flow control codepoint
+[WARNING] unicode codepoint changing visible direction of text present in comment
+  --> Cargo.toml:12:55
+   |
+12 | repository = "a �repository� everywhere"  # this is a �tricky� comment
+   |                                           ------------^------^--------
+   |                                           |           |      |
+   |                                           |           |      "/u{202c}"
+   |                                           |           "/u{202b}"
+   |                                           this comment contains an invisible unicode text flow control codepoint
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -186,18 +229,42 @@ workspace = true
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `text_direction_codepoint_in_comment`
-  --> Cargo.toml:11:1
-   |
-11 | text_direction_codepoint_in_comment = "warn"
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [WARNING] unknown lint: `text_direction_codepoint_in_literal`
   --> Cargo.toml:12:1
    |
 12 | text_direction_codepoint_in_literal = "warn"
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[WARNING] unicode codepoint changing visible direction of text present in comment
+ --> Cargo.toml:6:51
+  |
+6 | description = "a �description� here"  # this is a �tricky� comment
+  |                                       ------------^------^--------
+  |                                       |           |      |
+  |                                       |           |      "/u{202c}"
+  |                                       |           "/u{202b}"
+  |                                       this comment contains an invisible unicode text flow control codepoint
+  |
+  = [NOTE] `cargo::text_direction_codepoint_in_comment` is set to `warn` in `[lints]`
+[WARNING] unicode codepoint changing visible direction of text present in comment
+ --> Cargo.toml:7:46
+  |
+7 | homepage = "a �homepage� there"  # this is a �tricky� comment
+  |                                  ------------^------^--------
+  |                                  |           |      |
+  |                                  |           |      "/u{202c}"
+  |                                  |           "/u{202b}"
+  |                                  this comment contains an invisible unicode text flow control codepoint
+[WARNING] unicode codepoint changing visible direction of text present in comment
+ --> Cargo.toml:8:55
+  |
+8 | repository = "a �repository� everywhere"  # this is a �tricky� comment
+  |                                           ------------^------^--------
+  |                                           |           |      |
+  |                                           |           |      "/u{202c}"
+  |                                           |           "/u{202b}"
+  |                                           this comment contains an invisible unicode text flow control codepoint
 [CHECKING] bar v0.0.1 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 


### PR DESCRIPTION
### What does this PR try to resolve?

These are meant to mirror
- https://doc.rust-lang.org/nightly/rustc/lints/listing/deny-by-default.html#text-direction-codepoint-in-comment
- https://doc.rust-lang.org/nightly/rustc/lints/listing/deny-by-default.html#text-direction-codepoint-in-literal

Note: on publish we strip comments but the codepoints will still be unescaped in literals. I considered escaping by default in `toml` but there can be legitimate reasons to use these code points unescaped, hence why there are two lints.

Fixes #16374
Fixes #16373

Closes #16452

### How to test and review this PR?
