### PR TITLE
fix: stabilize `-Zrustdoc-depinfo`

### DIFF
--- a/doc/book/src/reference/unstable.md
+++ b/doc/book/src/reference/unstable.md
@@ -107,7 +107,6 @@ Each new feature described below should explain how to use it.
     * [rustdoc-map](#rustdoc-map) --- Provides mappings for documentation to link to external sites like [docs.rs](https://docs.rs/).
     * [scrape-examples](#scrape-examples) --- Shows examples within documentation.
     * [output-format](#output-format-for-rustdoc) --- Allows documentation to also be emitted in the experimental [JSON format](https://doc.rust-lang.org/nightly/nightly-rustc/rustdoc_json_types/).
-    * [rustdoc-depinfo](#rustdoc-depinfo) --- Use dep-info files in rustdoc rebuild detection.
     * [rustdoc-mergeable-info](#rustdoc-mergeable-info) --- Use rustdoc mergeable cross-crate-info files.
 * `Cargo.toml` extensions
     * [Profile `rustflags` option](#profile-rustflags-option) --- Passed directly to rustc.
@@ -1856,15 +1855,6 @@ Requires `-Zunstable-options`.
 See [`cargo package --message-format`](../commands/cargo-package.md#option-cargo-package---message-format)
 for more information.
 
-## rustdoc depinfo
-
-* Original Issue: [#12266](https://github.com/rust-lang/cargo/issues/12266)
-* Tracking Issue: [#15370](https://github.com/rust-lang/cargo/issues/15370)
-
-The `-Z rustdoc-depinfo` flag leverages rustdoc's dep-info files to determine
-whether documentations are required to re-generate. This can be combined with
-`-Z checksum-freshness` to detect checksum changes rather than file mtime.
-
 ## embed-metadata
 * Original Pull Request: [#15378](https://github.com/rust-lang/cargo/pull/15378)
 * Tracking Issue: [#15495](https://github.com/rust-lang/cargo/issues/15495)
@@ -2438,3 +2428,8 @@ Support for `resolver.lockfile-path` config field has been stabilized in Rust 1.
 ## warnings
 
 The `build.warnings` config field has been stabilized in Rust 1.97.
+
+## rustdoc-depinfo
+
+Using rustdoc's dep-info files for documentation rebuild detection
+was stabilized in the 1.99.0 release.

--- a/doc/book/src/reference/unstable.md
+++ b/doc/book/src/reference/unstable.md
@@ -107,7 +107,6 @@ Each new feature described below should explain how to use it.
     * [rustdoc-map](#rustdoc-map) --- Provides mappings for documentation to link to external sites like [docs.rs](https://docs.rs/).
     * [scrape-examples](#scrape-examples) --- Shows examples within documentation.
     * [output-format](#output-format-for-rustdoc) --- Allows documentation to also be emitted in the experimental [JSON format](https://doc.rust-lang.org/nightly/nightly-rustc/rustdoc_json_types/).
-    * [rustdoc-depinfo](#rustdoc-depinfo) --- Use dep-info files in rustdoc rebuild detection.
     * [rustdoc-mergeable-info](#rustdoc-mergeable-info) --- Use rustdoc mergeable cross-crate-info files.
 * `Cargo.toml` extensions
     * [Profile `rustflags` option](#profile-rustflags-option) --- Passed directly to rustc.
@@ -1921,15 +1920,6 @@ Requires `-Zunstable-options`.
 See [`cargo package --message-format`](../commands/cargo-package.md#option-cargo-package---message-format)
 for more information.
 
-## rustdoc depinfo
-
-* Original Issue: [#12266](https://github.com/rust-lang/cargo/issues/12266)
-* Tracking Issue: [#15370](https://github.com/rust-lang/cargo/issues/15370)
-
-The `-Z rustdoc-depinfo` flag leverages rustdoc's dep-info files to determine
-whether documentations are required to re-generate. This can be combined with
-`-Z checksum-freshness` to detect checksum changes rather than file mtime.
-
 ## embed-metadata
 * Original Pull Request: [#15378](https://github.com/rust-lang/cargo/pull/15378)
 * Tracking Issue: [#15495](https://github.com/rust-lang/cargo/issues/15495)
@@ -2503,3 +2493,8 @@ Support for `resolver.lockfile-path` config field has been stabilized in Rust 1.
 ## warnings
 
 The `build.warnings` config field has been stabilized in Rust 1.97.
+
+## rustdoc-depinfo
+
+Using rustdoc's dep-info files for documentation rebuild detection
+was stabilized in the 1.99.0 release.

--- a/src/compiler/fingerprint/mod.rs
+++ b/src/compiler/fingerprint/mod.rs
@@ -136,9 +136,8 @@
 //!   below for more details.
 //!
 //! Note that some units are a little different. A Unit for *running* a build
-//! script or for `rustdoc` does not have a dep-info file (it's not
-//! applicable). Build script `invoked.timestamp` files are in the build
-//! output directory.
+//! script does not have a dep-info file (it's not applicable).
+//! Build script `invoked.timestamp` files are in the build output directory.
 //!
 //! ## Fingerprint calculation
 //!
@@ -166,10 +165,11 @@
 //!
 //! #### `rustc` dep-info files
 //!
-//! Cargo passes the `--emit=dep-info` flag to `rustc` so that `rustc` will
-//! generate a "dep info" file (with the `.d` extension). This is a
-//! Makefile-like syntax that includes all of the source files used to build
-//! the crate. This file is used by Cargo to know which files to check to see
+//! Cargo passes the `--emit=dep-info` flag to `rustc` and `rustdoc`
+//! so that compiler will generate a "dep info" file (with the `.d` extension).
+//! This is a Makefile-like syntax that includes all of the source files used
+//! to build the crate.
+//! This file is used by Cargo to know which files to check to see
 //! if the crate will need to be rebuilt. Example:
 //!
 //! ```makefile
@@ -251,23 +251,15 @@
 //! build, so it takes a conservative approach of assuming the file was *not*
 //! included, and it should be rebuilt during the next build.
 //!
-//! #### Rustdoc mtime handling
-//!
-//! Rustdoc does not emit a dep-info file, so Cargo currently has a relatively
-//! simple system for detecting rebuilds. [`LocalFingerprint::Precalculated`] is
-//! used for rustdoc units. For registry packages, this is the package
-//! version. For git packages, it is the git hash. For path packages, it is
-//! a string of the mtime of the newest file in the package.
-//!
-//! There are some known bugs with how this works, so it should be improved at
-//! some point.
-//!
 //! #### Build script mtime handling
 //!
 //! Build script mtime handling runs in different modes. There is the "old
 //! style" where the build script does not emit any `rerun-if` directives. In
-//! this mode, Cargo will use [`LocalFingerprint::Precalculated`]. See the
-//! "rustdoc" section above how it works.
+//! this mode, Cargo will use [`LocalFingerprint::Precalculated`].
+//! For registry packages, this is the package version.
+//! For git packages, it is the git hash.
+//! For path packages, it is a string of the mtime of the newest file in the package.
+
 //!
 //! In the new-style, each `rerun-if` directive is translated to the
 //! corresponding [`LocalFingerprint`] variant. The [`RerunIfChanged`] variant
@@ -810,12 +802,11 @@ impl<'de> Deserialize<'de> for DepFingerprint {
 #[derive(Debug, Serialize, Deserialize, Hash)]
 enum LocalFingerprint {
     /// This is a precalculated fingerprint which has an opaque string we just
-    /// hash as usual. This variant is primarily used for rustdoc where we
-    /// don't have a dep-info file to compare against.
+    /// hash as usual.
     ///
-    /// This is also used for build scripts with no `rerun-if-*` statements, but
-    /// that's overall a mistake and causes bugs in Cargo. We shouldn't use this
-    /// for build scripts.
+    /// This variant is primarily used for build scripts with no `rerun-if-*`
+    /// statements, but that's overall a mistake and causes bugs in Cargo.
+    /// We shouldn't use this for build scripts.
     Precalculated(String),
 
     /// This is used for crate compilations. The `dep_info` file is a relative
@@ -1587,9 +1578,14 @@ fn calculate_normal(
     // Afterwards calculate our own fingerprint information.
     let build_root = build_root(build_runner);
     let is_any_doc_gen = unit.mode.is_doc() || unit.mode.is_doc_scrape();
-    let rustdoc_depinfo_enabled = build_runner.bcx.gctx.cli_unstable().rustdoc_depinfo;
-    let local = if is_any_doc_gen && !rustdoc_depinfo_enabled {
-        // rustdoc does not have dep-info files.
+    let wants_doc_json_output = build_runner.bcx.build_config.intent.wants_doc_json_output();
+    let local = if is_any_doc_gen && wants_doc_json_output {
+        // `--emit` would reject or drop the JSON doc output,
+        // so skip it and fall back to package fingerprint for JSON doc units.
+        //
+        // If we have `--emit=json-files` available,
+        // we could pass that along with `--emit=dep-info`.
+        // see rust-lang/rust#155679
         let fingerprint = pkg_fingerprint(build_runner.bcx, &unit.pkg).with_context(|| {
             format!(
                 "failed to determine package fingerprint for documenting {}",

--- a/src/compiler/fingerprint/mod.rs
+++ b/src/compiler/fingerprint/mod.rs
@@ -140,9 +140,8 @@
 //!   below for more details.
 //!
 //! Note that some units are a little different. A Unit for *running* a build
-//! script or for `rustdoc` does not have a dep-info file (it's not
-//! applicable). Build script `invoked.timestamp` files are in the build
-//! output directory.
+//! script does not have a dep-info file (it's not applicable).
+//! Build script `invoked.timestamp` files are in the build output directory.
 //!
 //! ## Fingerprint calculation
 //!
@@ -170,10 +169,11 @@
 //!
 //! #### `rustc` dep-info files
 //!
-//! Cargo passes the `--emit=dep-info` flag to `rustc` so that `rustc` will
-//! generate a "dep info" file (with the `.d` extension). This is a
-//! Makefile-like syntax that includes all of the source files used to build
-//! the crate. This file is used by Cargo to know which files to check to see
+//! Cargo passes the `--emit=dep-info` flag to `rustc` and `rustdoc`
+//! so that compiler will generate a "dep info" file (with the `.d` extension).
+//! This is a Makefile-like syntax that includes all of the source files used
+//! to build the crate.
+//! This file is used by Cargo to know which files to check to see
 //! if the crate will need to be rebuilt. Example:
 //!
 //! ```makefile
@@ -255,23 +255,15 @@
 //! build, so it takes a conservative approach of assuming the file was *not*
 //! included, and it should be rebuilt during the next build.
 //!
-//! #### Rustdoc mtime handling
-//!
-//! Rustdoc does not emit a dep-info file, so Cargo currently has a relatively
-//! simple system for detecting rebuilds. [`LocalFingerprint::Precalculated`] is
-//! used for rustdoc units. For registry packages, this is the package
-//! version. For git packages, it is the git hash. For path packages, it is
-//! a string of the mtime of the newest file in the package.
-//!
-//! There are some known bugs with how this works, so it should be improved at
-//! some point.
-//!
 //! #### Build script mtime handling
 //!
 //! Build script mtime handling runs in different modes. There is the "old
 //! style" where the build script does not emit any `rerun-if` directives. In
-//! this mode, Cargo will use [`LocalFingerprint::Precalculated`]. See the
-//! "rustdoc" section above how it works.
+//! this mode, Cargo will use [`LocalFingerprint::Precalculated`].
+//! For registry packages, this is the package version.
+//! For git packages, it is the git hash.
+//! For path packages, it is a string of the mtime of the newest file in the package.
+
 //!
 //! In the new-style, each `rerun-if` directive is translated to the
 //! corresponding [`LocalFingerprint`] variant. The [`RerunIfChanged`] variant
@@ -814,12 +806,11 @@ impl<'de> Deserialize<'de> for DepFingerprint {
 #[derive(Debug, Serialize, Deserialize, Hash)]
 enum LocalFingerprint {
     /// This is a precalculated fingerprint which has an opaque string we just
-    /// hash as usual. This variant is primarily used for rustdoc where we
-    /// don't have a dep-info file to compare against.
+    /// hash as usual.
     ///
-    /// This is also used for build scripts with no `rerun-if-*` statements, but
-    /// that's overall a mistake and causes bugs in Cargo. We shouldn't use this
-    /// for build scripts.
+    /// This variant is primarily used for build scripts with no `rerun-if-*`
+    /// statements, but that's overall a mistake and causes bugs in Cargo.
+    /// We shouldn't use this for build scripts.
     Precalculated(String),
 
     /// This is used for crate compilations. The `dep_info` file is a relative
@@ -1591,9 +1582,14 @@ fn calculate_normal(
     // Afterwards calculate our own fingerprint information.
     let build_root = build_root(build_runner);
     let is_any_doc_gen = unit.mode.is_doc() || unit.mode.is_doc_scrape();
-    let rustdoc_depinfo_enabled = build_runner.bcx.gctx.cli_unstable().rustdoc_depinfo;
-    let local = if is_any_doc_gen && !rustdoc_depinfo_enabled {
-        // rustdoc does not have dep-info files.
+    let wants_doc_json_output = build_runner.bcx.build_config.intent.wants_doc_json_output();
+    let local = if is_any_doc_gen && wants_doc_json_output {
+        // `--emit` would reject or drop the JSON doc output,
+        // so skip it and fall back to package fingerprint for JSON doc units.
+        //
+        // If we have `--emit=json-files` available,
+        // we could pass that along with `--emit=dep-info`.
+        // see rust-lang/rust#155679
         let fingerprint = pkg_fingerprint(build_runner.bcx, &unit.pkg).with_context(|| {
             format!(
                 "failed to determine package fingerprint for documenting {}",

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -891,7 +891,13 @@ fn prepare_rustdoc(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> CargoResu
     add_error_format_and_color(build_runner, &mut rustdoc);
     add_allow_features(build_runner, &mut rustdoc);
 
-    if build_runner.bcx.gctx.cli_unstable().rustdoc_depinfo {
+    // `--emit` would reject or drop the JSON doc output,
+    // so skip it and fall back to package fingerprint for JSON doc units.
+    //
+    // If we have `--emit=json-files` available,
+    // we could pass that along with `--emit=dep-info`.
+    // see rust-lang/rust#155679
+    if !build_runner.bcx.build_config.intent.wants_doc_json_output() {
         // html-static-files is required for keeping the shared styling resources
         // html-non-static-files is required for keeping the original rustdoc emission
         let mut arg = if build_runner.bcx.gctx.cli_unstable().rustdoc_mergeable_info {
@@ -903,13 +909,10 @@ fn prepare_rustdoc(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> CargoResu
         };
         arg.push(rustdoc_dep_info_loc(build_runner, unit));
         rustdoc.arg(arg);
+    }
 
-        if build_runner.bcx.gctx.cli_unstable().checksum_freshness {
-            rustdoc.arg("-Z").arg("checksum-hash-algorithm=blake3");
-        }
-    } else if build_runner.bcx.gctx.cli_unstable().rustdoc_mergeable_info {
-        // toolchain resources are written at the end, at the same time as merging
-        rustdoc.arg("--emit=html-non-static-files");
+    if build_runner.bcx.gctx.cli_unstable().checksum_freshness {
+        rustdoc.arg("-Z").arg("checksum-hash-algorithm=blake3");
     }
 
     if build_runner.bcx.gctx.cli_unstable().rustdoc_mergeable_info {
@@ -1009,7 +1012,6 @@ fn rustdoc(build_runner: &mut BuildRunner<'_, '_>, unit: &Unit) -> CargoResult<W
     let fingerprint_dir = build_runner.files().fingerprint_dir(unit);
     let is_local = unit.is_local();
     let env_config = Arc::clone(build_runner.bcx.gctx.env_config()?);
-    let rustdoc_depinfo_enabled = build_runner.bcx.gctx.cli_unstable().rustdoc_depinfo;
 
     let mut output_options = OutputOptions::for_dirty(build_runner, unit);
     let script_metadatas = build_runner.find_build_script_metadatas(unit);
@@ -1106,7 +1108,7 @@ fn rustdoc(build_runner: &mut BuildRunner<'_, '_>, unit: &Unit) -> CargoResult<W
             return Err(e);
         }
 
-        if rustdoc_depinfo_enabled && rustdoc_dep_info_loc.exists() {
+        if rustdoc_dep_info_loc.exists() {
             fingerprint::translate_dep_info(
                 &rustdoc_dep_info_loc,
                 &dep_info_loc,

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -906,7 +906,13 @@ fn prepare_rustdoc(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> CargoResu
     add_error_format_and_color(build_runner, &mut rustdoc);
     add_allow_features(build_runner, &mut rustdoc);
 
-    if build_runner.bcx.gctx.cli_unstable().rustdoc_depinfo {
+    // `--emit` would reject or drop the JSON doc output,
+    // so skip it and fall back to package fingerprint for JSON doc units.
+    //
+    // If we have `--emit=json-files` available,
+    // we could pass that along with `--emit=dep-info`.
+    // see rust-lang/rust#155679
+    if !build_runner.bcx.build_config.intent.wants_doc_json_output() {
         // html-static-files is required for keeping the shared styling resources
         // html-non-static-files is required for keeping the original rustdoc emission
         let mut arg = if wants_json_output {
@@ -920,13 +926,10 @@ fn prepare_rustdoc(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> CargoResu
         };
         arg.push(rustdoc_dep_info_loc(build_runner, unit));
         rustdoc.arg(arg);
+    }
 
-        if build_runner.bcx.gctx.cli_unstable().checksum_freshness {
-            rustdoc.arg("-Z").arg("checksum-hash-algorithm=blake3");
-        }
-    } else if build_runner.bcx.gctx.cli_unstable().rustdoc_mergeable_info && !wants_json_output {
-        // toolchain resources are written at the end, at the same time as merging
-        rustdoc.arg("--emit=html-non-static-files");
+    if build_runner.bcx.gctx.cli_unstable().checksum_freshness {
+        rustdoc.arg("-Z").arg("checksum-hash-algorithm=blake3");
     }
 
     if build_runner.bcx.gctx.cli_unstable().rustdoc_mergeable_info && !wants_json_output {
@@ -1026,7 +1029,6 @@ fn rustdoc(build_runner: &mut BuildRunner<'_, '_>, unit: &Unit) -> CargoResult<W
     let fingerprint_dir = build_runner.files().fingerprint_dir(unit);
     let is_local = unit.is_local();
     let env_config = Arc::clone(build_runner.bcx.gctx.env_config()?);
-    let rustdoc_depinfo_enabled = build_runner.bcx.gctx.cli_unstable().rustdoc_depinfo;
 
     let mut output_options = OutputOptions::for_dirty(build_runner, unit);
     let script_metadatas = build_runner.find_build_script_metadatas(unit);
@@ -1123,7 +1125,7 @@ fn rustdoc(build_runner: &mut BuildRunner<'_, '_>, unit: &Unit) -> CargoResult<W
             return Err(e);
         }
 
-        if rustdoc_depinfo_enabled && rustdoc_dep_info_loc.exists() {
+        if rustdoc_dep_info_loc.exists() {
             fingerprint::translate_dep_info(
                 &rustdoc_dep_info_loc,
                 &dep_info_loc,

--- a/src/workspace/features.rs
+++ b/src/workspace/features.rs
@@ -916,7 +916,6 @@ unstable_cli_options!(
     publish_timeout: bool = ("Enable the `publish.timeout` key in .cargo/config.toml file"),
     root_dir: Option<PathBuf> = ("Set the root directory relative to which paths are printed (defaults to workspace root)"),
     rustc_unicode: bool = ("Enable `rustc`'s unicode error format in Cargo's error messages"),
-    rustdoc_depinfo: bool = ("Use dep-info files in rustdoc rebuild detection"),
     rustdoc_map: bool = ("Allow passing external documentation mappings to rustdoc"),
     rustdoc_mergeable_info: bool = ("Use rustdoc mergeable cross-crate-info files"),
     rustdoc_scrape_examples: bool = ("Allows Rustdoc to scrape code examples from reverse-dependencies"),
@@ -1017,6 +1016,9 @@ const STABILIZED_CONFIG_INCLUDE: &str = "The `include` config key is now always 
 const STABILIZED_LOCKFILE_PATH: &str = "The `lockfile-path` config key is now always available";
 
 const STABILIZED_WARNINGS: &str = "The `build.warnings` config key is now always available";
+
+const STABILIZED_RUSTDOC_DEPINFO: &str = "Rustdoc dep-info-based rebuild detection \
+    is now always enabled.";
 
 fn deserialize_comma_separated_list<'de, D>(
     deserializer: D,
@@ -1424,6 +1426,7 @@ impl CliUnstable {
             "config-include" => stabilized_warn(k, "1.93", STABILIZED_CONFIG_INCLUDE),
             "lockfile-path" => stabilized_warn(k, "1.97", STABILIZED_LOCKFILE_PATH),
             "warnings" => stabilized_warn(k, "1.97", STABILIZED_WARNINGS),
+            "rustdoc-depinfo" => stabilized_warn(k, "1.99", STABILIZED_RUSTDOC_DEPINFO),
 
             // Unstable features
             // Sorted alphabetically:
@@ -1478,7 +1481,6 @@ impl CliUnstable {
             "publish-timeout" => self.publish_timeout = parse_empty(k, v)?,
             "root-dir" => self.root_dir = v.map(|v| v.into()),
             "rustc-unicode" => self.rustc_unicode = parse_empty(k, v)?,
-            "rustdoc-depinfo" => self.rustdoc_depinfo = parse_empty(k, v)?,
             "rustdoc-map" => self.rustdoc_map = parse_empty(k, v)?,
             "rustdoc-mergeable-info" => self.rustdoc_mergeable_info = parse_empty(k, v)?,
             "rustdoc-scrape-examples" => self.rustdoc_scrape_examples = parse_empty(k, v)?,

--- a/src/workspace/features.rs
+++ b/src/workspace/features.rs
@@ -921,7 +921,6 @@ unstable_cli_options!(
     publish_timeout: bool = ("Enable the `publish.timeout` key in .cargo/config.toml file"),
     root_dir: Option<PathBuf> = ("Set the root directory relative to which paths are printed (defaults to workspace root)"),
     rustc_unicode: bool = ("Enable `rustc`'s unicode error format in Cargo's error messages"),
-    rustdoc_depinfo: bool = ("Use dep-info files in rustdoc rebuild detection"),
     rustdoc_map: bool = ("Allow passing external documentation mappings to rustdoc"),
     rustdoc_mergeable_info: bool = ("Use rustdoc mergeable cross-crate-info files"),
     rustdoc_scrape_examples: bool = ("Allows Rustdoc to scrape code examples from reverse-dependencies"),
@@ -1022,6 +1021,9 @@ const STABILIZED_CONFIG_INCLUDE: &str = "The `include` config key is now always 
 const STABILIZED_LOCKFILE_PATH: &str = "The `lockfile-path` config key is now always available";
 
 const STABILIZED_WARNINGS: &str = "The `build.warnings` config key is now always available";
+
+const STABILIZED_RUSTDOC_DEPINFO: &str = "Rustdoc dep-info-based rebuild detection \
+    is now always enabled.";
 
 fn deserialize_comma_separated_list<'de, D>(
     deserializer: D,
@@ -1423,6 +1425,7 @@ impl CliUnstable {
             "config-include" => stabilized_warn(k, "1.93", STABILIZED_CONFIG_INCLUDE),
             "lockfile-path" => stabilized_warn(k, "1.97", STABILIZED_LOCKFILE_PATH),
             "warnings" => stabilized_warn(k, "1.97", STABILIZED_WARNINGS),
+            "rustdoc-depinfo" => stabilized_warn(k, "1.99", STABILIZED_RUSTDOC_DEPINFO),
 
             // Unstable features
             // Sorted alphabetically:
@@ -1477,7 +1480,6 @@ impl CliUnstable {
             "publish-timeout" => self.publish_timeout = parse_empty(k, v)?,
             "root-dir" => self.root_dir = v.map(|v| v.into()),
             "rustc-unicode" => self.rustc_unicode = parse_empty(k, v)?,
-            "rustdoc-depinfo" => self.rustdoc_depinfo = parse_empty(k, v)?,
             "rustdoc-map" => self.rustdoc_map = parse_empty(k, v)?,
             "rustdoc-mergeable-info" => self.rustdoc_mergeable_info = parse_empty(k, v)?,
             "rustdoc-scrape-examples" => self.rustdoc_scrape_examples = parse_empty(k, v)?,

--- a/tests/testsuite/cargo/z_help/stdout.term.svg
+++ b/tests/testsuite/cargo/z_help/stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="1255px" height="1010px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1255px" height="992px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -96,35 +96,33 @@
 </tspan>
     <tspan x="10px" y="730px"><tspan>    -Z rustc-unicode               Enable `rustc`'s unicode error format in Cargo's error messages</tspan>
 </tspan>
-    <tspan x="10px" y="748px"><tspan>    -Z rustdoc-depinfo             Use dep-info files in rustdoc rebuild detection</tspan>
+    <tspan x="10px" y="748px"><tspan>    -Z rustdoc-map                 Allow passing external documentation mappings to rustdoc</tspan>
 </tspan>
-    <tspan x="10px" y="766px"><tspan>    -Z rustdoc-map                 Allow passing external documentation mappings to rustdoc</tspan>
+    <tspan x="10px" y="766px"><tspan>    -Z rustdoc-mergeable-info      Use rustdoc mergeable cross-crate-info files</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan>    -Z rustdoc-mergeable-info      Use rustdoc mergeable cross-crate-info files</tspan>
+    <tspan x="10px" y="784px"><tspan>    -Z rustdoc-scrape-examples     Allows Rustdoc to scrape code examples from reverse-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan>    -Z rustdoc-scrape-examples     Allows Rustdoc to scrape code examples from reverse-dependencies</tspan>
+    <tspan x="10px" y="802px"><tspan>    -Z sbom                        Enable the `sbom` option in build config in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="820px"><tspan>    -Z sbom                        Enable the `sbom` option in build config in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="820px"><tspan>    -Z script                      Enable support for single-file, `.rs` packages</tspan>
 </tspan>
-    <tspan x="10px" y="838px"><tspan>    -Z script                      Enable support for single-file, `.rs` packages</tspan>
+    <tspan x="10px" y="838px"><tspan>    -Z section-timings             Enable support for extended compilation sections in --timings output</tspan>
 </tspan>
-    <tspan x="10px" y="856px"><tspan>    -Z section-timings             Enable support for extended compilation sections in --timings output</tspan>
+    <tspan x="10px" y="856px"><tspan>    -Z target-applies-to-host      Enable the `target-applies-to-host` key in the .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="874px"><tspan>    -Z target-applies-to-host      Enable the `target-applies-to-host` key in the .cargo/config.toml file</tspan>
+    <tspan x="10px" y="874px"><tspan>    -Z trim-paths                  Enable the `trim-paths` option in profiles</tspan>
 </tspan>
-    <tspan x="10px" y="892px"><tspan>    -Z trim-paths                  Enable the `trim-paths` option in profiles</tspan>
+    <tspan x="10px" y="892px"><tspan>    -Z unstable-options            Allow the usage of unstable options</tspan>
 </tspan>
-    <tspan x="10px" y="910px"><tspan>    -Z unstable-options            Allow the usage of unstable options</tspan>
+    <tspan x="10px" y="910px">
 </tspan>
-    <tspan x="10px" y="928px">
+    <tspan x="10px" y="928px"><tspan>Run with `cargo -Z [FLAG] [COMMAND]`</tspan>
 </tspan>
-    <tspan x="10px" y="946px"><tspan>Run with `cargo -Z [FLAG] [COMMAND]`</tspan>
+    <tspan x="10px" y="946px">
 </tspan>
-    <tspan x="10px" y="964px">
+    <tspan x="10px" y="964px"><tspan>See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html for more information about these flags.</tspan>
 </tspan>
-    <tspan x="10px" y="982px"><tspan>See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html for more information about these flags.</tspan>
-</tspan>
-    <tspan x="10px" y="1000px">
+    <tspan x="10px" y="982px">
 </tspan>
   </text>
 

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -2910,24 +2910,7 @@ Caused by:
         .run();
 }
 
-#[cargo_test(nightly, reason = "`rustdoc --emit` is unstable")]
-fn rustdoc_depinfo_gated() {
-    let p = project()
-        .file("Cargo.toml", &basic_lib_manifest("foo"))
-        .file("src/lib.rs", "")
-        .build();
-
-    p.cargo("doc -Zrustdoc-depinfo")
-        .with_status(101)
-        .with_stderr_data(str![[r#"
-[ERROR] the `-Z` flag is only accepted on the nightly channel of Cargo, but this is the `stable` channel
-See https://doc.rust-lang.org/book/appendix-07-nightly-rust.html for more information about Rust release channels.
-
-"#]])
-        .run();
-}
-
-#[cargo_test(nightly, reason = "`rustdoc --emit` is unstable")]
+#[cargo_test]
 fn rebuild_tracks_target_src_outside_package_root() {
     let p = cargo_test_support::project_in("parent")
         .file(
@@ -2943,8 +2926,7 @@ fn rebuild_tracks_target_src_outside_package_root() {
         .file("../lib.rs", "//! # depinfo-before")
         .build();
 
-    p.cargo("doc -Zrustdoc-depinfo")
-        .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
+    p.cargo("doc")
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.0.0 ([ROOT]/parent/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2958,8 +2940,7 @@ fn rebuild_tracks_target_src_outside_package_root() {
 
     p.change_file("../lib.rs", "//! # depinfo-after");
 
-    p.cargo("doc --verbose -Zrustdoc-depinfo")
-        .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
+    p.cargo("doc --verbose")
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.0.0 ([ROOT]/parent/foo): the file `../lib.rs` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [DOCUMENTING] foo v0.0.0 ([ROOT]/parent/foo)
@@ -2974,7 +2955,7 @@ fn rebuild_tracks_target_src_outside_package_root() {
     assert!(doc_html.contains("depinfo-after"));
 }
 
-#[cargo_test(nightly, reason = "`rustdoc --emit` is unstable")]
+#[cargo_test]
 fn rebuild_tracks_include_str() {
     let p = cargo_test_support::project_in("parent")
         .file("Cargo.toml", &basic_lib_manifest("foo"))
@@ -2982,8 +2963,7 @@ fn rebuild_tracks_include_str() {
         .file("../README", "# depinfo-before")
         .build();
 
-    p.cargo("doc -Zrustdoc-depinfo")
-        .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
+    p.cargo("doc")
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.5.0 ([ROOT]/parent/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2997,8 +2977,7 @@ fn rebuild_tracks_include_str() {
 
     p.change_file("../README", "# depinfo-after");
 
-    p.cargo("doc --verbose -Zrustdoc-depinfo")
-        .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
+    p.cargo("doc --verbose")
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.5.0 ([ROOT]/parent/foo): the file `src/../../README` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [DOCUMENTING] foo v0.5.0 ([ROOT]/parent/foo)
@@ -3013,7 +2992,7 @@ fn rebuild_tracks_include_str() {
     assert!(doc_html.contains("depinfo-after"));
 }
 
-#[cargo_test(nightly, reason = "`rustdoc --emit` is unstable")]
+#[cargo_test]
 fn rebuild_tracks_path_attr() {
     let p = cargo_test_support::project_in("parent")
         .file("Cargo.toml", &basic_lib_manifest("foo"))
@@ -3021,8 +3000,7 @@ fn rebuild_tracks_path_attr() {
         .file("../bar.rs", "//! # depinfo-before")
         .build();
 
-    p.cargo("doc -Zrustdoc-depinfo")
-        .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
+    p.cargo("doc")
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.5.0 ([ROOT]/parent/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -3036,8 +3014,7 @@ fn rebuild_tracks_path_attr() {
 
     p.change_file("../bar.rs", "//! # depinfo-after");
 
-    p.cargo("doc --verbose -Zrustdoc-depinfo")
-        .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
+    p.cargo("doc --verbose")
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.5.0 ([ROOT]/parent/foo): the file `src/../../bar.rs` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [DOCUMENTING] foo v0.5.0 ([ROOT]/parent/foo)
@@ -3052,7 +3029,7 @@ fn rebuild_tracks_path_attr() {
     assert!(doc_html.contains("depinfo-after"));
 }
 
-#[cargo_test(nightly, reason = "`rustdoc --emit` is unstable")]
+#[cargo_test]
 fn rebuild_tracks_env() {
     let env = "__RUSTDOC_INJECTED";
     let p = project()
@@ -3060,9 +3037,8 @@ fn rebuild_tracks_env() {
         .file("src/lib.rs", &format!(r#"#![doc = env!("{env}")]"#))
         .build();
 
-    p.cargo("doc -Zrustdoc-depinfo")
+    p.cargo("doc")
         .env(env, "# depinfo-before")
-        .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -3074,9 +3050,8 @@ fn rebuild_tracks_env() {
     let doc_html = p.read_file("target/doc/foo/index.html");
     assert!(doc_html.contains("depinfo-before"));
 
-    p.cargo("doc --verbose -Zrustdoc-depinfo")
+    p.cargo("doc --verbose")
         .env(env, "# depinfo-after")
-        .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.5.0 ([ROOT]/foo): the environment variable __RUSTDOC_INJECTED changed
 [DOCUMENTING] foo v0.5.0 ([ROOT]/foo)
@@ -3091,7 +3066,7 @@ fn rebuild_tracks_env() {
     assert!(doc_html.contains("depinfo-after"));
 }
 
-#[cargo_test(nightly, reason = "`rustdoc --emit` is unstable")]
+#[cargo_test]
 fn rebuild_tracks_env_in_dep() {
     let env = "__RUSTDOC_INJECTED";
     Package::new("bar", "0.1.0")
@@ -3113,9 +3088,8 @@ fn rebuild_tracks_env_in_dep() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("doc -Zrustdoc-depinfo")
+    p.cargo("doc")
         .env(env, "# depinfo-before")
-        .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
@@ -3136,9 +3110,8 @@ fn rebuild_tracks_env_in_dep() {
     let doc_html = p.read_file("target/doc/bar/index.html");
     assert!(doc_html.contains("depinfo-before"));
 
-    p.cargo("doc --verbose -Zrustdoc-depinfo")
+    p.cargo("doc --verbose")
         .env(env, "# depinfo-after")
-        .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
         .with_stderr_data(
             str![[r#"
 [DIRTY] bar v0.1.0: the environment variable __RUSTDOC_INJECTED changed
@@ -3164,7 +3137,7 @@ fn rebuild_tracks_env_in_dep() {
 
 #[cargo_test(
     nightly,
-    reason = "`rustdoc --emit` is unstable; requires -Zchecksum-hash-algorithm"
+    reason = "``rustdoc --emit` is stabilized in 1.97; requires -Zchecksum-hash-algorithm"
 )]
 fn rebuild_tracks_checksum() {
     let p = cargo_test_support::project_in("parent")
@@ -3173,8 +3146,8 @@ fn rebuild_tracks_checksum() {
         .file("../README", "# depinfo-before")
         .build();
 
-    p.cargo("doc -Zrustdoc-depinfo -Zchecksum-freshness")
-        .masquerade_as_nightly_cargo(&["rustdoc-depinfo", "checksum-freshness"])
+    p.cargo("doc -Zchecksum-freshness")
+        .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.5.0 ([ROOT]/parent/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -3190,8 +3163,8 @@ fn rebuild_tracks_checksum() {
     // Change mtime into the future
     p.root().move_into_the_future();
 
-    p.cargo("doc --verbose -Zrustdoc-depinfo -Zchecksum-freshness")
-        .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
+    p.cargo("doc --verbose -Zchecksum-freshness")
+        .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.5.0 ([ROOT]/parent/foo): file size changed (16 != 15) for `src/../../README`
 [DOCUMENTING] foo v0.5.0 ([ROOT]/parent/foo)
@@ -3515,7 +3488,7 @@ fn mergeable_info_rebuild_detection() {
         .with_stderr_data(
             str![[r#"
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name foo [..]--emit=html-non-static-files,dep-info=[..] --write-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for host
 [RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out`
@@ -3577,9 +3550,9 @@ fn mergeable_info_rebuild_detection() {
         .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info"])
         .with_stderr_data(
             str![[r#"
-[DIRTY] foo v0.0.0 ([ROOT]/foo): the precalculated components changed
+[DIRTY] foo v0.0.0 ([ROOT]/foo): the file `src/lib.rs` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name foo [..]--emit=html-non-static-files,dep-info=[..] --write-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for host
 [RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out`
@@ -3617,144 +3590,6 @@ fn mergeable_info_rebuild_detection() {
         .run();
 
     // Stay the same
-    assert_e2e().eq(
-        fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
-        str![[r#"
-{
-  "doc_parts": [
-    "debug/build/foo-[HASH]/out/foo.json"
-  ],
-  "rustc_vv": "{...}"
-}
-"#]]
-        .is_json(),
-    );
-}
-
-#[cargo_test(
-    nightly,
-    reason = "rustdoc mergeable crate info is unstable; `rustdoc --emit` is unstable"
-)]
-fn mergeable_info_rebuild_with_depinfo() {
-    let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-                [package]
-                name = "foo"
-                edition = "2015"
-            "#,
-        )
-        .file("src/lib.rs", "pub fn foo() {}")
-        .build();
-
-    p.cargo("doc -v -Zrustdoc-mergeable-info -Zrustdoc-depinfo")
-        .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info", "-Zrustdoc-depinfo"])
-        .with_stderr_data(
-            str![[r#"
-[DOCUMENTING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--emit=html-non-static-files,dep-info=[..] --write-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[MERGING] 1 doc for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out`
-[FINISHED] documentation merge in [ELAPSED]s
-[GENERATED] [ROOT]/foo/target/doc/foo/index.html
-
-"#]]
-        )
-        .run();
-
-    assert!(p.root().join("target/doc/foo/index.html").is_file());
-    assert_eq!(p.glob("target/debug/build/foo-*/out/foo.json").count(), 1);
-
-    assert_e2e().eq(
-        fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
-        str![[r#"
-{
-  "doc_parts": [
-    "debug/build/foo-[HASH]/out/foo.json"
-  ],
-  "rustc_vv": "{...}"
-}
-"#]]
-        .is_json(),
-    );
-
-    // Make sure it doesn't recompile.
-    p.cargo("doc -v -Zrustdoc-mergeable-info -Zrustdoc-depinfo")
-        .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info", "-Zrustdoc-depinfo"])
-        .with_stderr_data(str![[r#"
-[FRESH] foo v0.0.0 ([ROOT]/foo)
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[FRESH] doc-merge for host
-[FINISHED] documentation merge in [ELAPSED]s
-[GENERATED] [ROOT]/foo/target/doc/foo/index.html
-
-"#]])
-        .run();
-
-    // Still there
-    assert_e2e().eq(
-        fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
-        str![[r#"
-{
-  "doc_parts": [
-    "debug/build/foo-[HASH]/out/foo.json"
-  ],
-  "rustc_vv": "{...}"
-}
-"#]]
-        .is_json(),
-    );
-
-    // Changing source code trigger re-merge
-    p.change_file("src/lib.rs", "pub fn foo2() {}");
-
-    // Make sure it recompiles
-    p.cargo("doc -v -Zrustdoc-mergeable-info -Zrustdoc-depinfo")
-        .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info", "-Zrustdoc-depinfo"])
-        .with_stderr_data(
-            str![[r#"
-[DIRTY] foo v0.0.0 ([ROOT]/foo): the file `src/lib.rs` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
-[DOCUMENTING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--emit=html-non-static-files,dep-info=[..] --write-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[MERGING] 1 doc for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out`
-[FINISHED] documentation merge in [ELAPSED]s
-[GENERATED] [ROOT]/foo/target/doc/foo/index.html
-
-"#]]
-        )
-        .run();
-
-    // Make sure it doesn't recompile.
-    p.cargo("doc -v -Zrustdoc-mergeable-info -Zrustdoc-depinfo")
-        .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info", "-Zrustdoc-depinfo"])
-        .with_stderr_data(str![[r#"
-[FRESH] foo v0.0.0 ([ROOT]/foo)
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[FRESH] doc-merge for host
-[FINISHED] documentation merge in [ELAPSED]s
-[GENERATED] [ROOT]/foo/target/doc/foo/index.html
-
-"#]])
-        .run();
-
-    // Make sure it doesn't recompile after previous no-op build
-    p.cargo("doc -v -Zrustdoc-mergeable-info -Zrustdoc-depinfo")
-        .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info", "-Zrustdoc-depinfo"])
-        .with_stderr_data(str![[r#"
-[FRESH] foo v0.0.0 ([ROOT]/foo)
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[FRESH] doc-merge for host
-[FINISHED] documentation merge in [ELAPSED]s
-[GENERATED] [ROOT]/foo/target/doc/foo/index.html
-
-"#]])
-        .run();
-
-    // Still there
     assert_e2e().eq(
         fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
         str![[r#"

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -2910,24 +2910,7 @@ Caused by:
         .run();
 }
 
-#[cargo_test(nightly, reason = "`rustdoc --emit` is unstable")]
-fn rustdoc_depinfo_gated() {
-    let p = project()
-        .file("Cargo.toml", &basic_lib_manifest("foo"))
-        .file("src/lib.rs", "")
-        .build();
-
-    p.cargo("doc -Zrustdoc-depinfo")
-        .with_status(101)
-        .with_stderr_data(str![[r#"
-[ERROR] the `-Z` flag is only accepted on the nightly channel of Cargo, but this is the `stable` channel
-See https://doc.rust-lang.org/book/appendix-07-nightly-rust.html for more information about Rust release channels.
-
-"#]])
-        .run();
-}
-
-#[cargo_test(nightly, reason = "`rustdoc --emit` is unstable")]
+#[cargo_test]
 fn rebuild_tracks_target_src_outside_package_root() {
     let p = cargo_test_support::project_in("parent")
         .file(
@@ -2943,8 +2926,7 @@ fn rebuild_tracks_target_src_outside_package_root() {
         .file("../lib.rs", "//! # depinfo-before")
         .build();
 
-    p.cargo("doc -Zrustdoc-depinfo")
-        .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
+    p.cargo("doc")
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.0.0 ([ROOT]/parent/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2958,8 +2940,7 @@ fn rebuild_tracks_target_src_outside_package_root() {
 
     p.change_file("../lib.rs", "//! # depinfo-after");
 
-    p.cargo("doc --verbose -Zrustdoc-depinfo")
-        .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
+    p.cargo("doc --verbose")
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.0.0 ([ROOT]/parent/foo): the file `../lib.rs` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [DOCUMENTING] foo v0.0.0 ([ROOT]/parent/foo)
@@ -2974,7 +2955,7 @@ fn rebuild_tracks_target_src_outside_package_root() {
     assert!(doc_html.contains("depinfo-after"));
 }
 
-#[cargo_test(nightly, reason = "`rustdoc --emit` is unstable")]
+#[cargo_test]
 fn rebuild_tracks_include_str() {
     let p = cargo_test_support::project_in("parent")
         .file("Cargo.toml", &basic_lib_manifest("foo"))
@@ -2982,8 +2963,7 @@ fn rebuild_tracks_include_str() {
         .file("../README", "# depinfo-before")
         .build();
 
-    p.cargo("doc -Zrustdoc-depinfo")
-        .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
+    p.cargo("doc")
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.5.0 ([ROOT]/parent/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2997,8 +2977,7 @@ fn rebuild_tracks_include_str() {
 
     p.change_file("../README", "# depinfo-after");
 
-    p.cargo("doc --verbose -Zrustdoc-depinfo")
-        .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
+    p.cargo("doc --verbose")
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.5.0 ([ROOT]/parent/foo): the file `src/../../README` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [DOCUMENTING] foo v0.5.0 ([ROOT]/parent/foo)
@@ -3013,7 +2992,7 @@ fn rebuild_tracks_include_str() {
     assert!(doc_html.contains("depinfo-after"));
 }
 
-#[cargo_test(nightly, reason = "`rustdoc --emit` is unstable")]
+#[cargo_test]
 fn rebuild_tracks_path_attr() {
     let p = cargo_test_support::project_in("parent")
         .file("Cargo.toml", &basic_lib_manifest("foo"))
@@ -3021,8 +3000,7 @@ fn rebuild_tracks_path_attr() {
         .file("../bar.rs", "//! # depinfo-before")
         .build();
 
-    p.cargo("doc -Zrustdoc-depinfo")
-        .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
+    p.cargo("doc")
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.5.0 ([ROOT]/parent/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -3036,8 +3014,7 @@ fn rebuild_tracks_path_attr() {
 
     p.change_file("../bar.rs", "//! # depinfo-after");
 
-    p.cargo("doc --verbose -Zrustdoc-depinfo")
-        .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
+    p.cargo("doc --verbose")
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.5.0 ([ROOT]/parent/foo): the file `src/../../bar.rs` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [DOCUMENTING] foo v0.5.0 ([ROOT]/parent/foo)
@@ -3052,7 +3029,7 @@ fn rebuild_tracks_path_attr() {
     assert!(doc_html.contains("depinfo-after"));
 }
 
-#[cargo_test(nightly, reason = "`rustdoc --emit` is unstable")]
+#[cargo_test]
 fn rebuild_tracks_env() {
     let env = "__RUSTDOC_INJECTED";
     let p = project()
@@ -3060,9 +3037,8 @@ fn rebuild_tracks_env() {
         .file("src/lib.rs", &format!(r#"#![doc = env!("{env}")]"#))
         .build();
 
-    p.cargo("doc -Zrustdoc-depinfo")
+    p.cargo("doc")
         .env(env, "# depinfo-before")
-        .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -3074,9 +3050,8 @@ fn rebuild_tracks_env() {
     let doc_html = p.read_file("target/doc/foo/index.html");
     assert!(doc_html.contains("depinfo-before"));
 
-    p.cargo("doc --verbose -Zrustdoc-depinfo")
+    p.cargo("doc --verbose")
         .env(env, "# depinfo-after")
-        .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.5.0 ([ROOT]/foo): the environment variable __RUSTDOC_INJECTED changed
 [DOCUMENTING] foo v0.5.0 ([ROOT]/foo)
@@ -3091,7 +3066,7 @@ fn rebuild_tracks_env() {
     assert!(doc_html.contains("depinfo-after"));
 }
 
-#[cargo_test(nightly, reason = "`rustdoc --emit` is unstable")]
+#[cargo_test]
 fn rebuild_tracks_env_in_dep() {
     let env = "__RUSTDOC_INJECTED";
     Package::new("bar", "0.1.0")
@@ -3113,9 +3088,8 @@ fn rebuild_tracks_env_in_dep() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("doc -Zrustdoc-depinfo")
+    p.cargo("doc")
         .env(env, "# depinfo-before")
-        .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
@@ -3136,9 +3110,8 @@ fn rebuild_tracks_env_in_dep() {
     let doc_html = p.read_file("target/doc/bar/index.html");
     assert!(doc_html.contains("depinfo-before"));
 
-    p.cargo("doc --verbose -Zrustdoc-depinfo")
+    p.cargo("doc --verbose")
         .env(env, "# depinfo-after")
-        .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
         .with_stderr_data(
             str![[r#"
 [DIRTY] bar v0.1.0: the environment variable __RUSTDOC_INJECTED changed
@@ -3164,7 +3137,7 @@ fn rebuild_tracks_env_in_dep() {
 
 #[cargo_test(
     nightly,
-    reason = "`rustdoc --emit` is unstable; requires -Zchecksum-hash-algorithm"
+    reason = "``rustdoc --emit` is stabilized in 1.97; requires -Zchecksum-hash-algorithm"
 )]
 fn rebuild_tracks_checksum() {
     let p = cargo_test_support::project_in("parent")
@@ -3173,8 +3146,8 @@ fn rebuild_tracks_checksum() {
         .file("../README", "# depinfo-before")
         .build();
 
-    p.cargo("doc -Zrustdoc-depinfo -Zchecksum-freshness")
-        .masquerade_as_nightly_cargo(&["rustdoc-depinfo", "checksum-freshness"])
+    p.cargo("doc -Zchecksum-freshness")
+        .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.5.0 ([ROOT]/parent/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -3190,8 +3163,8 @@ fn rebuild_tracks_checksum() {
     // Change mtime into the future
     p.root().move_into_the_future();
 
-    p.cargo("doc --verbose -Zrustdoc-depinfo -Zchecksum-freshness")
-        .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
+    p.cargo("doc --verbose -Zchecksum-freshness")
+        .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.5.0 ([ROOT]/parent/foo): file size changed (16 != 15) for `src/../../README`
 [DOCUMENTING] foo v0.5.0 ([ROOT]/parent/foo)
@@ -3541,7 +3514,7 @@ fn mergeable_info_rebuild_detection() {
         .with_stderr_data(
             str![[r#"
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name foo [..]--emit=html-non-static-files,dep-info=[..] --write-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for host
 [RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out`
@@ -3603,9 +3576,9 @@ fn mergeable_info_rebuild_detection() {
         .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info"])
         .with_stderr_data(
             str![[r#"
-[DIRTY] foo v0.0.0 ([ROOT]/foo): the precalculated components changed
+[DIRTY] foo v0.0.0 ([ROOT]/foo): the file `src/lib.rs` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name foo [..]--emit=html-non-static-files,dep-info=[..] --write-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for host
 [RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out`
@@ -3643,144 +3616,6 @@ fn mergeable_info_rebuild_detection() {
         .run();
 
     // Stay the same
-    assert_e2e().eq(
-        fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
-        str![[r#"
-{
-  "doc_parts": [
-    "debug/build/foo-[HASH]/out/foo.json"
-  ],
-  "rustc_vv": "{...}"
-}
-"#]]
-        .is_json(),
-    );
-}
-
-#[cargo_test(
-    nightly,
-    reason = "rustdoc mergeable crate info is unstable; `rustdoc --emit` is unstable"
-)]
-fn mergeable_info_rebuild_with_depinfo() {
-    let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-                [package]
-                name = "foo"
-                edition = "2015"
-            "#,
-        )
-        .file("src/lib.rs", "pub fn foo() {}")
-        .build();
-
-    p.cargo("doc -v -Zrustdoc-mergeable-info -Zrustdoc-depinfo")
-        .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info", "-Zrustdoc-depinfo"])
-        .with_stderr_data(
-            str![[r#"
-[DOCUMENTING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--emit=html-non-static-files,dep-info=[..] --write-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[MERGING] 1 doc for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out`
-[FINISHED] documentation merge in [ELAPSED]s
-[GENERATED] [ROOT]/foo/target/doc/foo/index.html
-
-"#]]
-        )
-        .run();
-
-    assert!(p.root().join("target/doc/foo/index.html").is_file());
-    assert_eq!(p.glob("target/debug/build/foo-*/out/foo.json").count(), 1);
-
-    assert_e2e().eq(
-        fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
-        str![[r#"
-{
-  "doc_parts": [
-    "debug/build/foo-[HASH]/out/foo.json"
-  ],
-  "rustc_vv": "{...}"
-}
-"#]]
-        .is_json(),
-    );
-
-    // Make sure it doesn't recompile.
-    p.cargo("doc -v -Zrustdoc-mergeable-info -Zrustdoc-depinfo")
-        .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info", "-Zrustdoc-depinfo"])
-        .with_stderr_data(str![[r#"
-[FRESH] foo v0.0.0 ([ROOT]/foo)
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[FRESH] doc-merge for host
-[FINISHED] documentation merge in [ELAPSED]s
-[GENERATED] [ROOT]/foo/target/doc/foo/index.html
-
-"#]])
-        .run();
-
-    // Still there
-    assert_e2e().eq(
-        fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
-        str![[r#"
-{
-  "doc_parts": [
-    "debug/build/foo-[HASH]/out/foo.json"
-  ],
-  "rustc_vv": "{...}"
-}
-"#]]
-        .is_json(),
-    );
-
-    // Changing source code trigger re-merge
-    p.change_file("src/lib.rs", "pub fn foo2() {}");
-
-    // Make sure it recompiles
-    p.cargo("doc -v -Zrustdoc-mergeable-info -Zrustdoc-depinfo")
-        .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info", "-Zrustdoc-depinfo"])
-        .with_stderr_data(
-            str![[r#"
-[DIRTY] foo v0.0.0 ([ROOT]/foo): the file `src/lib.rs` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
-[DOCUMENTING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--emit=html-non-static-files,dep-info=[..] --write-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[MERGING] 1 doc for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out`
-[FINISHED] documentation merge in [ELAPSED]s
-[GENERATED] [ROOT]/foo/target/doc/foo/index.html
-
-"#]]
-        )
-        .run();
-
-    // Make sure it doesn't recompile.
-    p.cargo("doc -v -Zrustdoc-mergeable-info -Zrustdoc-depinfo")
-        .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info", "-Zrustdoc-depinfo"])
-        .with_stderr_data(str![[r#"
-[FRESH] foo v0.0.0 ([ROOT]/foo)
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[FRESH] doc-merge for host
-[FINISHED] documentation merge in [ELAPSED]s
-[GENERATED] [ROOT]/foo/target/doc/foo/index.html
-
-"#]])
-        .run();
-
-    // Make sure it doesn't recompile after previous no-op build
-    p.cargo("doc -v -Zrustdoc-mergeable-info -Zrustdoc-depinfo")
-        .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info", "-Zrustdoc-depinfo"])
-        .with_stderr_data(str![[r#"
-[FRESH] foo v0.0.0 ([ROOT]/foo)
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[FRESH] doc-merge for host
-[FINISHED] documentation merge in [ELAPSED]s
-[GENERATED] [ROOT]/foo/target/doc/foo/index.html
-
-"#]])
-        .run();
-
-    // Still there
     assert_e2e().eq(
         fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
         str![[r#"


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/cargo/pull/17020)*


### [---> FCP <---](https://github.com/rust-lang/cargo/pull/17020#issuecomment-4926926809)

Status: blocked on rustdoc <https://github.com/rust-lang/rust/issues/159743>. Rustdoc is working on extra features that may fix it for free <https://github.com/rust-lang/rust/pull/159415#discussion_r3605070232>.

### What does this PR try to resolve?

With this stabilization,
`cargo doc` unconditionally emits rustdoc depinfo
via `rustdoc --emit=dep-info`.
Before this, `cargo doc` used to track file changes via filesystem traversal just like build scripts, and it cannot detect these cases:

* Cargo target source files are outside the package root, e.g., `lib.path = "../lib.rs"`
* Using `include_str!` to include files outisde pakcage root, e.g., `#[doc = include_str!("../outside/pkgroot")]`
* path attribute pointing to outside package root, e.g., `#[path = "../outside/pkgroot"]` 
* Using `env!` in doc attribute, e.g., `#[doc = env!("…")]`


The depinfo files are emitted to Cargo's fingerprint which is a private location so we don't have to commit any stability around it if we want to move it somewhere else in future versions.

Fixes #15370

### How to test and review this PR?

While this is a bugfix, I assume we still need an FCP for it.


