### PR TITLE
feat: Break out `RegistryConfig` and `crate_url` for interpreting `RegistryConfig::dl`

### DIFF
--- a/crates/cargo-util-schemas/registry_config.schema.json
+++ b/crates/cargo-util-schemas/registry_config.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "RegistryConfig",
+  "description": "The [`config.json`] file stored in the index.\n\nThe config file may look like:\n\n```json\n{\n    \"dl\": \"https://example.com/api/{crate}/{version}/download\",\n    \"api\": \"https://example.com/api\",\n    \"auth-required\": false             # unstable feature (RFC 3139)\n}\n```\n\n[`config.json`]: https://doc.rust-lang.org/nightly/cargo/reference/registry-index.html#index-configuration",
+  "type": "object",
+  "properties": {
+    "dl": {
+      "description": "Download endpoint for all crates.\n\nThe string is a template which will generate the download URL for the\ntarball of a specific version of a crate. The substrings `{crate}` and\n`{version}` will be replaced with the crate's name and version\nrespectively.  The substring `{prefix}` will be replaced with the\ncrate's prefix directory name, and the substring `{lowerprefix}` will\nbe replaced with the crate's prefix directory name converted to\nlowercase. The substring `{sha256-checksum}` will be replaced with the\ncrate's sha256 checksum.\n\nFor backwards compatibility, if the string does not contain any\nmarkers (`{crate}`, `{version}`, `{prefix}`, or `{lowerprefix}`), it\nwill be extended with `/{crate}/{version}/download` to\nsupport registries like crates.io which were created before the\ntemplating setup was created.\n\nFor more on the template of the download URL, see [Index Configuration](\nhttps://doc.rust-lang.org/nightly/cargo/reference/registry-index.html#index-configuration).",
+      "type": "string"
+    },
+    "api": {
+      "description": "API endpoint for the registry. This is what's actually hit to perform\noperations like yanks, owner modifications, publish new crates, etc.\nIf this is None, the registry does not support API commands.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "auth-required": {
+      "description": "Whether all operations require authentication. See [RFC 3139].\n\n[RFC 3139]: https://rust-lang.github.io/rfcs/3139-cargo-alternative-registry-auth.html",
+      "type": "boolean",
+      "default": false
+    }
+  },
+  "required": [
+    "dl"
+  ]
+}

--- a/crates/cargo-util-schemas/registry_config.schema.json
+++ b/crates/cargo-util-schemas/registry_config.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "RegistryConfig",
-  "description": "The [`config.json`] file stored in the index.\n\nThe config file may look like:\n\n```json\n{\n    \"dl\": \"https://example.com/api/{crate}/{version}/download\",\n    \"api\": \"https://example.com/api\",\n    \"auth-required\": false             # unstable feature (RFC 3139)\n}\n```\n\n[`config.json`]: https://doc.rust-lang.org/nightly/cargo/reference/registry-index.html#index-configuration",
+  "description": "The [`config.json`] file stored in the index.\n\nThe config file may look like:\n\n```json\n{\n    \"dl\": \"https://example.com/api/{crate}/{version}/download\",\n    \"api\": \"https://example.com/api\",\n    \"auth-required\": false\n}\n```\n\n[`config.json`]: https://doc.rust-lang.org/nightly/cargo/reference/registry-index.html#index-configuration",
   "type": "object",
   "properties": {
     "dl": {

--- a/crates/cargo-util-schemas/src/index.rs
+++ b/crates/cargo-util-schemas/src/index.rs
@@ -257,7 +257,7 @@ fn dump_index_schema() {
 /// ```
 ///
 /// [`config.json`]: https://doc.rust-lang.org/nightly/cargo/reference/registry-index.html#index-configuration
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
 #[cfg_attr(feature = "unstable-schema", derive(schemars::JsonSchema))]
 pub struct RegistryConfig {

--- a/crates/cargo-util-schemas/src/index.rs
+++ b/crates/cargo-util-schemas/src/index.rs
@@ -259,6 +259,7 @@ fn dump_index_schema() {
 /// [`config.json`]: https://doc.rust-lang.org/nightly/cargo/reference/registry-index.html#index-configuration
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
+#[cfg_attr(feature = "unstable-schema", derive(schemars::JsonSchema))]
 pub struct RegistryConfig {
     /// Download endpoint for all crates.
     ///
@@ -296,6 +297,14 @@ pub struct RegistryConfig {
 impl RegistryConfig {
     /// File name of [`RegistryConfig`].
     pub const NAME: &'static str = "config.json";
+}
+
+#[cfg(feature = "unstable-schema")]
+#[test]
+fn dump_registry_schema() {
+    let schema = schemars::schema_for!(crate::index::RegistryConfig);
+    let dump = serde_json::to_string_pretty(&schema).unwrap();
+    snapbox::assert_data_eq!(dump, snapbox::file!("../registry_config.schema.json").raw());
 }
 
 #[test]

--- a/crates/cargo-util-schemas/src/index.rs
+++ b/crates/cargo-util-schemas/src/index.rs
@@ -252,7 +252,7 @@ fn dump_index_schema() {
 /// {
 ///     "dl": "https://example.com/api/{crate}/{version}/download",
 ///     "api": "https://example.com/api",
-///     "auth-required": false             # unstable feature (RFC 3139)
+///     "auth-required": false
 /// }
 /// ```
 ///

--- a/crates/cargo-util-schemas/src/index.rs
+++ b/crates/cargo-util-schemas/src/index.rs
@@ -244,6 +244,60 @@ fn dump_index_schema() {
     snapbox::assert_data_eq!(dump, snapbox::file!("../index.schema.json").raw());
 }
 
+/// The [`config.json`] file stored in the index.
+///
+/// The config file may look like:
+///
+/// ```json
+/// {
+///     "dl": "https://example.com/api/{crate}/{version}/download",
+///     "api": "https://example.com/api",
+///     "auth-required": false             # unstable feature (RFC 3139)
+/// }
+/// ```
+///
+/// [`config.json`]: https://doc.rust-lang.org/nightly/cargo/reference/registry-index.html#index-configuration
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct RegistryConfig {
+    /// Download endpoint for all crates.
+    ///
+    /// The string is a template which will generate the download URL for the
+    /// tarball of a specific version of a crate. The substrings `{crate}` and
+    /// `{version}` will be replaced with the crate's name and version
+    /// respectively.  The substring `{prefix}` will be replaced with the
+    /// crate's prefix directory name, and the substring `{lowerprefix}` will
+    /// be replaced with the crate's prefix directory name converted to
+    /// lowercase. The substring `{sha256-checksum}` will be replaced with the
+    /// crate's sha256 checksum.
+    ///
+    /// For backwards compatibility, if the string does not contain any
+    /// markers (`{crate}`, `{version}`, `{prefix}`, or `{lowerprefix}`), it
+    /// will be extended with `/{crate}/{version}/download` to
+    /// support registries like crates.io which were created before the
+    /// templating setup was created.
+    ///
+    /// For more on the template of the download URL, see [Index Configuration](
+    /// https://doc.rust-lang.org/nightly/cargo/reference/registry-index.html#index-configuration).
+    pub dl: String,
+
+    /// API endpoint for the registry. This is what's actually hit to perform
+    /// operations like yanks, owner modifications, publish new crates, etc.
+    /// If this is None, the registry does not support API commands.
+    pub api: Option<String>,
+
+    /// Whether all operations require authentication. See [RFC 3139].
+    ///
+    /// [RFC 3139]: https://rust-lang.github.io/rfcs/3139-cargo-alternative-registry-auth.html
+    #[serde(default)]
+    pub auth_required: bool,
+}
+
+impl RegistryConfig {
+    /// File name of [`RegistryConfig`].
+    pub const NAME: &'static str = "config.json";
+}
+
 #[test]
 fn pubtime_format() {
     use snapbox::str;

--- a/crates/cargo-util/src/registry.rs
+++ b/crates/cargo-util/src/registry.rs
@@ -25,6 +25,37 @@ pub fn make_dep_path(dep_name: &str, prefix_only: bool) -> String {
     }
 }
 
+pub fn crate_url(dl_template: &str, pkg_name: &str, pkg_version: &str, checksum: &str) -> String {
+    use std::fmt::Write as _;
+
+    let mut url = dl_template.to_owned();
+    if !url.contains(CRATE_TEMPLATE)
+        && !url.contains(VERSION_TEMPLATE)
+        && !url.contains(PREFIX_TEMPLATE)
+        && !url.contains(LOWER_PREFIX_TEMPLATE)
+        && !url.contains(CHECKSUM_TEMPLATE)
+    {
+        // Original format before customizing the download URL was supported.
+        write!(url, "/{}/{}/download", pkg_name, pkg_version).unwrap();
+    } else {
+        let prefix = make_dep_path(pkg_name, true);
+        url = url
+            .replace(CRATE_TEMPLATE, pkg_name)
+            .replace(VERSION_TEMPLATE, pkg_version)
+            .replace(PREFIX_TEMPLATE, &prefix)
+            .replace(LOWER_PREFIX_TEMPLATE, &prefix.to_lowercase())
+            .replace(CHECKSUM_TEMPLATE, checksum);
+    }
+
+    url
+}
+
+const CRATE_TEMPLATE: &str = "{crate}";
+const VERSION_TEMPLATE: &str = "{version}";
+const PREFIX_TEMPLATE: &str = "{prefix}";
+const LOWER_PREFIX_TEMPLATE: &str = "{lowerprefix}";
+const CHECKSUM_TEMPLATE: &str = "{sha256-checksum}";
+
 #[cfg(test)]
 mod tests {
     use super::make_dep_path;

--- a/crates/cargo-util/src/registry.rs
+++ b/crates/cargo-util/src/registry.rs
@@ -26,27 +26,24 @@ pub fn make_dep_path(dep_name: &str, prefix_only: bool) -> String {
 }
 
 pub fn crate_url(dl_template: &str, krate: &str, version: &str, sha256_checksum: &str) -> String {
-    use std::fmt::Write as _;
-
-    let mut url = dl_template.to_owned();
-    if !url.contains(CRATE_TEMPLATE)
-        && !url.contains(VERSION_TEMPLATE)
-        && !url.contains(PREFIX_TEMPLATE)
-        && !url.contains(LOWER_PREFIX_TEMPLATE)
-        && !url.contains(CHECKSUM_TEMPLATE)
+    let url = if !dl_template.contains(CRATE_TEMPLATE)
+        && !dl_template.contains(VERSION_TEMPLATE)
+        && !dl_template.contains(PREFIX_TEMPLATE)
+        && !dl_template.contains(LOWER_PREFIX_TEMPLATE)
+        && !dl_template.contains(CHECKSUM_TEMPLATE)
     {
         // Original format before customizing the download URL was supported.
-        write!(url, "/{}/{}/download", krate, version).unwrap();
+        format!("{dl_template}/{krate}/{version}/download")
     } else {
         let prefix = make_dep_path(krate, true);
         let lowerprefix = prefix.to_lowercase();
-        url = url
+        dl_template
             .replace(CRATE_TEMPLATE, krate)
             .replace(VERSION_TEMPLATE, version)
             .replace(PREFIX_TEMPLATE, &prefix)
             .replace(LOWER_PREFIX_TEMPLATE, &lowerprefix)
-            .replace(CHECKSUM_TEMPLATE, sha256_checksum);
-    }
+            .replace(CHECKSUM_TEMPLATE, sha256_checksum)
+    };
 
     url
 }

--- a/crates/cargo-util/src/registry.rs
+++ b/crates/cargo-util/src/registry.rs
@@ -25,7 +25,7 @@ pub fn make_dep_path(dep_name: &str, prefix_only: bool) -> String {
     }
 }
 
-pub fn crate_url(dl_template: &str, pkg_name: &str, pkg_version: &str, checksum: &str) -> String {
+pub fn crate_url(dl_template: &str, krate: &str, version: &str, sha256_checksum: &str) -> String {
     use std::fmt::Write as _;
 
     let mut url = dl_template.to_owned();
@@ -36,15 +36,16 @@ pub fn crate_url(dl_template: &str, pkg_name: &str, pkg_version: &str, checksum:
         && !url.contains(CHECKSUM_TEMPLATE)
     {
         // Original format before customizing the download URL was supported.
-        write!(url, "/{}/{}/download", pkg_name, pkg_version).unwrap();
+        write!(url, "/{}/{}/download", krate, version).unwrap();
     } else {
-        let prefix = make_dep_path(pkg_name, true);
+        let prefix = make_dep_path(krate, true);
+        let lowerprefix = prefix.to_lowercase();
         url = url
-            .replace(CRATE_TEMPLATE, pkg_name)
-            .replace(VERSION_TEMPLATE, pkg_version)
+            .replace(CRATE_TEMPLATE, krate)
+            .replace(VERSION_TEMPLATE, version)
             .replace(PREFIX_TEMPLATE, &prefix)
-            .replace(LOWER_PREFIX_TEMPLATE, &prefix.to_lowercase())
-            .replace(CHECKSUM_TEMPLATE, checksum);
+            .replace(LOWER_PREFIX_TEMPLATE, &lowerprefix)
+            .replace(CHECKSUM_TEMPLATE, sha256_checksum);
     }
 
     url

--- a/src/cargo/sources/registry/download.rs
+++ b/src/cargo/sources/registry/download.rs
@@ -7,7 +7,7 @@ use crate::util::interning::InternedString;
 use anyhow::Context as _;
 use cargo_credential::Operation;
 use cargo_util::Sha256;
-use cargo_util::registry::make_dep_path;
+use cargo_util::registry::crate_url;
 
 use crate::core::PackageId;
 use crate::core::global_cache_tracker;
@@ -17,17 +17,10 @@ use crate::util::auth;
 use crate::util::cache_lock::CacheLockMode;
 use crate::util::errors::CargoResult;
 use crate::util::{Filesystem, GlobalContext};
-use std::fmt::Write as FmtWrite;
 use std::fs::{self, File, OpenOptions};
 use std::io::SeekFrom;
 use std::io::prelude::*;
 use std::str;
-
-const CRATE_TEMPLATE: &str = "{crate}";
-const VERSION_TEMPLATE: &str = "{version}";
-const PREFIX_TEMPLATE: &str = "{prefix}";
-const LOWER_PREFIX_TEMPLATE: &str = "{lowerprefix}";
-const CHECKSUM_TEMPLATE: &str = "{sha256-checksum}";
 
 /// Checks if `pkg` is downloaded and ready under the directory at `cache_path`.
 /// If not, returns a URL to download it from.
@@ -64,24 +57,12 @@ pub(super) fn download(
         }
     }
 
-    let mut url = registry_config.dl;
-    if !url.contains(CRATE_TEMPLATE)
-        && !url.contains(VERSION_TEMPLATE)
-        && !url.contains(PREFIX_TEMPLATE)
-        && !url.contains(LOWER_PREFIX_TEMPLATE)
-        && !url.contains(CHECKSUM_TEMPLATE)
-    {
-        // Original format before customizing the download URL was supported.
-        write!(url, "/{}/{}/download", pkg.name(), pkg.version()).unwrap();
-    } else {
-        let prefix = make_dep_path(&pkg.name(), true);
-        url = url
-            .replace(CRATE_TEMPLATE, &*pkg.name())
-            .replace(VERSION_TEMPLATE, &pkg.version().to_string())
-            .replace(PREFIX_TEMPLATE, &prefix)
-            .replace(LOWER_PREFIX_TEMPLATE, &prefix.to_lowercase())
-            .replace(CHECKSUM_TEMPLATE, checksum);
-    }
+    let url = crate_url(
+        &registry_config.dl,
+        &*pkg.name(),
+        &pkg.version().to_string(),
+        checksum,
+    );
 
     let authorization = if registry_config.auth_required {
         Some(auth::auth_token(

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -213,6 +213,8 @@ use crate::util::interning::InternedString;
 use crate::util::{CargoResult, Filesystem, GlobalContext, LimitErrorReader, restricted_names};
 use crate::util::{VersionExt, hex};
 
+pub use cargo_util_schemas::index::RegistryConfig;
+
 /// The `.cargo-ok` file is used to track if the source is already unpacked.
 /// See [`RegistrySource::unpack_package`] for more.
 ///
@@ -268,55 +270,6 @@ pub struct RegistrySource<'gctx> {
     /// warning twice, with the assumption of (`dep.package_name()` + `--precise`
     /// version) being sufficient to uniquely identify the same query result.
     selected_precise_yanked: RefCell<HashSet<(InternedString, semver::Version)>>,
-}
-
-/// The [`config.json`] file stored in the index.
-///
-/// The config file may look like:
-///
-/// ```json
-/// {
-///     "dl": "https://example.com/api/{crate}/{version}/download",
-///     "api": "https://example.com/api",
-///     "auth-required": false             # unstable feature (RFC 3139)
-/// }
-/// ```
-///
-/// [`config.json`]: https://doc.rust-lang.org/nightly/cargo/reference/registry-index.html#index-configuration
-#[derive(Deserialize, Debug, Clone)]
-#[serde(rename_all = "kebab-case")]
-pub struct RegistryConfig {
-    /// Download endpoint for all crates.
-    ///
-    /// The string is a template which will generate the download URL for the
-    /// tarball of a specific version of a crate. The substrings `{crate}` and
-    /// `{version}` will be replaced with the crate's name and version
-    /// respectively.  The substring `{prefix}` will be replaced with the
-    /// crate's prefix directory name, and the substring `{lowerprefix}` will
-    /// be replaced with the crate's prefix directory name converted to
-    /// lowercase. The substring `{sha256-checksum}` will be replaced with the
-    /// crate's sha256 checksum.
-    ///
-    /// For backwards compatibility, if the string does not contain any
-    /// markers (`{crate}`, `{version}`, `{prefix}`, or `{lowerprefix}`), it
-    /// will be extended with `/{crate}/{version}/download` to
-    /// support registries like crates.io which were created before the
-    /// templating setup was created.
-    ///
-    /// For more on the template of the download URL, see [Index Configuration](
-    /// https://doc.rust-lang.org/nightly/cargo/reference/registry-index.html#index-configuration).
-    pub dl: String,
-
-    /// API endpoint for the registry. This is what's actually hit to perform
-    /// operations like yanks, owner modifications, publish new crates, etc.
-    /// If this is None, the registry does not support API commands.
-    pub api: Option<String>,
-
-    /// Whether all operations require authentication. See [RFC 3139].
-    ///
-    /// [RFC 3139]: https://rust-lang.github.io/rfcs/3139-cargo-alternative-registry-auth.html
-    #[serde(default)]
-    pub auth_required: bool,
 }
 
 /// Result from loading data from a registry.
@@ -963,11 +916,6 @@ impl<'gctx> Source for RegistrySource<'gctx> {
     async fn is_yanked(&self, pkg: PackageId) -> CargoResult<bool> {
         self.index.is_yanked(pkg, &*self.ops).await
     }
-}
-
-impl RegistryConfig {
-    /// File name of [`RegistryConfig`].
-    const NAME: &'static str = "config.json";
 }
 
 /// Get the maximum unpack size that Cargo permits


### PR DESCRIPTION
### What does this PR try to resolve?

I am working on a tool that involves downloading `.crate` files and splitting these out for use independent of the `cargo` package aligns with breaking out other logic (schemas, `cargo_util::registry:make_dep_path`).

### How to test and review this PR?

This is a two-way door as we can always move these back into Cargo if we want. The bar for breaking changes in these libraries is low.