### PR TITLE
test: Fixed arg order in rustdoc json test

### DIFF
--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -521,7 +521,7 @@ fn cargo_rustdoc_json_should_output_to_target_dir() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout rustdoc -Zunstable-options --output-format json")
+    p.cargo("-Zbuild-dir-new-layout -Zunstable-options rustdoc --output-format json")
         .masquerade_as_nightly_cargo(&["new build-dir layout", "rustdoc-output-format"])
         .enable_mac_dsym()
         .run();
@@ -537,10 +537,10 @@ fn cargo_rustdoc_json_should_output_to_target_dir() {
 [ROOT]/foo/build-dir/.rustdoc_fingerprint.json
 [ROOT]/foo/build-dir/CACHEDIR.TAG
 [ROOT]/foo/build-dir/debug/.cargo-build-lock
-[ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/doc-lib-foo
-[ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/doc-lib-foo.json
-[ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/invoked.timestamp
-[ROOT]/foo/build-dir/debug/build/foo-[HASH]/out/foo.json
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/doc-lib-foo
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/doc-lib-foo.json
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo.json
 
 "#
     ]);


### PR DESCRIPTION
While rebasing https://github.com/rust-lang/cargo/pull/16807 I notice a new test was added in #16773 that passes `-Zbuild-dir-new-layout` but the test is `assert`ing the old layout. Which I was initially quite confused by.
 
After investigating I realized it was due to `-Z` flags being before and after the command.
```
cargo -Zbuild-dir-new-layout <command> -Zunstable-options
```

Moving the `-Zunstable-options` before the command fixes the issue. (moving `-Zbuild-dir-new-layout` after the command also works)

Not quite sure if this is a bug or just initiative behavior. 
I do not see it documented in https://doc.rust-lang.org/cargo/reference/unstable.html so if its expected I think it might be worth documenting.
Maybe related: https://github.com/rust-lang/cargo/issues/15589