### PR TITLE
fix(rustdoc): Remove rustdoc --test, --bench and --all-targets arguments

### DIFF
--- a/src/bin/cargo/commands/rustdoc.rs
+++ b/src/bin/cargo/commands/rustdoc.rs
@@ -19,17 +19,12 @@ pub fn cli() -> Command {
         .arg_message_format()
         .arg_silent_suggestion()
         .arg_package("Package to document")
-        .arg_targets_all(
+        .arg_targets_lib_bin_example(
             "Build only this package's library",
             "Build only the specified binary",
             "Build all binaries",
             "Build only the specified example",
             "Build all examples",
-            "Build only the specified test target",
-            "Build all targets that have `test = true` set",
-            "Build only the specified bench target",
-            "Build all targets that have `bench = true` set",
-            "Build all targets",
         )
         .arg_features()
         .arg_parallel()

--- a/src/doc/man/cargo-rustdoc.md
+++ b/src/doc/man/cargo-rustdoc.md
@@ -53,7 +53,19 @@ binary and library targets of the selected package. The binary will be skipped
 if its name is the same as the lib target. Binaries are skipped if they have
 `required-features` that are missing.
 
-{{> options-targets }}
+{{#options}}
+{{> options-targets-lib-bin }}
+
+{{#option "`--example` _name_..." }}
+{{actionverb}} the specified example. This flag may be specified multiple times
+and supports common Unix glob patterns.
+{{/option}}
+
+{{#option "`--examples`" }}
+{{actionverb}} all example targets.
+{{/option}}
+
+{{/options}}
 
 {{> section-features }}
 

--- a/src/doc/man/generated_txt/cargo-rustdoc.txt
+++ b/src/doc/man/generated_txt/cargo-rustdoc.txt
@@ -51,13 +51,6 @@ OPTIONS
        be skipped if its name is the same as the lib target. Binaries are
        skipped if they have required-features that are missing.
 
-       Passing target selection flags will document only the specified targets.
-
-       Note that --bin, --example, --test and --bench flags also support common
-       Unix glob patterns like *, ? and []. However, to avoid your shell
-       accidentally expanding glob patterns before Cargo handles them, you must
-       use single quotes or double quotes around each glob pattern.
-
        --lib
            Document the package’s library.
 
@@ -74,36 +67,6 @@ OPTIONS
 
        --examples
            Document all example targets.
-
-       --test name…
-           Document the specified integration test. This flag may be specified
-           multiple times and supports common Unix glob patterns.
-
-       --tests
-           Document all targets that have the test = true manifest flag set. By
-           default this includes the library and binaries built as unittests,
-           and integration tests. Be aware that this will also build any
-           required dependencies, so the lib target may be built twice (once as
-           a unittest, and once as a dependency for binaries, integration
-           tests, etc.). Targets may be enabled or disabled by setting the test
-           flag in the manifest settings for the target.
-
-       --bench name…
-           Document the specified benchmark. This flag may be specified
-           multiple times and supports common Unix glob patterns.
-
-       --benches
-           Document all targets that have the bench = true manifest flag set.
-           By default this includes the library and binaries built as
-           benchmarks, and bench targets. Be aware that this will also build
-           any required dependencies, so the lib target may be built twice
-           (once as a benchmark, and once as a dependency for binaries,
-           benchmarks, etc.). Targets may be enabled or disabled by setting the
-           bench flag in the manifest settings for the target.
-
-       --all-targets
-           Document all targets. This is equivalent to specifying --lib --bins
-           --tests --benches --examples.
 
    Feature Selection
        The feature flags allow you to control which features are enabled. When

--- a/src/doc/src/commands/cargo-rustdoc.md
+++ b/src/doc/src/commands/cargo-rustdoc.md
@@ -67,16 +67,7 @@ binary and library targets of the selected package. The binary will be skipped
 if its name is the same as the lib target. Binaries are skipped if they have
 `required-features` that are missing.
 
-Passing target selection flags will document only the specified
-targets. 
-
-Note that `--bin`, `--example`, `--test` and `--bench` flags also 
-support common Unix glob patterns like `*`, `?` and `[]`. However, to avoid your 
-shell accidentally expanding glob patterns before Cargo handles them, you must 
-use single quotes or double quotes around each glob pattern.
-
 <dl>
-
 <dt class="option-term" id="option-cargo-rustdoc---lib"><a class="option-anchor" href="#option-cargo-rustdoc---lib"><code>--lib</code></a></dt>
 <dd class="option-desc"><p>Document the package’s library.</p>
 </dd>
@@ -101,45 +92,6 @@ and supports common Unix glob patterns.</p>
 
 <dt class="option-term" id="option-cargo-rustdoc---examples"><a class="option-anchor" href="#option-cargo-rustdoc---examples"><code>--examples</code></a></dt>
 <dd class="option-desc"><p>Document all example targets.</p>
-</dd>
-
-
-<dt class="option-term" id="option-cargo-rustdoc---test"><a class="option-anchor" href="#option-cargo-rustdoc---test"><code>--test</code> <em>name</em>…</a></dt>
-<dd class="option-desc"><p>Document the specified integration test. This flag may be specified
-multiple times and supports common Unix glob patterns.</p>
-</dd>
-
-
-<dt class="option-term" id="option-cargo-rustdoc---tests"><a class="option-anchor" href="#option-cargo-rustdoc---tests"><code>--tests</code></a></dt>
-<dd class="option-desc"><p>Document all targets that have the <code>test = true</code> manifest
-flag set. By default this includes the library and binaries built as
-unittests, and integration tests. Be aware that this will also build any
-required dependencies, so the lib target may be built twice (once as a
-unittest, and once as a dependency for binaries, integration tests, etc.).
-Targets may be enabled or disabled by setting the <code>test</code> flag in the
-manifest settings for the target.</p>
-</dd>
-
-
-<dt class="option-term" id="option-cargo-rustdoc---bench"><a class="option-anchor" href="#option-cargo-rustdoc---bench"><code>--bench</code> <em>name</em>…</a></dt>
-<dd class="option-desc"><p>Document the specified benchmark. This flag may be specified multiple
-times and supports common Unix glob patterns.</p>
-</dd>
-
-
-<dt class="option-term" id="option-cargo-rustdoc---benches"><a class="option-anchor" href="#option-cargo-rustdoc---benches"><code>--benches</code></a></dt>
-<dd class="option-desc"><p>Document all targets that have the <code>bench = true</code>
-manifest flag set. By default this includes the library and binaries built
-as benchmarks, and bench targets. Be aware that this will also build any
-required dependencies, so the lib target may be built twice (once as a
-benchmark, and once as a dependency for binaries, benchmarks, etc.).
-Targets may be enabled or disabled by setting the <code>bench</code> flag in the
-manifest settings for the target.</p>
-</dd>
-
-
-<dt class="option-term" id="option-cargo-rustdoc---all-targets"><a class="option-anchor" href="#option-cargo-rustdoc---all-targets"><code>--all-targets</code></a></dt>
-<dd class="option-desc"><p>Document all targets. This is equivalent to specifying <code>--lib --bins --tests --benches --examples</code>.</p>
 </dd>
 
 

--- a/src/etc/man/cargo-rustdoc.1
+++ b/src/etc/man/cargo-rustdoc.1
@@ -52,14 +52,6 @@ binary and library targets of the selected package. The binary will be skipped
 if its name is the same as the lib target. Binaries are skipped if they have
 \fBrequired\-features\fR that are missing.
 .sp
-Passing target selection flags will document only the specified
-targets.
-.sp
-Note that \fB\-\-bin\fR, \fB\-\-example\fR, \fB\-\-test\fR and \fB\-\-bench\fR flags also
-support common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your
-shell accidentally expanding glob patterns before Cargo handles them, you must
-use single quotes or double quotes around each glob pattern.
-.sp
 \fB\-\-lib\fR
 .RS 4
 Document the package\[cq]s library.
@@ -85,45 +77,6 @@ and supports common Unix glob patterns.
 \fB\-\-examples\fR
 .RS 4
 Document all example targets.
-.RE
-.sp
-\fB\-\-test\fR \fIname\fR\[u2026]
-.RS 4
-Document the specified integration test. This flag may be specified
-multiple times and supports common Unix glob patterns.
-.RE
-.sp
-\fB\-\-tests\fR
-.RS 4
-Document all targets that have the \fBtest = true\fR manifest
-flag set. By default this includes the library and binaries built as
-unittests, and integration tests. Be aware that this will also build any
-required dependencies, so the lib target may be built twice (once as a
-unittest, and once as a dependency for binaries, integration tests, etc.).
-Targets may be enabled or disabled by setting the \fBtest\fR flag in the
-manifest settings for the target.
-.RE
-.sp
-\fB\-\-bench\fR \fIname\fR\[u2026]
-.RS 4
-Document the specified benchmark. This flag may be specified multiple
-times and supports common Unix glob patterns.
-.RE
-.sp
-\fB\-\-benches\fR
-.RS 4
-Document all targets that have the \fBbench = true\fR
-manifest flag set. By default this includes the library and binaries built
-as benchmarks, and bench targets. Be aware that this will also build any
-required dependencies, so the lib target may be built twice (once as a
-benchmark, and once as a dependency for binaries, benchmarks, etc.).
-Targets may be enabled or disabled by setting the \fBbench\fR flag in the
-manifest settings for the target.
-.RE
-.sp
-\fB\-\-all\-targets\fR
-.RS 4
-Document all targets. This is equivalent to specifying \fB\-\-lib \-\-bins \-\-tests \-\-benches \-\-examples\fR\&.
 .RE
 .SS "Feature Selection"
 The feature flags allow you to control which features are enabled. When no

--- a/tests/testsuite/cargo_rustdoc/help/stdout.term.svg
+++ b/tests/testsuite/cargo_rustdoc/help/stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="844px" height="1100px" xmlns="http://www.w3.org/2000/svg">
+<svg width="844px" height="1010px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -80,65 +80,55 @@
 </tspan>
     <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Build only the specified example</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--tests</tspan><tspan>             Build all targets that have `test = true` set</tspan>
+    <tspan x="10px" y="568px">
 </tspan>
-    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--test</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>     Build only the specified test target</tspan>
+    <tspan x="10px" y="586px"><tspan class="fg-bright-green bold">Feature Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--benches</tspan><tspan>           Build all targets that have `bench = true` set</tspan>
+    <tspan x="10px" y="604px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bench</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>    Build only the specified bench target</tspan>
+    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all-targets</tspan><tspan>       Build all targets</tspan>
+    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
 </tspan>
     <tspan x="10px" y="658px">
 </tspan>
-    <tspan x="10px" y="676px"><tspan class="fg-bright-green bold">Feature Selection:</tspan>
+    <tspan x="10px" y="676px"><tspan class="fg-bright-green bold">Compilation Options:</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
+    <tspan x="10px" y="694px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
+    <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
+    <tspan x="10px" y="730px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-r</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--release</tspan><tspan>                 Build artifacts in release mode, with optimizations</tspan>
 </tspan>
-    <tspan x="10px" y="748px">
+    <tspan x="10px" y="748px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Build artifacts with the specified profile</tspan>
 </tspan>
-    <tspan x="10px" y="766px"><tspan class="fg-bright-green bold">Compilation Options:</tspan>
+    <tspan x="10px" y="766px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Build for the target triple</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
+    <tspan x="10px" y="784px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
+    <tspan x="10px" y="802px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--unit-graph</tspan><tspan>              Output build graph in JSON (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="820px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-r</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--release</tspan><tspan>                 Build artifacts in release mode, with optimizations</tspan>
+    <tspan x="10px" y="820px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan>                 Output a build timing report at the end of the build</tspan>
 </tspan>
-    <tspan x="10px" y="838px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Build artifacts with the specified profile</tspan>
+    <tspan x="10px" y="838px">
 </tspan>
-    <tspan x="10px" y="856px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Build for the target triple</tspan>
+    <tspan x="10px" y="856px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="874px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
+    <tspan x="10px" y="874px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-m</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="892px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--unit-graph</tspan><tspan>              Output build graph in JSON (unstable)</tspan>
+    <tspan x="10px" y="892px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
 </tspan>
-    <tspan x="10px" y="910px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan>                 Output a build timing report at the end of the build</tspan>
+    <tspan x="10px" y="910px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="928px">
+    <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="946px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
-    <tspan x="10px" y="964px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-m</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="964px">
 </tspan>
-    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
+    <tspan x="10px" y="982px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help rustdoc</tspan><tspan>` for more detailed information.</tspan>
 </tspan>
-    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
-</tspan>
-    <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
-</tspan>
-    <tspan x="10px" y="1036px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
-</tspan>
-    <tspan x="10px" y="1054px">
-</tspan>
-    <tspan x="10px" y="1072px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help rustdoc</tspan><tspan>` for more detailed information.</tspan>
-</tspan>
-    <tspan x="10px" y="1090px">
+    <tspan x="10px" y="1000px">
 </tspan>
   </text>
 

--- a/tests/testsuite/glob_targets.rs
+++ b/tests/testsuite/glob_targets.rs
@@ -409,12 +409,10 @@ fn rustdoc_bin() {
 fn rustdoc_bench() {
     full_project()
         .cargo("rustdoc -v --bench 'be*1'")
+        .with_status(1)
         .with_stderr_data(str![[r#"
-[DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustdoc --edition=2015 --crate-type bin --crate-name bench1 [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[GENERATED] [ROOT]/foo/target/doc/bench1/index.html
-
+[ERROR] unexpected argument '--bench' found
+...
 "#]])
         .run();
 }
@@ -423,12 +421,10 @@ fn rustdoc_bench() {
 fn rustdoc_test() {
     full_project()
         .cargo("rustdoc -v --test 'te*1'")
+        .with_status(1)
         .with_stderr_data(str![[r#"
-[DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustdoc --edition=2015 --crate-type bin --crate-name test1 [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[GENERATED] [ROOT]/foo/target/doc/test1/index.html
-
+[ERROR] unexpected argument '--test' found
+...
 "#]])
         .run();
 }

--- a/tests/testsuite/list_availables.rs
+++ b/tests/testsuite/list_availables.rs
@@ -701,32 +701,6 @@ No binaries available.
 
 
 "#]])
-            .with_test(str![[r#"
-[ERROR] "--test" takes one argument.
-Available test targets:
-    test1
-    test2
-
-
-"#]], str![[r#"
-[ERROR] "--test" takes one argument.
-No test targets available.
-
-
-"#]])
-            .with_bench(str![[r#"
-[ERROR] "--bench" takes one argument.
-Available bench targets:
-    bench1
-    bench2
-
-
-"#]], str![[r#"
-[ERROR] "--bench" takes one argument.
-No bench targets available.
-
-
-"#]])
             .with_package(str![[r#"
 [ERROR] "--package <SPEC>" requires a SPEC format value, which can be any package ID specifier in the dependency graph.
 Run `cargo help pkgid` for more information about SPEC format.


### PR DESCRIPTION
### What does this PR try to resolve?

Removes the --test, --tests, --bench, --benches and --all-targets arguments from the `rustdoc` command. Fixes #13427.

These arguments are generally broken, and --test(s) in particular can cause import errors.

From my own testing, these arguments appears to work (no errors) if there is no integration tests in the project, even though they are broken. So there is a chance that there are people who use these and will be affected by removing them.

This also brings `rustdoc` in line with the `doc` command so that they support the same targets.

### How to test and review this PR?

Run
`cargo rustdoc --test`
`cargo rustdoc --bench`
`etc..`
And verify they all return "unexpected argument" errors.
