### PR TITLE
fix: suggest 'fmt' when user types 'cargo rustfmt'

### DIFF
--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -293,7 +293,11 @@ fn execute_external_subcommand(gctx: &GlobalContext, cmd: &str, args: &[&OsStr])
                 )
             } else {
                 let suggestions = list_commands(gctx);
-                let did_you_mean = closest_msg(cmd, suggestions.keys(), |c| c, "command");
+                let did_you_mean = if cmd == "rustfmt" {
+                    "\n\nhelp: a command with a similar name exists: `fmt`".to_string()
+                } else {
+                    closest_msg(cmd, suggestions.keys(), |c| c, "command")
+                };
 
                 anyhow::format_err!(
                     "no such command: `{cmd}`{did_you_mean}\n\n\

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -219,7 +219,7 @@ fn cargo_rustfmt_suggestion() {
         .with_stderr_data(str![[r#"
 [ERROR] no such command: `rustfmt`
 
-[HELP] a command with a similar name exists: `rustc`
+[HELP] a command with a similar name exists: `fmt`
 
 [HELP] view all installed commands with `cargo --list`
 [HELP] find a package to install `rustfmt` with `cargo search cargo-rustfmt`

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -213,6 +213,22 @@ fn find_closest_capital_b_to_b() {
 }
 
 #[cargo_test]
+fn cargo_rustfmt_suggestion() {
+    cargo_process("rustfmt")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] no such command: `rustfmt`
+
+[HELP] a command with a similar name exists: `rustc`
+
+[HELP] view all installed commands with `cargo --list`
+[HELP] find a package to install `rustfmt` with `cargo search cargo-rustfmt`
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn find_closest_biuld_to_build() {
     cargo_process("biuld")
         .with_status(101)


### PR DESCRIPTION
Adds a direct suggestion for `fmt` when a user accidentally types `cargo rustfmt`. This bypasses the default edit-distance calculation which incorrectly suggested `rustc`.

Fixes #12887 