### PR TITLE
fix(vendor): add `$comment` to `.cargo-checksum.json`

### DIFF
--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -338,6 +338,8 @@ fn sync(
 
         // Finally, emit the metadata about this package
         let json = serde_json::json!({
+            "$comment": "This file only protects against accidental modifications. \
+                It is not a security mechanism and does not protect against malicious changes.",
             "package": checksums.get(id),
             "files": file_cksums,
         });

--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -1104,6 +1104,7 @@ fn ignore_files() {
         csum,
         str![[r#"
 {
+  "$comment": "This file only protects against accidental modifications. It is not a security mechanism and does not protect against malicious changes.",
   "files": {
     ".cargo_vcs_info.json": "[..]",
     "Cargo.toml": "[..]",


### PR DESCRIPTION
### What does this PR try to resolve?

Clarify it only protects against accidental modifications and is not a security mechanism.

Cargo doesn't set `deny_unknown_fields` on the [`Checksum`] struct, so older Cargo versions will just silently skip the `$comment` key. No backward compat issue.
However, if external tools reject unknown fields they may have issues.

Also, this add source diff churn when running `cargo vendor` between different toolchain versions even when dependencies have no changes.

[`Checksum`]: https://github.com/rust-lang/cargo/blob/230e325f0b78128d6a005b8fa606b2854f5227db/src/cargo/sources/directory.rs#L68-L79

### How to test and review this PR?

cc https://github.com/rust-lang/cargo/pull/16966

And see [#t-cargo > adding a comment on &#96;.cargo-checksum.json&#96;](https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/adding.20a.20comment.20on.20.60.2Ecargo-checksum.2Ejson.60/with/593120043)
