### PR TITLE
 Don't use the network for a publish dry-run test 

### DIFF
--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -7800,8 +7800,10 @@ Caused by:
         .run();
 }
 
-#[cargo_test(public_network_test)]
+#[cargo_test]
 fn publish_to_crates_io_warns() {
+    let registry = registry::RegistryBuilder::new().http_api().build();
+
     let p = project()
         .file(
             "Cargo.toml",
@@ -7817,6 +7819,7 @@ fn publish_to_crates_io_warns() {
         .build();
 
     p.cargo(&format!("publish --dry-run"))
+        .replace_crates_io(registry.index_url())
         .with_stderr_data(str![[r#"
 [UPDATING] crates.io index
 [WARNING] manifest has no license, license-file, documentation, homepage or repository

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -7802,6 +7802,7 @@ Caused by:
 
 #[cargo_test]
 fn publish_to_crates_io_warns() {
+    // Publishing to crates.io should warn about missing manifest fields.
     let registry = registry::RegistryBuilder::new().http_api().build();
 
     let p = project()
@@ -7839,6 +7840,8 @@ fn publish_to_crates_io_warns() {
 
 #[cargo_test]
 fn publish_to_alt_registry_warns() {
+    // When publishing to an alternate registry, suppress warnings about
+    // missing manifest fields.
     let _alt_reg = registry::RegistryBuilder::new().alternative().build();
 
     let p = project()


### PR DESCRIPTION
This test does not need to be accessing the network. The test infrastructure has a way to simulate the existence of crates.io, so let's use that.