### PR TITLE
docs: `.cargo-checksum.json` is not a security mechanism

### DIFF
--- a/src/doc/src/reference/source-replacement.md
+++ b/src/doc/src/reference/source-replacement.md
@@ -145,9 +145,9 @@ directory containing a number of other directories which contain the source code
 for crates (the unpacked version of `*.crate` files). Currently no restriction
 is placed on the name of each directory.
 
-Each crate in a directory source also has an associated metadata file indicating
-the checksum of each file in the crate to protect against accidental
-modifications.
+Each crate in a directory source also has an associated metadata file
+`.cargo-checksum.json` to protect against accidental modifications.
+It is not a security mechanism and does not protect against malicious changes.
 
 ## Git sources
 


### PR DESCRIPTION
### What does this PR try to resolve?

In today's Cargo meeting, we agreed on adding at least a clarification on the `.cargo-checksum.json` not a security mechanism.

See [#t-cargo > adding a comment on &#96;.cargo-checksum.json&#96;](https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/adding.20a.20comment.20on.20.60.2Ecargo-checksum.2Ejson.60/with/593077650)

A PR adding an inline comment in  `.cargo-checksum.json` will be submitted separately.