### PR TITLE
fix: don't cache failed rustc-wrapper output in rustc info cache

### DIFF
--- a/src/cargo/util/rustc.rs
+++ b/src/cargo/util/rustc.rs
@@ -259,41 +259,55 @@ impl Cache {
         extra_fingerprint: u64,
     ) -> CargoResult<(String, String)> {
         let key = process_fingerprint(cmd, extra_fingerprint);
-        if let std::collections::hash_map::Entry::Vacant(e) = self.data.outputs.entry(key) {
-            debug!("rustc info cache miss");
-            debug!("running {}", cmd);
-            let output = cmd.output()?;
-            let stdout = String::from_utf8(output.stdout)
-                .map_err(|e| anyhow::anyhow!("{}: {:?}", e, e.as_bytes()))
-                .with_context(|| format!("`{}` didn't return utf8 output", cmd))?;
-            let stderr = String::from_utf8(output.stderr)
-                .map_err(|e| anyhow::anyhow!("{}: {:?}", e, e.as_bytes()))
-                .with_context(|| format!("`{}` didn't return utf8 output", cmd))?;
-            e.insert(Output {
-                success: output.status.success(),
-                status: if output.status.success() {
-                    String::new()
-                } else {
-                    cargo_util::exit_status_to_string(output.status)
-                },
-                code: output.status.code(),
-                stdout,
-                stderr,
-            });
-            self.dirty = true;
-        } else {
-            debug!("rustc info cache hit");
+        match self.data.outputs.get(&key) {
+            Some(output) if output.success => {
+                debug!("rustc info cache hit");
+                return Ok((output.stdout.clone(), output.stderr.clone()));
+            }
+            Some(_) => {
+                // Previously cached a failure. Remove it so we retry the command,
+                // since failures may be transient (e.g., a rustc wrapper like
+                // sccache intermittently failing).
+                debug!("rustc info cache hit, but cached output was a failure; retrying");
+                self.data.outputs.remove(&key);
+                self.dirty = true;
+            }
+            None => {
+                debug!("rustc info cache miss");
+            }
         }
-        let output = &self.data.outputs[&key];
-        if output.success {
-            Ok((output.stdout.clone(), output.stderr.clone()))
+
+        debug!("running {}", cmd);
+        let output = cmd.output()?;
+        let stdout = String::from_utf8(output.stdout)
+            .map_err(|e| anyhow::anyhow!("{}: {:?}", e, e.as_bytes()))
+            .with_context(|| format!("`{}` didn't return utf8 output", cmd))?;
+        let stderr = String::from_utf8(output.stderr)
+            .map_err(|e| anyhow::anyhow!("{}: {:?}", e, e.as_bytes()))
+            .with_context(|| format!("`{}` didn't return utf8 output", cmd))?;
+
+        if output.status.success() {
+            self.data.outputs.insert(
+                key,
+                Output {
+                    success: true,
+                    status: String::new(),
+                    code: output.status.code(),
+                    stdout: stdout.clone(),
+                    stderr: stderr.clone(),
+                },
+            );
+            self.dirty = true;
+            Ok((stdout, stderr))
         } else {
+            // Don't cache failures — they may be transient (e.g., a wrapper
+            // process like sccache failing due to a temporary server issue).
             Err(ProcessError::new_raw(
                 &format!("process didn't exit successfully: {}", cmd),
-                output.code,
-                &output.status,
-                Some(output.stdout.as_ref()),
-                Some(output.stderr.as_ref()),
+                output.status.code(),
+                &cargo_util::exit_status_to_string(output.status),
+                Some(stdout.as_ref()),
+                Some(stderr.as_ref()),
             )
             .into())
         }
@@ -303,6 +317,9 @@ impl Cache {
 impl Drop for Cache {
     fn drop(&mut self) {
         if !self.dirty {
+            return;
+        }
+        if self.data.outputs.is_empty() && self.data.successes.is_empty() {
             return;
         }
         if let Some(ref path) = self.cache_location {

--- a/tests/testsuite/rustc_info_cache.rs
+++ b/tests/testsuite/rustc_info_cache.rs
@@ -171,18 +171,87 @@ fn rustc_info_cache_with_wrappers() {
             .env(wrapper_env, &wrapper)
             .with_stderr_contains("[..]different compiler, creating new rustc info cache[..]")
             .with_stderr_contains(MISS)
-            .with_stderr_contains(UPDATE)
             .with_stderr_does_not_contain(HIT)
+            .with_stderr_does_not_contain(UPDATE)
             .with_status(101)
             .run();
+        // Failures are not cached — a subsequent run should retry the command
+        // rather than replaying the cached failure.
         p.cargo("build")
             .env("CARGO_LOG", "cargo::util::rustc=debug")
             .env(wrapper_env, &wrapper)
-            .with_stderr_contains("[..]reusing existing rustc info cache[..]")
-            .with_stderr_contains(HIT)
+            .with_stderr_contains(MISS)
+            .with_stderr_does_not_contain(HIT)
             .with_stderr_does_not_contain(UPDATE)
-            .with_stderr_does_not_contain(MISS)
             .with_status(101)
             .run();
     }
+}
+
+#[cargo_test]
+fn rustc_info_cache_transient_failure_recovery() {
+    let wrapper_project = project()
+        .at("wrapper")
+        .file("Cargo.toml", &basic_bin_manifest("wrapper"))
+        .file("src/main.rs", r#"fn main() { }"#)
+        .build();
+    let wrapper = wrapper_project.bin("wrapper");
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "test"
+                version = "0.0.0"
+                authors = []
+                [workspace]
+            "#,
+        )
+        .file("src/main.rs", r#"fn main() { println!("hello"); }"#)
+        .build();
+
+    // Build a wrapper that fails (simulates a transient sccache failure).
+    wrapper_project.change_file(
+        "src/main.rs",
+        r#"
+        fn main() {
+            eprintln!("wrapper: error: Operation not permitted (os error 1)");
+            std::process::exit(1);
+        }
+        "#,
+    );
+    wrapper_project.cargo("build").with_status(0).run();
+
+    p.cargo("build")
+        .env("CARGO_LOG", "cargo::util::rustc=debug")
+        .env("RUSTC_WRAPPER", &wrapper)
+        .with_stderr_contains("[..]Operation not permitted[..]")
+        .with_status(101)
+        .run();
+
+    // Now fix the wrapper (simulates sccache recovering).
+    wrapper_project.change_file(
+        "src/main.rs",
+        r#"
+        fn main() {
+            let mut args = std::env::args_os();
+            let _me = args.next().unwrap();
+            let rustc = args.next().unwrap();
+            let status = std::process::Command::new(rustc).args(args).status().unwrap();
+            std::process::exit(if status.success() { 0 } else { 1 })
+        }
+        "#,
+    );
+    wrapper_project.cargo("build").with_status(0).run();
+
+    // The build should now succeed — the previous failure must not be cached.
+    p.cargo("build")
+        .env("CARGO_LOG", "cargo::util::rustc=debug")
+        .env("RUSTC_WRAPPER", &wrapper)
+        .with_stderr_contains(MISS)
+        .with_stderr_does_not_contain(HIT)
+        .with_stderr_contains(UPDATE)
+        .with_status(0)
+        .run();
 }


### PR DESCRIPTION
## Summary

When a `rustc_wrapper` (e.g., `sccache`) fails transiently, the failure output gets cached in `target/.rustc_info.json` and is replayed on every subsequent `cargo build`. Since the cache fingerprint is derived from binary mtime/size and toolchain metadata — not runtime state — the poisoned cache entry is never invalidated, permanently breaking builds until the user manually deletes the file.

## The Bug

`Cache::cached_output()` unconditionally inserts command output into the cache regardless of exit status. On a cache hit, it replays whatever was stored — including failures. The fingerprint only changes when the rustc/wrapper binary or toolchain changes, so a transient failure (server timeout, permission error, etc.) becomes permanent.

Real-world trigger: `sccache` server occasionally returns `EPERM` on startup race conditions. One failure poisons the cache and every build afterward fails with the same error — even after `sccache` recovers.

## The Fix

- Only cache **successful** command outputs. Failures are returned as errors but never persisted.
- On cache load, if a previously-cached failure is found, remove it and retry the command.
- Skip writing the cache file on `Drop` when there are no outputs to persist (avoids writing empty/useless cache files).

## Testing

- Updated `rustc_info_cache_with_wrappers` to verify failures are retried rather than replayed from cache.
- Added `rustc_info_cache_transient_failure_recovery` test that simulates a wrapper failing then recovering, verifying the build succeeds on retry without manual intervention.