### PR TITLE
fix(diag): Report deferred diagnostics like other diagnostics

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1330,6 +1330,8 @@ impl<'gctx> Workspace<'gctx> {
     }
 
     pub fn emit_parse_pkg_diagnostics(&self, pkg: &Package, path: &Path) -> CargoResult<()> {
+        let mut stats = DiagnosticStats::new();
+
         let toml_lints = pkg
             .manifest()
             .normalized_toml()
@@ -1343,8 +1345,6 @@ impl<'gctx> Workspace<'gctx> {
             .unwrap_or(manifest::TomlToolLints::default());
 
         if self.gctx.cli_unstable().cargo_lints {
-            let mut stats = DiagnosticStats::new();
-
             missing_lints_features(pkg.into(), &path, &cargo_lints, &mut stats, self.gctx)?;
             unknown_lints(pkg.into(), &path, &cargo_lints, &mut stats, self.gctx)?;
 
@@ -1373,9 +1373,9 @@ impl<'gctx> Workspace<'gctx> {
                 &mut stats,
                 self.gctx,
             )?;
-
-            stats.report_summary("parse", Some(&*pkg.name()), self.gctx)?;
         }
+
+        stats.report_summary("parse", Some(&*pkg.name()), self.gctx)?;
 
         Ok(())
     }

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1300,7 +1300,6 @@ impl<'gctx> Workspace<'gctx> {
         if let Err(err) = deferred_parse_diagnostics(
             (self, self.root_maybe()).into(),
             self.root_manifest(),
-            self.root_manifest.is_some(),
             self.gctx,
         ) {
             if first_emitted_error.is_none() {
@@ -1315,12 +1314,7 @@ impl<'gctx> Workspace<'gctx> {
                 {
                     first_emitted_error = Some(e);
                 }
-                if let Err(err) = deferred_parse_diagnostics(
-                    pkg.into(),
-                    path,
-                    self.root_manifest.is_some(),
-                    self.gctx,
-                ) {
+                if let Err(err) = deferred_parse_diagnostics(pkg.into(), path, self.gctx) {
                     if first_emitted_error.is_none() {
                         first_emitted_error = Some(err);
                     }

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1291,10 +1291,10 @@ impl<'gctx> Workspace<'gctx> {
         }
     }
 
-    pub fn emit_warnings(&self) -> CargoResult<()> {
+    pub fn emit_parse_diagnostics(&self) -> CargoResult<()> {
         let mut first_emitted_error = None;
 
-        if let Err(e) = self.emit_ws_lints() {
+        if let Err(e) = self.emit_parse_ws_diagnostics() {
             first_emitted_error = Some(e);
         }
         if let Err(err) = deferred_parse_diagnostics(
@@ -1309,7 +1309,7 @@ impl<'gctx> Workspace<'gctx> {
 
         for (path, maybe_pkg) in &self.packages.packages {
             if let MaybePackage::Package(pkg) = maybe_pkg {
-                if let Err(e) = self.emit_pkg_lints(pkg, &path)
+                if let Err(e) = self.emit_parse_pkg_diagnostics(pkg, &path)
                     && first_emitted_error.is_none()
                 {
                     first_emitted_error = Some(e);
@@ -1329,7 +1329,7 @@ impl<'gctx> Workspace<'gctx> {
         }
     }
 
-    pub fn emit_pkg_lints(&self, pkg: &Package, path: &Path) -> CargoResult<()> {
+    pub fn emit_parse_pkg_diagnostics(&self, pkg: &Package, path: &Path) -> CargoResult<()> {
         let toml_lints = pkg
             .manifest()
             .normalized_toml()
@@ -1380,7 +1380,7 @@ impl<'gctx> Workspace<'gctx> {
         Ok(())
     }
 
-    pub fn emit_ws_lints(&self) -> CargoResult<()> {
+    pub fn emit_parse_ws_diagnostics(&self) -> CargoResult<()> {
         let mut stats = DiagnosticStats::new();
 
         let cargo_lints = match self.root_maybe() {

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1297,15 +1297,6 @@ impl<'gctx> Workspace<'gctx> {
         if let Err(e) = self.emit_parse_ws_diagnostics() {
             first_emitted_error = Some(e);
         }
-        if let Err(err) = deferred_parse_diagnostics(
-            (self, self.root_maybe()).into(),
-            self.root_manifest(),
-            self.gctx,
-        ) {
-            if first_emitted_error.is_none() {
-                first_emitted_error = Some(err);
-            }
-        }
 
         for (path, maybe_pkg) in &self.packages.packages {
             if let MaybePackage::Package(pkg) = maybe_pkg {
@@ -1313,11 +1304,6 @@ impl<'gctx> Workspace<'gctx> {
                     && first_emitted_error.is_none()
                 {
                     first_emitted_error = Some(e);
-                }
-                if let Err(err) = deferred_parse_diagnostics(pkg.into(), path, self.gctx) {
-                    if first_emitted_error.is_none() {
-                        first_emitted_error = Some(err);
-                    }
                 }
             }
         }
@@ -1331,6 +1317,8 @@ impl<'gctx> Workspace<'gctx> {
 
     pub fn emit_parse_pkg_diagnostics(&self, pkg: &Package, path: &Path) -> CargoResult<()> {
         let mut stats = DiagnosticStats::new();
+
+        deferred_parse_diagnostics(pkg.into(), path, &mut stats, self.gctx)?;
 
         let toml_lints = pkg
             .manifest()
@@ -1382,6 +1370,13 @@ impl<'gctx> Workspace<'gctx> {
 
     pub fn emit_parse_ws_diagnostics(&self) -> CargoResult<()> {
         let mut stats = DiagnosticStats::new();
+
+        deferred_parse_diagnostics(
+            (self, self.root_maybe()).into(),
+            self.root_manifest(),
+            &mut stats,
+            self.gctx,
+        )?;
 
         let cargo_lints = match self.root_maybe() {
             MaybePackage::Package(pkg) => {

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -24,6 +24,7 @@ use crate::core::{EitherManifest, Package, SourceId, VirtualManifest};
 use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::rules::blanket_hint_mostly_unused;
 use crate::diagnostics::rules::check_im_a_teapot;
+use crate::diagnostics::rules::deferred_parse_diagnostics;
 use crate::diagnostics::rules::implicit_minimum_version_req_pkg;
 use crate::diagnostics::rules::implicit_minimum_version_req_ws;
 use crate::diagnostics::rules::missing_lints_features;
@@ -1296,6 +1297,16 @@ impl<'gctx> Workspace<'gctx> {
         if let Err(e) = self.emit_ws_lints() {
             first_emitted_error = Some(e);
         }
+        if let Err(err) = deferred_parse_diagnostics(
+            (self, self.root_maybe()).into(),
+            self.root_manifest(),
+            self.root_manifest.is_some(),
+            self.gctx,
+        ) {
+            if first_emitted_error.is_none() {
+                first_emitted_error = Some(err);
+            }
+        }
 
         for (path, maybe_pkg) in &self.packages.packages {
             if let MaybePackage::Package(pkg) = maybe_pkg {
@@ -1304,28 +1315,15 @@ impl<'gctx> Workspace<'gctx> {
                 {
                     first_emitted_error = Some(e);
                 }
-            }
-            let warnings = match maybe_pkg {
-                MaybePackage::Package(pkg) => pkg.manifest().warnings().warnings(),
-                MaybePackage::Virtual(vm) => vm.warnings().warnings(),
-            };
-            for warning in warnings {
-                if warning.is_critical {
-                    let err = anyhow::format_err!("{}", warning.message);
-                    let cx =
-                        anyhow::format_err!("failed to parse manifest at `{}`", path.display());
+                if let Err(err) = deferred_parse_diagnostics(
+                    pkg.into(),
+                    path,
+                    self.root_manifest.is_some(),
+                    self.gctx,
+                ) {
                     if first_emitted_error.is_none() {
-                        first_emitted_error = Some(err.context(cx));
+                        first_emitted_error = Some(err);
                     }
-                } else {
-                    let msg = if self.root_manifest.is_none() {
-                        warning.message.to_string()
-                    } else {
-                        // In a workspace, it can be confusing where a warning
-                        // originated, so include the path.
-                        format!("{}: {}", path.display(), warning.message)
-                    };
-                    self.gctx.shell().warn(msg)?
                 }
             }
         }

--- a/src/cargo/diagnostics/rules/deferred_parse_diagnostics.rs
+++ b/src/cargo/diagnostics/rules/deferred_parse_diagnostics.rs
@@ -6,6 +6,7 @@ use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::MaybePackage;
 use crate::diagnostics::ManifestFor;
+use crate::diagnostics::rel_cwd_manifest_path;
 
 #[instrument(skip_all)]
 pub fn deferred_parse_diagnostics(
@@ -28,14 +29,14 @@ pub fn deferred_parse_diagnostics(
         }
     };
 
+    let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
     for warning in warnings {
         if warning.is_critical {
             let err = anyhow::format_err!("{}", warning.message);
-            let cx =
-                anyhow::format_err!("failed to parse manifest at `{}`", manifest_path.display());
+            let cx = anyhow::format_err!("failed to parse manifest at `{manifest_path}`");
             return Err(err.context(cx));
         } else {
-            let msg = format!("{}: {}", manifest_path.display(), warning.message);
+            let msg = format!("{manifest_path}: {}", warning.message);
 
             gctx.shell().warn(msg)?
         }

--- a/src/cargo/diagnostics/rules/deferred_parse_diagnostics.rs
+++ b/src/cargo/diagnostics/rules/deferred_parse_diagnostics.rs
@@ -11,7 +11,6 @@ use crate::diagnostics::ManifestFor;
 pub fn deferred_parse_diagnostics(
     manifest: ManifestFor<'_>,
     manifest_path: &Path,
-    is_workspace: bool,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let warnings = match &manifest {
@@ -36,13 +35,7 @@ pub fn deferred_parse_diagnostics(
                 anyhow::format_err!("failed to parse manifest at `{}`", manifest_path.display());
             return Err(err.context(cx));
         } else {
-            let msg = if !is_workspace {
-                warning.message.to_string()
-            } else {
-                // In a workspace, it can be confusing where a warning
-                // originated, so include the path.
-                format!("{}: {}", manifest_path.display(), warning.message)
-            };
+            let msg = format!("{}: {}", manifest_path.display(), warning.message);
 
             gctx.shell().warn(msg)?
         }

--- a/src/cargo/diagnostics/rules/deferred_parse_diagnostics.rs
+++ b/src/cargo/diagnostics/rules/deferred_parse_diagnostics.rs
@@ -5,6 +5,7 @@ use tracing::instrument;
 use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::MaybePackage;
+use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::ManifestFor;
 use crate::diagnostics::rel_cwd_manifest_path;
 
@@ -12,6 +13,7 @@ use crate::diagnostics::rel_cwd_manifest_path;
 pub fn deferred_parse_diagnostics(
     manifest: ManifestFor<'_>,
     manifest_path: &Path,
+    stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let warnings = match &manifest {
@@ -31,13 +33,12 @@ pub fn deferred_parse_diagnostics(
 
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
     for warning in warnings {
+        let msg = format!("{manifest_path}: {}", warning.message);
         if warning.is_critical {
-            let err = anyhow::format_err!("{}", warning.message);
-            let cx = anyhow::format_err!("failed to parse manifest at `{manifest_path}`");
-            return Err(err.context(cx));
+            stats.record_error();
+            gctx.shell().error(msg)?
         } else {
-            let msg = format!("{manifest_path}: {}", warning.message);
-
+            stats.record_warning();
             gctx.shell().warn(msg)?
         }
     }

--- a/src/cargo/diagnostics/rules/deferred_parse_diagnostics.rs
+++ b/src/cargo/diagnostics/rules/deferred_parse_diagnostics.rs
@@ -1,0 +1,52 @@
+use std::path::Path;
+
+use tracing::instrument;
+
+use crate::CargoResult;
+use crate::GlobalContext;
+use crate::core::MaybePackage;
+use crate::diagnostics::ManifestFor;
+
+#[instrument(skip_all)]
+pub fn deferred_parse_diagnostics(
+    manifest: ManifestFor<'_>,
+    manifest_path: &Path,
+    is_workspace: bool,
+    gctx: &GlobalContext,
+) -> CargoResult<()> {
+    let warnings = match &manifest {
+        ManifestFor::Package(pkg) => pkg.manifest().warnings().warnings(),
+        ManifestFor::Workspace {
+            maybe_pkg: MaybePackage::Virtual(vm),
+            ..
+        } => vm.warnings().warnings(),
+        ManifestFor::Workspace {
+            maybe_pkg: MaybePackage::Package(_),
+            ..
+        } => {
+            // For real manifests, lint as a package, rather than a workspace
+            return Ok(());
+        }
+    };
+
+    for warning in warnings {
+        if warning.is_critical {
+            let err = anyhow::format_err!("{}", warning.message);
+            let cx =
+                anyhow::format_err!("failed to parse manifest at `{}`", manifest_path.display());
+            return Err(err.context(cx));
+        } else {
+            let msg = if !is_workspace {
+                warning.message.to_string()
+            } else {
+                // In a workspace, it can be confusing where a warning
+                // originated, so include the path.
+                format!("{}: {}", manifest_path.display(), warning.message)
+            };
+
+            gctx.shell().warn(msg)?
+        }
+    }
+
+    Ok(())
+}

--- a/src/cargo/diagnostics/rules/mod.rs
+++ b/src/cargo/diagnostics/rules/mod.rs
@@ -1,4 +1,5 @@
 mod blanket_hint_mostly_unused;
+mod deferred_parse_diagnostics;
 mod im_a_teapot;
 mod implicit_minimum_version_req;
 mod missing_lints_features;
@@ -18,6 +19,7 @@ mod unused_workspace_dependencies;
 mod unused_workspace_package_fields;
 
 pub use blanket_hint_mostly_unused::blanket_hint_mostly_unused;
+pub use deferred_parse_diagnostics::deferred_parse_diagnostics;
 pub use im_a_teapot::check_im_a_teapot;
 pub use implicit_minimum_version_req::implicit_minimum_version_req_pkg;
 pub use implicit_minimum_version_req::implicit_minimum_version_req_ws;

--- a/src/cargo/ops/cargo_compile/mod.rs
+++ b/src/cargo/ops/cargo_compile/mod.rs
@@ -143,7 +143,7 @@ pub fn compile_with_exec<'a>(
     options: &CompileOptions,
     exec: &Arc<dyn Executor>,
 ) -> CargoResult<Compilation<'a>> {
-    ws.emit_warnings()?;
+    ws.emit_parse_diagnostics()?;
     let compilation = compile_ws(ws, options, exec)?;
     if ws.gctx().warning_handling()? == WarningHandling::Deny && compilation.lint_warning_count > 0
     {

--- a/src/cargo/ops/cargo_fetch.rs
+++ b/src/cargo/ops/cargo_fetch.rs
@@ -20,7 +20,7 @@ pub fn fetch<'a>(
     ws: &Workspace<'a>,
     options: &FetchOptions<'a>,
 ) -> CargoResult<(Resolve, PackageSet<'a>)> {
-    ws.emit_warnings()?;
+    ws.emit_parse_diagnostics()?;
     let dry_run = false;
     let (mut packages, resolve) = ops::resolve_ws(ws, dry_run)?;
 

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -850,43 +850,43 @@ quiet = false
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] unused manifest key: alias
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: alias
 [HELP] alias is a valid .cargo/config.toml key
-[WARNING] unused manifest key: build
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: build
 [HELP] build is a valid .cargo/config.toml key
-[WARNING] unused manifest key: cache
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: cache
 [HELP] cache is a valid .cargo/config.toml key
-[WARNING] unused manifest key: cargo-new
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: cargo-new
 [HELP] cargo-new is a valid .cargo/config.toml key
-[WARNING] unused manifest key: credential-alias
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: credential-alias
 [HELP] credential-alias is a valid .cargo/config.toml key
-[WARNING] unused manifest key: doc
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: doc
 [HELP] doc is a valid .cargo/config.toml key
-[WARNING] unused manifest key: env
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: env
 [HELP] env is a valid .cargo/config.toml key
-[WARNING] unused manifest key: future-incompat-report
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: future-incompat-report
 [HELP] future-incompat-report is a valid .cargo/config.toml key
-[WARNING] unused manifest key: http
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: http
 [HELP] http is a valid .cargo/config.toml key
-[WARNING] unused manifest key: install
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: install
 [HELP] install is a valid .cargo/config.toml key
-[WARNING] unused manifest key: lib.build
-[WARNING] unused manifest key: net
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: lib.build
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: net
 [HELP] net is a valid .cargo/config.toml key
-[WARNING] unused manifest key: package.unused
-[WARNING] unused manifest key: paths
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: package.unused
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: paths
 [HELP] paths is a valid .cargo/config.toml key
-[WARNING] unused manifest key: registries
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: registries
 [HELP] registries is a valid .cargo/config.toml key
-[WARNING] unused manifest key: registry
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: registry
 [HELP] registry is a valid .cargo/config.toml key
-[WARNING] unused manifest key: resolver
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: resolver
 [HELP] resolver is a valid .cargo/config.toml key
-[WARNING] unused manifest key: source
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: source
 [HELP] source is a valid .cargo/config.toml key
-[WARNING] unused manifest key: target.cfg(unix).linker
-[WARNING] unused manifest key: target.foo.bar
-[WARNING] unused manifest key: term
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: target.cfg(unix).linker
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: target.foo.bar
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: term
 [HELP] term is a valid .cargo/config.toml key
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -980,7 +980,7 @@ fn dev_dependencies2() {
         .file("a/src/lib.rs", "")
         .build();
     p.cargo("check").with_stderr_data(str![[r#"
-[WARNING] `dev_dependencies` is deprecated in favor of `dev-dependencies` and will not work in the 2024 edition
+[WARNING] [ROOT]/foo/Cargo.toml: `dev_dependencies` is deprecated in favor of `dev-dependencies` and will not work in the 2024 edition
 (in the `foo` package)
 [LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
@@ -1059,7 +1059,7 @@ fn dev_dependencies2_conflict() {
         .file("a/src/lib.rs", "")
         .build();
     p.cargo("check").with_stderr_data(str![[r#"
-[WARNING] `dev_dependencies` is redundant with `dev-dependencies`, preferring `dev-dependencies` in the `foo` package
+[WARNING] [ROOT]/foo/Cargo.toml: `dev_dependencies` is redundant with `dev-dependencies`, preferring `dev-dependencies` in the `foo` package
 [LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1095,7 +1095,7 @@ fn build_dependencies2() {
         .file("a/src/lib.rs", "")
         .build();
     p.cargo("check").with_stderr_data(str![[r#"
-[WARNING] `build_dependencies` is deprecated in favor of `build-dependencies` and will not work in the 2024 edition
+[WARNING] [ROOT]/foo/Cargo.toml: `build_dependencies` is deprecated in favor of `build-dependencies` and will not work in the 2024 edition
 (in the `foo` package)
 [LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
@@ -1174,7 +1174,7 @@ fn build_dependencies2_conflict() {
         .file("a/src/lib.rs", "")
         .build();
     p.cargo("check").with_stderr_data(str![[r#"
-[WARNING] `build_dependencies` is redundant with `build-dependencies`, preferring `build-dependencies` in the `foo` package
+[WARNING] [ROOT]/foo/Cargo.toml: `build_dependencies` is redundant with `build-dependencies`, preferring `build-dependencies` in the `foo` package
 [LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1203,7 +1203,7 @@ fn lib_crate_type2() {
         .build();
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] `crate_type` is deprecated in favor of `crate-type` and will not work in the 2024 edition
+[WARNING] [ROOT]/foo/Cargo.toml: `crate_type` is deprecated in favor of `crate-type` and will not work in the 2024 edition
 (in the `foo` library target)
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1265,7 +1265,7 @@ fn lib_crate_type2_conflict() {
         .file("src/lib.rs", "pub fn foo() {}")
         .build();
     p.cargo("check").with_stderr_data(str![[r#"
-[WARNING] `crate_type` is redundant with `crate-type`, preferring `crate-type` in the `foo` library target
+[WARNING] [ROOT]/foo/Cargo.toml: `crate_type` is redundant with `crate-type`, preferring `crate-type` in the `foo` library target
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1294,7 +1294,7 @@ fn bin_crate_type2() {
         .build();
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] `crate_type` is deprecated in favor of `crate-type` and will not work in the 2024 edition
+[WARNING] [ROOT]/foo/Cargo.toml: `crate_type` is deprecated in favor of `crate-type` and will not work in the 2024 edition
 (in the `foo` binary target)
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1358,7 +1358,7 @@ fn bin_crate_type2_conflict() {
         .file("src/main.rs", "fn main() {}")
         .build();
     p.cargo("check").with_stderr_data(str![[r#"
-[WARNING] `crate_type` is redundant with `crate-type`, preferring `crate-type` in the `foo` binary target
+[WARNING] [ROOT]/foo/Cargo.toml: `crate_type` is redundant with `crate-type`, preferring `crate-type` in the `foo` binary target
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1403,9 +1403,9 @@ fn examples_crate_type2() {
         .build();
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] `crate_type` is deprecated in favor of `crate-type` and will not work in the 2024 edition
+[WARNING] [ROOT]/foo/Cargo.toml: `crate_type` is deprecated in favor of `crate-type` and will not work in the 2024 edition
 (in the `ex` example target)
-[WARNING] `crate_type` is deprecated in favor of `crate-type` and will not work in the 2024 edition
+[WARNING] [ROOT]/foo/Cargo.toml: `crate_type` is deprecated in favor of `crate-type` and will not work in the 2024 edition
 (in the `goodbye` example target)
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1502,8 +1502,8 @@ fn examples_crate_type2_conflict() {
         )
         .build();
     p.cargo("check").with_stderr_data(str![[r#"
-[WARNING] `crate_type` is redundant with `crate-type`, preferring `crate-type` in the `ex` example target
-[WARNING] `crate_type` is redundant with `crate-type`, preferring `crate-type` in the `goodbye` example target
+[WARNING] [ROOT]/foo/Cargo.toml: `crate_type` is redundant with `crate-type`, preferring `crate-type` in the `ex` example target
+[WARNING] [ROOT]/foo/Cargo.toml: `crate_type` is redundant with `crate-type`, preferring `crate-type` in the `goodbye` example target
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1542,7 +1542,7 @@ fn cargo_platform_build_dependencies2() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] `build_dependencies` is deprecated in favor of `build-dependencies` and will not work in the 2024 edition
+[WARNING] [ROOT]/foo/Cargo.toml: `build_dependencies` is deprecated in favor of `build-dependencies` and will not work in the 2024 edition
 (in the `[HOST_TARGET]` platform target)
 [LOCKING] 1 package to latest compatible version
 [COMPILING] build v0.5.0 ([ROOT]/foo/build)
@@ -1631,7 +1631,7 @@ fn cargo_platform_build_dependencies2_conflict() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] `build_dependencies` is redundant with `build-dependencies`, preferring `build-dependencies` in the `[HOST_TARGET]` platform target
+[WARNING] [ROOT]/foo/Cargo.toml: `build_dependencies` is redundant with `build-dependencies`, preferring `build-dependencies` in the `[HOST_TARGET]` platform target
 [LOCKING] 1 package to latest compatible version
 [COMPILING] build v0.5.0 ([ROOT]/foo/build)
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
@@ -1673,7 +1673,7 @@ fn cargo_platform_dev_dependencies2() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] `dev_dependencies` is deprecated in favor of `dev-dependencies` and will not work in the 2024 edition
+[WARNING] [ROOT]/foo/Cargo.toml: `dev_dependencies` is deprecated in favor of `dev-dependencies` and will not work in the 2024 edition
 (in the `[HOST_TARGET]` platform target)
 [LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
@@ -1758,7 +1758,7 @@ fn cargo_platform_dev_dependencies2_conflict() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] `dev_dependencies` is redundant with `dev-dependencies`, preferring `dev-dependencies` in the `[HOST_TARGET]` platform target
+[WARNING] [ROOT]/foo/Cargo.toml: `dev_dependencies` is redundant with `dev-dependencies`, preferring `dev-dependencies` in the `[HOST_TARGET]` platform target
 [LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1802,7 +1802,7 @@ fn default_features2() {
         .build();
 
     p.cargo("check").with_stderr_data(str![[r#"
-[WARNING] `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition
+[WARNING] [ROOT]/foo/Cargo.toml: `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition
 (in the `a` dependency)
 [LOCKING] 1 package to latest compatible version
 [CHECKING] a v0.1.0 ([ROOT]/foo/a)
@@ -1894,7 +1894,7 @@ fn default_features2_conflict() {
         .build();
 
     p.cargo("check").with_stderr_data(str![[r#"
-[WARNING] `default_features` is redundant with `default-features`, preferring `default-features` in the `a` dependency
+[WARNING] [ROOT]/foo/Cargo.toml: `default_features` is redundant with `default-features`, preferring `default-features` in the `a` dependency
 [LOCKING] 1 package to latest compatible version
 [CHECKING] a v0.1.0 ([ROOT]/foo/a)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
@@ -2088,7 +2088,7 @@ fn lib_proc_macro2() {
 
     foo.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] `proc_macro` is deprecated in favor of `proc-macro` and will not work in the 2024 edition
+[WARNING] [ROOT]/foo/Cargo.toml: `proc_macro` is deprecated in favor of `proc-macro` and will not work in the 2024 edition
 (in the `foo` library target)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2146,7 +2146,7 @@ fn lib_proc_macro2_conflict() {
         .build();
 
     foo.cargo("check").with_stderr_data(str![[r#"
-[WARNING] `proc_macro` is redundant with `proc-macro`, preferring `proc-macro` in the `foo` library target
+[WARNING] [ROOT]/foo/Cargo.toml: `proc_macro` is redundant with `proc-macro`, preferring `proc-macro` in the `foo` library target
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2176,7 +2176,7 @@ fn bin_proc_macro2() {
 
     foo.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] `proc_macro` is deprecated in favor of `proc-macro` and will not work in the 2024 edition
+[WARNING] [ROOT]/foo/Cargo.toml: `proc_macro` is deprecated in favor of `proc-macro` and will not work in the 2024 edition
 (in the `foo` binary target)
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2242,7 +2242,7 @@ fn bin_proc_macro2_conflict() {
         .build();
 
     foo.cargo("check").with_stderr_data(str![[r#"
-[WARNING] `proc_macro` is redundant with `proc-macro`, preferring `proc-macro` in the `foo` binary target
+[WARNING] [ROOT]/foo/Cargo.toml: `proc_macro` is redundant with `proc-macro`, preferring `proc-macro` in the `foo` binary target
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2374,7 +2374,7 @@ fn fragment_in_git_url() {
         // ...
         // [..]127.0.0.1[..]
         .with_stderr_data(str![[r#"
-[WARNING] URL fragment `#foo` in git URL is ignored for dependency (bar). If you were trying to specify a specific git revision, use `rev = "foo"` in the dependency declaration.
+[WARNING] [ROOT]/foo/Cargo.toml: URL fragment `#foo` in git URL is ignored for dependency (bar). If you were trying to specify a specific git revision, use `rev = "foo"` in the dependency declaration.
 [UPDATING] git repository `http://127.0.0.1/#foo`
 ...
 [ERROR] failed to get `bar` as a dependency of package `foo v0.0.0 ([ROOT]/foo)`
@@ -2968,7 +2968,7 @@ fn warn_semver_metadata() {
         .file("src/lib.rs", "")
         .build();
     p.cargo("check").with_stderr_data(str![[r#"
-[WARNING] version requirement `1.0.0+1234` for dependency `bar` includes semver metadata which will be ignored, removing the metadata is recommended to avoid confusion
+[WARNING] [ROOT]/foo/Cargo.toml: version requirement `1.0.0+1234` for dependency `bar` includes semver metadata which will be ignored, removing the metadata is recommended to avoid confusion
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
@@ -3655,7 +3655,7 @@ fn legacy_binary_paths_warnings() {
 
     p.cargo("check -v")
         .with_stderr_data(str![[r#"
-[WARNING] An explicit [[bin]] section is specified in Cargo.toml which currently
+[WARNING] [ROOT]/foo/Cargo.toml: An explicit [[bin]] section is specified in Cargo.toml which currently
 disables Cargo from automatically inferring other binary targets.
 This inference behavior will change in the Rust 2018 edition and the following
 files will be included as a binary target:
@@ -3670,7 +3670,7 @@ automatically infer them to be a target, such as in subfolders.
 
 For more information on this warning you can consult
 https://github.com/rust-lang/cargo/issues/5330
-[WARNING] path `src/main.rs` was erroneously implicitly accepted for binary `bar`,
+[WARNING] [ROOT]/foo/Cargo.toml: path `src/main.rs` was erroneously implicitly accepted for binary `bar`,
 please set bin.path in Cargo.toml
 [CHECKING] foo v1.0.0 ([ROOT]/foo)
 [RUNNING] `rustc [..]`
@@ -3700,7 +3700,7 @@ please set bin.path in Cargo.toml
 
     p.cargo("check -v")
         .with_stderr_data(str![[r#"
-[WARNING] An explicit [[bin]] section is specified in Cargo.toml which currently
+[WARNING] [ROOT]/foo/Cargo.toml: An explicit [[bin]] section is specified in Cargo.toml which currently
 disables Cargo from automatically inferring other binary targets.
 This inference behavior will change in the Rust 2018 edition and the following
 files will be included as a binary target:
@@ -3715,7 +3715,7 @@ automatically infer them to be a target, such as in subfolders.
 
 For more information on this warning you can consult
 https://github.com/rust-lang/cargo/issues/5330
-[WARNING] path `src/bin/main.rs` was erroneously implicitly accepted for binary `bar`,
+[WARNING] [ROOT]/foo/Cargo.toml: path `src/bin/main.rs` was erroneously implicitly accepted for binary `bar`,
 please set bin.path in Cargo.toml
 [CHECKING] foo v1.0.0 ([ROOT]/foo)
 [RUNNING] `rustc [..]`
@@ -3744,7 +3744,7 @@ please set bin.path in Cargo.toml
 
     p.cargo("check -v")
         .with_stderr_data(str![[r#"
-[WARNING] path `src/bar.rs` was erroneously implicitly accepted for binary `bar`,
+[WARNING] [ROOT]/foo/Cargo.toml: path `src/bar.rs` was erroneously implicitly accepted for binary `bar`,
 please set bin.path in Cargo.toml
 [CHECKING] foo v1.0.0 ([ROOT]/foo)
 [RUNNING] `rustc [..]`

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -850,43 +850,43 @@ quiet = false
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: alias
+[WARNING] Cargo.toml: unused manifest key: alias
 [HELP] alias is a valid .cargo/config.toml key
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: build
+[WARNING] Cargo.toml: unused manifest key: build
 [HELP] build is a valid .cargo/config.toml key
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: cache
+[WARNING] Cargo.toml: unused manifest key: cache
 [HELP] cache is a valid .cargo/config.toml key
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: cargo-new
+[WARNING] Cargo.toml: unused manifest key: cargo-new
 [HELP] cargo-new is a valid .cargo/config.toml key
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: credential-alias
+[WARNING] Cargo.toml: unused manifest key: credential-alias
 [HELP] credential-alias is a valid .cargo/config.toml key
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: doc
+[WARNING] Cargo.toml: unused manifest key: doc
 [HELP] doc is a valid .cargo/config.toml key
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: env
+[WARNING] Cargo.toml: unused manifest key: env
 [HELP] env is a valid .cargo/config.toml key
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: future-incompat-report
+[WARNING] Cargo.toml: unused manifest key: future-incompat-report
 [HELP] future-incompat-report is a valid .cargo/config.toml key
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: http
+[WARNING] Cargo.toml: unused manifest key: http
 [HELP] http is a valid .cargo/config.toml key
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: install
+[WARNING] Cargo.toml: unused manifest key: install
 [HELP] install is a valid .cargo/config.toml key
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: lib.build
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: net
+[WARNING] Cargo.toml: unused manifest key: lib.build
+[WARNING] Cargo.toml: unused manifest key: net
 [HELP] net is a valid .cargo/config.toml key
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: package.unused
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: paths
+[WARNING] Cargo.toml: unused manifest key: package.unused
+[WARNING] Cargo.toml: unused manifest key: paths
 [HELP] paths is a valid .cargo/config.toml key
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: registries
+[WARNING] Cargo.toml: unused manifest key: registries
 [HELP] registries is a valid .cargo/config.toml key
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: registry
+[WARNING] Cargo.toml: unused manifest key: registry
 [HELP] registry is a valid .cargo/config.toml key
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: resolver
+[WARNING] Cargo.toml: unused manifest key: resolver
 [HELP] resolver is a valid .cargo/config.toml key
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: source
+[WARNING] Cargo.toml: unused manifest key: source
 [HELP] source is a valid .cargo/config.toml key
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: target.cfg(unix).linker
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: target.foo.bar
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: term
+[WARNING] Cargo.toml: unused manifest key: target.cfg(unix).linker
+[WARNING] Cargo.toml: unused manifest key: target.foo.bar
+[WARNING] Cargo.toml: unused manifest key: term
 [HELP] term is a valid .cargo/config.toml key
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -911,7 +911,7 @@ fn unused_keys_in_virtual_manifest() {
         .build();
     p.cargo("check --workspace")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: workspace.unused
+[WARNING] Cargo.toml: unused manifest key: workspace.unused
 [CHECKING] bar v0.0.1 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -980,7 +980,7 @@ fn dev_dependencies2() {
         .file("a/src/lib.rs", "")
         .build();
     p.cargo("check").with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `dev_dependencies` is deprecated in favor of `dev-dependencies` and will not work in the 2024 edition
+[WARNING] Cargo.toml: `dev_dependencies` is deprecated in favor of `dev-dependencies` and will not work in the 2024 edition
 (in the `foo` package)
 [LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
@@ -1059,7 +1059,7 @@ fn dev_dependencies2_conflict() {
         .file("a/src/lib.rs", "")
         .build();
     p.cargo("check").with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `dev_dependencies` is redundant with `dev-dependencies`, preferring `dev-dependencies` in the `foo` package
+[WARNING] Cargo.toml: `dev_dependencies` is redundant with `dev-dependencies`, preferring `dev-dependencies` in the `foo` package
 [LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1095,7 +1095,7 @@ fn build_dependencies2() {
         .file("a/src/lib.rs", "")
         .build();
     p.cargo("check").with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `build_dependencies` is deprecated in favor of `build-dependencies` and will not work in the 2024 edition
+[WARNING] Cargo.toml: `build_dependencies` is deprecated in favor of `build-dependencies` and will not work in the 2024 edition
 (in the `foo` package)
 [LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
@@ -1174,7 +1174,7 @@ fn build_dependencies2_conflict() {
         .file("a/src/lib.rs", "")
         .build();
     p.cargo("check").with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `build_dependencies` is redundant with `build-dependencies`, preferring `build-dependencies` in the `foo` package
+[WARNING] Cargo.toml: `build_dependencies` is redundant with `build-dependencies`, preferring `build-dependencies` in the `foo` package
 [LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1203,7 +1203,7 @@ fn lib_crate_type2() {
         .build();
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `crate_type` is deprecated in favor of `crate-type` and will not work in the 2024 edition
+[WARNING] Cargo.toml: `crate_type` is deprecated in favor of `crate-type` and will not work in the 2024 edition
 (in the `foo` library target)
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1265,7 +1265,7 @@ fn lib_crate_type2_conflict() {
         .file("src/lib.rs", "pub fn foo() {}")
         .build();
     p.cargo("check").with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `crate_type` is redundant with `crate-type`, preferring `crate-type` in the `foo` library target
+[WARNING] Cargo.toml: `crate_type` is redundant with `crate-type`, preferring `crate-type` in the `foo` library target
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1294,7 +1294,7 @@ fn bin_crate_type2() {
         .build();
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `crate_type` is deprecated in favor of `crate-type` and will not work in the 2024 edition
+[WARNING] Cargo.toml: `crate_type` is deprecated in favor of `crate-type` and will not work in the 2024 edition
 (in the `foo` binary target)
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1358,7 +1358,7 @@ fn bin_crate_type2_conflict() {
         .file("src/main.rs", "fn main() {}")
         .build();
     p.cargo("check").with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `crate_type` is redundant with `crate-type`, preferring `crate-type` in the `foo` binary target
+[WARNING] Cargo.toml: `crate_type` is redundant with `crate-type`, preferring `crate-type` in the `foo` binary target
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1403,9 +1403,9 @@ fn examples_crate_type2() {
         .build();
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `crate_type` is deprecated in favor of `crate-type` and will not work in the 2024 edition
+[WARNING] Cargo.toml: `crate_type` is deprecated in favor of `crate-type` and will not work in the 2024 edition
 (in the `ex` example target)
-[WARNING] [ROOT]/foo/Cargo.toml: `crate_type` is deprecated in favor of `crate-type` and will not work in the 2024 edition
+[WARNING] Cargo.toml: `crate_type` is deprecated in favor of `crate-type` and will not work in the 2024 edition
 (in the `goodbye` example target)
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1502,8 +1502,8 @@ fn examples_crate_type2_conflict() {
         )
         .build();
     p.cargo("check").with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `crate_type` is redundant with `crate-type`, preferring `crate-type` in the `ex` example target
-[WARNING] [ROOT]/foo/Cargo.toml: `crate_type` is redundant with `crate-type`, preferring `crate-type` in the `goodbye` example target
+[WARNING] Cargo.toml: `crate_type` is redundant with `crate-type`, preferring `crate-type` in the `ex` example target
+[WARNING] Cargo.toml: `crate_type` is redundant with `crate-type`, preferring `crate-type` in the `goodbye` example target
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1542,7 +1542,7 @@ fn cargo_platform_build_dependencies2() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `build_dependencies` is deprecated in favor of `build-dependencies` and will not work in the 2024 edition
+[WARNING] Cargo.toml: `build_dependencies` is deprecated in favor of `build-dependencies` and will not work in the 2024 edition
 (in the `[HOST_TARGET]` platform target)
 [LOCKING] 1 package to latest compatible version
 [COMPILING] build v0.5.0 ([ROOT]/foo/build)
@@ -1631,7 +1631,7 @@ fn cargo_platform_build_dependencies2_conflict() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `build_dependencies` is redundant with `build-dependencies`, preferring `build-dependencies` in the `[HOST_TARGET]` platform target
+[WARNING] Cargo.toml: `build_dependencies` is redundant with `build-dependencies`, preferring `build-dependencies` in the `[HOST_TARGET]` platform target
 [LOCKING] 1 package to latest compatible version
 [COMPILING] build v0.5.0 ([ROOT]/foo/build)
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
@@ -1673,7 +1673,7 @@ fn cargo_platform_dev_dependencies2() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `dev_dependencies` is deprecated in favor of `dev-dependencies` and will not work in the 2024 edition
+[WARNING] Cargo.toml: `dev_dependencies` is deprecated in favor of `dev-dependencies` and will not work in the 2024 edition
 (in the `[HOST_TARGET]` platform target)
 [LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
@@ -1758,7 +1758,7 @@ fn cargo_platform_dev_dependencies2_conflict() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `dev_dependencies` is redundant with `dev-dependencies`, preferring `dev-dependencies` in the `[HOST_TARGET]` platform target
+[WARNING] Cargo.toml: `dev_dependencies` is redundant with `dev-dependencies`, preferring `dev-dependencies` in the `[HOST_TARGET]` platform target
 [LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1802,7 +1802,7 @@ fn default_features2() {
         .build();
 
     p.cargo("check").with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition
+[WARNING] Cargo.toml: `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition
 (in the `a` dependency)
 [LOCKING] 1 package to latest compatible version
 [CHECKING] a v0.1.0 ([ROOT]/foo/a)
@@ -1894,7 +1894,7 @@ fn default_features2_conflict() {
         .build();
 
     p.cargo("check").with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `default_features` is redundant with `default-features`, preferring `default-features` in the `a` dependency
+[WARNING] Cargo.toml: `default_features` is redundant with `default-features`, preferring `default-features` in the `a` dependency
 [LOCKING] 1 package to latest compatible version
 [CHECKING] a v0.1.0 ([ROOT]/foo/a)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
@@ -1977,7 +1977,7 @@ fn workspace_default_features2() {
 [CHECKING] package_only v0.1.0 ([ROOT]/foo/package_only)
 [CHECKING] workspace_only v0.1.0 ([ROOT]/foo/workspace_only)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[WARNING] [ROOT]/foo/workspace_only/Cargo.toml: `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition
+[WARNING] workspace_only/Cargo.toml: `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition
 (in the `dep_workspace_only` dependency)
 
 "#]]
@@ -2088,7 +2088,7 @@ fn lib_proc_macro2() {
 
     foo.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `proc_macro` is deprecated in favor of `proc-macro` and will not work in the 2024 edition
+[WARNING] Cargo.toml: `proc_macro` is deprecated in favor of `proc-macro` and will not work in the 2024 edition
 (in the `foo` library target)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2146,7 +2146,7 @@ fn lib_proc_macro2_conflict() {
         .build();
 
     foo.cargo("check").with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `proc_macro` is redundant with `proc-macro`, preferring `proc-macro` in the `foo` library target
+[WARNING] Cargo.toml: `proc_macro` is redundant with `proc-macro`, preferring `proc-macro` in the `foo` library target
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2176,7 +2176,7 @@ fn bin_proc_macro2() {
 
     foo.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `proc_macro` is deprecated in favor of `proc-macro` and will not work in the 2024 edition
+[WARNING] Cargo.toml: `proc_macro` is deprecated in favor of `proc-macro` and will not work in the 2024 edition
 (in the `foo` binary target)
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2242,7 +2242,7 @@ fn bin_proc_macro2_conflict() {
         .build();
 
     foo.cargo("check").with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `proc_macro` is redundant with `proc-macro`, preferring `proc-macro` in the `foo` binary target
+[WARNING] Cargo.toml: `proc_macro` is redundant with `proc-macro`, preferring `proc-macro` in the `foo` binary target
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2374,7 +2374,7 @@ fn fragment_in_git_url() {
         // ...
         // [..]127.0.0.1[..]
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: URL fragment `#foo` in git URL is ignored for dependency (bar). If you were trying to specify a specific git revision, use `rev = "foo"` in the dependency declaration.
+[WARNING] Cargo.toml: URL fragment `#foo` in git URL is ignored for dependency (bar). If you were trying to specify a specific git revision, use `rev = "foo"` in the dependency declaration.
 [UPDATING] git repository `http://127.0.0.1/#foo`
 ...
 [ERROR] failed to get `bar` as a dependency of package `foo v0.0.0 ([ROOT]/foo)`
@@ -2968,7 +2968,7 @@ fn warn_semver_metadata() {
         .file("src/lib.rs", "")
         .build();
     p.cargo("check").with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: version requirement `1.0.0+1234` for dependency `bar` includes semver metadata which will be ignored, removing the metadata is recommended to avoid confusion
+[WARNING] Cargo.toml: version requirement `1.0.0+1234` for dependency `bar` includes semver metadata which will be ignored, removing the metadata is recommended to avoid confusion
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
@@ -3291,7 +3291,7 @@ fn bad_example_name() {
         .cargo("check")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
+[ERROR] failed to parse manifest at `Cargo.toml`
 
 Caused by:
   can't find `example.rs` example at `examples/example.rs.rs` or `examples/example.rs/main.rs`. Please specify example.path if you want to use a non-default path.
@@ -3308,7 +3308,7 @@ fn bad_test_name() {
         .cargo("check")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
+[ERROR] failed to parse manifest at `Cargo.toml`
 
 Caused by:
   can't find `test.rs` test at `tests/test.rs.rs` or `tests/test.rs/main.rs`. Please specify test.path if you want to use a non-default path.
@@ -3325,7 +3325,7 @@ fn bad_bench_name() {
         .cargo("check")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
+[ERROR] failed to parse manifest at `Cargo.toml`
 
 Caused by:
   can't find `bench.rs` bench at `benches/bench.rs.rs` or `benches/bench.rs/main.rs`. Please specify bench.path if you want to use a non-default path.
@@ -3361,7 +3361,7 @@ fn non_existing_test() {
     p.cargo("check --tests -v")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
+[ERROR] failed to parse manifest at `Cargo.toml`
 
 Caused by:
   can't find `hello` test at `tests/hello.rs` or `tests/hello/main.rs`. Please specify test.path if you want to use a non-default path.
@@ -3395,7 +3395,7 @@ fn non_existing_example() {
     p.cargo("check --examples -v")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
+[ERROR] failed to parse manifest at `Cargo.toml`
 
 Caused by:
   can't find `hello` example at `examples/hello.rs` or `examples/hello/main.rs`. Please specify example.path if you want to use a non-default path.
@@ -3429,7 +3429,7 @@ fn non_existing_benchmark() {
     p.cargo("check --benches -v")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
+[ERROR] failed to parse manifest at `Cargo.toml`
 
 Caused by:
   can't find `hello` bench at `benches/hello.rs` or `benches/hello/main.rs`. Please specify bench.path if you want to use a non-default path.
@@ -3486,7 +3486,7 @@ fn commonly_wrong_path_of_test() {
     p.cargo("check --tests -v")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
+[ERROR] failed to parse manifest at `Cargo.toml`
 
 Caused by:
   can't find `foo` test at default paths, but found a file at `test/foo.rs`.
@@ -3522,7 +3522,7 @@ fn commonly_wrong_path_of_example() {
     p.cargo("check --examples -v")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
+[ERROR] failed to parse manifest at `Cargo.toml`
 
 Caused by:
   can't find `foo` example at default paths, but found a file at `example/foo.rs`.
@@ -3558,7 +3558,7 @@ fn commonly_wrong_path_of_benchmark() {
     p.cargo("check --benches -v")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
+[ERROR] failed to parse manifest at `Cargo.toml`
 
 Caused by:
   can't find `foo` bench at default paths, but found a file at `bench/foo.rs`.
@@ -3655,7 +3655,7 @@ fn legacy_binary_paths_warnings() {
 
     p.cargo("check -v")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: An explicit [[bin]] section is specified in Cargo.toml which currently
+[WARNING] Cargo.toml: An explicit [[bin]] section is specified in Cargo.toml which currently
 disables Cargo from automatically inferring other binary targets.
 This inference behavior will change in the Rust 2018 edition and the following
 files will be included as a binary target:
@@ -3670,7 +3670,7 @@ automatically infer them to be a target, such as in subfolders.
 
 For more information on this warning you can consult
 https://github.com/rust-lang/cargo/issues/5330
-[WARNING] [ROOT]/foo/Cargo.toml: path `src/main.rs` was erroneously implicitly accepted for binary `bar`,
+[WARNING] Cargo.toml: path `src/main.rs` was erroneously implicitly accepted for binary `bar`,
 please set bin.path in Cargo.toml
 [CHECKING] foo v1.0.0 ([ROOT]/foo)
 [RUNNING] `rustc [..]`
@@ -3700,7 +3700,7 @@ please set bin.path in Cargo.toml
 
     p.cargo("check -v")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: An explicit [[bin]] section is specified in Cargo.toml which currently
+[WARNING] Cargo.toml: An explicit [[bin]] section is specified in Cargo.toml which currently
 disables Cargo from automatically inferring other binary targets.
 This inference behavior will change in the Rust 2018 edition and the following
 files will be included as a binary target:
@@ -3715,7 +3715,7 @@ automatically infer them to be a target, such as in subfolders.
 
 For more information on this warning you can consult
 https://github.com/rust-lang/cargo/issues/5330
-[WARNING] [ROOT]/foo/Cargo.toml: path `src/bin/main.rs` was erroneously implicitly accepted for binary `bar`,
+[WARNING] Cargo.toml: path `src/bin/main.rs` was erroneously implicitly accepted for binary `bar`,
 please set bin.path in Cargo.toml
 [CHECKING] foo v1.0.0 ([ROOT]/foo)
 [RUNNING] `rustc [..]`
@@ -3744,7 +3744,7 @@ please set bin.path in Cargo.toml
 
     p.cargo("check -v")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: path `src/bar.rs` was erroneously implicitly accepted for binary `bar`,
+[WARNING] Cargo.toml: path `src/bar.rs` was erroneously implicitly accepted for binary `bar`,
 please set bin.path in Cargo.toml
 [CHECKING] foo v1.0.0 ([ROOT]/foo)
 [RUNNING] `rustc [..]`

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -888,6 +888,7 @@ quiet = false
 [WARNING] Cargo.toml: unused manifest key: target.foo.bar
 [WARNING] Cargo.toml: unused manifest key: term
 [HELP] term is a valid .cargo/config.toml key
+[WARNING] `foo` (manifest) generated 21 warnings
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -912,6 +913,7 @@ fn unused_keys_in_virtual_manifest() {
     p.cargo("check --workspace")
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: unused manifest key: workspace.unused
+[WARNING] workspace (manifest) generated 1 warning
 [CHECKING] bar v0.0.1 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -982,6 +984,7 @@ fn dev_dependencies2() {
     p.cargo("check").with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `dev_dependencies` is deprecated in favor of `dev-dependencies` and will not work in the 2024 edition
 (in the `foo` package)
+[WARNING] `foo` (manifest) generated 1 warning
 [LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1060,6 +1063,7 @@ fn dev_dependencies2_conflict() {
         .build();
     p.cargo("check").with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `dev_dependencies` is redundant with `dev-dependencies`, preferring `dev-dependencies` in the `foo` package
+[WARNING] `foo` (manifest) generated 1 warning
 [LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1097,6 +1101,7 @@ fn build_dependencies2() {
     p.cargo("check").with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `build_dependencies` is deprecated in favor of `build-dependencies` and will not work in the 2024 edition
 (in the `foo` package)
+[WARNING] `foo` (manifest) generated 1 warning
 [LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1175,6 +1180,7 @@ fn build_dependencies2_conflict() {
         .build();
     p.cargo("check").with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `build_dependencies` is redundant with `build-dependencies`, preferring `build-dependencies` in the `foo` package
+[WARNING] `foo` (manifest) generated 1 warning
 [LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1205,6 +1211,7 @@ fn lib_crate_type2() {
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `crate_type` is deprecated in favor of `crate-type` and will not work in the 2024 edition
 (in the `foo` library target)
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1266,6 +1273,7 @@ fn lib_crate_type2_conflict() {
         .build();
     p.cargo("check").with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `crate_type` is redundant with `crate-type`, preferring `crate-type` in the `foo` library target
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1296,6 +1304,7 @@ fn bin_crate_type2() {
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `crate_type` is deprecated in favor of `crate-type` and will not work in the 2024 edition
 (in the `foo` binary target)
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1359,6 +1368,7 @@ fn bin_crate_type2_conflict() {
         .build();
     p.cargo("check").with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `crate_type` is redundant with `crate-type`, preferring `crate-type` in the `foo` binary target
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1407,6 +1417,7 @@ fn examples_crate_type2() {
 (in the `ex` example target)
 [WARNING] Cargo.toml: `crate_type` is deprecated in favor of `crate-type` and will not work in the 2024 edition
 (in the `goodbye` example target)
+[WARNING] `foo` (manifest) generated 2 warnings
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1504,6 +1515,7 @@ fn examples_crate_type2_conflict() {
     p.cargo("check").with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `crate_type` is redundant with `crate-type`, preferring `crate-type` in the `ex` example target
 [WARNING] Cargo.toml: `crate_type` is redundant with `crate-type`, preferring `crate-type` in the `goodbye` example target
+[WARNING] `foo` (manifest) generated 2 warnings
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1544,6 +1556,7 @@ fn cargo_platform_build_dependencies2() {
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `build_dependencies` is deprecated in favor of `build-dependencies` and will not work in the 2024 edition
 (in the `[HOST_TARGET]` platform target)
+[WARNING] `foo` (manifest) generated 1 warning
 [LOCKING] 1 package to latest compatible version
 [COMPILING] build v0.5.0 ([ROOT]/foo/build)
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
@@ -1632,6 +1645,7 @@ fn cargo_platform_build_dependencies2_conflict() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `build_dependencies` is redundant with `build-dependencies`, preferring `build-dependencies` in the `[HOST_TARGET]` platform target
+[WARNING] `foo` (manifest) generated 1 warning
 [LOCKING] 1 package to latest compatible version
 [COMPILING] build v0.5.0 ([ROOT]/foo/build)
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
@@ -1675,6 +1689,7 @@ fn cargo_platform_dev_dependencies2() {
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `dev_dependencies` is deprecated in favor of `dev-dependencies` and will not work in the 2024 edition
 (in the `[HOST_TARGET]` platform target)
+[WARNING] `foo` (manifest) generated 1 warning
 [LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1759,6 +1774,7 @@ fn cargo_platform_dev_dependencies2_conflict() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `dev_dependencies` is redundant with `dev-dependencies`, preferring `dev-dependencies` in the `[HOST_TARGET]` platform target
+[WARNING] `foo` (manifest) generated 1 warning
 [LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1804,6 +1820,7 @@ fn default_features2() {
     p.cargo("check").with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition
 (in the `a` dependency)
+[WARNING] `foo` (manifest) generated 1 warning
 [LOCKING] 1 package to latest compatible version
 [CHECKING] a v0.1.0 ([ROOT]/foo/a)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
@@ -1895,6 +1912,7 @@ fn default_features2_conflict() {
 
     p.cargo("check").with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `default_features` is redundant with `default-features`, preferring `default-features` in the `a` dependency
+[WARNING] `foo` (manifest) generated 1 warning
 [LOCKING] 1 package to latest compatible version
 [CHECKING] a v0.1.0 ([ROOT]/foo/a)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
@@ -1979,6 +1997,7 @@ fn workspace_default_features2() {
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [WARNING] workspace_only/Cargo.toml: `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition
 (in the `dep_workspace_only` dependency)
+[WARNING] `workspace_only` (manifest) generated 1 warning
 
 "#]]
             .unordered(),
@@ -2090,6 +2109,7 @@ fn lib_proc_macro2() {
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `proc_macro` is deprecated in favor of `proc-macro` and will not work in the 2024 edition
 (in the `foo` library target)
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2147,6 +2167,7 @@ fn lib_proc_macro2_conflict() {
 
     foo.cargo("check").with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `proc_macro` is redundant with `proc-macro`, preferring `proc-macro` in the `foo` library target
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2178,6 +2199,7 @@ fn bin_proc_macro2() {
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `proc_macro` is deprecated in favor of `proc-macro` and will not work in the 2024 edition
 (in the `foo` binary target)
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2243,6 +2265,7 @@ fn bin_proc_macro2_conflict() {
 
     foo.cargo("check").with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `proc_macro` is redundant with `proc-macro`, preferring `proc-macro` in the `foo` binary target
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2375,6 +2398,7 @@ fn fragment_in_git_url() {
         // [..]127.0.0.1[..]
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: URL fragment `#foo` in git URL is ignored for dependency (bar). If you were trying to specify a specific git revision, use `rev = "foo"` in the dependency declaration.
+[WARNING] `foo` (manifest) generated 1 warning
 [UPDATING] git repository `http://127.0.0.1/#foo`
 ...
 [ERROR] failed to get `bar` as a dependency of package `foo v0.0.0 ([ROOT]/foo)`
@@ -2969,6 +2993,7 @@ fn warn_semver_metadata() {
         .build();
     p.cargo("check").with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: version requirement `1.0.0+1234` for dependency `bar` includes semver metadata which will be ignored, removing the metadata is recommended to avoid confusion
+[WARNING] `foo` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
@@ -3291,12 +3316,10 @@ fn bad_example_name() {
         .cargo("check")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to parse manifest at `Cargo.toml`
+[ERROR] Cargo.toml: can't find `example.rs` example at `examples/example.rs.rs` or `examples/example.rs/main.rs`. Please specify example.path if you want to use a non-default path.
 
-Caused by:
-  can't find `example.rs` example at `examples/example.rs.rs` or `examples/example.rs/main.rs`. Please specify example.path if you want to use a non-default path.
-
-  [HELP] a example with a similar name exists: `example`
+[HELP] a example with a similar name exists: `example`
+[ERROR] could not parse `bad-example-name` (manifest) due to 1 previous error
 
 "#]])
         .run();
@@ -3308,12 +3331,10 @@ fn bad_test_name() {
         .cargo("check")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to parse manifest at `Cargo.toml`
+[ERROR] Cargo.toml: can't find `test.rs` test at `tests/test.rs.rs` or `tests/test.rs/main.rs`. Please specify test.path if you want to use a non-default path.
 
-Caused by:
-  can't find `test.rs` test at `tests/test.rs.rs` or `tests/test.rs/main.rs`. Please specify test.path if you want to use a non-default path.
-
-  [HELP] a test with a similar name exists: `test`
+[HELP] a test with a similar name exists: `test`
+[ERROR] could not parse `bad-test-name` (manifest) due to 1 previous error
 
 "#]])
         .run();
@@ -3325,12 +3346,10 @@ fn bad_bench_name() {
         .cargo("check")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to parse manifest at `Cargo.toml`
+[ERROR] Cargo.toml: can't find `bench.rs` bench at `benches/bench.rs.rs` or `benches/bench.rs/main.rs`. Please specify bench.path if you want to use a non-default path.
 
-Caused by:
-  can't find `bench.rs` bench at `benches/bench.rs.rs` or `benches/bench.rs/main.rs`. Please specify bench.path if you want to use a non-default path.
-
-  [HELP] a bench with a similar name exists: `bench`
+[HELP] a bench with a similar name exists: `bench`
+[ERROR] could not parse `bad-bench-name` (manifest) due to 1 previous error
 
 "#]])
         .run();
@@ -3361,10 +3380,8 @@ fn non_existing_test() {
     p.cargo("check --tests -v")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to parse manifest at `Cargo.toml`
-
-Caused by:
-  can't find `hello` test at `tests/hello.rs` or `tests/hello/main.rs`. Please specify test.path if you want to use a non-default path.
+[ERROR] Cargo.toml: can't find `hello` test at `tests/hello.rs` or `tests/hello/main.rs`. Please specify test.path if you want to use a non-default path.
+[ERROR] could not parse `foo` (manifest) due to 1 previous error
 
 "#]])
         .run();
@@ -3395,10 +3412,8 @@ fn non_existing_example() {
     p.cargo("check --examples -v")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to parse manifest at `Cargo.toml`
-
-Caused by:
-  can't find `hello` example at `examples/hello.rs` or `examples/hello/main.rs`. Please specify example.path if you want to use a non-default path.
+[ERROR] Cargo.toml: can't find `hello` example at `examples/hello.rs` or `examples/hello/main.rs`. Please specify example.path if you want to use a non-default path.
+[ERROR] could not parse `foo` (manifest) due to 1 previous error
 
 "#]])
         .run();
@@ -3429,10 +3444,8 @@ fn non_existing_benchmark() {
     p.cargo("check --benches -v")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to parse manifest at `Cargo.toml`
-
-Caused by:
-  can't find `hello` bench at `benches/hello.rs` or `benches/hello/main.rs`. Please specify bench.path if you want to use a non-default path.
+[ERROR] Cargo.toml: can't find `hello` bench at `benches/hello.rs` or `benches/hello/main.rs`. Please specify bench.path if you want to use a non-default path.
+[ERROR] could not parse `foo` (manifest) due to 1 previous error
 
 "#]])
         .run();
@@ -3486,11 +3499,9 @@ fn commonly_wrong_path_of_test() {
     p.cargo("check --tests -v")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to parse manifest at `Cargo.toml`
-
-Caused by:
-  can't find `foo` test at default paths, but found a file at `test/foo.rs`.
-  Perhaps rename the file to `tests/foo.rs` for target auto-discovery, or specify test.path if you want to use a non-default path.
+[ERROR] Cargo.toml: can't find `foo` test at default paths, but found a file at `test/foo.rs`.
+Perhaps rename the file to `tests/foo.rs` for target auto-discovery, or specify test.path if you want to use a non-default path.
+[ERROR] could not parse `foo` (manifest) due to 1 previous error
 
 "#]])
         .run();
@@ -3522,11 +3533,9 @@ fn commonly_wrong_path_of_example() {
     p.cargo("check --examples -v")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to parse manifest at `Cargo.toml`
-
-Caused by:
-  can't find `foo` example at default paths, but found a file at `example/foo.rs`.
-  Perhaps rename the file to `examples/foo.rs` for target auto-discovery, or specify example.path if you want to use a non-default path.
+[ERROR] Cargo.toml: can't find `foo` example at default paths, but found a file at `example/foo.rs`.
+Perhaps rename the file to `examples/foo.rs` for target auto-discovery, or specify example.path if you want to use a non-default path.
+[ERROR] could not parse `foo` (manifest) due to 1 previous error
 
 "#]])
         .run();
@@ -3558,11 +3567,9 @@ fn commonly_wrong_path_of_benchmark() {
     p.cargo("check --benches -v")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to parse manifest at `Cargo.toml`
-
-Caused by:
-  can't find `foo` bench at default paths, but found a file at `bench/foo.rs`.
-  Perhaps rename the file to `benches/foo.rs` for target auto-discovery, or specify bench.path if you want to use a non-default path.
+[ERROR] Cargo.toml: can't find `foo` bench at default paths, but found a file at `bench/foo.rs`.
+Perhaps rename the file to `benches/foo.rs` for target auto-discovery, or specify bench.path if you want to use a non-default path.
+[ERROR] could not parse `foo` (manifest) due to 1 previous error
 
 "#]])
         .run();
@@ -3672,6 +3679,7 @@ For more information on this warning you can consult
 https://github.com/rust-lang/cargo/issues/5330
 [WARNING] Cargo.toml: path `src/main.rs` was erroneously implicitly accepted for binary `bar`,
 please set bin.path in Cargo.toml
+[WARNING] `foo` (manifest) generated 2 warnings
 [CHECKING] foo v1.0.0 ([ROOT]/foo)
 [RUNNING] `rustc [..]`
 [RUNNING] `rustc [..]`
@@ -3717,6 +3725,7 @@ For more information on this warning you can consult
 https://github.com/rust-lang/cargo/issues/5330
 [WARNING] Cargo.toml: path `src/bin/main.rs` was erroneously implicitly accepted for binary `bar`,
 please set bin.path in Cargo.toml
+[WARNING] `foo` (manifest) generated 2 warnings
 [CHECKING] foo v1.0.0 ([ROOT]/foo)
 [RUNNING] `rustc [..]`
 [RUNNING] `rustc [..]`
@@ -3746,6 +3755,7 @@ please set bin.path in Cargo.toml
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: path `src/bar.rs` was erroneously implicitly accepted for binary `bar`,
 please set bin.path in Cargo.toml
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v1.0.0 ([ROOT]/foo)
 [RUNNING] `rustc [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -715,7 +715,7 @@ fn bench_autodiscover_2015() {
 
     p.cargo("bench bench_basic")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: An explicit [[bench]] section is specified in Cargo.toml which currently
+[WARNING] Cargo.toml: An explicit [[bench]] section is specified in Cargo.toml which currently
 disables Cargo from automatically inferring other benchmark targets.
 This inference behavior will change in the Rust 2018 edition and the following
 files will be included as a benchmark target:
@@ -1943,7 +1943,7 @@ fn legacy_bench_name() {
 
     p.cargo("bench")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: path `src/bench.rs` was erroneously implicitly accepted for benchmark `bench`,
+[WARNING] Cargo.toml: path `src/bench.rs` was erroneously implicitly accepted for benchmark `bench`,
 please set bench.path in Cargo.toml
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -730,6 +730,7 @@ automatically infer them to be a target, such as in subfolders.
 
 For more information on this warning you can consult
 https://github.com/rust-lang/cargo/issues/5330
+[WARNING] `foo` (manifest) generated 1 warning
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
 [RUNNING] [..] (target/release/deps/foo-[HASH][EXE])
@@ -1945,6 +1946,7 @@ fn legacy_bench_name() {
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: path `src/bench.rs` was erroneously implicitly accepted for benchmark `bench`,
 please set bench.path in Cargo.toml
+[WARNING] `foo` (manifest) generated 1 warning
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
 [RUNNING] unittests src/lib.rs (target/release/deps/foo-[HASH][EXE])

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -715,7 +715,7 @@ fn bench_autodiscover_2015() {
 
     p.cargo("bench bench_basic")
         .with_stderr_data(str![[r#"
-[WARNING] An explicit [[bench]] section is specified in Cargo.toml which currently
+[WARNING] [ROOT]/foo/Cargo.toml: An explicit [[bench]] section is specified in Cargo.toml which currently
 disables Cargo from automatically inferring other benchmark targets.
 This inference behavior will change in the Rust 2018 edition and the following
 files will be included as a benchmark target:
@@ -1943,7 +1943,7 @@ fn legacy_bench_name() {
 
     p.cargo("bench")
         .with_stderr_data(str![[r#"
-[WARNING] path `src/bench.rs` was erroneously implicitly accepted for benchmark `bench`,
+[WARNING] [ROOT]/foo/Cargo.toml: path `src/bench.rs` was erroneously implicitly accepted for benchmark `bench`,
 please set bench.path in Cargo.toml
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -483,7 +483,7 @@ fn cargo_compile_duplicate_build_targets() {
 
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: file `[ROOT]/foo/src/main.rs` found to be present in multiple build targets:
+[WARNING] Cargo.toml: file `[ROOT]/foo/src/main.rs` found to be present in multiple build targets:
   * `lib` target `main`
   * `bin` target `foo`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -634,7 +634,7 @@ fn cargo_compile_with_bin_and_crate_type() {
     p.cargo("build")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
+[ERROR] failed to parse manifest at `Cargo.toml`
 
 Caused by:
   the target `the_foo_bin` is a binary and can't have any crate-types set (currently "cdylib, rlib")
@@ -722,7 +722,7 @@ fn cargo_compile_with_bin_and_proc() {
     p.cargo("build")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
+[ERROR] failed to parse manifest at `Cargo.toml`
 
 Caused by:
   the target `the_foo_bin` is a binary and can't have `proc-macro` set `true`
@@ -2004,7 +2004,7 @@ fn many_crate_types_old_style_lib_location() {
         .build();
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: path `src/foo.rs` was erroneously implicitly accepted for library `foo`,
+[WARNING] Cargo.toml: path `src/foo.rs` was erroneously implicitly accepted for library `foo`,
 please rename the file to `src/lib.rs` or set lib.path in Cargo.toml
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -5055,7 +5055,7 @@ fn target_edition() {
 
     p.cargo("build -v")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `edition` is set on library `foo` which is deprecated
+[WARNING] Cargo.toml: `edition` is set on library `foo` which is deprecated
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc [..]--edition=2018 [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -486,6 +486,7 @@ fn cargo_compile_duplicate_build_targets() {
 [WARNING] Cargo.toml: file `[ROOT]/foo/src/main.rs` found to be present in multiple build targets:
   * `lib` target `main`
   * `bin` target `foo`
+[WARNING] `foo` (manifest) generated 1 warning
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -634,10 +635,8 @@ fn cargo_compile_with_bin_and_crate_type() {
     p.cargo("build")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to parse manifest at `Cargo.toml`
-
-Caused by:
-  the target `the_foo_bin` is a binary and can't have any crate-types set (currently "cdylib, rlib")
+[ERROR] Cargo.toml: the target `the_foo_bin` is a binary and can't have any crate-types set (currently "cdylib, rlib")
+[ERROR] could not parse `foo` (manifest) due to 1 previous error
 
 "#]])
         .run();
@@ -722,10 +721,8 @@ fn cargo_compile_with_bin_and_proc() {
     p.cargo("build")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to parse manifest at `Cargo.toml`
-
-Caused by:
-  the target `the_foo_bin` is a binary and can't have `proc-macro` set `true`
+[ERROR] Cargo.toml: the target `the_foo_bin` is a binary and can't have `proc-macro` set `true`
+[ERROR] could not parse `foo` (manifest) due to 1 previous error
 
 "#]])
         .run();
@@ -2006,6 +2003,7 @@ fn many_crate_types_old_style_lib_location() {
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: path `src/foo.rs` was erroneously implicitly accepted for library `foo`,
 please rename the file to `src/lib.rs` or set lib.path in Cargo.toml
+[WARNING] `foo` (manifest) generated 1 warning
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -5056,6 +5054,7 @@ fn target_edition() {
     p.cargo("build -v")
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `edition` is set on library `foo` which is deprecated
+[WARNING] `foo` (manifest) generated 1 warning
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc [..]--edition=2018 [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -483,7 +483,7 @@ fn cargo_compile_duplicate_build_targets() {
 
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[WARNING] file `[ROOT]/foo/src/main.rs` found to be present in multiple build targets:
+[WARNING] [ROOT]/foo/Cargo.toml: file `[ROOT]/foo/src/main.rs` found to be present in multiple build targets:
   * `lib` target `main`
   * `bin` target `foo`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -2004,7 +2004,7 @@ fn many_crate_types_old_style_lib_location() {
         .build();
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[WARNING] path `src/foo.rs` was erroneously implicitly accepted for library `foo`,
+[WARNING] [ROOT]/foo/Cargo.toml: path `src/foo.rs` was erroneously implicitly accepted for library `foo`,
 please rename the file to `src/lib.rs` or set lib.path in Cargo.toml
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -5055,7 +5055,7 @@ fn target_edition() {
 
     p.cargo("build -v")
         .with_stderr_data(str![[r#"
-[WARNING] `edition` is set on library `foo` which is deprecated
+[WARNING] [ROOT]/foo/Cargo.toml: `edition` is set on library `foo` which is deprecated
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc [..]--edition=2018 [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -262,7 +262,7 @@ fn stable_feature_warns() {
         .build();
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: the cargo feature `test-dummy-stable` has been stabilized in the 1.0 release and is no longer necessary to be listed in the manifest
+[WARNING] Cargo.toml: the cargo feature `test-dummy-stable` has been stabilized in the 1.0 release and is no longer necessary to be listed in the manifest
   See https://doc.rust-lang.org/cargo/ for more information about using this feature.
 [CHECKING] a v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -264,6 +264,7 @@ fn stable_feature_warns() {
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: the cargo feature `test-dummy-stable` has been stabilized in the 1.0 release and is no longer necessary to be listed in the manifest
   See https://doc.rust-lang.org/cargo/ for more information about using this feature.
+[WARNING] `a` (manifest) generated 1 warning
 [CHECKING] a v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -262,7 +262,7 @@ fn stable_feature_warns() {
         .build();
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] the cargo feature `test-dummy-stable` has been stabilized in the 1.0 release and is no longer necessary to be listed in the manifest
+[WARNING] [ROOT]/foo/Cargo.toml: the cargo feature `test-dummy-stable` has been stabilized in the 1.0 release and is no longer necessary to be listed in the manifest
   See https://doc.rust-lang.org/cargo/ for more information about using this feature.
 [CHECKING] a v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/cargo_targets.rs
+++ b/tests/testsuite/cargo_targets.rs
@@ -54,7 +54,7 @@ fn reserved_windows_target_name() {
     if cfg!(windows) {
         p.cargo("check")
             .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/Cargo.toml: binary target `con` is a reserved Windows filename, this target will not work on Windows platforms
+[WARNING] Cargo.toml: binary target `con` is a reserved Windows filename, this target will not work on Windows platforms
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/cargo_targets.rs
+++ b/tests/testsuite/cargo_targets.rs
@@ -54,7 +54,7 @@ fn reserved_windows_target_name() {
     if cfg!(windows) {
         p.cargo("check")
             .with_stderr_data(str![[r#"
-[WARNING] binary target `con` is a reserved Windows filename, this target will not work on Windows platforms
+[WARNING] [ROOT]/Cargo.toml: binary target `con` is a reserved Windows filename, this target will not work on Windows platforms
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/cargo_targets.rs
+++ b/tests/testsuite/cargo_targets.rs
@@ -55,6 +55,7 @@ fn reserved_windows_target_name() {
         p.cargo("check")
             .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: binary target `con` is a reserved Windows filename, this target will not work on Windows platforms
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -1092,6 +1092,7 @@ fn warn_manifest_with_project() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `[project]` is deprecated in favor of `[package]`
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1149,6 +1150,7 @@ fn warn_manifest_package_and_project() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `[project]` is deprecated in favor of `[package]`
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1612,6 +1614,7 @@ fn check_unused_manifest_keys() {
 [WARNING] Cargo.toml: unused manifest key: target.bar.build-dependencies.foo.wxz
 [WARNING] Cargo.toml: unused manifest key: target.cfg(windows).dependencies.foo.wxz
 [WARNING] Cargo.toml: unused manifest key: target.wasm32-wasip1.dev-dependencies.foo.wxz
+[WARNING] `bar` (manifest) generated 7 warnings
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -1091,7 +1091,7 @@ fn warn_manifest_with_project() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `[project]` is deprecated in favor of `[package]`
+[WARNING] Cargo.toml: `[project]` is deprecated in favor of `[package]`
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1148,7 +1148,7 @@ fn warn_manifest_package_and_project() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `[project]` is deprecated in favor of `[package]`
+[WARNING] Cargo.toml: `[project]` is deprecated in favor of `[package]`
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1605,13 +1605,13 @@ fn check_unused_manifest_keys() {
     p.cargo("check")
         .with_stderr_data(
             str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: dependencies.dep.wxz
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: dependencies.foo.abc
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: dev-dependencies.foo.wxz
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: build-dependencies.foo.wxz
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: target.bar.build-dependencies.foo.wxz
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: target.cfg(windows).dependencies.foo.wxz
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: target.wasm32-wasip1.dev-dependencies.foo.wxz
+[WARNING] Cargo.toml: unused manifest key: dependencies.dep.wxz
+[WARNING] Cargo.toml: unused manifest key: dependencies.foo.abc
+[WARNING] Cargo.toml: unused manifest key: dev-dependencies.foo.wxz
+[WARNING] Cargo.toml: unused manifest key: build-dependencies.foo.wxz
+[WARNING] Cargo.toml: unused manifest key: target.bar.build-dependencies.foo.wxz
+[WARNING] Cargo.toml: unused manifest key: target.cfg(windows).dependencies.foo.wxz
+[WARNING] Cargo.toml: unused manifest key: target.wasm32-wasip1.dev-dependencies.foo.wxz
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -1091,7 +1091,7 @@ fn warn_manifest_with_project() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] `[project]` is deprecated in favor of `[package]`
+[WARNING] [ROOT]/foo/Cargo.toml: `[project]` is deprecated in favor of `[package]`
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1148,7 +1148,7 @@ fn warn_manifest_package_and_project() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] `[project]` is deprecated in favor of `[package]`
+[WARNING] [ROOT]/foo/Cargo.toml: `[project]` is deprecated in favor of `[package]`
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1605,13 +1605,13 @@ fn check_unused_manifest_keys() {
     p.cargo("check")
         .with_stderr_data(
             str![[r#"
-[WARNING] unused manifest key: dependencies.dep.wxz
-[WARNING] unused manifest key: dependencies.foo.abc
-[WARNING] unused manifest key: dev-dependencies.foo.wxz
-[WARNING] unused manifest key: build-dependencies.foo.wxz
-[WARNING] unused manifest key: target.bar.build-dependencies.foo.wxz
-[WARNING] unused manifest key: target.cfg(windows).dependencies.foo.wxz
-[WARNING] unused manifest key: target.wasm32-wasip1.dev-dependencies.foo.wxz
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: dependencies.dep.wxz
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: dependencies.foo.abc
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: dev-dependencies.foo.wxz
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: build-dependencies.foo.wxz
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: target.bar.build-dependencies.foo.wxz
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: target.cfg(windows).dependencies.foo.wxz
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: target.wasm32-wasip1.dev-dependencies.foo.wxz
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...

--- a/tests/testsuite/check_cfg.rs
+++ b/tests/testsuite/check_cfg.rs
@@ -634,7 +634,7 @@ fn config_invalid_position() {
 
     p.cargo("check -v")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: `lints.rust.use_bracket.check-cfg`
+[WARNING] Cargo.toml: unused manifest key: `lints.rust.use_bracket.check-cfg`
 ...
 "#]])
         .with_stderr_does_not_contain(x!("rustc" => "cfg" of "has_foo"))

--- a/tests/testsuite/check_cfg.rs
+++ b/tests/testsuite/check_cfg.rs
@@ -634,7 +634,7 @@ fn config_invalid_position() {
 
     p.cargo("check -v")
         .with_stderr_data(str![[r#"
-[WARNING] unused manifest key: `lints.rust.use_bracket.check-cfg`
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: `lints.rust.use_bracket.check-cfg`
 ...
 "#]])
         .with_stderr_does_not_contain(x!("rustc" => "cfg" of "has_foo"))

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -490,7 +490,7 @@ fn linker() {
         .arg(&target)
         .with_status(101)
         .with_stderr_data(str![[r#"
-[WARNING] path `src/foo.rs` was erroneously implicitly accepted for binary `foo`,
+[WARNING] [ROOT]/Cargo.toml: path `src/foo.rs` was erroneously implicitly accepted for binary `foo`,
 please set bin.path in Cargo.toml
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo --edition=2015 src/foo.rs [..]--crate-type bin --emit=[..]link[..]-C debuginfo=2 [..] -C metadata=[..] --out-dir [ROOT]/foo/target/[ALT_TARGET]/debug/deps --target [ALT_TARGET] -C linker=my-linker-tool -L dependency=[ROOT]/foo/target/[ALT_TARGET]/debug/deps -L dependency=[ROOT]/foo/target/debug/deps`

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -490,7 +490,7 @@ fn linker() {
         .arg(&target)
         .with_status(101)
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/Cargo.toml: path `src/foo.rs` was erroneously implicitly accepted for binary `foo`,
+[WARNING] Cargo.toml: path `src/foo.rs` was erroneously implicitly accepted for binary `foo`,
 please set bin.path in Cargo.toml
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo --edition=2015 src/foo.rs [..]--crate-type bin --emit=[..]link[..]-C debuginfo=2 [..] -C metadata=[..] --out-dir [ROOT]/foo/target/[ALT_TARGET]/debug/deps --target [ALT_TARGET] -C linker=my-linker-tool -L dependency=[ROOT]/foo/target/[ALT_TARGET]/debug/deps -L dependency=[ROOT]/foo/target/debug/deps`

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -492,6 +492,7 @@ fn linker() {
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: path `src/foo.rs` was erroneously implicitly accepted for binary `foo`,
 please set bin.path in Cargo.toml
+[WARNING] `foo` (manifest) generated 1 warning
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo --edition=2015 src/foo.rs [..]--crate-type bin --emit=[..]link[..]-C debuginfo=2 [..] -C metadata=[..] --out-dir [ROOT]/foo/target/[ALT_TARGET]/debug/deps --target [ALT_TARGET] -C linker=my-linker-tool -L dependency=[ROOT]/foo/target/[ALT_TARGET]/debug/deps -L dependency=[ROOT]/foo/target/debug/deps`
 [ERROR] linker `my-linker-tool` not found

--- a/tests/testsuite/edition.rs
+++ b/tests/testsuite/edition.rs
@@ -135,7 +135,7 @@ fn unset_edition_with_unset_rust_version() {
 
     p.cargo("check -v")
         .with_stderr_data(str![[r#"
-[WARNING] `package.edition` is unspecified, defaulting to `2015` while the latest is `[..]`
+[WARNING] [ROOT]/foo/Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [RUNNING] `rustc [..] --edition=2015 [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -186,7 +186,7 @@ fn unset_edition_works_on_old_msrv() {
 
     p.cargo("check -v")
         .with_stderr_data(str![[r#"
-[WARNING] `package.edition` is unspecified, defaulting to `2015` while 2018 is compatible with `rust-version`
+[WARNING] [ROOT]/foo/Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while 2018 is compatible with `rust-version`
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [RUNNING] `rustc [..] --edition=2015 [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/edition.rs
+++ b/tests/testsuite/edition.rs
@@ -136,6 +136,7 @@ fn unset_edition_with_unset_rust_version() {
     p.cargo("check -v")
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [RUNNING] `rustc [..] --edition=2015 [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -187,6 +188,7 @@ fn unset_edition_works_on_old_msrv() {
     p.cargo("check -v")
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while 2018 is compatible with `rust-version`
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [RUNNING] `rustc [..] --edition=2015 [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/edition.rs
+++ b/tests/testsuite/edition.rs
@@ -135,7 +135,7 @@ fn unset_edition_with_unset_rust_version() {
 
     p.cargo("check -v")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
+[WARNING] Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [RUNNING] `rustc [..] --edition=2015 [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -186,7 +186,7 @@ fn unset_edition_works_on_old_msrv() {
 
     p.cargo("check -v")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while 2018 is compatible with `rust-version`
+[WARNING] Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while 2018 is compatible with `rust-version`
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [RUNNING] `rustc [..] --edition=2015 [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -1906,6 +1906,7 @@ fn warn_if_default_features() {
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `[features]` defines a feature named `default-features`
 [NOTE] only a feature named `default` will be enabled by default
+[WARNING] `foo` (manifest) generated 1 warning
 [LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -1904,7 +1904,7 @@ fn warn_if_default_features() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] `[features]` defines a feature named `default-features`
+[WARNING] [ROOT]/foo/Cargo.toml: `[features]` defines a feature named `default-features`
 [NOTE] only a feature named `default` will be enabled by default
 [LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.0.1 ([ROOT]/foo)

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -1904,7 +1904,7 @@ fn warn_if_default_features() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `[features]` defines a feature named `default-features`
+[WARNING] Cargo.toml: `[features]` defines a feature named `default-features`
 [NOTE] only a feature named `default` will be enabled by default
 [LOCKING] 1 package to latest compatible version
 [CHECKING] foo v0.0.1 ([ROOT]/foo)

--- a/tests/testsuite/fetch.rs
+++ b/tests/testsuite/fetch.rs
@@ -144,6 +144,7 @@ fn fetch_warning() {
     p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: unused manifest key: package.misspelled
+[WARNING] `foo` (manifest) generated 1 warning
 
 "#]])
         .run();

--- a/tests/testsuite/fetch.rs
+++ b/tests/testsuite/fetch.rs
@@ -143,7 +143,7 @@ fn fetch_warning() {
         .build();
     p.cargo("fetch")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: package.misspelled
+[WARNING] Cargo.toml: unused manifest key: package.misspelled
 
 "#]])
         .run();

--- a/tests/testsuite/fetch.rs
+++ b/tests/testsuite/fetch.rs
@@ -143,7 +143,7 @@ fn fetch_warning() {
         .build();
     p.cargo("fetch")
         .with_stderr_data(str![[r#"
-[WARNING] unused manifest key: package.misspelled
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: package.misspelled
 
 "#]])
         .run();

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -2255,7 +2255,7 @@ fn edition_change_invalidates() {
     );
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `edition` is set on library `foo` which is deprecated
+[WARNING] Cargo.toml: `edition` is set on library `foo` which is deprecated
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2263,7 +2263,7 @@ fn edition_change_invalidates() {
         .run();
     p.cargo("build -v")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `edition` is set on library `foo` which is deprecated
+[WARNING] Cargo.toml: `edition` is set on library `foo` which is deprecated
 [FRESH] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -2256,6 +2256,7 @@ fn edition_change_invalidates() {
     p.cargo("build")
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `edition` is set on library `foo` which is deprecated
+[WARNING] `foo` (manifest) generated 1 warning
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2264,6 +2265,7 @@ fn edition_change_invalidates() {
     p.cargo("build -v")
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `edition` is set on library `foo` which is deprecated
+[WARNING] `foo` (manifest) generated 1 warning
 [FRESH] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -2255,7 +2255,7 @@ fn edition_change_invalidates() {
     );
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[WARNING] `edition` is set on library `foo` which is deprecated
+[WARNING] [ROOT]/foo/Cargo.toml: `edition` is set on library `foo` which is deprecated
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2263,7 +2263,7 @@ fn edition_change_invalidates() {
         .run();
     p.cargo("build -v")
         .with_stderr_data(str![[r#"
-[WARNING] `edition` is set on library `foo` which is deprecated
+[WARNING] [ROOT]/foo/Cargo.toml: `edition` is set on library `foo` which is deprecated
 [FRESH] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/freshness_checksum.rs
+++ b/tests/testsuite/freshness_checksum.rs
@@ -2031,6 +2031,7 @@ fn edition_change_invalidates() {
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `edition` is set on library `foo` which is deprecated
+[WARNING] `foo` (manifest) generated 1 warning
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2040,6 +2041,7 @@ fn edition_change_invalidates() {
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `edition` is set on library `foo` which is deprecated
+[WARNING] `foo` (manifest) generated 1 warning
 [FRESH] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/freshness_checksum.rs
+++ b/tests/testsuite/freshness_checksum.rs
@@ -2030,7 +2030,7 @@ fn edition_change_invalidates() {
     p.cargo("build -Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
-[WARNING] `edition` is set on library `foo` which is deprecated
+[WARNING] [ROOT]/foo/Cargo.toml: `edition` is set on library `foo` which is deprecated
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2039,7 +2039,7 @@ fn edition_change_invalidates() {
     p.cargo("build -Zchecksum-freshness -v")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
-[WARNING] `edition` is set on library `foo` which is deprecated
+[WARNING] [ROOT]/foo/Cargo.toml: `edition` is set on library `foo` which is deprecated
 [FRESH] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/freshness_checksum.rs
+++ b/tests/testsuite/freshness_checksum.rs
@@ -2030,7 +2030,7 @@ fn edition_change_invalidates() {
     p.cargo("build -Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `edition` is set on library `foo` which is deprecated
+[WARNING] Cargo.toml: `edition` is set on library `foo` which is deprecated
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2039,7 +2039,7 @@ fn edition_change_invalidates() {
     p.cargo("build -Zchecksum-freshness -v")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `edition` is set on library `foo` which is deprecated
+[WARNING] Cargo.toml: `edition` is set on library `foo` which is deprecated
 [FRESH] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/hints.rs
+++ b/tests/testsuite/hints.rs
@@ -67,7 +67,7 @@ fn unknown_hints_warn() {
         .build();
     p.cargo("check -v")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: hints.this-is-an-unknown-hint
+[WARNING] Cargo.toml: unused manifest key: hints.this-is-an-unknown-hint
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...

--- a/tests/testsuite/hints.rs
+++ b/tests/testsuite/hints.rs
@@ -67,7 +67,7 @@ fn unknown_hints_warn() {
         .build();
     p.cargo("check -v")
         .with_stderr_data(str![[r#"
-[WARNING] unused manifest key: hints.this-is-an-unknown-hint
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: hints.this-is-an-unknown-hint
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...

--- a/tests/testsuite/hints.rs
+++ b/tests/testsuite/hints.rs
@@ -68,6 +68,7 @@ fn unknown_hints_warn() {
     p.cargo("check -v")
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: unused manifest key: hints.this-is-an-unknown-hint
+[WARNING] `foo` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...

--- a/tests/testsuite/inheritable_workspace_fields.rs
+++ b/tests/testsuite/inheritable_workspace_fields.rs
@@ -756,7 +756,7 @@ fn inherit_workspace_fields() {
 [PACKAGING] bar v1.2.3 ([ROOT]/foo/bar)
 [PACKAGED] 8 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [VERIFYING] bar v1.2.3 ([ROOT]/foo/bar)
-[WARNING] only one of `license` or `license-file` is necessary
+[WARNING] [ROOT]/foo/target/package/bar-1.2.3/Cargo.toml: only one of `license` or `license-file` is necessary
 `license` should be used if the package license can be expressed with a standard SPDX expression.
 `license-file` should be used if the package uses a non-standard license.
 See https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields for more information.

--- a/tests/testsuite/inheritable_workspace_fields.rs
+++ b/tests/testsuite/inheritable_workspace_fields.rs
@@ -756,7 +756,7 @@ fn inherit_workspace_fields() {
 [PACKAGING] bar v1.2.3 ([ROOT]/foo/bar)
 [PACKAGED] 8 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 [VERIFYING] bar v1.2.3 ([ROOT]/foo/bar)
-[WARNING] [ROOT]/foo/target/package/bar-1.2.3/Cargo.toml: only one of `license` or `license-file` is necessary
+[WARNING] ../target/package/bar-1.2.3/Cargo.toml: only one of `license` or `license-file` is necessary
 `license` should be used if the package license can be expressed with a standard SPDX expression.
 `license-file` should be used if the package uses a non-standard license.
 See https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields for more information.
@@ -1538,7 +1538,7 @@ fn warn_inherit_def_feat_true_member_def_feat_false() {
         .build();
 
     p.cargo("check").with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `default-features` is ignored for dep, since `default-features` was true for `workspace.dependencies.dep`, this could become a hard error in the future
+[WARNING] Cargo.toml: `default-features` is ignored for dep, since `default-features` was true for `workspace.dependencies.dep`, this could become a hard error in the future
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
@@ -1630,7 +1630,7 @@ fn warn_inherit_simple_member_def_feat_false() {
         .build();
 
     p.cargo("check").with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `default-features` is ignored for dep, since `default-features` was not specified for `workspace.dependencies.dep`, this could become a hard error in the future
+[WARNING] Cargo.toml: `default-features` is ignored for dep, since `default-features` was not specified for `workspace.dependencies.dep`, this could become a hard error in the future
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
@@ -1810,8 +1810,8 @@ fn warn_inherit_unused_manifest_key_dep() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: workspace.dependencies.dep.wxz
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: dependencies.dep.wxz
+[WARNING] Cargo.toml: unused manifest key: workspace.dependencies.dep.wxz
+[WARNING] Cargo.toml: unused manifest key: dependencies.dep.wxz
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
@@ -1847,7 +1847,7 @@ fn warn_unused_workspace_package_field() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: workspace.package.name
+[WARNING] Cargo.toml: unused manifest key: workspace.package.name
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1904,20 +1904,20 @@ fn warn_inherit_unused_manifest_key_package() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: package.authors.xyz
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: package.categories.xyz
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: package.description.xyz
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: package.documentation.xyz
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: package.edition.xyz
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: package.exclude.xyz
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: package.homepage.xyz
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: package.include.xyz
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: package.keywords.xyz
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: package.license.xyz
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: package.publish.xyz
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: package.repository.xyz
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: package.rust-version.xyz
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: package.version.xyz
+[WARNING] Cargo.toml: unused manifest key: package.authors.xyz
+[WARNING] Cargo.toml: unused manifest key: package.categories.xyz
+[WARNING] Cargo.toml: unused manifest key: package.description.xyz
+[WARNING] Cargo.toml: unused manifest key: package.documentation.xyz
+[WARNING] Cargo.toml: unused manifest key: package.edition.xyz
+[WARNING] Cargo.toml: unused manifest key: package.exclude.xyz
+[WARNING] Cargo.toml: unused manifest key: package.homepage.xyz
+[WARNING] Cargo.toml: unused manifest key: package.include.xyz
+[WARNING] Cargo.toml: unused manifest key: package.keywords.xyz
+[WARNING] Cargo.toml: unused manifest key: package.license.xyz
+[WARNING] Cargo.toml: unused manifest key: package.publish.xyz
+[WARNING] Cargo.toml: unused manifest key: package.repository.xyz
+[WARNING] Cargo.toml: unused manifest key: package.rust-version.xyz
+[WARNING] Cargo.toml: unused manifest key: package.version.xyz
 [CHECKING] bar v1.2.3 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/inheritable_workspace_fields.rs
+++ b/tests/testsuite/inheritable_workspace_fields.rs
@@ -760,6 +760,7 @@ fn inherit_workspace_fields() {
 `license` should be used if the package license can be expressed with a standard SPDX expression.
 `license-file` should be used if the package uses a non-standard license.
 See https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields for more information.
+[WARNING] `bar` (manifest) generated 1 warning
 [COMPILING] bar v1.2.3 ([ROOT]/foo/target/package/bar-1.2.3)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [UPLOADING] bar v1.2.3 ([ROOT]/foo/bar)
@@ -1539,6 +1540,7 @@ fn warn_inherit_def_feat_true_member_def_feat_false() {
 
     p.cargo("check").with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `default-features` is ignored for dep, since `default-features` was true for `workspace.dependencies.dep`, this could become a hard error in the future
+[WARNING] `bar` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
@@ -1631,6 +1633,7 @@ fn warn_inherit_simple_member_def_feat_false() {
 
     p.cargo("check").with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `default-features` is ignored for dep, since `default-features` was not specified for `workspace.dependencies.dep`, this could become a hard error in the future
+[WARNING] `bar` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
@@ -1812,6 +1815,7 @@ fn warn_inherit_unused_manifest_key_dep() {
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: unused manifest key: workspace.dependencies.dep.wxz
 [WARNING] Cargo.toml: unused manifest key: dependencies.dep.wxz
+[WARNING] `bar` (manifest) generated 2 warnings
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
@@ -1848,6 +1852,7 @@ fn warn_unused_workspace_package_field() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: unused manifest key: workspace.package.name
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1918,6 +1923,7 @@ fn warn_inherit_unused_manifest_key_package() {
 [WARNING] Cargo.toml: unused manifest key: package.repository.xyz
 [WARNING] Cargo.toml: unused manifest key: package.rust-version.xyz
 [WARNING] Cargo.toml: unused manifest key: package.version.xyz
+[WARNING] `bar` (manifest) generated 14 warnings
 [CHECKING] bar v1.2.3 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/lints/unused_workspace_package_fields.rs
+++ b/tests/testsuite/lints/unused_workspace_package_fields.rs
@@ -73,6 +73,7 @@ workspace = true
   |
 [WARNING] workspace (manifest) generated 2 warnings
 [WARNING] Cargo.toml: unused manifest key: workspace.package.unknown
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/lints/unused_workspace_package_fields.rs
+++ b/tests/testsuite/lints/unused_workspace_package_fields.rs
@@ -72,7 +72,7 @@ workspace = true
 9 - unknown = "foo"
   |
 [WARNING] workspace (manifest) generated 2 warnings
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: workspace.package.unknown
+[WARNING] Cargo.toml: unused manifest key: workspace.package.unknown
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/lints_table.rs
+++ b/tests/testsuite/lints_table.rs
@@ -754,7 +754,7 @@ authors = []
 
     foo.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] unused manifest key `lints.cargo` (may be supported in a future version)
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key `lints.cargo` (may be supported in a future version)
 
 this Cargo does not support nightly features, but if you
 switch to nightly channel you can pass
@@ -790,7 +790,7 @@ im-a-teapot = true
     foo.cargo("check")
         .masquerade_as_nightly_cargo(&["cargo-lints", "test-dummy-unstable"])
         .with_stderr_data(str![[r#"
-[WARNING] unused manifest key `lints.cargo` (may be supported in a future version)
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key `lints.cargo` (may be supported in a future version)
 
 consider passing `-Zcargo-lints` to enable this feature.
 [CHECKING] foo v0.0.1 ([ROOT]/foo)

--- a/tests/testsuite/lints_table.rs
+++ b/tests/testsuite/lints_table.rs
@@ -104,7 +104,7 @@ fn fail_on_invalid_tool() {
         .build();
 
     foo.cargo("check").with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: unrecognized lint tool `lints.super-awesome-linter`, specifying unrecognized tools may break in the future.
+[WARNING] Cargo.toml: unrecognized lint tool `lints.super-awesome-linter`, specifying unrecognized tools may break in the future.
 supported tools: cargo, clippy, rust, rustdoc
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -165,8 +165,8 @@ fn warn_on_unused_key() {
 
     foo.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: `lints.rust.rust-2018-idioms.unused`
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: `lints.rust.rust-2018-idioms.unused`
+[WARNING] Cargo.toml: unused manifest key: `lints.rust.rust-2018-idioms.unused`
+[WARNING] Cargo.toml: unused manifest key: `lints.rust.rust-2018-idioms.unused`
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -754,7 +754,7 @@ authors = []
 
     foo.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key `lints.cargo` (may be supported in a future version)
+[WARNING] Cargo.toml: unused manifest key `lints.cargo` (may be supported in a future version)
 
 this Cargo does not support nightly features, but if you
 switch to nightly channel you can pass
@@ -790,7 +790,7 @@ im-a-teapot = true
     foo.cargo("check")
         .masquerade_as_nightly_cargo(&["cargo-lints", "test-dummy-unstable"])
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key `lints.cargo` (may be supported in a future version)
+[WARNING] Cargo.toml: unused manifest key `lints.cargo` (may be supported in a future version)
 
 consider passing `-Zcargo-lints` to enable this feature.
 [CHECKING] foo v0.0.1 ([ROOT]/foo)

--- a/tests/testsuite/lints_table.rs
+++ b/tests/testsuite/lints_table.rs
@@ -106,6 +106,7 @@ fn fail_on_invalid_tool() {
     foo.cargo("check").with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: unrecognized lint tool `lints.super-awesome-linter`, specifying unrecognized tools may break in the future.
 supported tools: cargo, clippy, rust, rustdoc
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -167,6 +168,7 @@ fn warn_on_unused_key() {
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: unused manifest key: `lints.rust.rust-2018-idioms.unused`
 [WARNING] Cargo.toml: unused manifest key: `lints.rust.rust-2018-idioms.unused`
+[WARNING] `foo` (manifest) generated 2 warnings
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -759,6 +761,7 @@ authors = []
 this Cargo does not support nightly features, but if you
 switch to nightly channel you can pass
 `-Zcargo-lints` to enable this feature.
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -793,6 +796,7 @@ im-a-teapot = true
 [WARNING] Cargo.toml: unused manifest key `lints.cargo` (may be supported in a future version)
 
 consider passing `-Zcargo-lints` to enable this feature.
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/proc_macro.rs
+++ b/tests/testsuite/proc_macro.rs
@@ -375,6 +375,7 @@ fn proc_macro_crate_type_warning() {
     foo.cargo("check")
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: library `foo` should only specify `proc-macro = true` instead of setting `crate-type`
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -402,6 +403,7 @@ fn lib_plugin_unused_key_warning() {
     foo.cargo("check")
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: unused manifest key: lib.plugin
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -429,6 +431,7 @@ fn proc_macro_crate_type_warning_plugin() {
     foo.cargo("check")
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: library `foo` should only specify `proc-macro = true` instead of setting `crate-type`
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/proc_macro.rs
+++ b/tests/testsuite/proc_macro.rs
@@ -374,7 +374,7 @@ fn proc_macro_crate_type_warning() {
 
     foo.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: library `foo` should only specify `proc-macro = true` instead of setting `crate-type`
+[WARNING] Cargo.toml: library `foo` should only specify `proc-macro = true` instead of setting `crate-type`
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -401,7 +401,7 @@ fn lib_plugin_unused_key_warning() {
 
     foo.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: lib.plugin
+[WARNING] Cargo.toml: unused manifest key: lib.plugin
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -428,7 +428,7 @@ fn proc_macro_crate_type_warning_plugin() {
 
     foo.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: library `foo` should only specify `proc-macro = true` instead of setting `crate-type`
+[WARNING] Cargo.toml: library `foo` should only specify `proc-macro = true` instead of setting `crate-type`
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/proc_macro.rs
+++ b/tests/testsuite/proc_macro.rs
@@ -374,7 +374,7 @@ fn proc_macro_crate_type_warning() {
 
     foo.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] library `foo` should only specify `proc-macro = true` instead of setting `crate-type`
+[WARNING] [ROOT]/foo/Cargo.toml: library `foo` should only specify `proc-macro = true` instead of setting `crate-type`
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -401,7 +401,7 @@ fn lib_plugin_unused_key_warning() {
 
     foo.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] unused manifest key: lib.plugin
+[WARNING] [ROOT]/foo/Cargo.toml: unused manifest key: lib.plugin
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -428,7 +428,7 @@ fn proc_macro_crate_type_warning_plugin() {
 
     foo.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] library `foo` should only specify `proc-macro = true` instead of setting `crate-type`
+[WARNING] [ROOT]/foo/Cargo.toml: library `foo` should only specify `proc-macro = true` instead of setting `crate-type`
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -361,8 +361,8 @@ fn profile_panic_test_bench() {
 
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `panic` setting is ignored for `bench` profile
-[WARNING] [ROOT]/foo/Cargo.toml: `panic` setting is ignored for `test` profile
+[WARNING] Cargo.toml: `panic` setting is ignored for `bench` profile
+[WARNING] Cargo.toml: `panic` setting is ignored for `test` profile
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -390,7 +390,7 @@ fn profile_doc_deprecated() {
 
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: profile `doc` is deprecated and has no effect
+[WARNING] Cargo.toml: profile `doc` is deprecated and has no effect
 ...
 "#]])
         .run();

--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -363,6 +363,7 @@ fn profile_panic_test_bench() {
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `panic` setting is ignored for `bench` profile
 [WARNING] Cargo.toml: `panic` setting is ignored for `test` profile
+[WARNING] `foo` (manifest) generated 2 warnings
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -361,8 +361,8 @@ fn profile_panic_test_bench() {
 
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[WARNING] `panic` setting is ignored for `bench` profile
-[WARNING] `panic` setting is ignored for `test` profile
+[WARNING] [ROOT]/foo/Cargo.toml: `panic` setting is ignored for `bench` profile
+[WARNING] [ROOT]/foo/Cargo.toml: `panic` setting is ignored for `test` profile
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -390,7 +390,7 @@ fn profile_doc_deprecated() {
 
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[WARNING] profile `doc` is deprecated and has no effect
+[WARNING] [ROOT]/foo/Cargo.toml: profile `doc` is deprecated and has no effect
 ...
 "#]])
         .run();

--- a/tests/testsuite/pub_priv.rs
+++ b/tests/testsuite/pub_priv.rs
@@ -141,7 +141,7 @@ fn requires_feature() {
     p.cargo("check --message-format=short")
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: ignoring `public` on dependency pub_dep, pass `-Zpublic-dependency` to enable support for it
+[WARNING] Cargo.toml: ignoring `public` on dependency pub_dep, pass `-Zpublic-dependency` to enable support for it
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
@@ -227,7 +227,7 @@ fn pub_dev_dependency_without_feature() {
 
     p.cargo("check --message-format=short")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: 'public' specifier can only be used on regular dependencies, not dev-dependencies
+[WARNING] Cargo.toml: 'public' specifier can only be used on regular dependencies, not dev-dependencies
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/pub_priv.rs
+++ b/tests/testsuite/pub_priv.rs
@@ -141,7 +141,7 @@ fn requires_feature() {
     p.cargo("check --message-format=short")
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(str![[r#"
-[WARNING] ignoring `public` on dependency pub_dep, pass `-Zpublic-dependency` to enable support for it
+[WARNING] [ROOT]/foo/Cargo.toml: ignoring `public` on dependency pub_dep, pass `-Zpublic-dependency` to enable support for it
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
@@ -227,7 +227,7 @@ fn pub_dev_dependency_without_feature() {
 
     p.cargo("check --message-format=short")
         .with_stderr_data(str![[r#"
-[WARNING] 'public' specifier can only be used on regular dependencies, not dev-dependencies
+[WARNING] [ROOT]/foo/Cargo.toml: 'public' specifier can only be used on regular dependencies, not dev-dependencies
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/pub_priv.rs
+++ b/tests/testsuite/pub_priv.rs
@@ -142,6 +142,7 @@ fn requires_feature() {
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: ignoring `public` on dependency pub_dep, pass `-Zpublic-dependency` to enable support for it
+[WARNING] `foo` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [DOWNLOADING] crates ...
@@ -228,6 +229,7 @@ fn pub_dev_dependency_without_feature() {
     p.cargo("check --message-format=short")
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: 'public' specifier can only be used on regular dependencies, not dev-dependencies
+[WARNING] `foo` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -608,7 +608,7 @@ fn run_example_autodiscover_2015() {
     p.cargo("run --example a")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[WARNING] An explicit [[example]] section is specified in Cargo.toml which currently
+[WARNING] [ROOT]/foo/Cargo.toml: An explicit [[example]] section is specified in Cargo.toml which currently
 disables Cargo from automatically inferring other example targets.
 This inference behavior will change in the Rust 2018 edition and the following
 files will be included as a example target:

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -608,7 +608,7 @@ fn run_example_autodiscover_2015() {
     p.cargo("run --example a")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: An explicit [[example]] section is specified in Cargo.toml which currently
+[WARNING] Cargo.toml: An explicit [[example]] section is specified in Cargo.toml which currently
 disables Cargo from automatically inferring other example targets.
 This inference behavior will change in the Rust 2018 edition and the following
 files will be included as a example target:

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -623,6 +623,7 @@ automatically infer them to be a target, such as in subfolders.
 
 For more information on this warning you can consult
 https://github.com/rust-lang/cargo/issues/5330
+[WARNING] `foo` (manifest) generated 1 warning
 [ERROR] no example target named `a` in default-run packages
 [HELP] available example targets:
     do_magic

--- a/tests/testsuite/script/cargo.rs
+++ b/tests/testsuite/script/cargo.rs
@@ -2155,6 +2155,7 @@ script.path = "script.rs"
         .with_status(101)
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
+[WARNING] `foo` (manifest) generated 1 warning
 [ERROR] failed to get `script` as a dependency of package `foo v0.1.0 ([ROOT]/foo)`
 
 Caused by:

--- a/tests/testsuite/script/cargo.rs
+++ b/tests/testsuite/script/cargo.rs
@@ -2154,7 +2154,7 @@ script.path = "script.rs"
         .masquerade_as_nightly_cargo(&["script"])
         .with_status(101)
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
+[WARNING] Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
 [ERROR] failed to get `script` as a dependency of package `foo v0.1.0 ([ROOT]/foo)`
 
 Caused by:

--- a/tests/testsuite/script/cargo.rs
+++ b/tests/testsuite/script/cargo.rs
@@ -2154,7 +2154,7 @@ script.path = "script.rs"
         .masquerade_as_nightly_cargo(&["script"])
         .with_status(101)
         .with_stderr_data(str![[r#"
-[WARNING] `package.edition` is unspecified, defaulting to `2015` while the latest is `[..]`
+[WARNING] [ROOT]/foo/Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
 [ERROR] failed to get `script` as a dependency of package `foo v0.1.0 ([ROOT]/foo)`
 
 Caused by:

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -5136,7 +5136,7 @@ fn panic_abort_only_test() {
 
     p.cargo("test -Z panic-abort-tests -v")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `panic` setting is ignored for `test` profile
+[WARNING] Cargo.toml: `panic` setting is ignored for `test` profile
 ...
 "#]])
         .masquerade_as_nightly_cargo(&["panic-abort-tests"])

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -5136,7 +5136,7 @@ fn panic_abort_only_test() {
 
     p.cargo("test -Z panic-abort-tests -v")
         .with_stderr_data(str![[r#"
-[WARNING] `panic` setting is ignored for `test` profile
+[WARNING] [ROOT]/foo/Cargo.toml: `panic` setting is ignored for `test` profile
 ...
 "#]])
         .masquerade_as_nightly_cargo(&["panic-abort-tests"])

--- a/tests/testsuite/warning_override.rs
+++ b/tests/testsuite/warning_override.rs
@@ -255,6 +255,7 @@ fn hard_warning_deny() {
         .arg("-ox.rs")
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
+[WARNING] `foo` (manifest) generated 1 warning
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [WARNING] foo@0.0.1: from a build script
 [WARNING] [..]
@@ -274,6 +275,7 @@ fn hard_warning_deny() {
         .arg("-ox.rs")
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
+[WARNING] `foo` (manifest) generated 1 warning
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [WARNING] foo@0.0.1: from a build script
 [WARNING] [..]
@@ -294,6 +296,7 @@ fn hard_warning_deny() {
         .arg("-ox.rs")
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
+[WARNING] `foo` (manifest) generated 1 warning
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [WARNING] foo@0.0.1: from a build script
 [WARNING] [..]
@@ -335,6 +338,7 @@ fn hard_warning_allow() {
         .arg("-ox.rs")
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
+[WARNING] `foo` (manifest) generated 1 warning
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [WARNING] foo@0.0.1: from a build script
 [WARNING] [..]
@@ -355,6 +359,7 @@ fn hard_warning_allow() {
         .arg("-ox.rs")
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
+[WARNING] `foo` (manifest) generated 1 warning
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [WARNING] foo@0.0.1: from a build script
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -371,6 +376,7 @@ fn hard_warning_allow() {
         .arg("-ox.rs")
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
+[WARNING] `foo` (manifest) generated 1 warning
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [WARNING] foo@0.0.1: from a build script
 [WARNING] [..]

--- a/tests/testsuite/warning_override.rs
+++ b/tests/testsuite/warning_override.rs
@@ -254,7 +254,7 @@ fn hard_warning_deny() {
         .arg("--")
         .arg("-ox.rs")
         .with_stderr_data(str![[r#"
-[WARNING] `package.edition` is unspecified, defaulting to `2015` while the latest is `[..]`
+[WARNING] [ROOT]/foo/Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [WARNING] foo@0.0.1: from a build script
 [WARNING] [..]
@@ -273,7 +273,7 @@ fn hard_warning_deny() {
         .arg("--")
         .arg("-ox.rs")
         .with_stderr_data(str![[r#"
-[WARNING] `package.edition` is unspecified, defaulting to `2015` while the latest is `[..]`
+[WARNING] [ROOT]/foo/Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [WARNING] foo@0.0.1: from a build script
 [WARNING] [..]
@@ -293,7 +293,7 @@ fn hard_warning_deny() {
         .arg("--")
         .arg("-ox.rs")
         .with_stderr_data(str![[r#"
-[WARNING] `package.edition` is unspecified, defaulting to `2015` while the latest is `[..]`
+[WARNING] [ROOT]/foo/Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [WARNING] foo@0.0.1: from a build script
 [WARNING] [..]
@@ -334,7 +334,7 @@ fn hard_warning_allow() {
         .arg("--")
         .arg("-ox.rs")
         .with_stderr_data(str![[r#"
-[WARNING] `package.edition` is unspecified, defaulting to `2015` while the latest is `[..]`
+[WARNING] [ROOT]/foo/Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [WARNING] foo@0.0.1: from a build script
 [WARNING] [..]
@@ -354,7 +354,7 @@ fn hard_warning_allow() {
         .arg("--")
         .arg("-ox.rs")
         .with_stderr_data(str![[r#"
-[WARNING] `package.edition` is unspecified, defaulting to `2015` while the latest is `[..]`
+[WARNING] [ROOT]/foo/Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [WARNING] foo@0.0.1: from a build script
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -370,7 +370,7 @@ fn hard_warning_allow() {
         .arg("--")
         .arg("-ox.rs")
         .with_stderr_data(str![[r#"
-[WARNING] `package.edition` is unspecified, defaulting to `2015` while the latest is `[..]`
+[WARNING] [ROOT]/foo/Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [WARNING] foo@0.0.1: from a build script
 [WARNING] [..]

--- a/tests/testsuite/warning_override.rs
+++ b/tests/testsuite/warning_override.rs
@@ -254,7 +254,7 @@ fn hard_warning_deny() {
         .arg("--")
         .arg("-ox.rs")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
+[WARNING] Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [WARNING] foo@0.0.1: from a build script
 [WARNING] [..]
@@ -273,7 +273,7 @@ fn hard_warning_deny() {
         .arg("--")
         .arg("-ox.rs")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
+[WARNING] Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [WARNING] foo@0.0.1: from a build script
 [WARNING] [..]
@@ -293,7 +293,7 @@ fn hard_warning_deny() {
         .arg("--")
         .arg("-ox.rs")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
+[WARNING] Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [WARNING] foo@0.0.1: from a build script
 [WARNING] [..]
@@ -334,7 +334,7 @@ fn hard_warning_allow() {
         .arg("--")
         .arg("-ox.rs")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
+[WARNING] Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [WARNING] foo@0.0.1: from a build script
 [WARNING] [..]
@@ -354,7 +354,7 @@ fn hard_warning_allow() {
         .arg("--")
         .arg("-ox.rs")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
+[WARNING] Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [WARNING] foo@0.0.1: from a build script
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -370,7 +370,7 @@ fn hard_warning_allow() {
         .arg("--")
         .arg("-ox.rs")
         .with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
+[WARNING] Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [WARNING] foo@0.0.1: from a build script
 [WARNING] [..]

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -2448,7 +2448,7 @@ fn ws_warn_path() {
         .build();
 
     p.cargo("check").with_stderr_data(str![[r#"
-[WARNING] [ROOT]/foo/a/Cargo.toml: the cargo feature `edition` has been stabilized in the 1.31 release and is no longer necessary to be listed in the manifest
+[WARNING] a/Cargo.toml: the cargo feature `edition` has been stabilized in the 1.31 release and is no longer necessary to be listed in the manifest
   See https://doc.rust-lang.org/cargo/reference/manifest.html#the-edition-field for more information about using this feature.
 [CHECKING] foo v0.1.0 ([ROOT]/foo/a)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -2450,6 +2450,7 @@ fn ws_warn_path() {
     p.cargo("check").with_stderr_data(str![[r#"
 [WARNING] a/Cargo.toml: the cargo feature `edition` has been stabilized in the 1.31 release and is no longer necessary to be listed in the manifest
   See https://doc.rust-lang.org/cargo/reference/manifest.html#the-edition-field for more information about using this feature.
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.1.0 ([ROOT]/foo/a)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 


### PR DESCRIPTION
### What does this PR try to resolve?

This is giving deferred diagnostics the same semantics as semantics as the rest of the diagnostics.

This is building on #16975 in prep for moving the knowledge of the parse diagnostics pass out of `core` and into `diagnostics` to reduce the number of places to touch when adding a diagnostic and to remove a layer violation (`ops -> core -> diagnostics -> core`).

### How to test and review this PR?

The `Origin` of the diagnostics is rendered differently than our normal diagnostics. I could put these in an `annotate_snippets::Report` and add an `Origin` but some of these deferred diagnostics have hacked in `note:`s and `help:`s which won't render in the prettiest of ways. This should be resolved as we migrate away from deferring diagnostics to have actual, individual diagnostic rules.

This is part of #12235.
