### PR TITLE
Report package typos before non-member feature errors

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -14,8 +14,8 @@ use url::Url;
 use crate::core::compiler::Unit;
 use crate::core::features::Features;
 use crate::core::registry::PackageRegistry;
-use crate::core::resolver::ResolveBehavior;
 use crate::core::resolver::features::CliFeatures;
+use crate::core::resolver::{Resolve, ResolveBehavior};
 use crate::core::{
     Dependency, Edition, FeatureValue, PackageId, PackageIdSpec, PackageIdSpecQuery, Patch,
     PatchLocation,
@@ -1309,6 +1309,68 @@ impl<'gctx> Workspace<'gctx> {
         }
     }
 
+    pub(crate) fn members_with_features_for_resolve(
+        &self,
+        specs: &[PackageIdSpec],
+        cli_features: &CliFeatures,
+    ) -> CargoResult<Vec<(&Package, CliFeatures)>> {
+        if self.should_defer_non_member_feature_validation(specs, cli_features) {
+            // Resolve the graph before deciding whether the package spec is
+            // missing or a non-workspace package with unsupported feature flags.
+            return Ok(self
+                .members()
+                .map(|m| (m, CliFeatures::new_all(false)))
+                .collect());
+        }
+        self.members_with_features(specs, cli_features)
+    }
+
+    pub(crate) fn validate_non_member_features(
+        &self,
+        specs: &[PackageIdSpec],
+        cli_features: &CliFeatures,
+        resolve: &Resolve,
+    ) -> CargoResult<()> {
+        if self.should_defer_non_member_feature_validation(specs, cli_features) {
+            resolve.specs_to_ids(specs)?;
+            bail!(
+                "cannot specify features for packages outside of workspace{}",
+                self.non_member_feature_hint(specs)
+            );
+        }
+        Ok(())
+    }
+
+    pub(crate) fn should_defer_non_member_feature_validation(
+        &self,
+        specs: &[PackageIdSpec],
+        cli_features: &CliFeatures,
+    ) -> bool {
+        !specs.is_empty()
+            && self.allows_new_cli_feature_behavior()
+            && !(cli_features.features.is_empty()
+                && !cli_features.all_features
+                && cli_features.uses_default_features)
+            && !self
+                .members()
+                .any(|m| specs.iter().any(|spec| spec.matches(m.package_id())))
+    }
+
+    fn non_member_feature_hint(&self, specs: &[PackageIdSpec]) -> String {
+        specs
+            .iter()
+            .map(|spec| {
+                closest_msg(
+                    spec.name(),
+                    self.members(),
+                    |m| m.name().as_str(),
+                    "workspace member",
+                )
+            })
+            .find(|msg| !msg.is_empty())
+            .unwrap_or_default()
+    }
+
     /// Returns the requested features for the given member.
     /// This filters out any named features that the member does not have.
     fn collect_matching_features(
@@ -1659,19 +1721,10 @@ impl<'gctx> Workspace<'gctx> {
                 && !cli_features.all_features
                 && cli_features.uses_default_features)
             {
-                let hint = specs
-                    .iter()
-                    .map(|spec| {
-                        closest_msg(
-                            spec.name(),
-                            self.members(),
-                            |m| m.name().as_str(),
-                            "workspace member",
-                        )
-                    })
-                    .find(|msg| !msg.is_empty())
-                    .unwrap_or_default();
-                bail!("cannot specify features for packages outside of workspace{hint}");
+                bail!(
+                    "cannot specify features for packages outside of workspace{}",
+                    self.non_member_feature_hint(specs)
+                );
             }
             // Add all members from the workspace so we can ensure `-p nonmember`
             // is in the resolve graph.

--- a/src/cargo/ops/cargo_compile/mod.rs
+++ b/src/cargo/ops/cargo_compile/mod.rs
@@ -293,7 +293,7 @@ pub fn create_bcx<'a, 'gctx>(
         // workspace, if any of those packages need dev-dependencies, then we need include dev-dependencies
         // to scrape those packages.
         let any_pkg_has_scrape_enabled = ws
-            .members_with_features(&specs, cli_features)?
+            .members_with_features_for_resolve(&specs, cli_features)?
             .iter()
             .any(|(pkg, _)| {
                 pkg.targets()

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -173,6 +173,21 @@ pub fn resolve_ws_with_opts<'gctx>(
         .cloned()
         .collect();
     let specs = &specs[..];
+    if ws.should_defer_non_member_feature_validation(specs, cli_features) {
+        let mut registry = ws.package_registry()?;
+        let previous = ops::load_pkg_lockfile(ws)?;
+        let resolved = resolve_with_previous(
+            &mut registry,
+            ws,
+            cli_features,
+            has_dev_units,
+            previous.as_ref(),
+            None,
+            specs,
+            true,
+        )?;
+        ws.validate_non_member_features(specs, cli_features, &resolved)?;
+    }
     let mut registry = ws.package_registry()?;
     let (resolve, resolved_with_overrides) = if ws.ignore_lock() {
         let add_patches = true;
@@ -485,7 +500,7 @@ pub fn resolve_with_previous<'gctx>(
 
     let summaries: Vec<(Summary, ResolveOpts)> = {
         let _span = tracing::span!(tracing::Level::TRACE, "registry.lock").entered();
-        ws.members_with_features(specs, cli_features)?
+        ws.members_with_features_for_resolve(specs, cli_features)?
             .into_iter()
             .map(|(member, features)| {
                 let summary = registry.lock(member.summary().clone());

--- a/tests/testsuite/package_features.rs
+++ b/tests/testsuite/package_features.rs
@@ -802,7 +802,7 @@ fn non_member_typo() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    p.cargo("build -p barr --all-features")
+    p.cargo("build -p barr --features asdf")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] cannot specify features for packages outside of workspace

--- a/tests/testsuite/package_features.rs
+++ b/tests/testsuite/package_features.rs
@@ -745,6 +745,7 @@ fn non_member() {
     p.cargo("check -p dep --features f1")
         .with_status(101)
         .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
 [ERROR] cannot specify features for packages outside of workspace
 
 [HELP] a workspace member with a similar name exists: `foo`
@@ -755,6 +756,7 @@ fn non_member() {
     p.cargo("check -p dep --all-features")
         .with_status(101)
         .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
 [ERROR] cannot specify features for packages outside of workspace
 
 [HELP] a workspace member with a similar name exists: `foo`
@@ -765,6 +767,7 @@ fn non_member() {
     p.cargo("check -p dep --no-default-features")
         .with_status(101)
         .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
 [ERROR] cannot specify features for packages outside of workspace
 
 [HELP] a workspace member with a similar name exists: `foo`
@@ -787,8 +790,9 @@ fn non_member() {
 
 #[cargo_test]
 fn non_member_typo() {
-    // -p with a mistyped package name shows a helpful error hint
-    // about similarly named workspace members.
+    // https://github.com/rust-lang/cargo/issues/16963
+    // A mistyped package name with feature flags should report the missing
+    // package, not the non-workspace feature restriction.
     let p = project()
         .file(
             "Cargo.toml",
@@ -805,9 +809,9 @@ fn non_member_typo() {
     p.cargo("build -p barr --features asdf")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] cannot specify features for packages outside of workspace
+[ERROR] package ID specification `barr` did not match any packages
 
-[HELP] a workspace member with a similar name exists: `bar`
+[HELP] a package with a similar name exists: `bar`
 
 "#]])
         .run();
@@ -1017,27 +1021,27 @@ fn non_member_feature() {
     p.cargo("check -p bar --features bar")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] cannot specify features for packages outside of workspace
+[ERROR] package ID specification `bar` did not match any packages
 
-[HELP] a workspace member with a similar name exists: `foo`
+[HELP] a package with a similar name exists: `foo`
 
 "#]])
         .run();
     p.cargo("check -p bar --features bar/jazz")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] cannot specify features for packages outside of workspace
+[ERROR] package ID specification `bar` did not match any packages
 
-[HELP] a workspace member with a similar name exists: `foo`
+[HELP] a package with a similar name exists: `foo`
 
 "#]])
         .run();
     p.cargo("check -p bar --features foo/bar")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] cannot specify features for packages outside of workspace
+[ERROR] package ID specification `bar` did not match any packages
 
-[HELP] a workspace member with a similar name exists: `foo`
+[HELP] a package with a similar name exists: `foo`
 
 "#]])
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes #16963.

It defers the non-member feature validation until Cargo can distinguish between a missing package spec and a real non-workspace package, allowing missing package spec to use the existing package-ID diagnostic while real non-workspace packages still report the existing feature restriction.

### How to test and review this PR?

Best reviewed commit-by-commit.
