### PR TITLE
fix(diag): Track Cargo diagnostic warning/error count like is done for rustc

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1368,7 +1368,7 @@ impl<'gctx> Workspace<'gctx> {
                 self.gctx,
             )?;
 
-            verify_stats.report_summary("verifying")?;
+            verify_stats.report_summary("parse", Some(&*pkg.name()))?;
 
             let mut run_stats = DiagnosticStats::new();
 
@@ -1404,7 +1404,7 @@ impl<'gctx> Workspace<'gctx> {
                 self.gctx,
             )?;
 
-            run_stats.report_summary("running")?;
+            run_stats.report_summary("parse", Some(&*pkg.name()))?;
         }
 
         Ok(())
@@ -1452,7 +1452,7 @@ impl<'gctx> Workspace<'gctx> {
                 self.gctx,
             )?;
 
-            verify_stats.report_summary("verifying")?;
+            verify_stats.report_summary("parse", None)?;
 
             unused_workspace_package_fields(
                 self,
@@ -1508,7 +1508,7 @@ impl<'gctx> Workspace<'gctx> {
             )?;
         }
 
-        run_stats.report_summary("running")?;
+        run_stats.report_summary("parse", None)?;
         Ok(())
     }
 

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1368,17 +1368,7 @@ impl<'gctx> Workspace<'gctx> {
                 self.gctx,
             )?;
 
-            if verify_stats.error_count() > 0 {
-                let plural = if verify_stats.error_count() == 1 {
-                    ""
-                } else {
-                    "s"
-                };
-                bail!(
-                    "encountered {} error{plural} while verifying lints",
-                    verify_stats.error_count()
-                )
-            }
+            verify_stats.report_summary("verifying")?;
 
             let mut run_stats = DiagnosticStats::new();
 
@@ -1414,17 +1404,7 @@ impl<'gctx> Workspace<'gctx> {
                 self.gctx,
             )?;
 
-            if run_stats.error_count() > 0 {
-                let plural = if run_stats.error_count() == 1 {
-                    ""
-                } else {
-                    "s"
-                };
-                bail!(
-                    "encountered {} error{plural} while running lints",
-                    run_stats.error_count()
-                )
-            }
+            run_stats.report_summary("running")?;
         }
 
         Ok(())
@@ -1472,17 +1452,7 @@ impl<'gctx> Workspace<'gctx> {
                 self.gctx,
             )?;
 
-            if verify_stats.error_count() > 0 {
-                let plural = if verify_stats.error_count() == 1 {
-                    ""
-                } else {
-                    "s"
-                };
-                bail!(
-                    "encountered {} error{plural} while verifying lints",
-                    verify_stats.error_count()
-                )
-            }
+            verify_stats.report_summary("verifying")?;
 
             unused_workspace_package_fields(
                 self,
@@ -1538,19 +1508,8 @@ impl<'gctx> Workspace<'gctx> {
             )?;
         }
 
-        if run_stats.error_count() > 0 {
-            let plural = if run_stats.error_count() == 1 {
-                ""
-            } else {
-                "s"
-            };
-            bail!(
-                "encountered {} error{plural} while running lints",
-                run_stats.error_count()
-            )
-        } else {
-            Ok(())
-        }
+        run_stats.report_summary("running")?;
+        Ok(())
     }
 
     pub fn set_target_dir(&mut self, target_dir: Filesystem) {

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -21,6 +21,7 @@ use crate::core::{
     PatchLocation,
 };
 use crate::core::{EitherManifest, Package, SourceId, VirtualManifest};
+use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::rules::blanket_hint_mostly_unused;
 use crate::diagnostics::rules::check_im_a_teapot;
 use crate::diagnostics::rules::implicit_minimum_version_req_pkg;
@@ -1350,85 +1351,79 @@ impl<'gctx> Workspace<'gctx> {
             .unwrap_or(manifest::TomlToolLints::default());
 
         if self.gctx.cli_unstable().cargo_lints {
-            let mut verify_error_count = 0;
+            let mut verify_stats = DiagnosticStats::new();
 
             missing_lints_features(
                 pkg.into(),
                 &path,
                 &cargo_lints,
-                &mut verify_error_count,
+                &mut verify_stats,
                 self.gctx,
             )?;
             unknown_lints(
                 pkg.into(),
                 &path,
                 &cargo_lints,
-                &mut verify_error_count,
+                &mut verify_stats,
                 self.gctx,
             )?;
 
-            if verify_error_count > 0 {
-                let plural = if verify_error_count == 1 { "" } else { "s" };
-                bail!("encountered {verify_error_count} error{plural} while verifying lints")
+            if verify_stats.error_count() > 0 {
+                let plural = if verify_stats.error_count() == 1 {
+                    ""
+                } else {
+                    "s"
+                };
+                bail!(
+                    "encountered {} error{plural} while verifying lints",
+                    verify_stats.error_count()
+                )
             }
 
-            let mut run_error_count = 0;
+            let mut run_stats = DiagnosticStats::new();
 
-            check_im_a_teapot(pkg, &path, &cargo_lints, &mut run_error_count, self.gctx)?;
-            implicit_minimum_version_req_pkg(
-                pkg,
-                &path,
-                &cargo_lints,
-                &mut run_error_count,
-                self.gctx,
-            )?;
-            non_kebab_case_packages(pkg, &path, &cargo_lints, &mut run_error_count, self.gctx)?;
-            non_snake_case_packages(pkg, &path, &cargo_lints, &mut run_error_count, self.gctx)?;
-            non_kebab_case_bins(
-                self,
-                pkg,
-                &path,
-                &cargo_lints,
-                &mut run_error_count,
-                self.gctx,
-            )?;
-            non_kebab_case_features(pkg, &path, &cargo_lints, &mut run_error_count, self.gctx)?;
-            non_snake_case_features(pkg, &path, &cargo_lints, &mut run_error_count, self.gctx)?;
+            check_im_a_teapot(pkg, &path, &cargo_lints, &mut run_stats, self.gctx)?;
+            implicit_minimum_version_req_pkg(pkg, &path, &cargo_lints, &mut run_stats, self.gctx)?;
+            non_kebab_case_packages(pkg, &path, &cargo_lints, &mut run_stats, self.gctx)?;
+            non_snake_case_packages(pkg, &path, &cargo_lints, &mut run_stats, self.gctx)?;
+            non_kebab_case_bins(self, pkg, &path, &cargo_lints, &mut run_stats, self.gctx)?;
+            non_kebab_case_features(pkg, &path, &cargo_lints, &mut run_stats, self.gctx)?;
+            non_snake_case_features(pkg, &path, &cargo_lints, &mut run_stats, self.gctx)?;
             unused_build_dependencies_no_build_rs(
                 pkg,
                 &path,
                 &cargo_lints,
-                &mut run_error_count,
+                &mut run_stats,
                 self.gctx,
             )?;
-            redundant_readme(pkg, &path, &cargo_lints, &mut run_error_count, self.gctx)?;
-            redundant_homepage(pkg, &path, &cargo_lints, &mut run_error_count, self.gctx)?;
-            missing_lints_inheritance(
-                self,
-                pkg,
-                &path,
-                &cargo_lints,
-                &mut run_error_count,
-                self.gctx,
-            )?;
+            redundant_readme(pkg, &path, &cargo_lints, &mut run_stats, self.gctx)?;
+            redundant_homepage(pkg, &path, &cargo_lints, &mut run_stats, self.gctx)?;
+            missing_lints_inheritance(self, pkg, &path, &cargo_lints, &mut run_stats, self.gctx)?;
             text_direction_codepoint_in_comment(
                 pkg.into(),
                 &path,
                 &cargo_lints,
-                &mut run_error_count,
+                &mut run_stats,
                 self.gctx,
             )?;
             text_direction_codepoint_in_literal(
                 pkg.into(),
                 &path,
                 &cargo_lints,
-                &mut run_error_count,
+                &mut run_stats,
                 self.gctx,
             )?;
 
-            if run_error_count > 0 {
-                let plural = if run_error_count == 1 { "" } else { "s" };
-                bail!("encountered {run_error_count} error{plural} while running lints")
+            if run_stats.error_count() > 0 {
+                let plural = if run_stats.error_count() == 1 {
+                    ""
+                } else {
+                    "s"
+                };
+                bail!(
+                    "encountered {} error{plural} while running lints",
+                    run_stats.error_count()
+                )
             }
         }
 
@@ -1436,7 +1431,7 @@ impl<'gctx> Workspace<'gctx> {
     }
 
     pub fn emit_ws_lints(&self) -> CargoResult<()> {
-        let mut run_error_count = 0;
+        let mut run_stats = DiagnosticStats::new();
 
         let cargo_lints = match self.root_maybe() {
             MaybePackage::Package(pkg) => {
@@ -1460,26 +1455,33 @@ impl<'gctx> Workspace<'gctx> {
         .unwrap_or(manifest::TomlToolLints::default());
 
         if self.gctx.cli_unstable().cargo_lints {
-            let mut verify_error_count = 0;
+            let mut verify_stats = DiagnosticStats::new();
 
             missing_lints_features(
                 (self, self.root_maybe()).into(),
                 self.root_manifest(),
                 &cargo_lints,
-                &mut verify_error_count,
+                &mut verify_stats,
                 self.gctx,
             )?;
             unknown_lints(
                 (self, self.root_maybe()).into(),
                 self.root_manifest(),
                 &cargo_lints,
-                &mut verify_error_count,
+                &mut verify_stats,
                 self.gctx,
             )?;
 
-            if verify_error_count > 0 {
-                let plural = if verify_error_count == 1 { "" } else { "s" };
-                bail!("encountered {verify_error_count} error{plural} while verifying lints")
+            if verify_stats.error_count() > 0 {
+                let plural = if verify_stats.error_count() == 1 {
+                    ""
+                } else {
+                    "s"
+                };
+                bail!(
+                    "encountered {} error{plural} while verifying lints",
+                    verify_stats.error_count()
+                )
             }
 
             unused_workspace_package_fields(
@@ -1487,7 +1489,7 @@ impl<'gctx> Workspace<'gctx> {
                 self.root_maybe(),
                 self.root_manifest(),
                 &cargo_lints,
-                &mut run_error_count,
+                &mut run_stats,
                 self.gctx,
             )?;
             unused_workspace_dependencies(
@@ -1495,7 +1497,7 @@ impl<'gctx> Workspace<'gctx> {
                 self.root_maybe(),
                 self.root_manifest(),
                 &cargo_lints,
-                &mut run_error_count,
+                &mut run_stats,
                 self.gctx,
             )?;
             implicit_minimum_version_req_ws(
@@ -1503,21 +1505,21 @@ impl<'gctx> Workspace<'gctx> {
                 self.root_maybe(),
                 self.root_manifest(),
                 &cargo_lints,
-                &mut run_error_count,
+                &mut run_stats,
                 self.gctx,
             )?;
             text_direction_codepoint_in_comment(
                 (self, self.root_maybe()).into(),
                 self.root_manifest(),
                 &cargo_lints,
-                &mut run_error_count,
+                &mut run_stats,
                 self.gctx,
             )?;
             text_direction_codepoint_in_literal(
                 (self, self.root_maybe()).into(),
                 self.root_manifest(),
                 &cargo_lints,
-                &mut run_error_count,
+                &mut run_stats,
                 self.gctx,
             )?;
         }
@@ -1531,14 +1533,21 @@ impl<'gctx> Workspace<'gctx> {
                 self.root_maybe(),
                 self.root_manifest(),
                 &cargo_lints,
-                &mut run_error_count,
+                &mut run_stats,
                 self.gctx,
             )?;
         }
 
-        if run_error_count > 0 {
-            let plural = if run_error_count == 1 { "" } else { "s" };
-            bail!("encountered {run_error_count} error{plural} while running lints")
+        if run_stats.error_count() > 0 {
+            let plural = if run_stats.error_count() == 1 {
+                ""
+            } else {
+                "s"
+            };
+            bail!(
+                "encountered {} error{plural} while running lints",
+                run_stats.error_count()
+            )
         } else {
             Ok(())
         }

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1368,7 +1368,7 @@ impl<'gctx> Workspace<'gctx> {
                 self.gctx,
             )?;
 
-            verify_stats.report_summary("parse", Some(&*pkg.name()))?;
+            verify_stats.report_summary("parse", Some(&*pkg.name()), self.gctx)?;
 
             let mut run_stats = DiagnosticStats::new();
 
@@ -1404,7 +1404,7 @@ impl<'gctx> Workspace<'gctx> {
                 self.gctx,
             )?;
 
-            run_stats.report_summary("parse", Some(&*pkg.name()))?;
+            run_stats.report_summary("parse", Some(&*pkg.name()), self.gctx)?;
         }
 
         Ok(())
@@ -1452,7 +1452,7 @@ impl<'gctx> Workspace<'gctx> {
                 self.gctx,
             )?;
 
-            verify_stats.report_summary("parse", None)?;
+            verify_stats.report_summary("parse", None, self.gctx)?;
 
             unused_workspace_package_fields(
                 self,
@@ -1508,7 +1508,7 @@ impl<'gctx> Workspace<'gctx> {
             )?;
         }
 
-        run_stats.report_summary("parse", None)?;
+        run_stats.report_summary("parse", None, self.gctx)?;
         Ok(())
     }
 

--- a/src/cargo/diagnostics/mod.rs
+++ b/src/cargo/diagnostics/mod.rs
@@ -37,11 +37,14 @@ impl DiagnosticStats {
         }
     }
 
-    pub fn report_summary(&self, action: &str) -> CargoResult<()> {
+    pub fn report_summary(&self, action: &str, name: Option<&str>) -> CargoResult<()> {
         if 0 < self.error_count {
             let plural = if self.error_count == 1 { "" } else { "s" };
+            let name = name
+                .map(|n| format!("`{n}`"))
+                .unwrap_or_else(|| "workspace".to_owned());
             bail!(
-                "encountered {} error{plural} while {action} lints",
+                "could not {action} {name} (manifest) due to {} previous error{plural}",
                 self.error_count
             )
         }

--- a/src/cargo/diagnostics/mod.rs
+++ b/src/cargo/diagnostics/mod.rs
@@ -13,6 +13,33 @@ pub use lint::{Lint, LintGroup, LintLevel, LintLevelSource};
 pub use report::{AsIndex, get_key_value, get_key_value_span, rel_cwd_manifest_path};
 pub use rules::{LINT_GROUPS, LINTS};
 
+pub struct DiagnosticStats {
+    error_count: usize,
+}
+
+impl DiagnosticStats {
+    pub fn new() -> Self {
+        Self { error_count: 0 }
+    }
+
+    pub fn error_count(&self) -> usize {
+        self.error_count
+    }
+
+    pub fn record_error(&mut self) {
+        self.error_count += 1;
+    }
+
+    pub fn record_lint(&mut self, lint: LintLevel) {
+        match lint {
+            LintLevel::Forbid | LintLevel::Deny => {
+                self.record_error();
+            }
+            LintLevel::Warn | LintLevel::Allow => {}
+        }
+    }
+}
+
 /// Scope at which a lint runs: package-level or workspace-level.
 pub enum ManifestFor<'a> {
     /// Lint runs for a specific package.

--- a/src/cargo/diagnostics/mod.rs
+++ b/src/cargo/diagnostics/mod.rs
@@ -1,6 +1,8 @@
+use anyhow::bail;
 use cargo_util_schemas::manifest::RustVersion;
 use cargo_util_schemas::manifest::TomlToolLints;
 
+use crate::CargoResult;
 use crate::core::Workspace;
 use crate::core::{Edition, Features, MaybePackage, Package};
 
@@ -22,10 +24,6 @@ impl DiagnosticStats {
         Self { error_count: 0 }
     }
 
-    pub fn error_count(&self) -> usize {
-        self.error_count
-    }
-
     pub fn record_error(&mut self) {
         self.error_count += 1;
     }
@@ -37,6 +35,18 @@ impl DiagnosticStats {
             }
             LintLevel::Warn | LintLevel::Allow => {}
         }
+    }
+
+    pub fn report_summary(&self, action: &str) -> CargoResult<()> {
+        if 0 < self.error_count {
+            let plural = if self.error_count == 1 { "" } else { "s" };
+            bail!(
+                "encountered {} error{plural} while {action} lints",
+                self.error_count
+            )
+        }
+
+        Ok(())
     }
 }
 

--- a/src/cargo/diagnostics/mod.rs
+++ b/src/cargo/diagnostics/mod.rs
@@ -5,6 +5,7 @@ use cargo_util_schemas::manifest::TomlToolLints;
 use crate::CargoResult;
 use crate::core::Workspace;
 use crate::core::{Edition, Features, MaybePackage, Package};
+use crate::util::GlobalContext;
 
 mod lint;
 mod report;
@@ -16,12 +17,20 @@ pub use report::{AsIndex, get_key_value, get_key_value_span, rel_cwd_manifest_pa
 pub use rules::{LINT_GROUPS, LINTS};
 
 pub struct DiagnosticStats {
+    warning_count: usize,
     error_count: usize,
 }
 
 impl DiagnosticStats {
     pub fn new() -> Self {
-        Self { error_count: 0 }
+        Self {
+            warning_count: 0,
+            error_count: 0,
+        }
+    }
+
+    pub fn record_warning(&mut self) {
+        self.warning_count += 1;
     }
 
     pub fn record_error(&mut self) {
@@ -33,11 +42,30 @@ impl DiagnosticStats {
             LintLevel::Forbid | LintLevel::Deny => {
                 self.record_error();
             }
-            LintLevel::Warn | LintLevel::Allow => {}
+            LintLevel::Warn => {
+                self.record_warning();
+            }
+            LintLevel::Allow => {}
         }
     }
 
-    pub fn report_summary(&self, action: &str, name: Option<&str>) -> CargoResult<()> {
+    pub fn report_summary(
+        &self,
+        action: &str,
+        name: Option<&str>,
+        gctx: &GlobalContext,
+    ) -> CargoResult<()> {
+        if 0 < self.warning_count {
+            let plural = if self.warning_count == 1 { "" } else { "s" };
+            let name = name
+                .map(|n| format!("`{n}`"))
+                .unwrap_or_else(|| "workspace".to_owned());
+            gctx.shell().warn(format!(
+                "{name} (manifest) generated {} warning{plural}",
+                self.warning_count
+            ))?;
+        }
+
         if 0 < self.error_count {
             let plural = if self.error_count == 1 { "" } else { "s" };
             let name = name

--- a/src/cargo/diagnostics/rules/blanket_hint_mostly_unused.rs
+++ b/src/cargo/diagnostics/rules/blanket_hint_mostly_unused.rs
@@ -121,7 +121,6 @@ pub fn blanket_hint_mostly_unused(
     }
 
     for (i, (path, show_per_pkg_suggestion)) in paths.iter().enumerate() {
-        stats.record_lint(lint_level);
         let title = "`hint-mostly-unused` is being blanket applied to all dependencies";
         let help_txt =
             "scope `hint-mostly-unused` to specific packages with a lot of unused object code";
@@ -176,6 +175,7 @@ pub fn blanket_hint_mostly_unused(
         // The primary group should always be first
         report.insert(0, primary_group);
 
+        stats.record_lint(lint_level);
         gctx.shell().print_report(&report, lint_level.force())?;
     }
 

--- a/src/cargo/diagnostics/rules/blanket_hint_mostly_unused.rs
+++ b/src/cargo/diagnostics/rules/blanket_hint_mostly_unused.rs
@@ -15,6 +15,7 @@ use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::MaybePackage;
 use crate::core::Workspace;
+use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevel;
 use crate::diagnostics::get_key_value_span;
@@ -61,7 +62,7 @@ pub fn blanket_hint_mostly_unused(
     maybe_pkg: &MaybePackage,
     path: &Path,
     pkg_lints: &TomlToolLints,
-    error_count: &mut usize,
+    stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let (lint_level, source) = LINT.level(
@@ -120,9 +121,7 @@ pub fn blanket_hint_mostly_unused(
     }
 
     for (i, (path, show_per_pkg_suggestion)) in paths.iter().enumerate() {
-        if lint_level.is_error() {
-            *error_count += 1;
-        }
+        stats.record_lint(lint_level);
         let title = "`hint-mostly-unused` is being blanket applied to all dependencies";
         let help_txt =
             "scope `hint-mostly-unused` to specific packages with a lot of unused object code";

--- a/src/cargo/diagnostics/rules/im_a_teapot.rs
+++ b/src/cargo/diagnostics/rules/im_a_teapot.rs
@@ -50,7 +50,6 @@ pub fn check_im_a_teapot(
         .package()
         .is_some_and(|p| p.im_a_teapot.is_some())
     {
-        stats.record_lint(lint_level);
         let level = lint_level.to_diagnostic_level();
         let manifest_path = rel_cwd_manifest_path(path, gctx);
         let emitted_source = LINT.emitted_source(lint_level, source);
@@ -73,6 +72,7 @@ pub fn check_im_a_teapot(
 
         let report = &[desc.element(Level::NOTE.message(&emitted_source))];
 
+        stats.record_lint(lint_level);
         gctx.shell().print_report(report, lint_level.force())?;
     }
     Ok(())

--- a/src/cargo/diagnostics/rules/im_a_teapot.rs
+++ b/src/cargo/diagnostics/rules/im_a_teapot.rs
@@ -13,6 +13,7 @@ use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::Feature;
 use crate::core::Package;
+use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevel;
 use crate::diagnostics::get_key_value_span;
@@ -33,7 +34,7 @@ pub fn check_im_a_teapot(
     pkg: &Package,
     path: &Path,
     pkg_lints: &TomlToolLints,
-    error_count: &mut usize,
+    stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let manifest = pkg.manifest();
@@ -49,9 +50,7 @@ pub fn check_im_a_teapot(
         .package()
         .is_some_and(|p| p.im_a_teapot.is_some())
     {
-        if lint_level.is_error() {
-            *error_count += 1;
-        }
+        stats.record_lint(lint_level);
         let level = lint_level.to_diagnostic_level();
         let manifest_path = rel_cwd_manifest_path(path, gctx);
         let emitted_source = LINT.emitted_source(lint_level, source);

--- a/src/cargo/diagnostics/rules/implicit_minimum_version_req.rs
+++ b/src/cargo/diagnostics/rules/implicit_minimum_version_req.rs
@@ -20,6 +20,7 @@ use crate::core::Manifest;
 use crate::core::MaybePackage;
 use crate::core::Package;
 use crate::core::Workspace;
+use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevel;
 use crate::diagnostics::LintLevelSource;
@@ -88,7 +89,7 @@ pub fn implicit_minimum_version_req_pkg(
     pkg: &Package,
     manifest_path: &Path,
     cargo_lints: &TomlToolLints,
-    error_count: &mut usize,
+    stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let (lint_level, source) = LINT.level(
@@ -141,9 +142,7 @@ pub fn implicit_minimum_version_req_pkg(
             emit_source = false;
         }
 
-        if lint_level.is_error() {
-            *error_count += 1;
-        }
+        stats.record_lint(lint_level);
         gctx.shell().print_report(&report, lint_level.force())?;
     }
 
@@ -156,7 +155,7 @@ pub fn implicit_minimum_version_req_ws(
     maybe_pkg: &MaybePackage,
     manifest_path: &Path,
     cargo_lints: &TomlToolLints,
-    error_count: &mut usize,
+    stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let (lint_level, source) = LINT.level(
@@ -225,9 +224,7 @@ pub fn implicit_minimum_version_req_ws(
             emit_source = false;
         }
 
-        if lint_level.is_error() {
-            *error_count += 1;
-        }
+        stats.record_lint(lint_level);
         gctx.shell().print_report(&report, lint_level.force())?;
     }
 

--- a/src/cargo/diagnostics/rules/missing_lints_features.rs
+++ b/src/cargo/diagnostics/rules/missing_lints_features.rs
@@ -11,6 +11,7 @@ use super::find_lint_or_group;
 use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::Feature;
+use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::ManifestFor;
 use crate::diagnostics::get_key_value_span;
 use crate::diagnostics::rel_cwd_manifest_path;
@@ -20,7 +21,7 @@ pub fn missing_lints_features(
     manifest: ManifestFor<'_>,
     manifest_path: &Path,
     cargo_lints: &TomlToolLints,
-    error_count: &mut usize,
+    stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
@@ -41,14 +42,7 @@ pub fn missing_lints_features(
         if let Some(feature_gate) = feature_gate
             && !manifest.unstable_features().is_enabled(feature_gate)
         {
-            report_feature_not_enabled(
-                name,
-                feature_gate,
-                &manifest,
-                &manifest_path,
-                error_count,
-                gctx,
-            )?;
+            report_feature_not_enabled(name, feature_gate, &manifest, &manifest_path, stats, gctx)?;
         }
     }
 
@@ -60,7 +54,7 @@ fn report_feature_not_enabled(
     feature_gate: &Feature,
     manifest: &ManifestFor<'_>,
     manifest_path: &str,
-    error_count: &mut usize,
+    stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let dash_feature_name = feature_gate.name().replace("_", "-");
@@ -92,7 +86,7 @@ fn report_feature_not_enabled(
         "consider adding `cargo-features = [\"{dash_feature_name}\"]` to the top of the manifest"
     )))];
 
-    *error_count += 1;
+    stats.record_error();
     gctx.shell().print_report(&report, true)?;
 
     Ok(())

--- a/src/cargo/diagnostics/rules/missing_lints_inheritance.rs
+++ b/src/cargo/diagnostics/rules/missing_lints_inheritance.rs
@@ -13,6 +13,7 @@ use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::Package;
 use crate::core::Workspace;
+use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevel;
 use crate::diagnostics::rel_cwd_manifest_path;
@@ -59,7 +60,7 @@ pub fn missing_lints_inheritance(
     pkg: &Package,
     manifest_path: &Path,
     cargo_lints: &TomlToolLints,
-    error_count: &mut usize,
+    stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let (lint_level, source) = LINT.level(
@@ -119,9 +120,7 @@ pub fn missing_lints_inheritance(
         report.push(help);
     }
 
-    if lint_level.is_error() {
-        *error_count += 1;
-    }
+    stats.record_lint(lint_level);
     gctx.shell().print_report(&report, lint_level.force())?;
 
     Ok(())

--- a/src/cargo/diagnostics/rules/non_kebab_case_bins.rs
+++ b/src/cargo/diagnostics/rules/non_kebab_case_bins.rs
@@ -15,6 +15,7 @@ use crate::GlobalContext;
 use crate::core::Package;
 use crate::core::Workspace;
 use crate::diagnostics::AsIndex;
+use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevel;
 use crate::diagnostics::LintLevelSource;
@@ -68,7 +69,7 @@ pub fn non_kebab_case_bins(
     pkg: &Package,
     manifest_path: &Path,
     cargo_lints: &TomlToolLints,
-    error_count: &mut usize,
+    stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let (lint_level, source) = LINT.level(
@@ -83,15 +84,7 @@ pub fn non_kebab_case_bins(
 
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
 
-    lint_package(
-        ws,
-        pkg,
-        &manifest_path,
-        lint_level,
-        source,
-        error_count,
-        gctx,
-    )
+    lint_package(ws, pkg, &manifest_path, lint_level, source, stats, gctx)
 }
 
 fn lint_package(
@@ -100,7 +93,7 @@ fn lint_package(
     manifest_path: &str,
     lint_level: LintLevel,
     source: LintLevelSource,
-    error_count: &mut usize,
+    stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let manifest = pkg.manifest();
@@ -247,9 +240,7 @@ path = "src/main.rs""#
             report.push(help);
         }
 
-        if lint_level.is_error() {
-            *error_count += 1;
-        }
+        stats.record_lint(lint_level);
         gctx.shell().print_report(&report, lint_level.force())?;
     }
 

--- a/src/cargo/diagnostics/rules/non_kebab_case_features.rs
+++ b/src/cargo/diagnostics/rules/non_kebab_case_features.rs
@@ -13,6 +13,7 @@ use super::RESTRICTION;
 use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::Package;
+use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevel;
 use crate::diagnostics::LintLevelSource;
@@ -61,7 +62,7 @@ pub fn non_kebab_case_features(
     pkg: &Package,
     manifest_path: &Path,
     cargo_lints: &TomlToolLints,
-    error_count: &mut usize,
+    stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let (lint_level, source) = LINT.level(
@@ -76,7 +77,7 @@ pub fn non_kebab_case_features(
 
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
 
-    lint_package(pkg, &manifest_path, lint_level, source, error_count, gctx)
+    lint_package(pkg, &manifest_path, lint_level, source, stats, gctx)
 }
 
 fn lint_package(
@@ -84,7 +85,7 @@ fn lint_package(
     manifest_path: &str,
     lint_level: LintLevel,
     source: LintLevelSource,
-    error_count: &mut usize,
+    stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     for original_name in pkg.summary().features().keys() {
@@ -146,9 +147,7 @@ fn lint_package(
             report.push(help);
         }
 
-        if lint_level.is_error() {
-            *error_count += 1;
-        }
+        stats.record_lint(lint_level);
         gctx.shell().print_report(&report, lint_level.force())?;
     }
 

--- a/src/cargo/diagnostics/rules/non_kebab_case_packages.rs
+++ b/src/cargo/diagnostics/rules/non_kebab_case_packages.rs
@@ -13,6 +13,7 @@ use super::RESTRICTION;
 use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::Package;
+use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevel;
 use crate::diagnostics::LintLevelSource;
@@ -61,7 +62,7 @@ pub fn non_kebab_case_packages(
     pkg: &Package,
     manifest_path: &Path,
     cargo_lints: &TomlToolLints,
-    error_count: &mut usize,
+    stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let (lint_level, source) = LINT.level(
@@ -76,7 +77,7 @@ pub fn non_kebab_case_packages(
 
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
 
-    lint_package(pkg, &manifest_path, lint_level, source, error_count, gctx)
+    lint_package(pkg, &manifest_path, lint_level, source, stats, gctx)
 }
 
 fn lint_package(
@@ -84,7 +85,7 @@ fn lint_package(
     manifest_path: &str,
     lint_level: LintLevel,
     source: LintLevelSource,
-    error_count: &mut usize,
+    stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let manifest = pkg.manifest();
@@ -147,9 +148,7 @@ fn lint_package(
         report.push(help);
     }
 
-    if lint_level.is_error() {
-        *error_count += 1;
-    }
+    stats.record_lint(lint_level);
     gctx.shell().print_report(&report, lint_level.force())?;
 
     Ok(())

--- a/src/cargo/diagnostics/rules/non_snake_case_features.rs
+++ b/src/cargo/diagnostics/rules/non_snake_case_features.rs
@@ -13,6 +13,7 @@ use super::RESTRICTION;
 use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::Package;
+use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevel;
 use crate::diagnostics::LintLevelSource;
@@ -61,7 +62,7 @@ pub fn non_snake_case_features(
     pkg: &Package,
     manifest_path: &Path,
     cargo_lints: &TomlToolLints,
-    error_count: &mut usize,
+    stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let (lint_level, source) = LINT.level(
@@ -76,7 +77,7 @@ pub fn non_snake_case_features(
 
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
 
-    lint_package(pkg, &manifest_path, lint_level, source, error_count, gctx)
+    lint_package(pkg, &manifest_path, lint_level, source, stats, gctx)
 }
 
 fn lint_package(
@@ -84,7 +85,7 @@ fn lint_package(
     manifest_path: &str,
     lint_level: LintLevel,
     source: LintLevelSource,
-    error_count: &mut usize,
+    stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     for original_name in pkg.summary().features().keys() {
@@ -146,9 +147,7 @@ fn lint_package(
             report.push(help);
         }
 
-        if lint_level.is_error() {
-            *error_count += 1;
-        }
+        stats.record_lint(lint_level);
         gctx.shell().print_report(&report, lint_level.force())?;
     }
 

--- a/src/cargo/diagnostics/rules/non_snake_case_packages.rs
+++ b/src/cargo/diagnostics/rules/non_snake_case_packages.rs
@@ -13,6 +13,7 @@ use super::RESTRICTION;
 use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::Package;
+use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevel;
 use crate::diagnostics::LintLevelSource;
@@ -61,7 +62,7 @@ pub fn non_snake_case_packages(
     pkg: &Package,
     manifest_path: &Path,
     cargo_lints: &TomlToolLints,
-    error_count: &mut usize,
+    stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let (lint_level, source) = LINT.level(
@@ -76,7 +77,7 @@ pub fn non_snake_case_packages(
 
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
 
-    lint_package(pkg, &manifest_path, lint_level, source, error_count, gctx)
+    lint_package(pkg, &manifest_path, lint_level, source, stats, gctx)
 }
 
 fn lint_package(
@@ -84,7 +85,7 @@ fn lint_package(
     manifest_path: &str,
     lint_level: LintLevel,
     source: LintLevelSource,
-    error_count: &mut usize,
+    stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let manifest = pkg.manifest();
@@ -147,9 +148,7 @@ fn lint_package(
         report.push(help);
     }
 
-    if lint_level.is_error() {
-        *error_count += 1;
-    }
+    stats.record_lint(lint_level);
     gctx.shell().print_report(&report, lint_level.force())?;
 
     Ok(())

--- a/src/cargo/diagnostics/rules/redundant_homepage.rs
+++ b/src/cargo/diagnostics/rules/redundant_homepage.rs
@@ -14,6 +14,7 @@ use super::STYLE;
 use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::Package;
+use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevel;
 use crate::diagnostics::LintLevelSource;
@@ -65,7 +66,7 @@ pub fn redundant_homepage(
     pkg: &Package,
     manifest_path: &Path,
     cargo_lints: &TomlToolLints,
-    error_count: &mut usize,
+    stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let (lint_level, source) = LINT.level(
@@ -80,7 +81,7 @@ pub fn redundant_homepage(
 
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
 
-    lint_package(pkg, &manifest_path, lint_level, source, error_count, gctx)
+    lint_package(pkg, &manifest_path, lint_level, source, stats, gctx)
 }
 
 fn lint_package(
@@ -88,7 +89,7 @@ fn lint_package(
     manifest_path: &str,
     lint_level: LintLevel,
     source: LintLevelSource,
-    error_count: &mut usize,
+    stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let manifest = pkg.manifest();
@@ -155,9 +156,7 @@ fn lint_package(
         report.push(help);
     }
 
-    if lint_level.is_error() {
-        *error_count += 1;
-    }
+    stats.record_lint(lint_level);
     gctx.shell().print_report(&report, lint_level.force())?;
 
     Ok(())

--- a/src/cargo/diagnostics/rules/redundant_readme.rs
+++ b/src/cargo/diagnostics/rules/redundant_readme.rs
@@ -15,6 +15,7 @@ use super::STYLE;
 use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::Package;
+use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevel;
 use crate::diagnostics::LintLevelSource;
@@ -67,7 +68,7 @@ pub fn redundant_readme(
     pkg: &Package,
     manifest_path: &Path,
     cargo_lints: &TomlToolLints,
-    error_count: &mut usize,
+    stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let (lint_level, source) = LINT.level(
@@ -82,7 +83,7 @@ pub fn redundant_readme(
 
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
 
-    lint_package(pkg, &manifest_path, lint_level, source, error_count, gctx)
+    lint_package(pkg, &manifest_path, lint_level, source, stats, gctx)
 }
 
 fn lint_package(
@@ -90,7 +91,7 @@ fn lint_package(
     manifest_path: &str,
     lint_level: LintLevel,
     source: LintLevelSource,
-    error_count: &mut usize,
+    stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let manifest = pkg.manifest();
@@ -158,9 +159,7 @@ fn lint_package(
         report.push(help);
     }
 
-    if lint_level.is_error() {
-        *error_count += 1;
-    }
+    stats.record_lint(lint_level);
     gctx.shell().print_report(&report, lint_level.force())?;
 
     Ok(())

--- a/src/cargo/diagnostics/rules/text_direction_codepoint_in_comment.rs
+++ b/src/cargo/diagnostics/rules/text_direction_codepoint_in_comment.rs
@@ -17,6 +17,7 @@ use super::CORRECTNESS;
 use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::MaybePackage;
+use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevel;
 use crate::diagnostics::ManifestFor;
@@ -51,7 +52,7 @@ pub fn text_direction_codepoint_in_comment(
     manifest: ManifestFor<'_>,
     manifest_path: &Path,
     cargo_lints: &TomlToolLints,
-    error_count: &mut usize,
+    stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let (lint_level, source) = manifest.lint_level(cargo_lints, LINT);
@@ -91,9 +92,7 @@ pub fn text_direction_codepoint_in_comment(
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
     let mut emitted_source = None;
     for event in events {
-        if lint_level.is_error() {
-            *error_count += 1;
-        }
+        stats.record_lint(lint_level);
 
         let token_span = event.token.span();
         let token_span = token_span.start()..token_span.end();

--- a/src/cargo/diagnostics/rules/text_direction_codepoint_in_comment.rs
+++ b/src/cargo/diagnostics/rules/text_direction_codepoint_in_comment.rs
@@ -92,8 +92,6 @@ pub fn text_direction_codepoint_in_comment(
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
     let mut emitted_source = None;
     for event in events {
-        stats.record_lint(lint_level);
-
         let token_span = event.token.span();
         let token_span = token_span.start()..token_span.end();
         let mut snippet = Snippet::source(contents).path(&manifest_path).annotation(
@@ -115,6 +113,8 @@ pub fn text_direction_codepoint_in_comment(
         }
 
         let report = [primary];
+
+        stats.record_lint(lint_level);
         gctx.shell().print_report(&report, lint_level.force())?;
     }
 

--- a/src/cargo/diagnostics/rules/text_direction_codepoint_in_literal.rs
+++ b/src/cargo/diagnostics/rules/text_direction_codepoint_in_literal.rs
@@ -18,6 +18,7 @@ use super::CORRECTNESS;
 use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::MaybePackage;
+use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevel;
 use crate::diagnostics::ManifestFor;
@@ -52,7 +53,7 @@ pub fn text_direction_codepoint_in_literal(
     manifest: ManifestFor<'_>,
     manifest_path: &Path,
     cargo_lints: &TomlToolLints,
-    error_count: &mut usize,
+    stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let (lint_level, source) = manifest.lint_level(cargo_lints, LINT);
@@ -93,9 +94,7 @@ pub fn text_direction_codepoint_in_literal(
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
     let mut emitted_source = None;
     for event in events {
-        if lint_level.is_error() {
-            *error_count += 1;
-        }
+        stats.record_lint(lint_level);
 
         let token_span = event.token.span();
         let token_span = token_span.start()..token_span.end();

--- a/src/cargo/diagnostics/rules/text_direction_codepoint_in_literal.rs
+++ b/src/cargo/diagnostics/rules/text_direction_codepoint_in_literal.rs
@@ -94,8 +94,6 @@ pub fn text_direction_codepoint_in_literal(
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
     let mut emitted_source = None;
     for event in events {
-        stats.record_lint(lint_level);
-
         let token_span = event.token.span();
         let token_span = token_span.start()..token_span.end();
         let mut snippet = Snippet::source(contents).path(&manifest_path).annotation(
@@ -158,6 +156,8 @@ pub fn text_direction_codepoint_in_literal(
         let help = Group::with_title(Level::HELP.secondary_title("if you want to keep them but make them visible in your source code, you can escape them")).element(help_snippet);
 
         let report = [primary, help];
+
+        stats.record_lint(lint_level);
         gctx.shell().print_report(&report, lint_level.force())?;
     }
 

--- a/src/cargo/diagnostics/rules/unknown_lints.rs
+++ b/src/cargo/diagnostics/rules/unknown_lints.rs
@@ -73,7 +73,6 @@ pub fn unknown_lints(
     let level = lint_level.to_diagnostic_level();
     let mut emitted_source = None;
     for lint_name in unknown_lints {
-        stats.record_lint(lint_level);
         let title = format!("{}: `{lint_name}`", LINT.desc);
         let underscore_lint_name = lint_name.replace("-", "_");
         let matching = if let Some(lint) = LINTS.iter().find(|l| l.name == underscore_lint_name) {
@@ -119,6 +118,7 @@ pub fn unknown_lints(
         }
         report.push(group);
 
+        stats.record_lint(lint_level);
         gctx.shell().print_report(&report, lint_level.force())?;
     }
 

--- a/src/cargo/diagnostics/rules/unknown_lints.rs
+++ b/src/cargo/diagnostics/rules/unknown_lints.rs
@@ -14,6 +14,7 @@ use super::SUSPICIOUS;
 use super::find_lint_or_group;
 use crate::CargoResult;
 use crate::GlobalContext;
+use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevel;
 use crate::diagnostics::ManifestFor;
@@ -51,7 +52,7 @@ pub fn unknown_lints(
     manifest: ManifestFor<'_>,
     manifest_path: &Path,
     cargo_lints: &TomlToolLints,
-    error_count: &mut usize,
+    stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let (lint_level, source) = manifest.lint_level(cargo_lints, LINT);
@@ -72,9 +73,7 @@ pub fn unknown_lints(
     let level = lint_level.to_diagnostic_level();
     let mut emitted_source = None;
     for lint_name in unknown_lints {
-        if lint_level.is_error() {
-            *error_count += 1;
-        }
+        stats.record_lint(lint_level);
         let title = format!("{}: `{lint_name}`", LINT.desc);
         let underscore_lint_name = lint_name.replace("-", "_");
         let matching = if let Some(lint) = LINTS.iter().find(|l| l.name == underscore_lint_name) {

--- a/src/cargo/diagnostics/rules/unused_dependencies.rs
+++ b/src/cargo/diagnostics/rules/unused_dependencies.rs
@@ -14,6 +14,7 @@ use super::STYLE;
 use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::Package;
+use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevel;
 use crate::diagnostics::get_key_value_span;
@@ -87,7 +88,7 @@ pub fn unused_build_dependencies_no_build_rs(
     pkg: &Package,
     manifest_path: &Path,
     cargo_lints: &TomlToolLints,
-    error_count: &mut usize,
+    stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let (lint_level, reason) = LINT.level(
@@ -155,9 +156,7 @@ pub fn unused_build_dependencies_no_build_rs(
             report.push(help);
         }
 
-        if lint_level.is_error() {
-            *error_count += 1;
-        }
+        stats.record_lint(lint_level);
         gctx.shell().print_report(&report, lint_level.force())?;
     }
 

--- a/src/cargo/diagnostics/rules/unused_workspace_dependencies.rs
+++ b/src/cargo/diagnostics/rules/unused_workspace_dependencies.rs
@@ -16,6 +16,7 @@ use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::MaybePackage;
 use crate::core::Workspace;
+use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevel;
 use crate::diagnostics::get_key_value_span;
@@ -52,7 +53,7 @@ pub fn unused_workspace_dependencies(
     maybe_pkg: &MaybePackage,
     manifest_path: &Path,
     cargo_lints: &TomlToolLints,
-    error_count: &mut usize,
+    stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let (lint_level, source) = LINT.level(
@@ -170,9 +171,7 @@ pub fn unused_workspace_dependencies(
             report.push(help);
         }
 
-        if lint_level.is_error() {
-            *error_count += 1;
-        }
+        stats.record_lint(lint_level);
         gctx.shell().print_report(&report, lint_level.force())?;
     }
 

--- a/src/cargo/diagnostics/rules/unused_workspace_package_fields.rs
+++ b/src/cargo/diagnostics/rules/unused_workspace_package_fields.rs
@@ -15,6 +15,7 @@ use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::MaybePackage;
 use crate::core::Workspace;
+use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevel;
 use crate::diagnostics::get_key_value_span;
@@ -52,7 +53,7 @@ pub fn unused_workspace_package_fields(
     maybe_pkg: &MaybePackage,
     manifest_path: &Path,
     cargo_lints: &TomlToolLints,
-    error_count: &mut usize,
+    stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let (lint_level, source) = LINT.level(
@@ -139,9 +140,7 @@ pub fn unused_workspace_package_fields(
             report.push(help);
         }
 
-        if lint_level.is_error() {
-            *error_count += 1;
-        }
+        stats.record_lint(lint_level);
         gctx.shell().print_report(&report, lint_level.force())?;
     }
 

--- a/tests/testsuite/lints/blanket_hint_mostly_unused.rs
+++ b/tests/testsuite/lints/blanket_hint_mostly_unused.rs
@@ -35,6 +35,7 @@ hint-mostly-unused = true
   |
 7 | [profile.dev.package.<pkg_name>]
   |             +++++++++++++++++++
+[WARNING] workspace (manifest) generated 1 warning
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -73,6 +74,7 @@ hint-mostly-unused = true
   |
   = [HELP] scope `hint-mostly-unused` to specific packages with a lot of unused object code
   = [NOTE] `cargo::blanket_hint_mostly_unused` is set to `warn` by default
+[WARNING] workspace (manifest) generated 1 warning
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -111,6 +113,7 @@ hint-mostly-unused = true
   |
   = [HELP] scope `hint-mostly-unused` to specific packages with a lot of unused object code
   = [NOTE] `cargo::blanket_hint_mostly_unused` is set to `warn` by default
+[WARNING] workspace (manifest) generated 1 warning
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -158,6 +161,7 @@ authors = []
   |
   = [HELP] scope `hint-mostly-unused` to specific packages with a lot of unused object code
   = [NOTE] `cargo::blanket_hint_mostly_unused` is set to `warn` by default
+[WARNING] workspace (manifest) generated 1 warning
 [CHECKING] foo v0.0.1 ([ROOT]/foo/foo)
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/lints/blanket_hint_mostly_unused.rs
+++ b/tests/testsuite/lints/blanket_hint_mostly_unused.rs
@@ -203,7 +203,7 @@ blanket_hint_mostly_unused = "deny"
   |
 7 | [profile.dev.package.<pkg_name>]
   |             +++++++++++++++++++
-[ERROR] encountered 1 error while running lints
+[ERROR] could not parse workspace (manifest) due to 1 previous error
 
 "#]])
         .run();

--- a/tests/testsuite/lints/error/stderr.term.svg
+++ b/tests/testsuite/lints/error/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-blue bold">= </tspan><tspan class="bold">note</tspan><tspan>: `cargo::im_a_teapot` is set to `deny` in `[lints]`</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-bright-red bold">error</tspan><tspan>: encountered 1 error while running lints</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-red bold">error</tspan><tspan>: could not parse `foo` (manifest) due to 1 previous error</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/lints/implicit_minimum_version_req.rs
+++ b/tests/testsuite/lints/implicit_minimum_version_req.rs
@@ -44,6 +44,7 @@ implicit_minimum_version_req = "warn"
   |
 7 | dep = "1.0.0"
   |         ++++
+[WARNING] `foo` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
@@ -103,6 +104,7 @@ implicit_minimum_version_req = "warn"
   |
 7 | dep = "1.0.0"
   |           ++
+[WARNING] `foo` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
@@ -210,6 +212,7 @@ implicit_minimum_version_req = "warn"
   |
 7 | dep = { version = "1.0.0" }
   |                     ++++
+[WARNING] `foo` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
@@ -269,6 +272,7 @@ implicit_minimum_version_req = "warn"
   |
 7 | dep = ">=1.0.0"
   |             ++
+[WARNING] `foo` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
@@ -568,6 +572,7 @@ implicit_minimum_version_req = "warn"
   |
 7 | dep = ">=1.0.0, <2.0"
   |             ++
+[WARNING] `foo` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
@@ -785,6 +790,7 @@ edition = "2021"
   |
 7 | bar = { path = "bar", version = "0.1.0" }
   |                                     ++
+[WARNING] `foo` (manifest) generated 1 warning
 [LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
@@ -901,6 +907,7 @@ implicit_minimum_version_req = "warn"
   |
 7 | bar = { git = '[ROOTURL]/bar', version = "0.1.0" }
   |                                          [..]++
+[WARNING] `foo` (manifest) generated 1 warning
 [UPDATING] git repository `[ROOTURL]/bar`
 [LOCKING] 1 package to latest compatible version
 [CHECKING] bar v0.1.0 ([ROOTURL]/bar#[..])
@@ -958,6 +965,7 @@ implicit_minimum_version_req = "warn"
   |
 7 | dep = "1.0.0"
   |         ++++
+[WARNING] `foo` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
@@ -1004,6 +1012,7 @@ implicit_minimum_version_req = "warn"
   |
 7 | dep = "1.0.0"
   |           ++
+[WARNING] `foo` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
@@ -1064,6 +1073,7 @@ implicit_minimum_version_req = "warn"
   |
 8 | dep = "1.0.0"
   |         ++++
+[WARNING] `foo` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
@@ -1116,6 +1126,7 @@ implicit_minimum_version_req = "warn"
   |
 8 | dep = "1.0.0"
   |         ++++
+[WARNING] `foo` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
@@ -1249,6 +1260,7 @@ workspace = true
   |
 7 | dep = "1.0.0"
   |         ++++
+[WARNING] workspace (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
@@ -1331,6 +1343,7 @@ edition = "2021"
   |
 7 | dep = "1.0.0"
   |         ++++
+[WARNING] workspace (manifest) generated 2 warnings
 [CHECKING] member v0.0.0 ([ROOT]/foo/member)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1400,6 +1413,7 @@ workspace = true
   |
 7 | dep = "1.0.0"
   |         ++++
+[WARNING] workspace (manifest) generated 2 warnings
 [WARNING] dependency version requirement without an explicit minimum version
  --> member/Cargo.toml:7:7
   |
@@ -1411,6 +1425,7 @@ workspace = true
   |
 7 | dep = "1.0.0"
   |           ++
+[WARNING] `member` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...

--- a/tests/testsuite/lints/implicit_minimum_version_req.rs
+++ b/tests/testsuite/lints/implicit_minimum_version_req.rs
@@ -1471,7 +1471,7 @@ implicit_minimum_version_req = "deny"
   |
 7 | dep = "1.0.0"
   |         ++++
-[ERROR] encountered 1 error while running lints
+[ERROR] could not parse `foo` (manifest) due to 1 previous error
 
 "#]])
         .run();

--- a/tests/testsuite/lints/inherited/stderr.term.svg
+++ b/tests/testsuite/lints/inherited/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-blue bold">= </tspan><tspan class="bold">help</tspan><tspan>: consider adding `cargo-features = ["test-dummy-unstable"]` to the top of the manifest</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-bright-red bold">error</tspan><tspan>: encountered 1 error while verifying lints</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-red bold">error</tspan><tspan>: could not parse workspace (manifest) due to 1 previous error</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/lints/missing_lints_inheritance.rs
+++ b/tests/testsuite/lints/missing_lints_inheritance.rs
@@ -78,6 +78,7 @@ edition = "2015"
 5 ~ edition = "2015"
 6 + [lints]
   |
+[WARNING] `bar` (manifest) generated 1 warning
 [CHECKING] bar v0.0.1 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/lints/mod.rs
+++ b/tests/testsuite/lints/mod.rs
@@ -47,6 +47,7 @@ im-a-teapot = "warn"
     foo.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints", "test-dummy-unstable"])
         .with_stderr_data(str![[r#"
+[WARNING] workspace (manifest) generated 1 warning
 [WARNING] unknown lint: `im-a-teapot`
   --> Cargo.toml:12:1
    |
@@ -55,6 +56,7 @@ im-a-teapot = "warn"
    |
    = [NOTE] `cargo::unknown_lints` is set to `warn` by default
    = [HELP] there is a lint with a similar name: `im_a_teapot`
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -193,6 +195,7 @@ im-a-teapot = true
  9 ~ im-a-teapot = true
 10 + [lints]
    |
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.0.1 ([ROOT]/foo/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -415,6 +418,7 @@ authors = []
 7 ~             
 8 + [lints]
   |
+[WARNING] `foo` (manifest) generated 1 warning
 [ERROR] could not parse workspace (manifest) due to 2 previous errors
 
 "#]])
@@ -453,6 +457,7 @@ im_a_teapot = { level = "warn", priority = 10 }
   │ ━━━━━━━━━━━━━━━━━━
   │
   ╰ [NOTE] `cargo::im_a_teapot` is set to `warn` in `[lints]`
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/lints/mod.rs
+++ b/tests/testsuite/lints/mod.rs
@@ -96,7 +96,7 @@ test_dummy_unstable = { level = "forbid", priority = -1 }
   | ^^^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::im_a_teapot` is set to `forbid` in `[lints]`
-[ERROR] encountered 1 error while running lints
+[ERROR] could not parse `foo` (manifest) due to 1 previous error
 
 "#]])
         .run();
@@ -139,7 +139,7 @@ workspace = true
    | ^^^^^^^^^^^^^^^^^^
    |
    = [NOTE] `cargo::im_a_teapot` is set to `forbid` in `[lints]`
-[ERROR] encountered 1 error while running lints
+[ERROR] could not parse `foo` (manifest) due to 1 previous error
 
 "#]])
         .run();
@@ -296,7 +296,7 @@ im_a_teapot = "warn"
   | ^^^^^^^^^^^ this is behind `test-dummy-unstable`, which is not enabled
   |
   = [HELP] consider adding `cargo-features = ["test-dummy-unstable"]` to the top of the manifest
-[ERROR] encountered 1 error while verifying lints
+[ERROR] could not parse `foo` (manifest) due to 1 previous error
 
 "#]])
         .run();
@@ -350,7 +350,7 @@ workspace = true
   | ^^^^^^^^^^^^^^^^^^^ this is behind `test-dummy-unstable`, which is not enabled
   |
   = [HELP] consider adding `cargo-features = ["test-dummy-unstable"]` to the top of the manifest
-[ERROR] encountered 2 errors while verifying lints
+[ERROR] could not parse workspace (manifest) due to 2 previous errors
 
 "#]])
         .run();
@@ -415,7 +415,7 @@ authors = []
 7 ~             
 8 + [lints]
   |
-[ERROR] encountered 2 errors while verifying lints
+[ERROR] could not parse workspace (manifest) due to 2 previous errors
 
 "#]])
         .run();

--- a/tests/testsuite/lints/mod.rs
+++ b/tests/testsuite/lints/mod.rs
@@ -47,7 +47,6 @@ im-a-teapot = "warn"
     foo.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints", "test-dummy-unstable"])
         .with_stderr_data(str![[r#"
-[WARNING] workspace (manifest) generated 1 warning
 [WARNING] unknown lint: `im-a-teapot`
   --> Cargo.toml:12:1
    |

--- a/tests/testsuite/lints/non_kebab_case_bins.rs
+++ b/tests/testsuite/lints/non_kebab_case_bins.rs
@@ -40,6 +40,7 @@ non_kebab_case_bins = "warn"
 9 - name = "foo_bar"
 9 + name = "foo-bar"
   |
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -89,6 +90,7 @@ non_kebab_case_bins = "warn"
 11 + name = "foo-bar"
 12 + path = "src/main.rs"
    |
+[WARNING] `foo_bar` (manifest) generated 1 warning
 [CHECKING] foo_bar v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -129,6 +131,7 @@ non_kebab_case_bins = "warn"
 1 - src/bin/foo_bar.rs
 1 + src/bin/foo-bar.rs
   |
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -166,6 +169,7 @@ fn main() {}"#,
 1 - foo_bar
 1 + foo-bar
   |
+[WARNING] `foo_bar` (manifest) generated 1 warning
 [CHECKING] foo_bar v0.0.0 ([ROOT]/foo/foo_bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/lints/non_kebab_case_features.rs
+++ b/tests/testsuite/lints/non_kebab_case_features.rs
@@ -40,6 +40,7 @@ non_kebab_case_features = "warn"
 9 - foo_bar = []
 9 + foo-bar = []
   |
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -82,6 +83,7 @@ non_kebab_case_features = "warn"
   |
   = [NOTE] see also <https://doc.rust-lang.org/cargo/reference/features.html#optional-dependencies>
   = [NOTE] `cargo::non_kebab_case_features` is set to `warn` in `[lints]`
+[WARNING] `foo` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.0.1 ([ROOT]/foo)

--- a/tests/testsuite/lints/non_kebab_case_packages.rs
+++ b/tests/testsuite/lints/non_kebab_case_packages.rs
@@ -36,6 +36,7 @@ non_kebab_case_packages = "warn"
 3 - name = "foo_bar"
 3 + name = "foo-bar"
   |
+[WARNING] `foo_bar` (manifest) generated 1 warning
 [CHECKING] foo_bar v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -81,6 +82,7 @@ fn main() {}"#,
 1 - foo_bar
 1 + foo-bar
   |
+[WARNING] `foo_bar` (manifest) generated 2 warnings
 [CHECKING] foo_bar v0.0.0 ([ROOT]/foo/foo_bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/lints/non_snake_case_features.rs
+++ b/tests/testsuite/lints/non_snake_case_features.rs
@@ -40,6 +40,7 @@ non_snake_case_features = "warn"
 9 - foo-bar = []
 9 + foo_bar = []
   |
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -82,6 +83,7 @@ non_snake_case_features = "warn"
   |
   = [NOTE] see also <https://doc.rust-lang.org/cargo/reference/features.html#optional-dependencies>
   = [NOTE] `cargo::non_snake_case_features` is set to `warn` in `[lints]`
+[WARNING] `foo` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.0.1 ([ROOT]/foo)

--- a/tests/testsuite/lints/non_snake_case_packages.rs
+++ b/tests/testsuite/lints/non_snake_case_packages.rs
@@ -36,6 +36,7 @@ non_snake_case_packages = "warn"
 3 - name = "foo-bar"
 3 + name = "foo_bar"
   |
+[WARNING] `foo-bar` (manifest) generated 1 warning
 [CHECKING] foo-bar v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -70,6 +71,7 @@ fn main() {}"#,
 1 - [ROOT]/foo/foo-bar
 1 + [ROOT]/foo/foo_bar
   |
+[WARNING] `foo-bar` (manifest) generated 1 warning
 [CHECKING] foo-bar v0.0.0 ([ROOT]/foo/foo-bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/lints/redundant_homepage.rs
+++ b/tests/testsuite/lints/redundant_homepage.rs
@@ -39,6 +39,7 @@ redundant_homepage = "warn"
   |
 7 - homepage = "https://github.com/rust-lang/cargo/"
   |
+[WARNING] `cargo` (manifest) generated 1 warning
 [CHECKING] cargo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -83,6 +84,7 @@ redundant_homepage = "warn"
   |
 7 - homepage = "https://docs.rs/cargo/latest/cargo/"
   |
+[WARNING] `cargo` (manifest) generated 1 warning
 [CHECKING] cargo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -131,6 +133,7 @@ redundant_homepage = "warn"
    |
 11 - homepage.workspace = true
    |
+[WARNING] `cargo` (manifest) generated 1 warning
 [CHECKING] cargo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/lints/redundant_readme.rs
+++ b/tests/testsuite/lints/redundant_readme.rs
@@ -37,6 +37,7 @@ redundant_readme = "warn"
   |
 7 - readme = "README.md"
   |
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/lints/text_direction_codepoint.rs
+++ b/tests/testsuite/lints/text_direction_codepoint.rs
@@ -61,6 +61,7 @@ text_direction_codepoint_in_literal = \"allow\"
   |                                           |           |      "/u{202c}"
   |                                           |           "/u{202b}"
   |                                           this comment contains an invisible unicode text flow control codepoint
+[WARNING] `foo` (manifest) generated 3 warnings
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -134,6 +135,7 @@ text_direction_codepoint_in_literal = \"warn\"
 9 - repository = "a �repository� everywhere"  # this is a �tricky� comment
 9 + repository = "a /u{202E}repository/u{202A} everywhere"  # this is a �tricky� comment
   |
+[WARNING] `foo` (manifest) generated 3 warnings
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -250,6 +252,7 @@ edition = \"2015\"
 12 - repository = "a �repository� everywhere"  # this is a �tricky� comment
 12 + repository = "a /u{202E}repository/u{202A} everywhere"  # this is a �tricky� comment
    |
+[WARNING] `foo` (manifest) generated 6 warnings
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -375,6 +378,7 @@ workspace = true
 8 - repository = "a �repository� everywhere"  # this is a �tricky� comment
 8 + repository = "a /u{202E}repository/u{202A} everywhere"  # this is a �tricky� comment
   |
+[WARNING] workspace (manifest) generated 6 warnings
 [CHECKING] bar v0.0.1 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/lints/unknown_lints.rs
+++ b/tests/testsuite/lints/unknown_lints.rs
@@ -24,6 +24,7 @@ this-lint-does-not-exist = "warn"
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
+[WARNING] workspace (manifest) generated 1 warning
 [WARNING] unknown lint: `this-lint-does-not-exist`
  --> Cargo.toml:9:1
   |
@@ -31,6 +32,7 @@ this-lint-does-not-exist = "warn"
   | ^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -77,6 +79,8 @@ workspace = true
   | ^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[WARNING] workspace (manifest) generated 1 warning
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.0.1 ([ROOT]/foo/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -120,6 +124,7 @@ authors = []
   | ^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+[WARNING] workspace (manifest) generated 1 warning
 [WARNING] missing `[lints]` to inherit `[workspace.lints]`
  --> foo/Cargo.toml
   = [NOTE] `cargo::missing_lints_inheritance` is set to `warn` by default
@@ -134,6 +139,7 @@ authors = []
 7 ~             
 8 + [lints]
   |
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.0.1 ([ROOT]/foo/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/lints/unknown_lints.rs
+++ b/tests/testsuite/lints/unknown_lints.rs
@@ -24,7 +24,6 @@ this-lint-does-not-exist = "warn"
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] workspace (manifest) generated 1 warning
 [WARNING] unknown lint: `this-lint-does-not-exist`
  --> Cargo.toml:9:1
   |
@@ -80,7 +79,6 @@ workspace = true
   |
   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
 [WARNING] workspace (manifest) generated 1 warning
-[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.0.1 ([ROOT]/foo/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/lints/unused_dependencies.rs
+++ b/tests/testsuite/lints/unused_dependencies.rs
@@ -161,6 +161,7 @@ fn unused_dep_build_no_build_rs() {
   |
 9 -             unused = "0.1.0"
   |
+[WARNING] `foo` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...

--- a/tests/testsuite/lints/unused_workspace_dependencies.rs
+++ b/tests/testsuite/lints/unused_workspace_dependencies.rs
@@ -99,6 +99,7 @@ workspace = true
    |
 11 - unused = "1"
    |
+[WARNING] workspace (manifest) generated 2 warnings
 [WARNING] unused dependency
  --> bar/Cargo.toml:9:1
   |
@@ -111,6 +112,7 @@ workspace = true
 9 - build-dep.workspace = true
 9 + .workspace = true
   |
+[WARNING] `bar` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
 [LOCKING] 6 packages to latest compatible versions
 [DOWNLOADING] crates ...

--- a/tests/testsuite/lints/unused_workspace_package_fields.rs
+++ b/tests/testsuite/lints/unused_workspace_package_fields.rs
@@ -71,6 +71,7 @@ workspace = true
   |
 9 - unknown = "foo"
   |
+[WARNING] workspace (manifest) generated 2 warnings
 [WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: workspace.package.unknown
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/lints/warning/stderr.term.svg
+++ b/tests/testsuite/lints/warning/stderr.term.svg
@@ -1,7 +1,7 @@
-<svg width="740px" height="200px" xmlns="http://www.w3.org/2000/svg">
+<svg width="936px" height="218px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
-    .bg { background: #000000 }
+    .bg { fill: #000000 }
     .fg-bright-blue { fill: #5555FF }
     .fg-bright-green { fill: #55FF55 }
     .fg-yellow { fill: #AA5500 }
@@ -34,11 +34,13 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-blue bold">= </tspan><tspan class="bold">note</tspan><tspan>: `cargo::im_a_teapot` is set to `warn` in `[lints]`</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">    Checking</tspan><tspan> foo v0.0.1 ([ROOT]/foo)</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `foo` (manifest) generated 1 warning</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">    Finished</tspan><tspan> </tspan><tspan><a href="https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles">`dev` profile [unoptimized + debuginfo]</a></tspan><tspan> target(s) in [ELAPSED]s</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">    Checking</tspan><tspan> foo v0.0.1 ([ROOT]/foo)</tspan>
 </tspan>
-    <tspan x="10px" y="190px">
+    <tspan x="10px" y="190px"><tspan class="fg-bright-green bold">    Finished</tspan><tspan> </tspan><tspan><a href="https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles">`dev` profile [unoptimized + debuginfo]</a></tspan><tspan> target(s) in [ELAPSED]s</tspan>
+</tspan>
+    <tspan x="10px" y="208px">
 </tspan>
   </text>
 

--- a/tests/testsuite/lints_table.rs
+++ b/tests/testsuite/lints_table.rs
@@ -832,6 +832,7 @@ im_a_teapot = "warn"
   | ^^^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::im_a_teapot` is set to `warn` in `[lints]`
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 


### PR DESCRIPTION
### What does this PR try to resolve?

This is one of the steps towards stabilizing #12235.

This has the counts separate from the existing summaries because those are per-build-target while this is for the entire manifest.

This does not yet cover `unused_dependencies`.

### How to test and review this PR?

This is also one of the steps for the plan laid out in #16975 as this will help us in unifying more of the existing diagnostics into this new diagnostic system.