### PR TITLE
Emit build plan in JSON message output

### DIFF
--- a/src/cargo/core/compiler/unit_graph.rs
+++ b/src/cargo/core/compiler/unit_graph.rs
@@ -12,6 +12,7 @@ use crate::core::dependency::Dependency;
 use crate::core::profiles::{Profile, UnitFor};
 use crate::util::CargoResult;
 use crate::util::Unhashed;
+use crate::util::machine_message::Message as _;
 use crate::util::interning::InternedString;
 use std::collections::HashMap;
 
@@ -60,6 +61,19 @@ struct SerializedUnitGraph<'a> {
 }
 
 #[derive(serde::Serialize)]
+struct SerializedBuildPlan<'a> {
+    unit_count: usize,
+    #[serde(flatten)]
+    graph: SerializedUnitGraph<'a>,
+}
+
+impl<'a> crate::util::machine_message::Message for SerializedBuildPlan<'a> {
+    fn reason(&self) -> &str {
+        "build-plan"
+    }
+}
+
+#[derive(serde::Serialize)]
 struct SerializedUnit<'a> {
     pkg_id: PackageIdSpec,
     target: &'a Target,
@@ -96,6 +110,31 @@ pub fn emit_serialized_unit_graph(
     unit_graph: &UnitGraph,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
+    gctx.shell()
+        .print_json(&serialized_unit_graph(root_units, unit_graph, gctx))
+}
+
+/// Emits the resolved build plan as a line-delimited JSON machine message.
+pub fn emit_build_plan_message(
+    root_units: &[Unit],
+    unit_graph: &UnitGraph,
+    gctx: &GlobalContext,
+) -> CargoResult<()> {
+    let graph = serialized_unit_graph(root_units, unit_graph, gctx);
+    let msg = SerializedBuildPlan {
+        unit_count: graph.units.len(),
+        graph,
+    };
+    let mut shell = gctx.shell();
+    writeln!(shell.out(), "{}", msg.to_json_string())?;
+    Ok(())
+}
+
+fn serialized_unit_graph<'a>(
+    root_units: &'a [Unit],
+    unit_graph: &'a UnitGraph,
+    gctx: &GlobalContext,
+) -> SerializedUnitGraph<'a> {
     let mut units: Vec<(&Unit, &Vec<UnitDep>)> = unit_graph.iter().collect();
     units.sort_unstable();
     // Create a map for quick lookup for dependencies.
@@ -143,9 +182,9 @@ pub fn emit_serialized_unit_graph(
         })
         .collect();
 
-    gctx.shell().print_json(&SerializedUnitGraph {
+    SerializedUnitGraph {
         version: VERSION,
         units: ser_units,
         roots,
-    })
+    }
 }

--- a/src/cargo/ops/cargo_compile/mod.rs
+++ b/src/cargo/ops/cargo_compile/mod.rs
@@ -189,6 +189,9 @@ pub fn compile_ws<'a>(
         unit_graph::emit_serialized_unit_graph(&bcx.roots, &bcx.unit_graph, ws.gctx())?;
         return Compilation::new(&bcx);
     }
+    if options.build_config.emit_json() {
+        unit_graph::emit_build_plan_message(&bcx.roots, &bcx.unit_graph, ws.gctx())?;
+    }
     crate::core::gc::auto_gc(bcx.gctx);
     let build_runner = BuildRunner::new(&bcx)?;
     if options.build_config.dry_run {

--- a/src/doc/src/reference/external-tools.md
+++ b/src/doc/src/reference/external-tools.md
@@ -40,8 +40,14 @@ information during the build:
 
 * results of the build scripts (for example, native dependencies).
 
+Cargo also emits a `build-plan` message before compilation starts. This message
+contains Cargo's resolved unit graph and a `unit_count` value matching the build
+progress denominator.
+
 The output goes to stdout in the JSON object per line format. The `reason` field
 distinguishes different kinds of messages.
+Consumers should ignore message reasons they do not recognize so Cargo can add
+new message kinds over time.
 The `package_id` field is a unique identifier for referring to the package, and
 as the `--package` argument to many commands. The syntax grammar can be found in
 chapter [Package ID Specifications].

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1879,6 +1879,10 @@ fn doc_message_format() {
             str![[r##"
 [
   {
+    "reason": "build-plan",
+    "...": "{...}"
+  },
+  {
     "manifest_path": "[ROOT]/foo/Cargo.toml",
     "message": {
       "$message_type": "diagnostic",

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -127,6 +127,10 @@ fn simple_with_message_format() {
             str![[r#"
 [
   {
+    "reason": "build-plan",
+    "...": "{...}"
+  },
+  {
     "executable": null,
     "features": [],
     "filenames": "{...}",

--- a/tests/testsuite/message_format.rs
+++ b/tests/testsuite/message_format.rs
@@ -47,6 +47,48 @@ fn double_json_works() {
 }
 
 #[cargo_test]
+fn json_emits_build_plan_before_work() {
+    let p = project()
+        .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("check --message-format json")
+        .with_stdout_data(
+            str![[r#"
+[
+  {
+    "reason": "build-plan",
+    "roots": [
+      0
+    ],
+    "unit_count": 1,
+    "units": [
+      {
+        "mode": "check",
+        "pkg_id": "path+[ROOTURL]/foo#0.1.0",
+        "...": "{...}"
+      }
+    ],
+    "version": 1
+  },
+  {
+    "reason": "compiler-artifact",
+    "...": "{...}"
+  },
+  {
+    "reason": "build-finished",
+    "success": true
+  }
+]
+"#]]
+            .is_json()
+            .against_jsonlines(),
+        )
+        .run();
+}
+
+#[cargo_test]
 fn cargo_renders() {
     let p = project()
         .file(
@@ -70,6 +112,10 @@ fn cargo_renders() {
         .with_stdout_data(
             str![[r#"
 [
+  {
+    "reason": "build-plan",
+    "...": "{...}"
+  },
   {
     "reason": "compiler-artifact",
     "...": "{...}"


### PR DESCRIPTION
### What changed

This adds a new line-delimited JSON message with `"reason": "build-plan"` when Cargo is invoked with JSON message output. The message is emitted after the build context is resolved and before compilation begins, and includes the resolved unit graph plus a `unit_count` field matching Cargo's build progress denominator.

### Why

External tools can already consume compiler artifacts and build-script output from `--message-format=json`, but they cannot know the build plan or progress denominator until work is already underway. Emitting the resolved plan lets build monitors, IDEs, job routers, and CI frontends initialize their own progress/state model without scraping human stderr progress output.

### Prototype consumer

The motivating consumer is rheo, a job-router daemon that uses Cargo's build plan to announce job topology and progress to display clients before rustc work begins:

https://github.com/holo-q/rheo

### Notes

Consumers should ignore unknown `reason` values so Cargo can add new message kinds over time.

### Tests

Not run locally; patch includes testsuite coverage for the new JSON message ordering and docs updates.
