### PR TITLE
feat: Add --output-format=json to cargo doc as an unstable option

### DIFF
--- a/src/bin/cargo/commands/doc.rs
+++ b/src/bin/cargo/commands/doc.rs
@@ -1,6 +1,6 @@
 use crate::command_prelude::*;
 
-use cargo::ops::{self, DocOptions};
+use cargo::ops::{self, DocOptions, OutputFormat};
 
 pub fn cli() -> Command {
     subcommand("doc")
@@ -16,6 +16,11 @@ pub fn cli() -> Command {
             "Don't build documentation for dependencies",
         ))
         .arg(flag("document-private-items", "Document private items"))
+        .arg(
+            opt("output-format", "The output type to write (unstable)")
+                .value_name("FMT")
+                .value_parser(OutputFormat::POSSIBLE_VALUES),
+        )
         .arg_message_format()
         .arg_silent_suggestion()
         .arg_package_spec(
@@ -47,9 +52,16 @@ pub fn cli() -> Command {
 
 pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
     let ws = args.workspace(gctx)?;
+    let output_format = if let Some(output_format) = args._value_of("output-format") {
+        gctx.cli_unstable()
+            .fail_if_stable_opt("--output-format", 13283)?;
+        output_format.parse()?
+    } else {
+        OutputFormat::Html
+    };
     let intent = UserIntent::Doc {
         deps: !args.flag("no-deps"),
-        json: false,
+        json: matches!(output_format, OutputFormat::Json),
     };
     let mut compile_opts =
         args.compile_options(gctx, intent, Some(&ws), ProfileChecking::Custom)?;
@@ -57,7 +69,7 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
 
     let doc_opts = DocOptions {
         open_result: args.flag("open"),
-        output_format: ops::OutputFormat::Html,
+        output_format,
         compile_opts,
     };
     ops::doc(&ws, &doc_opts)?;

--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -546,6 +546,45 @@ fn cargo_rustdoc_json_should_output_to_target_dir() {
     ]);
 }
 
+#[cargo_test(nightly, reason = "--output-format is unstable")]
+fn cargo_doc_json_should_output_to_target_dir() {
+    let p = project()
+        .file("src/lib.rs", "")
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [build]
+            target-dir = "target-dir"
+            build-dir = "build-dir"
+            "#,
+        )
+        .build();
+
+    p.cargo("-Zbuild-dir-new-layout -Zunstable-options doc --no-deps --output-format json")
+        .masquerade_as_nightly_cargo(&["new build-dir layout", "rustdoc-output-format"])
+        .enable_mac_dsym()
+        .run();
+
+    let docs_dir = p.root().join("target-dir/doc");
+
+    assert_exists(&docs_dir);
+    assert_exists(&docs_dir.join("foo.json"));
+
+    p.root().join("build-dir").assert_build_dir_layout(str![
+        r#"
+[ROOT]/foo/build-dir/.rustc_info.json
+[ROOT]/foo/build-dir/.rustdoc_fingerprint.json
+[ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/debug/.cargo-build-lock
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/doc-lib-foo
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/doc-lib-foo.json
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo.json
+
+"#
+    ]);
+}
+
 #[cargo_test]
 fn cargo_package_should_build_in_build_dir_and_output_to_target_dir() {
     let p = project()

--- a/tests/testsuite/build_dir_legacy.rs
+++ b/tests/testsuite/build_dir_legacy.rs
@@ -504,6 +504,45 @@ fn cargo_rustdoc_json_should_output_to_target_dir() {
     ]);
 }
 
+#[cargo_test(nightly, reason = "--output-format is unstable")]
+fn cargo_doc_json_should_output_to_target_dir() {
+    let p = project()
+        .file("src/lib.rs", "")
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [build]
+            target-dir = "target-dir"
+            build-dir = "build-dir"
+            "#,
+        )
+        .build();
+
+    p.cargo("doc --no-deps -Zunstable-options --output-format json")
+        .masquerade_as_nightly_cargo(&["rustdoc-output-format"])
+        .enable_mac_dsym()
+        .run();
+
+    let docs_dir = p.root().join("target-dir/doc");
+
+    assert_exists(&docs_dir);
+    assert_exists(&docs_dir.join("foo.json"));
+
+    p.root().join("build-dir").assert_build_dir_layout(str![
+        r#"
+[ROOT]/foo/build-dir/.rustc_info.json
+[ROOT]/foo/build-dir/.rustdoc_fingerprint.json
+[ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/debug/.cargo-build-lock
+[ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/doc-lib-foo
+[ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/doc-lib-foo.json
+[ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/invoked.timestamp
+[ROOT]/foo/build-dir/debug/build/foo-[HASH]/out/foo.json
+
+"#
+    ]);
+}
+
 #[cargo_test]
 fn cargo_package_should_build_in_build_dir_and_output_to_target_dir() {
     let p = project()

--- a/tests/testsuite/cargo_doc/help/stdout.term.svg
+++ b/tests/testsuite/cargo_doc/help/stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="827px" height="1028px" xmlns="http://www.w3.org/2000/svg">
+<svg width="844px" height="1046px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -36,101 +36,103 @@
 </tspan>
     <tspan x="10px" y="154px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--document-private-items</tspan><tspan>   Document private items</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--message-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>     Error format [possible values: human, short, json,</tspan>
+    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--output-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>      The output type to write (unstable) [possible values: html, json]</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>                                 json-diagnostic-short, json-diagnostic-rendered-ansi,</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--message-format</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FMT&gt;</tspan><tspan>     Error format [possible values: human, short, json,</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>                                 json-render-diagnostics]</tspan>
+    <tspan x="10px" y="208px"><tspan>                                 json-diagnostic-short, json-diagnostic-rendered-ansi,</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
+    <tspan x="10px" y="226px"><tspan>                                 json-render-diagnostics]</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
+    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                    Do not print cargo log messages</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--color</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;WHEN&gt;</tspan><tspan>             Coloring [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
+    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE|PATH&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>                                 details</tspan>
+    <tspan x="10px" y="316px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-Z</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FLAG&gt;</tspan><tspan>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
+    <tspan x="10px" y="334px"><tspan>                                 details</tspan>
 </tspan>
-    <tspan x="10px" y="352px">
+    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                     Print help</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan class="fg-bright-green bold">Package Selection:</tspan>
+    <tspan x="10px" y="370px">
 </tspan>
-    <tspan x="10px" y="388px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package to document</tspan>
+    <tspan x="10px" y="388px"><tspan class="fg-bright-green bold">Package Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--workspace</tspan><tspan>         Document all packages in the workspace</tspan>
+    <tspan x="10px" y="406px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-p</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--package</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Package to document</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--exclude</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>    Exclude packages from the build</tspan>
+    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--workspace</tspan><tspan>         Document all packages in the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all</tspan><tspan>               Alias for --workspace (deprecated)</tspan>
+    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--exclude</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;SPEC&gt;</tspan><tspan>    Exclude packages from the build</tspan>
 </tspan>
-    <tspan x="10px" y="460px">
+    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all</tspan><tspan>               Alias for --workspace (deprecated)</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan class="fg-bright-green bold">Feature Selection:</tspan>
+    <tspan x="10px" y="478px">
 </tspan>
-    <tspan x="10px" y="496px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
+    <tspan x="10px" y="496px"><tspan class="fg-bright-green bold">Feature Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
+    <tspan x="10px" y="514px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-F</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--features</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;FEATURES&gt;</tspan><tspan>  Space or comma separated list of features to activate</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
+    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--all-features</tspan><tspan>         Activate all available features</tspan>
 </tspan>
-    <tspan x="10px" y="550px">
+    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-default-features</tspan><tspan>  Do not activate the `default` feature</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan class="fg-bright-green bold">Target Selection:</tspan>
+    <tspan x="10px" y="568px">
 </tspan>
-    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lib</tspan><tspan>               Document only this package's library</tspan>
+    <tspan x="10px" y="586px"><tspan class="fg-bright-green bold">Target Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bins</tspan><tspan>              Document all binaries</tspan>
+    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--lib</tspan><tspan>               Document only this package's library</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bin</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>      Document only the specified binary</tspan>
+    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bins</tspan><tspan>              Document all binaries</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--examples</tspan><tspan>          Document all examples</tspan>
+    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--bin</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>      Document only the specified binary</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Document only the specified example</tspan>
+    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--examples</tspan><tspan>          Document all examples</tspan>
 </tspan>
-    <tspan x="10px" y="676px">
+    <tspan x="10px" y="676px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--example</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;NAME&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>  Document only the specified example</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan class="fg-bright-green bold">Compilation Options:</tspan>
+    <tspan x="10px" y="694px">
 </tspan>
-    <tspan x="10px" y="712px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
+    <tspan x="10px" y="712px"><tspan class="fg-bright-green bold">Compilation Options:</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
+    <tspan x="10px" y="730px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-j</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--jobs</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;N&gt;</tspan><tspan>                Number of parallel jobs, defaults to # of CPUs.</tspan>
 </tspan>
-    <tspan x="10px" y="748px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-r</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--release</tspan><tspan>                 Build artifacts in release mode, with optimizations</tspan>
+    <tspan x="10px" y="748px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
 </tspan>
-    <tspan x="10px" y="766px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Build artifacts with the specified profile</tspan>
+    <tspan x="10px" y="766px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-r</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--release</tspan><tspan>                 Build artifacts in release mode, with optimizations</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Build for the target triple</tspan>
+    <tspan x="10px" y="784px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Build artifacts with the specified profile</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
+    <tspan x="10px" y="802px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Build for the target triple</tspan>
 </tspan>
-    <tspan x="10px" y="820px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--unit-graph</tspan><tspan>              Output build graph in JSON (unstable)</tspan>
+    <tspan x="10px" y="820px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target-dir</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>  Directory for all generated artifacts</tspan>
 </tspan>
-    <tspan x="10px" y="838px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan>                 Output a build timing report at the end of the build</tspan>
+    <tspan x="10px" y="838px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--unit-graph</tspan><tspan>              Output build graph in JSON (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="856px">
+    <tspan x="10px" y="856px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--timings</tspan><tspan>                 Output a build timing report at the end of the build</tspan>
 </tspan>
-    <tspan x="10px" y="874px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
+    <tspan x="10px" y="874px">
 </tspan>
-    <tspan x="10px" y="892px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-m</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="892px"><tspan class="fg-bright-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="910px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
+    <tspan x="10px" y="910px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-m</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages</tspan>
 </tspan>
-    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="982px">
+    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
-    <tspan x="10px" y="1000px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help doc</tspan><tspan>` for more detailed information.</tspan>
+    <tspan x="10px" y="1000px">
 </tspan>
-    <tspan x="10px" y="1018px">
+    <tspan x="10px" y="1018px"><tspan>Run `</tspan><tspan class="fg-bright-cyan bold">cargo help doc</tspan><tspan>` for more detailed information.</tspan>
+</tspan>
+    <tspan x="10px" y="1036px">
 </tspan>
   </text>
 

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -4029,3 +4029,162 @@ fn mergeable_info_dep_collision() {
     // ...and the fingerprint content are different (path to dep.json different)
     assert_ne!(first_fingerprint, second_fingerprint);
 }
+
+#[cargo_test]
+fn doc_output_format_html_stable() {
+    let p = project().file("src/lib.rs", "").build();
+
+    p.cargo("doc --output-format html -v")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] the `--output-format` flag is unstable, and only available on the nightly channel of Cargo, but this is the `stable` channel
+See https://doc.rust-lang.org/book/[..].html for more information about Rust release channels.
+See https://github.com/rust-lang/cargo/issues/13283 for more information about the `--output-format` flag.
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn doc_invalid_output_format() {
+    let p = project().file("src/lib.rs", "").build();
+
+    p.cargo("doc -Z unstable-options --output-format pdf -v")
+        .masquerade_as_nightly_cargo(&["rustdoc-output-format"])
+        .with_status(1)
+        .with_stderr_data(str![[r#"
+[ERROR] invalid value 'pdf' for '--output-format <FMT>'
+  [possible values: html, json]
+
+For more information, try '--help'.
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn doc_output_format_json_without_unstable_options() {
+    let p = project().file("src/lib.rs", "").build();
+
+    p.cargo("doc --output-format json -v")
+        .masquerade_as_nightly_cargo(&["rustdoc-output-format"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] the `--output-format` flag is unstable, pass `-Z unstable-options` to enable it
+See https://github.com/rust-lang/cargo/issues/13283 for more information about the `--output-format` flag.
+
+"#]])
+        .run();
+}
+
+#[cargo_test(nightly, reason = "--output-format is unstable")]
+fn doc_output_format_json_no_deps() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                bar = { path = "bar" }
+            "#,
+        )
+        .file("src/lib.rs", "pub fn foo_fn() {}")
+        .file(
+            "bar/Cargo.toml",
+            r#"
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                edition = "2021"
+            "#,
+        )
+        .file("bar/src/lib.rs", "pub fn bar_fn() {}")
+        .build();
+
+    p.cargo("doc --no-deps -Z unstable-options --output-format json -v")
+        .masquerade_as_nightly_cargo(&["rustdoc-output-format"])
+        .with_stderr_data(str![[r#"
+[LOCKING] 1 package to latest compatible version
+[CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
+[RUNNING] `rustc [..]--crate-name bar [..]`
+[DOCUMENTING] foo v0.1.0 ([ROOT]/foo)
+[RUNNING] `rustdoc [..]--crate-name foo [..]--output-format=json[..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[GENERATED] [ROOT]/foo/target/doc/foo.json
+
+"#]])
+        .run();
+
+    assert!(p.root().join("target/doc/foo.json").is_file());
+    assert!(!p.root().join("target/doc/bar.json").exists());
+    assert!(!p.root().join("target/doc/foo/index.html").exists());
+
+    let foo_json = fs::read_to_string(p.root().join("target/doc/foo.json")).unwrap();
+    assert!(foo_json.contains("foo_fn"));
+}
+
+#[cargo_test(nightly, reason = "--output-format is unstable")]
+fn doc_output_format_json_with_deps() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                bar = { path = "bar" }
+            "#,
+        )
+        .file("src/lib.rs", "pub fn foo_fn() {}")
+        .file(
+            "bar/Cargo.toml",
+            r#"
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                edition = "2021"
+            "#,
+        )
+        .file("bar/src/lib.rs", "pub fn bar_fn() {}")
+        .build();
+
+    p.cargo("doc -Z unstable-options --output-format json -v")
+        .masquerade_as_nightly_cargo(&["rustdoc-output-format"])
+        .with_stderr_data(
+            str![[r#"
+[LOCKING] 1 package to latest compatible version
+[CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
+[RUNNING] `rustc [..]--crate-name bar [..]`
+[DOCUMENTING] bar v0.1.0 ([ROOT]/foo/bar)
+[RUNNING] `rustdoc [..]--crate-name bar [..]--output-format=json[..]`
+[DOCUMENTING] foo v0.1.0 ([ROOT]/foo)
+[RUNNING] `rustdoc [..]--crate-name foo [..]--output-format=json[..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[GENERATED] [ROOT]/foo/target/doc/foo.json
+
+"#]]
+            .unordered(),
+        )
+        .run();
+
+    let foo_json_path = p.root().join("target/doc/foo.json");
+    let bar_json_path = p.root().join("target/doc/bar.json");
+    assert!(foo_json_path.is_file());
+    assert!(bar_json_path.is_file());
+
+    let foo_json = fs::read_to_string(&foo_json_path).unwrap();
+    assert!(foo_json.contains("foo_fn"));
+
+    let bar_json = fs::read_to_string(&bar_json_path).unwrap();
+    assert!(bar_json.contains("bar_fn"));
+
+    assert!(!p.root().join("target/doc/foo/index.html").exists());
+    assert!(!p.root().join("target/doc/bar/index.html").exists());
+}


### PR DESCRIPTION
### What does this PR try to resolve?

In https://github.com/rust-lang/cargo/issues/13283, the issue of naming conflict between doc artefacts was raised as a reason to wait before adding `--output-format` support to `cargo doc`.
Given the changes in https://github.com/rust-lang/cargo/pull/16773, I argue we shouldn't treat that oustanding design question as a blocker: since JSON doc output is now locked in to use the new build directory layout, we get benefits from first-class support in `cargo doc` even if the conflicts in the target directory remain unresolved.
Namely, it becomes possible to compute the JSON docs for the whole workspace at once and then retrieve the artefacts directly from the build directory. This would significantly speed up tools like [cheadergen](github.com/LukeMathWalker/cheadergen) when launched on workspaces that inevitably have multiple versions of the same crate in their dependency tree.

### How to test and review this PR?

I followed the same testing approach used in https://github.com/rust-lang/cargo/pull/16773 to ease review. Happy to add more test cases if we deem they are necessary.
