### PR TITLE
Allow individual features be disabled from the CLI

### DIFF
--- a/benches/benchsuite/benches/resolve.rs
+++ b/benches/benchsuite/benches/resolve.rs
@@ -26,7 +26,7 @@ fn do_resolve<'gctx>(gctx: &'gctx GlobalContext, ws_root: &Path) -> ResolveInfo<
     let requested_kinds = [CompileKind::Host];
     let ws = Workspace::new(&ws_root.join("Cargo.toml"), gctx).unwrap();
     let mut target_data = RustcTargetData::new(&ws, &requested_kinds).unwrap();
-    let cli_features = CliFeatures::from_command_line(&[], false, true).unwrap();
+    let cli_features = CliFeatures::from_command_line(gctx, &[], false, true).unwrap();
     let pkgs = cargo::ops::Packages::Default;
     let specs = pkgs.to_package_id_specs(&ws).unwrap();
     let has_dev_units = HasDevUnits::Yes;

--- a/src/bin/cargo/commands/metadata.rs
+++ b/src/bin/cargo/commands/metadata.rs
@@ -47,7 +47,7 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
     };
 
     let options = OutputMetadataOptions {
-        cli_features: args.cli_features()?,
+        cli_features: args.cli_features(gctx)?,
         no_deps: args.flag("no-deps"),
         filter_platforms: args._values_of("filter-platform"),
         version,

--- a/src/bin/cargo/commands/package.rs
+++ b/src/bin/cargo/commands/package.rs
@@ -91,7 +91,7 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
             targets: args.targets()?,
             jobs: args.jobs()?,
             keep_going: args.keep_going(),
-            cli_features: args.cli_features()?,
+            cli_features: args.cli_features(gctx)?,
             reg_or_index,
             dry_run: false,
         },

--- a/src/bin/cargo/commands/publish.rs
+++ b/src/bin/cargo/commands/publish.rs
@@ -69,7 +69,7 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
             jobs: args.jobs()?,
             keep_going: args.keep_going(),
             dry_run: args.dry_run(),
-            cli_features: args.cli_features()?,
+            cli_features: args.cli_features(gctx)?,
         },
     )?;
     Ok(())

--- a/src/bin/cargo/commands/tree.rs
+++ b/src/bin/cargo/commands/tree.rs
@@ -240,7 +240,7 @@ help: if you are in a workspace and want to search across all members, use:
         }
     }
     let opts = tree::TreeOptions {
-        cli_features: args.cli_features()?,
+        cli_features: args.cli_features(gctx)?,
         packages,
         target,
         edge_kinds,

--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -87,7 +87,7 @@ pub fn resolve_std<'gctx>(
         ],
     };
     let cli_features = CliFeatures::from_command_line(
-        &features, /*all_features*/ false, /*uses_default_features*/ false,
+        gctx, &features, /*all_features*/ false, /*uses_default_features*/ false,
     )?;
     let dry_run = false;
     let mut resolve = ops::resolve_ws_with_opts(

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -876,6 +876,7 @@ unstable_cli_options!(
     codegen_backend: bool = ("Enable the `codegen-backend` option in profiles in .cargo/config.toml file"),
     direct_minimal_versions: bool = ("Resolve minimal dependency versions instead of maximum (direct dependencies only)"),
     dual_proc_macros: bool = ("Build proc-macros for both the host and the target"),
+    feature_disabling: bool = ("Allow specific features to be disabled"),
     feature_unification: bool = ("Enable new feature unification modes in workspaces"),
     features: Option<Vec<String>>,
     fine_grain_locking: bool = ("Use fine grain locking instead of locking the entire build cache"),
@@ -1410,6 +1411,7 @@ impl CliUnstable {
             "codegen-backend" => self.codegen_backend = parse_empty(k, v)?,
             "direct-minimal-versions" => self.direct_minimal_versions = parse_empty(k, v)?,
             "dual-proc-macros" => self.dual_proc_macros = parse_empty(k, v)?,
+            "feature-disabling" => self.feature_disabling = parse_empty(k, v)?,
             "feature-unification" => self.feature_unification = parse_empty(k, v)?,
             "fine-grain-locking" => self.fine_grain_locking = parse_empty(k, v)?,
             "fix-edition" => {

--- a/src/cargo/core/resolver/dep_cache.rs
+++ b/src/cargo/core/resolver/dep_cache.rs
@@ -13,7 +13,7 @@ use crate::core::resolver::context::ResolverContext;
 use crate::core::resolver::errors::describe_path_in_context;
 use crate::core::resolver::types::{ConflictReason, DepInfo, FeaturesSet};
 use crate::core::resolver::{
-    ActivateError, ActivateResult, CliFeatures, RequestedFeatures, ResolveOpts, VersionOrdering,
+    ActivateError, ActivateResult, RequestedFeatures, ResolveOpts, VersionOrdering,
     VersionPreferences,
 };
 use crate::core::{
@@ -381,36 +381,13 @@ fn build_requirements<'a, 'b: 'a>(
     opts: &'b ResolveOpts,
 ) -> ActivateResult<Requirements<'a>> {
     let mut reqs = Requirements::new(s);
-
-    let handle_default = |uses_default_features, reqs: &mut Requirements<'_>| {
-        if uses_default_features && s.features().contains_key("default") {
-            if let Err(e) = reqs.require_feature(INTERNED_DEFAULT) {
-                return Err(e.into_activate_error(parent, s));
-            }
-        }
-        Ok(())
-    };
-
     match &opts.features {
-        RequestedFeatures::CliFeatures(CliFeatures {
-            features,
-            all_features,
-            uses_default_features,
-        }) => {
-            if *all_features {
-                for key in s.features().keys() {
-                    if let Err(e) = reqs.require_feature(*key) {
-                        return Err(e.into_activate_error(parent, s));
-                    }
-                }
-            }
-
-            for fv in features.iter() {
-                if let Err(e) = reqs.require_value(fv) {
+        RequestedFeatures::CliFeatures(cli_features) => {
+            for fv in cli_features.resolve_requested(s.features()) {
+                if let Err(e) = reqs.require_value(&fv) {
                     return Err(e.into_activate_error(parent, s));
                 }
             }
-            handle_default(*uses_default_features, &mut reqs)?;
         }
         RequestedFeatures::DepFeatures {
             features,
@@ -421,7 +398,11 @@ fn build_requirements<'a, 'b: 'a>(
                     return Err(e.into_activate_error(parent, s));
                 }
             }
-            handle_default(*uses_default_features, &mut reqs)?;
+            if *uses_default_features && s.features().contains_key("default") {
+                if let Err(e) = reqs.require_feature(INTERNED_DEFAULT) {
+                    return Err(e.into_activate_error(parent, s));
+                }
+            }
         }
     }
 

--- a/src/cargo/core/resolver/features.rs
+++ b/src/cargo/core/resolver/features.rs
@@ -38,11 +38,12 @@
 //! [new feature resolver]: https://doc.rust-lang.org/nightly/cargo/reference/resolver.html#feature-resolver-version-2
 //! [`resolve_ws_with_opts`]: crate::ops::resolve_ws_with_opts
 
+use crate::GlobalContext;
 use crate::core::compiler::{CompileKind, CompileTarget, RustcTargetData};
 use crate::core::dependency::{ArtifactTarget, DepKind, Dependency};
 use crate::core::resolver::types::FeaturesSet;
 use crate::core::resolver::{Resolve, ResolveBehavior};
-use crate::core::{FeatureValue, PackageId, PackageIdSpec, PackageSet, Workspace};
+use crate::core::{FeatureMap, FeatureValue, PackageId, PackageIdSpec, PackageSet, Workspace};
 use crate::util::CargoResult;
 use crate::util::interning::{INTERNED_DEFAULT, InternedString};
 use anyhow::{Context, bail};
@@ -252,40 +253,79 @@ pub enum RequestedFeatures {
 pub struct CliFeatures {
     /// Features from the `--features` flag.
     pub features: Rc<BTreeSet<FeatureValue>>,
+    /// Features from the `--features` flag that were specified to be removed.
+    pub disabled_features: Rc<BTreeSet<InternedString>>,
     /// The `--all-features` flag.
     pub all_features: bool,
     /// Inverse of `--no-default-features` flag.
     pub uses_default_features: bool,
 }
 
+enum CliFeaturePrefix {
+    Enable,
+    Disable,
+}
+
 impl CliFeatures {
     /// Creates a new `CliFeatures` from the given command-line flags.
     pub fn from_command_line(
+        gctx: &GlobalContext,
         features: &[String],
         all_features: bool,
-        uses_default_features: bool,
+        mut uses_default_features: bool,
     ) -> CargoResult<CliFeatures> {
-        let features = Rc::new(CliFeatures::split_features(features));
-        // Some early validation to ensure correct syntax.
-        for feature in features.iter() {
-            match feature {
-                // Maybe call validate_feature_name here once it is an error?
-                FeatureValue::Feature(_) => {}
-                FeatureValue::Dep { .. } => {
-                    bail!(
-                        "feature `{}` is not allowed to use explicit `dep:` syntax",
-                        feature
-                    );
+        // Process all the features in order, to correctly handle enables/disables
+        // that are cancelled by later flags. We also do some early validation to
+        // ensure correct syntax.
+        let mut enabled_features = BTreeSet::new();
+        let mut disabled_features = BTreeSet::new();
+        for (prefix, feature) in CliFeatures::split_features(gctx, features)? {
+            match prefix {
+                CliFeaturePrefix::Enable => {
+                    match feature {
+                        // Maybe call validate_feature_name here once it is an error?
+                        FeatureValue::Feature(f) => {
+                            disabled_features.remove(&f);
+                            enabled_features.insert(feature);
+                        }
+                        FeatureValue::Dep { .. } => {
+                            bail!(
+                                "feature `{feature}` is not allowed to use explicit `dep:` syntax"
+                            );
+                        }
+                        FeatureValue::DepFeature { dep_feature, .. } => {
+                            if dep_feature.contains('/') {
+                                bail!("multiple slashes in feature `{feature}` is not allowed");
+                            }
+                            enabled_features.insert(feature);
+                        }
+                    }
                 }
-                FeatureValue::DepFeature { dep_feature, .. } => {
-                    if dep_feature.contains('/') {
-                        bail!("multiple slashes in feature `{}` is not allowed", feature);
+                CliFeaturePrefix::Disable => {
+                    match feature {
+                        // Maybe call validate_feature_name here once it is an error?
+                        FeatureValue::Feature(f) => {
+                            if f == INTERNED_DEFAULT {
+                                uses_default_features = false;
+                            }
+                            enabled_features.remove(&feature);
+                            disabled_features.insert(f.clone());
+                        }
+                        FeatureValue::Dep { .. } => {
+                            bail!("`dep:` features are not allowed to be negative (`-{feature}`)");
+                        }
+                        FeatureValue::DepFeature { .. } => {
+                            bail!(
+                                "dependency features are not allowed to be negative (`-{feature}`)"
+                            );
+                        }
                     }
                 }
             }
         }
         Ok(CliFeatures {
-            features,
+            features: Rc::new(enabled_features),
+            disabled_features: Rc::new(disabled_features),
             all_features,
             uses_default_features,
         })
@@ -295,20 +335,88 @@ impl CliFeatures {
     pub fn new_all(all_features: bool) -> CliFeatures {
         CliFeatures {
             features: Rc::new(BTreeSet::new()),
+            disabled_features: Rc::new(BTreeSet::new()),
             all_features,
             uses_default_features: true,
         }
     }
 
-    fn split_features(features: &[String]) -> BTreeSet<FeatureValue> {
+    fn split_features(
+        gctx: &GlobalContext,
+        features: &[String],
+    ) -> CargoResult<Vec<(CliFeaturePrefix, FeatureValue)>> {
         features
             .iter()
             .flat_map(|s| s.split_whitespace())
             .flat_map(|s| s.split(','))
             .filter(|s| !s.is_empty())
-            .map(|s| s.into())
-            .map(FeatureValue::new)
+            .map(|s| {
+                if !gctx.cli_unstable().feature_disabling {
+                    if s.starts_with('-') {
+                        bail!("specifying `-feature`  requires `-Zfeature-disabling`");
+                    } else if s.starts_with('+') {
+                        bail!(
+                            "specifying `+feature` requires `-Zfeature-disabling` (you can omit the `+`)"
+                        );
+                    }
+                }
+
+                let (prefix, s) = match s.strip_prefix('-') {
+                    Some(s) => (CliFeaturePrefix::Disable, s),
+                    None => (CliFeaturePrefix::Enable, s.strip_prefix('+').unwrap_or(s)),
+                };
+                Ok((prefix, FeatureValue::new(s.into())))
+            })
             .collect()
+    }
+
+    /// Resolves the requested CLI features given the feature map of a crate.
+    ///
+    /// Only resolves the directly requested features, including the default and
+    /// all-features flags, does not resolve transitive relationships.
+    pub fn resolve_requested(&self, feature_map: &FeatureMap) -> BTreeSet<FeatureValue> {
+        let mut result = (*self.features).clone();
+
+        // Turn off the "default" feature if one of its directly implied
+        // features has been explicitly turned off, but still add the other
+        // features if uses_default_features is true.
+        let default_feats = feature_map
+            .get(&INTERNED_DEFAULT)
+            .map(|v| v.as_slice())
+            .unwrap_or_default();
+        let non_excluded_default_feats: Vec<&FeatureValue> = default_feats
+            .iter()
+            .filter(|f| match f {
+                FeatureValue::Feature(s) => !self.disabled_features.contains(s),
+                FeatureValue::Dep { .. } | FeatureValue::DepFeature { .. } => true,
+            })
+            .collect();
+        let default_disabled = non_excluded_default_feats.len() != default_feats.len();
+
+        if self.all_features {
+            result.extend(
+                feature_map
+                    .keys()
+                    .filter(|f| {
+                        if **f == INTERNED_DEFAULT {
+                            !default_disabled
+                        } else {
+                            !self.disabled_features.contains(*f)
+                        }
+                    })
+                    .map(|k| FeatureValue::Feature(*k)),
+            );
+        }
+
+        if self.uses_default_features {
+            if default_disabled {
+                result.extend(non_excluded_default_feats.into_iter().cloned());
+            } else if feature_map.contains_key(&INTERNED_DEFAULT) {
+                result.insert(FeatureValue::Feature(INTERNED_DEFAULT));
+            }
+        }
+
+        result
     }
 }
 
@@ -504,6 +612,19 @@ impl<'a, 'gctx> FeatureResolver<'a, 'gctx> {
                 FeaturesFor::default()
             };
             self.activate_pkg(member.package_id(), fk, &fvs)?;
+        }
+
+        // Warn if any disabled feature was enabled transitively.
+        let mut unwarned_disabled_features = (*cli_features.disabled_features).clone();
+        for ((pkg_id, _dep_kind), feats) in self.activated_features.iter() {
+            for feat in feats {
+                if unwarned_disabled_features.remove(feat) {
+                    self.ws.gctx().shell().warn(format!(
+                        "disabled feature `{feat}` was enabled transitively in package `{}`",
+                        pkg_id.name()
+                    ))?;
+                }
+            }
         }
         Ok(())
     }
@@ -757,17 +878,10 @@ impl<'a, 'gctx> FeatureResolver<'a, 'gctx> {
     ) -> Vec<FeatureValue> {
         let summary = self.resolve.summary(pkg_id);
         let feature_map = summary.features();
-
-        let mut result: Vec<FeatureValue> = cli_features.features.iter().cloned().collect();
-        if cli_features.uses_default_features && feature_map.contains_key(&INTERNED_DEFAULT) {
-            result.push(FeatureValue::Feature(INTERNED_DEFAULT));
-        }
-
-        if cli_features.all_features {
-            result.extend(feature_map.keys().map(|k| FeatureValue::Feature(*k)))
-        }
-
-        result
+        cli_features
+            .resolve_requested(feature_map)
+            .into_iter()
+            .collect()
     }
 
     /// Returns the dependencies for a package, filtering out inactive targets.

--- a/src/cargo/core/resolver/features.rs
+++ b/src/cargo/core/resolver/features.rs
@@ -614,13 +614,13 @@ impl<'a, 'gctx> FeatureResolver<'a, 'gctx> {
             self.activate_pkg(member.package_id(), fk, &fvs)?;
         }
 
-        // Warn if any disabled feature was enabled transitively.
+        // Warn if any disabled feature was re-enabled transitively.
         let mut unwarned_disabled_features = (*cli_features.disabled_features).clone();
         for ((pkg_id, _dep_kind), feats) in self.activated_features.iter() {
             for feat in feats {
                 if unwarned_disabled_features.remove(feat) {
                     self.ws.gctx().shell().warn(format!(
-                        "disabled feature `{feat}` was enabled transitively in package `{}`",
+                        "disabled feature `{feat}` was re-enabled transitively in package `{}`",
                         pkg_id.name()
                     ))?;
                 }

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1968,12 +1968,12 @@ impl<'gctx> Workspace<'gctx> {
         if *cli_features.features != found_features {
             self.report_unknown_features_error(specs, &cli_features.features, &found_features)?;
         } else if *cli_features.disabled_features != found_disabled_features {
-            let specified_feats = cli_features
-                .disabled_features
-                .iter()
-                .map(|f| FeatureValue::Feature(f.clone()))
-                .collect();
-            self.report_unknown_features_error(specs, &specified_feats, &found_features)?;
+            let conv = |f: &BTreeSet<InternedString>| {
+                f.iter().map(|f| FeatureValue::Feature(f.clone())).collect()
+            };
+            let specified_disabled = conv(&cli_features.disabled_features);
+            let found_disabled = conv(&found_disabled_features);
+            self.report_unknown_features_error(specs, &specified_disabled, &found_disabled)?;
         }
         Ok(members)
     }

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1585,8 +1585,9 @@ impl<'gctx> Workspace<'gctx> {
         member: &Package,
         cli_features: &CliFeatures,
         found_features: &mut BTreeSet<FeatureValue>,
+        found_disabled_features: &mut BTreeSet<InternedString>,
     ) -> CliFeatures {
-        if cli_features.features.is_empty() {
+        if cli_features.features.is_empty() && cli_features.disabled_features.is_empty() {
             return cli_features.clone();
         }
 
@@ -1652,8 +1653,18 @@ impl<'gctx> Workspace<'gctx> {
                 }
             }
         }
+
+        let mut disabled_features = BTreeSet::new();
+        for feature in cli_features.disabled_features.iter() {
+            if summary_features.contains_key(feature) {
+                disabled_features.insert(feature.clone());
+                found_disabled_features.insert(feature.clone());
+            }
+        }
+
         CliFeatures {
             features: Rc::new(features),
+            disabled_features: Rc::new(disabled_features),
             all_features: cli_features.all_features,
             uses_default_features: cli_features.uses_default_features,
         }
@@ -1662,7 +1673,7 @@ impl<'gctx> Workspace<'gctx> {
     fn missing_feature_spelling_suggestions(
         &self,
         selected_members: &[&Package],
-        cli_features: &CliFeatures,
+        specified_features: &BTreeSet<FeatureValue>,
         found_features: &BTreeSet<FeatureValue>,
     ) -> Vec<String> {
         // Keeps track of which features were contained in summary of `member` to suggest similar features in errors
@@ -1721,8 +1732,7 @@ impl<'gctx> Workspace<'gctx> {
             edit_distance(a.as_str(), b.as_str(), 3).is_some()
         };
 
-        cli_features
-            .features
+        specified_features
             .difference(found_features)
             .map(|feature| match feature {
                 // Simple feature, check if any of the optional dependency features or member features are close enough
@@ -1811,7 +1821,7 @@ impl<'gctx> Workspace<'gctx> {
             .unique()
             .filter(|element| {
                 let feature = FeatureValue::new(element.into());
-                !cli_features.features.contains(&feature) && !found_features.contains(&feature)
+                !specified_features.contains(&feature) && !found_features.contains(&feature)
             })
             .sorted()
             .take(5)
@@ -1821,11 +1831,10 @@ impl<'gctx> Workspace<'gctx> {
     fn report_unknown_features_error(
         &self,
         specs: &[PackageIdSpec],
-        cli_features: &CliFeatures,
+        specified_features: &BTreeSet<FeatureValue>,
         found_features: &BTreeSet<FeatureValue>,
     ) -> CargoResult<()> {
-        let unknown: Vec<_> = cli_features
-            .features
+        let unknown: Vec<_> = specified_features
             .difference(found_features)
             .map(|feature| feature.to_string())
             .sorted()
@@ -1880,7 +1889,7 @@ impl<'gctx> Workspace<'gctx> {
         } else {
             let suggestions = self.missing_feature_spelling_suggestions(
                 &selected_members,
-                cli_features,
+                specified_features,
                 found_features,
             );
             if !suggestions.is_empty() {
@@ -1910,6 +1919,7 @@ impl<'gctx> Workspace<'gctx> {
         // Keeps track of which features matched `member` to produce an error
         // if any of them did not match anywhere.
         let mut found_features = Default::default();
+        let mut found_disabled_features = Default::default();
 
         let members: Vec<(&Package, CliFeatures)> = self
             .members()
@@ -1917,7 +1927,12 @@ impl<'gctx> Workspace<'gctx> {
             .map(|m| {
                 (
                     m,
-                    Workspace::collect_matching_features(m, cli_features, &mut found_features),
+                    Workspace::collect_matching_features(
+                        m,
+                        cli_features,
+                        &mut found_features,
+                        &mut found_disabled_features,
+                    ),
                 )
             })
             .collect();
@@ -1951,7 +1966,14 @@ impl<'gctx> Workspace<'gctx> {
                 .collect());
         }
         if *cli_features.features != found_features {
-            self.report_unknown_features_error(specs, cli_features, &found_features)?;
+            self.report_unknown_features_error(specs, &cli_features.features, &found_features)?;
+        } else if *cli_features.disabled_features != found_disabled_features {
+            let specified_feats = cli_features
+                .disabled_features
+                .iter()
+                .map(|f| FeatureValue::Feature(f.clone()))
+                .collect();
+            self.report_unknown_features_error(specs, &specified_feats, &found_features)?;
         }
         Ok(members)
     }
@@ -2012,6 +2034,7 @@ impl<'gctx> Workspace<'gctx> {
                     Some(current) if member_id == current.package_id() => {
                         let feats = CliFeatures {
                             features: Rc::new(cwd_features.clone()),
+                            disabled_features: cli_features.disabled_features.clone(),
                             all_features: cli_features.all_features,
                             uses_default_features: cli_features.uses_default_features,
                         };
@@ -2035,6 +2058,7 @@ impl<'gctx> Workspace<'gctx> {
                                         .remove(member.name().as_str())
                                         .unwrap_or_default(),
                                 ),
+                                disabled_features: cli_features.disabled_features.clone(),
                                 uses_default_features: true,
                                 all_features: cli_features.all_features,
                             };

--- a/src/cargo/ops/common_for_install_and_uninstall.rs
+++ b/src/cargo/ops/common_for_install_and_uninstall.rs
@@ -22,6 +22,7 @@ use crate::util::GlobalContext;
 use crate::util::cache_lock::CacheLockMode;
 use crate::util::context::{ConfigRelativePath, Definition};
 use crate::util::errors::CargoResult;
+use crate::util::interning::InternedString;
 use crate::util::{FileLock, Filesystem};
 
 /// On-disk tracking for which package installed which binary.
@@ -73,6 +74,7 @@ struct InstallInfo {
     bins: BTreeSet<String>,
     /// Set of features explicitly enabled.
     features: BTreeSet<String>,
+    disabled_features: BTreeSet<String>,
     all_features: bool,
     no_default_features: bool,
     /// Either "debug" or "release".
@@ -457,6 +459,7 @@ impl CrateListingV2 {
             info.bins.append(&mut bins.clone());
             info.version_req = version_req;
             info.features = feature_set(&opts.cli_features.features);
+            info.disabled_features = disabled_feature_set(&opts.cli_features.disabled_features);
             info.all_features = opts.cli_features.all_features;
             info.no_default_features = !opts.cli_features.uses_default_features;
             info.profile = opts.build_config.requested_profile.to_string();
@@ -469,6 +472,7 @@ impl CrateListingV2 {
                     version_req,
                     bins: bins.clone(),
                     features: feature_set(&opts.cli_features.features),
+                    disabled_features: disabled_feature_set(&opts.cli_features.disabled_features),
                     all_features: opts.cli_features.all_features,
                     no_default_features: !opts.cli_features.uses_default_features,
                     profile: opts.build_config.requested_profile.to_string(),
@@ -521,6 +525,7 @@ impl InstallInfo {
             version_req: None,
             bins: set.clone(),
             features: BTreeSet::new(),
+            disabled_features: BTreeSet::new(),
             all_features: false,
             no_default_features: false,
             profile: "release".to_string(),
@@ -535,6 +540,7 @@ impl InstallInfo {
     /// This does not do Package/Source/Version checking.
     fn is_up_to_date(&self, opts: &CompileOptions, target: &str, exes: &BTreeSet<String>) -> bool {
         self.features == feature_set(&opts.cli_features.features)
+            && self.disabled_features == disabled_feature_set(&opts.cli_features.disabled_features)
             && self.all_features == opts.cli_features.all_features
             && self.no_default_features != opts.cli_features.uses_default_features
             && self.profile.as_str() == opts.build_config.requested_profile.as_str()
@@ -779,6 +785,10 @@ where
 /// Helper to convert features to a `BTreeSet`.
 fn feature_set(features: &Rc<BTreeSet<FeatureValue>>) -> BTreeSet<String> {
     features.iter().map(|s| s.to_string()).collect()
+}
+
+fn disabled_feature_set(disabled_features: &Rc<BTreeSet<InternedString>>) -> BTreeSet<String> {
+    disabled_features.iter().map(|s| s.to_string()).collect()
 }
 
 /// Helper to get the executable names from a filter.

--- a/src/cargo/ops/tree/graph.rs
+++ b/src/cargo/ops/tree/graph.rs
@@ -8,6 +8,7 @@ use crate::core::resolver::features::{CliFeatures, FeaturesFor, ResolvedFeatures
 use crate::core::{FeatureMap, FeatureValue, Package, PackageId, PackageIdSpec, Workspace};
 use crate::util::CargoResult;
 use crate::util::interning::{INTERNED_DEFAULT, InternedString};
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Copy, Clone)]
@@ -619,19 +620,14 @@ fn add_cli_features(
     // NOTE: Recursive enabling of features will be handled by
     // add_internal_features.
 
-    // Create a set of feature names requested on the command-line.
-    let mut to_add: HashSet<FeatureValue> = HashSet::new();
-    if cli_features.all_features {
-        to_add.extend(feature_map.keys().map(|feat| FeatureValue::Feature(*feat)));
+    // Ensure default can show up as enabled even if does not exist.
+    let mut feature_map = Cow::Borrowed(feature_map);
+    if !feature_map.contains_key(&INTERNED_DEFAULT) {
+        feature_map.to_mut().insert(INTERNED_DEFAULT, Vec::new());
     }
-
-    if cli_features.uses_default_features {
-        to_add.insert(FeatureValue::Feature(INTERNED_DEFAULT));
-    }
-    to_add.extend(cli_features.features.iter().cloned());
 
     // Add each feature as a node, and mark as "from command-line" in graph.cli_features.
-    for fv in to_add {
+    for fv in cli_features.resolve_requested(&feature_map) {
         match fv {
             FeatureValue::Feature(feature) => {
                 let feature_edge = Edge {

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -282,6 +282,7 @@ pub trait CommandExt: Sized {
             )
             .short('F')
             .help_heading(heading::FEATURE_SELECTION)
+            .allow_hyphen_values(true)
             .add(clap_complete::ArgValueCandidates::new(|| {
                 get_feature_candidates().unwrap_or_default()
             })),
@@ -831,7 +832,7 @@ Run `{cmd}` to see possible targets."
 
         let opts = CompileOptions {
             build_config,
-            cli_features: self.cli_features()?,
+            cli_features: self.cli_features(gctx)?,
             spec,
             filter: CompileFilter::from_raw_arguments(
                 self.flag("lib"),
@@ -867,8 +868,9 @@ Run `{cmd}` to see possible targets."
         Ok(opts)
     }
 
-    fn cli_features(&self) -> CargoResult<CliFeatures> {
+    fn cli_features(&self, gctx: &GlobalContext) -> CargoResult<CliFeatures> {
         CliFeatures::from_command_line(
+            gctx,
             &self._values_of("features"),
             self.flag("all-features"),
             !self.flag("no-default-features"),

--- a/tests/testsuite/cargo/z_help/stdout.term.svg
+++ b/tests/testsuite/cargo/z_help/stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="1255px" height="974px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1255px" height="992px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -50,77 +50,79 @@
 </tspan>
     <tspan x="10px" y="316px"><tspan>    -Z dual-proc-macros            Build proc-macros for both the host and the target</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>    -Z feature-unification         Enable new feature unification modes in workspaces</tspan>
+    <tspan x="10px" y="334px"><tspan>    -Z feature-disabling           Allow specific features to be disabled</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>    -Z fine-grain-locking          Use fine grain locking instead of locking the entire build cache</tspan>
+    <tspan x="10px" y="352px"><tspan>    -Z feature-unification         Enable new feature unification modes in workspaces</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>    -Z fix-edition                 Permanently unstable edition migration helper</tspan>
+    <tspan x="10px" y="370px"><tspan>    -Z fine-grain-locking          Use fine grain locking instead of locking the entire build cache</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>    -Z gc                          Track cache usage and "garbage collect" unused files</tspan>
+    <tspan x="10px" y="388px"><tspan>    -Z fix-edition                 Permanently unstable edition migration helper</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>    -Z git                         Enable support for shallow git fetch operations</tspan>
+    <tspan x="10px" y="406px"><tspan>    -Z gc                          Track cache usage and "garbage collect" unused files</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>    -Z gitoxide                    Use gitoxide for the given git interactions, or all of them if no argument is given</tspan>
+    <tspan x="10px" y="424px"><tspan>    -Z git                         Enable support for shallow git fetch operations</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>    -Z host-config                 Enable the `[host]` section in the .cargo/config.toml file</tspan>
+    <tspan x="10px" y="442px"><tspan>    -Z gitoxide                    Use gitoxide for the given git interactions, or all of them if no argument is given</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>    -Z json-target-spec            Enable `.json` target spec files</tspan>
+    <tspan x="10px" y="460px"><tspan>    -Z host-config                 Enable the `[host]` section in the .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>    -Z minimal-versions            Resolve minimal dependency versions instead of maximum</tspan>
+    <tspan x="10px" y="478px"><tspan>    -Z json-target-spec            Enable `.json` target spec files</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>    -Z msrv-policy                 Enable rust-version aware policy within cargo</tspan>
+    <tspan x="10px" y="496px"><tspan>    -Z minimal-versions            Resolve minimal dependency versions instead of maximum</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>    -Z mtime-on-use                Configure Cargo to update the mtime of used files</tspan>
+    <tspan x="10px" y="514px"><tspan>    -Z msrv-policy                 Enable rust-version aware policy within cargo</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>    -Z no-embed-metadata           Avoid embedding metadata in library artifacts</tspan>
+    <tspan x="10px" y="532px"><tspan>    -Z mtime-on-use                Configure Cargo to update the mtime of used files</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>    -Z no-index-update             Do not update the registry index even if the cache is outdated</tspan>
+    <tspan x="10px" y="550px"><tspan>    -Z no-embed-metadata           Avoid embedding metadata in library artifacts</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>    -Z panic-abort-tests           Enable support to run tests with -Cpanic=abort</tspan>
+    <tspan x="10px" y="568px"><tspan>    -Z no-index-update             Do not update the registry index even if the cache is outdated</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>    -Z panic-immediate-abort       Enable setting `panic = "immediate-abort"` in profiles</tspan>
+    <tspan x="10px" y="586px"><tspan>    -Z panic-abort-tests           Enable support to run tests with -Cpanic=abort</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>    -Z profile-hint-mostly-unused  Enable the `hint-mostly-unused` setting in profiles to mark a crate as mostly unused.</tspan>
+    <tspan x="10px" y="604px"><tspan>    -Z panic-immediate-abort       Enable setting `panic = "immediate-abort"` in profiles</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>    -Z profile-rustflags           Enable the `rustflags` option in profiles in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="622px"><tspan>    -Z profile-hint-mostly-unused  Enable the `hint-mostly-unused` setting in profiles to mark a crate as mostly unused.</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>    -Z public-dependency           Respect a dependency's `public` field in Cargo.toml to control public/private dependencies</tspan>
+    <tspan x="10px" y="640px"><tspan>    -Z profile-rustflags           Enable the `rustflags` option in profiles in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>    -Z publish-timeout             Enable the `publish.timeout` key in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="658px"><tspan>    -Z public-dependency           Respect a dependency's `public` field in Cargo.toml to control public/private dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan>    -Z root-dir                    Set the root directory relative to which paths are printed (defaults to workspace root)</tspan>
+    <tspan x="10px" y="676px"><tspan>    -Z publish-timeout             Enable the `publish.timeout` key in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan>    -Z rustc-unicode               Enable `rustc`'s unicode error format in Cargo's error messages</tspan>
+    <tspan x="10px" y="694px"><tspan>    -Z root-dir                    Set the root directory relative to which paths are printed (defaults to workspace root)</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>    -Z rustdoc-depinfo             Use dep-info files in rustdoc rebuild detection</tspan>
+    <tspan x="10px" y="712px"><tspan>    -Z rustc-unicode               Enable `rustc`'s unicode error format in Cargo's error messages</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>    -Z rustdoc-map                 Allow passing external documentation mappings to rustdoc</tspan>
+    <tspan x="10px" y="730px"><tspan>    -Z rustdoc-depinfo             Use dep-info files in rustdoc rebuild detection</tspan>
 </tspan>
-    <tspan x="10px" y="748px"><tspan>    -Z rustdoc-mergeable-info      Use rustdoc mergeable cross-crate-info files</tspan>
+    <tspan x="10px" y="748px"><tspan>    -Z rustdoc-map                 Allow passing external documentation mappings to rustdoc</tspan>
 </tspan>
-    <tspan x="10px" y="766px"><tspan>    -Z rustdoc-scrape-examples     Allows Rustdoc to scrape code examples from reverse-dependencies</tspan>
+    <tspan x="10px" y="766px"><tspan>    -Z rustdoc-mergeable-info      Use rustdoc mergeable cross-crate-info files</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan>    -Z sbom                        Enable the `sbom` option in build config in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="784px"><tspan>    -Z rustdoc-scrape-examples     Allows Rustdoc to scrape code examples from reverse-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan>    -Z script                      Enable support for single-file, `.rs` packages</tspan>
+    <tspan x="10px" y="802px"><tspan>    -Z sbom                        Enable the `sbom` option in build config in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="820px"><tspan>    -Z section-timings             Enable support for extended compilation sections in --timings output</tspan>
+    <tspan x="10px" y="820px"><tspan>    -Z script                      Enable support for single-file, `.rs` packages</tspan>
 </tspan>
-    <tspan x="10px" y="838px"><tspan>    -Z target-applies-to-host      Enable the `target-applies-to-host` key in the .cargo/config.toml file</tspan>
+    <tspan x="10px" y="838px"><tspan>    -Z section-timings             Enable support for extended compilation sections in --timings output</tspan>
 </tspan>
-    <tspan x="10px" y="856px"><tspan>    -Z trim-paths                  Enable the `trim-paths` option in profiles</tspan>
+    <tspan x="10px" y="856px"><tspan>    -Z target-applies-to-host      Enable the `target-applies-to-host` key in the .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="874px"><tspan>    -Z unstable-options            Allow the usage of unstable options</tspan>
+    <tspan x="10px" y="874px"><tspan>    -Z trim-paths                  Enable the `trim-paths` option in profiles</tspan>
 </tspan>
-    <tspan x="10px" y="892px">
+    <tspan x="10px" y="892px"><tspan>    -Z unstable-options            Allow the usage of unstable options</tspan>
 </tspan>
-    <tspan x="10px" y="910px"><tspan>Run with `cargo -Z [FLAG] [COMMAND]`</tspan>
+    <tspan x="10px" y="910px">
 </tspan>
-    <tspan x="10px" y="928px">
+    <tspan x="10px" y="928px"><tspan>Run with `cargo -Z [FLAG] [COMMAND]`</tspan>
 </tspan>
-    <tspan x="10px" y="946px"><tspan>See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html for more information about these flags.</tspan>
+    <tspan x="10px" y="946px">
 </tspan>
-    <tspan x="10px" y="964px">
+    <tspan x="10px" y="964px"><tspan>See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html for more information about these flags.</tspan>
+</tspan>
+    <tspan x="10px" y="982px">
 </tspan>
   </text>
 

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -2509,7 +2509,7 @@ fn test_feature_disable() {
         .with_stderr_data(str![[r#"
 [WARNING] disabled feature `z` was re-enabled transitively in package `foo`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `target/debug/foo`
+[RUNNING] `target/debug/foo[EXE]`
 
 "#]])
         .run();

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -2507,7 +2507,7 @@ fn test_feature_disable() {
     p.cargo("run --no-default-features --features a,c,y,-z -Zfeature-disabling")
         .masquerade_as_nightly_cargo(&["feature-disabling"])
         .with_stderr_data(str![[r#"
-[WARNING] disabled feature `z` was enabled transitively in package `foo`
+[WARNING] disabled feature `z` was re-enabled transitively in package `foo`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `target/debug/foo`
 

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -2457,3 +2457,60 @@ required-features = ["feat"]
     p.cargo(&format!("check --target={host} --examples --frozen"))
         .run();
 }
+
+#[cargo_test]
+fn test_feature_disable() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2018"
+
+                [features]
+                default = ["a", "b", "c"]
+                a = []
+                b = []
+                c = []
+                x = []
+                y = ["z"]
+                z = []
+            "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+                fn main() {
+                    assert!(!cfg!(feature = "default"));
+                    assert!(cfg!(feature = "a"));
+                    assert!(!cfg!(feature = "b"));
+                    assert!(cfg!(feature = "c"));
+                    assert!(!cfg!(feature = "x"));
+                    assert!(cfg!(feature = "y"));
+                    assert!(cfg!(feature = "z"));
+                }
+            "#,
+        )
+        .build();
+
+    p.cargo("run --features -b,x,y,z --features -x -Zfeature-disabling")
+        .masquerade_as_nightly_cargo(&["feature-disabling"])
+        .run();
+    p.cargo("run --all-features --features -b,-x -Zfeature-disabling")
+        .masquerade_as_nightly_cargo(&["feature-disabling"])
+        .run();
+    p.cargo("run --features +a,+c,+y,-default -Zfeature-disabling")
+        .masquerade_as_nightly_cargo(&["feature-disabling"])
+        .run();
+    p.cargo("run --no-default-features --features a,c,y,-z -Zfeature-disabling")
+        .masquerade_as_nightly_cargo(&["feature-disabling"])
+        .with_stderr_data(str![[r#"
+[WARNING] disabled feature `z` was enabled transitively in package `foo`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[RUNNING] `target/debug/foo`
+
+"#]])
+        .run();
+}


### PR DESCRIPTION
Helps address the problems in https://github.com/rust-lang/cargo/issues/3126. Also solves the closed issue https://github.com/rust-lang/cargo/issues/11467.


This PR implements `-Zfeature-disabling`. When this flag is set the `--features` flag to `cargo` is extended with the following functionality:

 - Features may now be specified with a leading `+`. This is purely cosmetic and optional.
 - Features may now be requested to be *disabled* when written as `-feature`.


When a feature is *disabled* it:

1. is removed from the default features list,
2. is excluded from `--all-features`,
3. undoes any previous manual enabling of that feature.

Enabling/disabling features is order sensitive, so `--features -x --features x` would end up ultimately enabling `x`, whereas `--features x --features -x` would end up disabling `x`. This only applies to `--features`, the flags `--all-features` and `--no-default-features` are simple binary toggles, regardless of where they're specified.

For simplicity I've only implemented the above functionality with basic features. `crate/feature` and `dep:feature` style features can currently not be disabled.

---

Note that disabling a feature only modifies the "initial requested set of features". Feature unification / dependency resolving might turn it back on regardless. If this occurs a warning is emitted:

```toml
[features]
foo = ["bar"]
bar = []
```

```
$ cargo run --features +foo,-bar
warning: disabled feature `bar` was re-enabled transitively in package `my-package`
```

Some more clarification surrounding `default` is also necessary. If the `default` feature of a package is enabled but a disabled feature occurs in its list, the `default` feature is disabled and any non-disabled features in its list are added back explicitly. This is necessary, because otherwise we would be unable to disable default features - feature resolving would immediately turn it back on while giving the above warning.
