### PR TITLE
fix(clean): respect `build.target` config for `clean -p`

### DIFF
--- a/src/cargo/core/compiler/compile_kind.rs
+++ b/src/cargo/core/compiler/compile_kind.rs
@@ -91,7 +91,6 @@ impl CompileKind {
                 .map(|value| {
                     // This neatly substitutes the manually-specified `host-tuple` target directive
                     // with the compiling machine's target triple.
-
                     if value.as_str() == "host-tuple" {
                         let host_triple = env!("RUST_HOST_TARGET");
                         Ok(CompileKind::Target(CompileTarget::new(

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -203,7 +203,7 @@ fn clean_specs(
         .collect::<CargoResult<_>>()?;
     // A Vec of layouts. This is a little convoluted because there can only be
     // one host_layout.
-    let layouts = if targets.is_empty() {
+    let layouts = if target_layouts.is_empty() {
         vec![(CompileKind::Host, &host_layout)]
     } else {
         target_layouts

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -723,15 +723,15 @@ fn clean_p_respects_build_target_config() {
         .build();
 
     p.cargo("build").run();
-    // FIXME: should match target-specific artifacts, but currently reports 0 files
-    // because `build.target` config is ignored by `clean -p`.
     p.cargo("clean -p foo --dry-run")
         .with_stderr_data(str![[r#"
-[SUMMARY] 0 files
+[SUMMARY] [FILE_NUM] files, [FILE_SIZE]B total
 [WARNING] no files deleted due to --dry-run
 
 "#]])
         .run();
+    p.cargo("clean -p foo").run();
+    assert_all_clean(&p.build_dir().join(rustc_host()));
 }
 
 // Ensures that all files for the package have been deleted.

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -711,6 +711,29 @@ fn package_cleans_all_the_things() {
     assert_all_clean(&p.build_dir());
 }
 
+#[cargo_test]
+fn clean_p_respects_build_target_config() {
+    let p = project()
+        .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
+        .file("src/lib.rs", "")
+        .file(
+            ".cargo/config.toml",
+            &format!("[build]\ntarget = \"{}\"", rustc_host()),
+        )
+        .build();
+
+    p.cargo("build").run();
+    // FIXME: should match target-specific artifacts, but currently reports 0 files
+    // because `build.target` config is ignored by `clean -p`.
+    p.cargo("clean -p foo --dry-run")
+        .with_stderr_data(str![[r#"
+[SUMMARY] 0 files
+[WARNING] no files deleted due to --dry-run
+
+"#]])
+        .run();
+}
+
 // Ensures that all files for the package have been deleted.
 #[track_caller]
 fn assert_all_clean(build_dir: &Path) {


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes #16974.

`cargo clean -p` ignored `build.target` config. `clean_specs` resolves `requested_kinds` with the config fallback, but the layout selection rechecked the raw CLI `targets` vec instead. Switched to checking `target_layouts.is_empty()`.

### How should we test and review this PR?

Two commits: a test capturing the buggy `Summary 0 files` output, then a one-line fix that flips the test expectation.