### PR TITLE
Fix heading level of `build.warnings` documentation.

### DIFF
--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -459,7 +459,7 @@ recursive_example = "rr --example recursions"
 
 The `[build]` table controls build-time operations and compiler settings.
 
-### `build.warnings`
+#### `build.warnings`
 * Type: string
 * Default: `"warn"`
 * Environment: `CARGO_BUILD_WARNINGS`


### PR DESCRIPTION
### What does this PR try to resolve?

The hierarchy of the configuration documentation is incorrect. `build.warnings` needs to be one deeper to be under the `[build]` section.

### How to test and review this PR?

You can check the outline as GitHub sees it at <https://github.com/kpreid/cargo/blob/99fbe956ab2a42a81a458ace66114d033d6da9f2/src/doc/src/reference/config.md>. I haven’t built the book to test that, but the fix seems obvious enough.