### PR TITLE
Rebuild when -Zpublic-dependency changes

### DIFF
--- a/src/cargo/core/compiler/fingerprint/mod.rs
+++ b/src/cargo/core/compiler/fingerprint/mod.rs
@@ -88,6 +88,7 @@
 //! `is_std`                                   |             | ✓                        | ✓
 //! `[lints]` table[^6]                        | ✓           |                          |
 //! `[lints.rust.unexpected_cfgs.check-cfg]`   | ✓           |                          |
+//! `--extern priv:`                           | ✓           |                          |
 //!
 //! [^1]: Bin dependencies are not included.
 //!
@@ -1651,6 +1652,12 @@ fn calculate_normal(
     if let Some(allow_features) = &build_runner.bcx.gctx.cli_unstable().allow_features {
         allow_features.hash(&mut config);
     }
+    // -Zpublic-dependency changes how library units pass dependency privacy
+    // to rustc via `--extern`.
+    (unit.target.is_lib()
+        && build_runner.unit_deps(unit).iter().any(|dep| !dep.public)
+        && super::is_public_dependency_enabled(build_runner, unit))
+    .hash(&mut config);
     // -Zno-embed-metadata changes how all units are compiled, and it also changes how we tell
     // rustc to link to deps using `--extern`. If it changes, we should rebuild everything.
     build_runner

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1887,6 +1887,15 @@ pub fn lib_search_paths(
     Ok(lib_search_paths)
 }
 
+fn is_public_dependency_enabled(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> bool {
+    unit.pkg
+        .manifest()
+        .unstable_features()
+        .require(Feature::public_dependency())
+        .is_ok()
+        || build_runner.bcx.gctx.cli_unstable().public_dependency
+}
+
 /// Generates a list of `--extern` arguments.
 pub fn extern_args(
     build_runner: &BuildRunner<'_, '_>,
@@ -1897,6 +1906,7 @@ pub fn extern_args(
     let deps = build_runner.unit_deps(unit);
 
     let no_embed_metadata = build_runner.bcx.gctx.cli_unstable().no_embed_metadata;
+    let public_dependency_enabled = is_public_dependency_enabled(build_runner, unit);
 
     // Closure to add one dependency to `result`.
     let mut link_to = |dep: &UnitDep,
@@ -1906,14 +1916,7 @@ pub fn extern_args(
      -> CargoResult<()> {
         let mut value = OsString::new();
         let mut opts = Vec::new();
-        let is_public_dependency_enabled = unit
-            .pkg
-            .manifest()
-            .unstable_features()
-            .require(Feature::public_dependency())
-            .is_ok()
-            || build_runner.bcx.gctx.cli_unstable().public_dependency;
-        if !dep.public && unit.target.is_lib() && is_public_dependency_enabled {
+        if !dep.public && unit.target.is_lib() && public_dependency_enabled {
             opts.push("priv");
             *unstable_opts = true;
         }

--- a/tests/testsuite/pub_priv.rs
+++ b/tests/testsuite/pub_priv.rs
@@ -725,8 +725,7 @@ src/lib.rs:3:13: [WARNING] type `FromDep` from private dependency 'dep' in publi
 
     p.cargo("check --message-format=short")
         .with_stderr_data(str![[r#"
-src/lib.rs:3:13: [WARNING] type `FromDep` from private dependency 'dep' in public interface
-[WARNING] `foo` (lib) generated 1 warning
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -743,6 +742,9 @@ src/lib.rs:3:13: [WARNING] type `FromDep` from private dependency 'dep' in publi
     p.cargo("check -Zpublic-dependency --message-format=short")
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(str![[r#"
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+src/lib.rs:3:13: [WARNING] type `FromDep` from private dependency 'dep' in public interface
+[WARNING] `foo` (lib) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])

--- a/tests/testsuite/pub_priv.rs
+++ b/tests/testsuite/pub_priv.rs
@@ -686,6 +686,69 @@ src/lib.rs:6:13: [WARNING] type `FromPriv` from private dependency 'priv_dep' in
         .run();
 }
 
+// Regression test for https://github.com/rust-lang/cargo/issues/16962.
+#[cargo_test(nightly, reason = "exported_private_dependencies lint is unstable")]
+fn z_public_dependency_invalidates_fingerprint() {
+    Package::new("dep", "0.1.0")
+        .file("src/lib.rs", "pub struct FromDep;")
+        .publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                edition = "2015"
+
+                [dependencies]
+                dep = "0.1.0"
+            "#,
+        )
+        .file(
+            "src/lib.rs",
+            "
+            extern crate dep;
+            pub fn use_dep(_: dep::FromDep) {}
+        ",
+        )
+        .build();
+
+    p.cargo("check -Zpublic-dependency --message-format=short")
+        .masquerade_as_nightly_cargo(&["public-dependency"])
+        .with_stderr_data(str![[r#"
+...
+src/lib.rs:3:13: [WARNING] type `FromDep` from private dependency 'dep' in public interface
+...
+"#]])
+        .run();
+
+    p.cargo("check --message-format=short")
+        .with_stderr_data(str![[r#"
+src/lib.rs:3:13: [WARNING] type `FromDep` from private dependency 'dep' in public interface
+[WARNING] `foo` (lib) generated 1 warning
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+
+    p.cargo("clean").run();
+
+    p.cargo("check --message-format=short")
+        .with_stderr_data(str![[r#"
+...
+"#]])
+        .run();
+
+    p.cargo("check -Zpublic-dependency --message-format=short")
+        .masquerade_as_nightly_cargo(&["public-dependency"])
+        .with_stderr_data(str![[r#"
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
 #[cargo_test(nightly, reason = "exported_private_dependencies lint is unstable")]
 fn manifest_location() {
     Package::new("dep", "0.1.0")


### PR DESCRIPTION
Fixes #16962.

### What does this PR try to resolve?

`-Zpublic-dependency` changes how Cargo passes private dependencies to rustc for library units. With the option enabled, Cargo marks private dependencies with `priv` in `--extern` so rustc can run the `exported_private_dependencies` lint.

The fingerprint config hash did not include that effective mode, so toggling `-Zpublic-dependency` could leave the library fresh even though the rustc invocation should change.

This PR hashes the effective condition that changes the `--extern` args and keeps the predicate shared with `extern_args`.

### How to test and review this PR?

The new test covers both stale directions:

- first build with `-Zpublic-dependency`, then without it
- first build without `-Zpublic-dependency`, then with it
