### PR TITLE
feat(diag): Add the 'cargo::default' group

### DIFF
--- a/crates/xtask-lint-docs/src/main.rs
+++ b/crates/xtask-lint-docs/src/main.rs
@@ -103,12 +103,16 @@ fn lint_groups(buf: &mut String) -> anyhow::Result<()> {
             continue;
         }
         let group_name = format!("`cargo::{}`", group.name);
+        // HACK: `default` is a secondary group without its own level
+        let group_level = if group.name == "default" {
+            "warn/deny".to_owned()
+        } else {
+            group.default_level.to_string()
+        };
         writeln!(
             buf,
             "| {:<max_name_len$} | {:<max_desc_len$} | {:<default_level_len$} |",
-            group_name,
-            group.desc,
-            group.default_level.to_string(),
+            group_name, group.desc, group_level,
         )?;
     }
     writeln!(buf, "\n")?;

--- a/src/cargo/diagnostics/lint.rs
+++ b/src/cargo/diagnostics/lint.rs
@@ -246,4 +246,116 @@ mod tests {
         assert_eq!(level, LintLevel::Deny);
         assert_eq!(source, LintLevelSource::Package);
     }
+
+    #[test]
+    fn default_group_overrides_default() {
+        let lint = test_lint("non_kebab_case_bins", &STYLE);
+
+        let mut pkg_lints = manifest::TomlToolLints::new();
+        pkg_lints.insert(
+            "style".to_string(),
+            manifest::TomlLint::Level(manifest::TomlLintLevel::Deny),
+        );
+        let features = Features::default();
+
+        let LintLevelProduct { level, source } = lint.level(&pkg_lints, None, &features);
+        assert_eq!(level, LintLevel::Deny);
+        assert_eq!(source, LintLevelSource::Package);
+    }
+
+    #[test]
+    fn default_before_primary() {
+        let lint = test_lint("non_kebab_case_bins", &STYLE);
+
+        let mut pkg_lints = manifest::TomlToolLints::new();
+        pkg_lints.insert(
+            "default".to_string(),
+            manifest::TomlLint::Level(manifest::TomlLintLevel::Deny),
+        );
+        pkg_lints.insert(
+            "style".to_string(),
+            manifest::TomlLint::Level(manifest::TomlLintLevel::Allow),
+        );
+        let features = Features::default();
+
+        let LintLevelProduct { level, source } = lint.level(&pkg_lints, None, &features);
+        assert_eq!(level, LintLevel::Allow);
+        assert_eq!(source, LintLevelSource::Package);
+    }
+
+    #[test]
+    fn default_after_primary() {
+        let lint = test_lint("non_kebab_case_bins", &STYLE);
+
+        let mut pkg_lints = manifest::TomlToolLints::new();
+        pkg_lints.insert(
+            "style".to_string(),
+            manifest::TomlLint::Level(manifest::TomlLintLevel::Allow),
+        );
+        pkg_lints.insert(
+            "default".to_string(),
+            manifest::TomlLint::Level(manifest::TomlLintLevel::Deny),
+        );
+        let features = Features::default();
+
+        let LintLevelProduct { level, source } = lint.level(&pkg_lints, None, &features);
+        assert_eq!(level, LintLevel::Allow);
+        assert_eq!(source, LintLevelSource::Package);
+    }
+
+    #[test]
+    fn default_higher_than_primary() {
+        let lint = test_lint("non_kebab_case_bins", &STYLE);
+
+        let mut pkg_lints = manifest::TomlToolLints::new();
+        pkg_lints.insert(
+            "default".to_string(),
+            manifest::TomlLint::Config(manifest::TomlLintConfig {
+                level: manifest::TomlLintLevel::Deny,
+                priority: 1,
+                config: Default::default(),
+            }),
+        );
+        pkg_lints.insert(
+            "style".to_string(),
+            manifest::TomlLint::Config(manifest::TomlLintConfig {
+                level: manifest::TomlLintLevel::Allow,
+                priority: -1,
+                config: Default::default(),
+            }),
+        );
+        let features = Features::default();
+
+        let LintLevelProduct { level, source } = lint.level(&pkg_lints, None, &features);
+        assert_eq!(level, LintLevel::Allow);
+        assert_eq!(source, LintLevelSource::Package);
+    }
+
+    #[test]
+    fn default_lower_than_primary() {
+        let lint = test_lint("non_kebab_case_bins", &STYLE);
+
+        let mut pkg_lints = manifest::TomlToolLints::new();
+        pkg_lints.insert(
+            "default".to_string(),
+            manifest::TomlLint::Config(manifest::TomlLintConfig {
+                level: manifest::TomlLintLevel::Deny,
+                priority: -1,
+                config: Default::default(),
+            }),
+        );
+        pkg_lints.insert(
+            "style".to_string(),
+            manifest::TomlLint::Config(manifest::TomlLintConfig {
+                level: manifest::TomlLintLevel::Allow,
+                priority: 1,
+                config: Default::default(),
+            }),
+        );
+        let features = Features::default();
+
+        let LintLevelProduct { level, source } = lint.level(&pkg_lints, None, &features);
+        assert_eq!(level, LintLevel::Allow);
+        assert_eq!(source, LintLevelSource::Package);
+    }
 }

--- a/src/cargo/diagnostics/lint.rs
+++ b/src/cargo/diagnostics/lint.rs
@@ -60,11 +60,20 @@ impl Lint {
             pkg_lints,
         );
 
+        let default_group = if LintLevel::Warn <= self.primary_group.default_level {
+            let lint_level_priority =
+                level_priority("default", self.primary_group.default_level, pkg_lints);
+            Some(("default", lint_level_priority))
+        } else {
+            None
+        };
+
         let (_, (level, source, _)) = [
             (self.name, lint_level_priority),
             (self.primary_group.name, group_level_priority),
         ]
         .into_iter()
+        .chain(default_group)
         .max_by_key(|(n, (l, s, p))| {
             (
                 l == &LintLevel::Forbid,
@@ -255,7 +264,7 @@ mod tests {
 
         let mut pkg_lints = manifest::TomlToolLints::new();
         pkg_lints.insert(
-            "style".to_string(),
+            "default".to_string(),
             manifest::TomlLint::Level(manifest::TomlLintLevel::Deny),
         );
         let features = Features::default();
@@ -281,7 +290,7 @@ mod tests {
         let features = Features::default();
 
         let LintLevelProduct { level, source } = lint.level(&pkg_lints, None, &features);
-        assert_eq!(level, LintLevel::Allow);
+        assert_eq!(level, LintLevel::Deny);
         assert_eq!(source, LintLevelSource::Package);
     }
 
@@ -301,7 +310,7 @@ mod tests {
         let features = Features::default();
 
         let LintLevelProduct { level, source } = lint.level(&pkg_lints, None, &features);
-        assert_eq!(level, LintLevel::Allow);
+        assert_eq!(level, LintLevel::Deny);
         assert_eq!(source, LintLevelSource::Package);
     }
 
@@ -329,7 +338,7 @@ mod tests {
         let features = Features::default();
 
         let LintLevelProduct { level, source } = lint.level(&pkg_lints, None, &features);
-        assert_eq!(level, LintLevel::Allow);
+        assert_eq!(level, LintLevel::Deny);
         assert_eq!(source, LintLevelSource::Package);
     }
 

--- a/src/cargo/diagnostics/lint.rs
+++ b/src/cargo/diagnostics/lint.rs
@@ -1,4 +1,4 @@
-use std::cmp::{Reverse, max_by_key};
+use std::cmp::Reverse;
 use std::fmt::Display;
 
 use cargo_util_schemas::manifest;
@@ -60,18 +60,20 @@ impl Lint {
             pkg_lints,
         );
 
-        let (_, (level, source, _)) = max_by_key(
+        let (_, (level, source, _)) = [
             (self.name, lint_level_priority),
             (self.primary_group.name, group_level_priority),
-            |(n, (l, s, p))| {
-                (
-                    l == &LintLevel::Forbid,
-                    *s != LintLevelSource::Default,
-                    *p,
-                    Reverse(*n),
-                )
-            },
-        );
+        ]
+        .into_iter()
+        .max_by_key(|(n, (l, s, p))| {
+            (
+                l == &LintLevel::Forbid,
+                *s != LintLevelSource::Default,
+                *p,
+                Reverse(*n),
+            )
+        })
+        .unwrap();
         LintLevelProduct { level, source }
     }
 

--- a/src/cargo/diagnostics/rules/mod.rs
+++ b/src/cargo/diagnostics/rules/mod.rs
@@ -134,6 +134,7 @@ static CARGO_LINTS_MSRV: cargo_util_schemas::manifest::RustVersion =
     cargo_util_schemas::manifest::RustVersion::new(1, 79, 0);
 
 pub static LINT_GROUPS: &[LintGroup] = &[
+    DEFAULT,
     COMPLEXITY,
     CORRECTNESS,
     NURSERY,
@@ -144,6 +145,14 @@ pub static LINT_GROUPS: &[LintGroup] = &[
     SUSPICIOUS,
     TEST_DUMMY_UNSTABLE,
 ];
+
+const DEFAULT: LintGroup = LintGroup {
+    name: "default",
+    desc: "all lints that are on by default (correctness, suspicious, style, complexity, perf)",
+    default_level: LintLevel::Warn,
+    feature_gate: None,
+    hidden: false,
+};
 
 const COMPLEXITY: LintGroup = LintGroup {
     name: "complexity",
@@ -283,7 +292,7 @@ mod tests {
         );
         let actual = LINT_GROUPS
             .iter()
-            .map(|l| l.name.to_uppercase())
+            .map(|l| (l.name != "default", l.name.to_uppercase()))
             .collect::<Vec<_>>();
 
         let mut expected = actual.clone();

--- a/src/cargo/diagnostics/rules/mod.rs
+++ b/src/cargo/diagnostics/rules/mod.rs
@@ -135,14 +135,14 @@ static CARGO_LINTS_MSRV: cargo_util_schemas::manifest::RustVersion =
 
 pub static LINT_GROUPS: &[LintGroup] = &[
     DEFAULT,
-    COMPLEXITY,
     CORRECTNESS,
-    NURSERY,
-    PEDANTIC,
+    COMPLEXITY,
     PERF,
-    RESTRICTION,
     STYLE,
     SUSPICIOUS,
+    NURSERY,
+    PEDANTIC,
+    RESTRICTION,
     TEST_DUMMY_UNSTABLE,
 ];
 
@@ -247,6 +247,7 @@ fn find_lint_or_group<'a>(
 mod tests {
     use itertools::Itertools;
     use snapbox::ToDebug;
+    use std::cmp::Reverse;
     use std::collections::HashSet;
 
     use super::*;
@@ -292,7 +293,13 @@ mod tests {
         );
         let actual = LINT_GROUPS
             .iter()
-            .map(|l| (l.name != "default", l.name.to_uppercase()))
+            .map(|l| {
+                (
+                    l.name != "default",
+                    Reverse(l.default_level),
+                    l.name.to_uppercase(),
+                )
+            })
             .collect::<Vec<_>>();
 
         let mut expected = actual.clone();

--- a/src/doc/src/reference/lints.md
+++ b/src/doc/src/reference/lints.md
@@ -4,16 +4,17 @@ Note: [Cargo's linting system is unstable](unstable.md#lintscargo) and can only 
 
 
 
-| Group                | Description                                                      | Default level |
-|----------------------|------------------------------------------------------------------|---------------|
-| `cargo::complexity`  | code that does something simple but in a complex way             | warn          |
-| `cargo::correctness` | code that is outright wrong or useless                           | deny          |
-| `cargo::nursery`     | new lints that are still under development                       | allow         |
-| `cargo::pedantic`    | lints which are rather strict or have occasional false positives | allow         |
-| `cargo::perf`        | code that can be written to run faster                           | warn          |
-| `cargo::restriction` | lints which prevent the use of Cargo features                    | allow         |
-| `cargo::style`       | code that should be written in a more idiomatic way              | warn          |
-| `cargo::suspicious`  | code that is most likely wrong or useless                        | warn          |
+| Group                | Description                                                                         | Default level |
+|----------------------|-------------------------------------------------------------------------------------|---------------|
+| `cargo::default`     | all lints that are on by default (correctness, suspicious, style, complexity, perf) | warn/deny     |
+| `cargo::complexity`  | code that does something simple but in a complex way                                | warn          |
+| `cargo::correctness` | code that is outright wrong or useless                                              | deny          |
+| `cargo::nursery`     | new lints that are still under development                                          | allow         |
+| `cargo::pedantic`    | lints which are rather strict or have occasional false positives                    | allow         |
+| `cargo::perf`        | code that can be written to run faster                                              | warn          |
+| `cargo::restriction` | lints which prevent the use of Cargo features                                       | allow         |
+| `cargo::style`       | code that should be written in a more idiomatic way                                 | warn          |
+| `cargo::suspicious`  | code that is most likely wrong or useless                                           | warn          |
 
 
 ## Allowed-by-default

--- a/src/doc/src/reference/lints.md
+++ b/src/doc/src/reference/lints.md
@@ -7,14 +7,14 @@ Note: [Cargo's linting system is unstable](unstable.md#lintscargo) and can only 
 | Group                | Description                                                                         | Default level |
 |----------------------|-------------------------------------------------------------------------------------|---------------|
 | `cargo::default`     | all lints that are on by default (correctness, suspicious, style, complexity, perf) | warn/deny     |
-| `cargo::complexity`  | code that does something simple but in a complex way                                | warn          |
 | `cargo::correctness` | code that is outright wrong or useless                                              | deny          |
-| `cargo::nursery`     | new lints that are still under development                                          | allow         |
-| `cargo::pedantic`    | lints which are rather strict or have occasional false positives                    | allow         |
+| `cargo::complexity`  | code that does something simple but in a complex way                                | warn          |
 | `cargo::perf`        | code that can be written to run faster                                              | warn          |
-| `cargo::restriction` | lints which prevent the use of Cargo features                                       | allow         |
 | `cargo::style`       | code that should be written in a more idiomatic way                                 | warn          |
 | `cargo::suspicious`  | code that is most likely wrong or useless                                           | warn          |
+| `cargo::nursery`     | new lints that are still under development                                          | allow         |
+| `cargo::pedantic`    | lints which are rather strict or have occasional false positives                    | allow         |
+| `cargo::restriction` | lints which prevent the use of Cargo features                                       | allow         |
 
 
 ## Allowed-by-default

--- a/tests/testsuite/lints/blanket_hint_mostly_unused.rs
+++ b/tests/testsuite/lints/blanket_hint_mostly_unused.rs
@@ -185,6 +185,7 @@ edition = "2015"
 hint-mostly-unused = true
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 blanket_hint_mostly_unused = "deny"
 "#,
         )

--- a/tests/testsuite/lints/implicit_minimum_version_req.rs
+++ b/tests/testsuite/lints/implicit_minimum_version_req.rs
@@ -24,6 +24,7 @@ edition = "2021"
 dep = "1"
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 implicit_minimum_version_req = "warn"
 "#,
         )
@@ -70,6 +71,7 @@ edition = "2021"
 dep = "1.0"
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 implicit_minimum_version_req = "warn"
 "#,
         )
@@ -116,6 +118,7 @@ edition = "2021"
 dep = "1.0.0"
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 implicit_minimum_version_req = "warn"
 "#,
         )
@@ -150,6 +153,7 @@ edition = "2021"
 dep = { version = "1" }
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 implicit_minimum_version_req = "warn"
 "#,
         )
@@ -196,6 +200,7 @@ edition = "2021"
 dep = ">=1.0"
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 implicit_minimum_version_req = "warn"
 "#,
         )
@@ -242,6 +247,7 @@ edition = "2021"
 dep = "<2.0"
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 implicit_minimum_version_req = "warn"
 "#,
         )
@@ -276,6 +282,7 @@ edition = "2021"
 dep = "1.*"
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 implicit_minimum_version_req = "warn"
 "#,
         )
@@ -310,6 +317,7 @@ edition = "2021"
 dep = "1.0.*"
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 implicit_minimum_version_req = "warn"
 "#,
         )
@@ -344,6 +352,7 @@ edition = "2021"
 dep = ">1.0"
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 implicit_minimum_version_req = "warn"
 "#,
         )
@@ -378,6 +387,7 @@ edition = "2021"
 dep = "<=2.0"
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 implicit_minimum_version_req = "warn"
 "#,
         )
@@ -412,6 +422,7 @@ edition = "2021"
 dep = ">=1.0, <2.0"
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 implicit_minimum_version_req = "warn"
 "#,
         )
@@ -458,6 +469,7 @@ edition = "2021"
 dep = "~1.0"
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 implicit_minimum_version_req = "warn"
 "#,
         )
@@ -492,6 +504,7 @@ edition = "2021"
 dep = "=1"
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 implicit_minimum_version_req = "warn"
 "#,
         )
@@ -524,6 +537,7 @@ edition = "2021"
 bar = { path = "bar" }
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 implicit_minimum_version_req = "warn"
 "#,
         )
@@ -564,6 +578,7 @@ edition = "2021"
 bar = { path = "bar", version = "0.1" }
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 implicit_minimum_version_req = "warn"
 "#,
         )
@@ -622,6 +637,7 @@ edition = "2021"
 bar = {{ git = '{}' }}
 
 [lints.cargo]
+default = {{ level = "allow", priority = -1 }}
 implicit_minimum_version_req = "warn"
 "#,
                 git_project.url()
@@ -661,6 +677,7 @@ edition = "2021"
 bar = {{ git = '{}', version = "0.1" }}
 
 [lints.cargo]
+default = {{ level = "allow", priority = -1 }}
 implicit_minimum_version_req = "warn"
 "#,
                 git_project.url()
@@ -707,6 +724,7 @@ edition = "2021"
 dep = "1"
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 implicit_minimum_version_req = "warn"
 "#,
         )
@@ -753,6 +771,7 @@ edition = "2021"
 dep = "1.0"
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 implicit_minimum_version_req = "warn"
 "#,
         )
@@ -801,6 +820,7 @@ edition = "2021"
 dep = "1"
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 implicit_minimum_version_req = "warn"
 "#,
         )
@@ -848,6 +868,7 @@ edition = "2021"
 dep = "1"
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 implicit_minimum_version_req = "warn"
 "#,
         )
@@ -896,6 +917,7 @@ dep = "1"
 regex = "1.0"
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 implicit_minimum_version_req = "warn"
 "#,
         )
@@ -947,6 +969,7 @@ resolver = "2"
 dep = "1"
 
 [workspace.lints.cargo]
+default = { level = "allow", priority = -1 }
 implicit_minimum_version_req = "warn"
 "#,
         )
@@ -1008,6 +1031,7 @@ resolver = "2"
 dep = "1"
 
 [workspace.lints.cargo]
+default = { level = "allow", priority = -1 }
 implicit_minimum_version_req = "warn"
 "#,
         )
@@ -1027,17 +1051,6 @@ edition = "2021"
     p.cargo("fetch -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unused workspace dependency
- --> Cargo.toml:7:1
-  |
-7 | dep = "1"
-  | ^^^
-  |
-  = [NOTE] `cargo::unused_workspace_dependencies` is set to `warn` by default
-[HELP] consider removing the unused dependency
-  |
-7 - dep = "1"
-  |
 [WARNING] dependency version requirement without an explicit minimum version
  --> Cargo.toml:7:7
   |
@@ -1049,7 +1062,7 @@ edition = "2021"
   |
 7 | dep = "1.0.0"
   |         ++++
-[WARNING] workspace (manifest) generated 2 warnings
+[WARNING] workspace (manifest) generated 1 warning
 
 "#]])
         .run();
@@ -1072,6 +1085,7 @@ resolver = "2"
 dep = "1"
 
 [workspace.lints.cargo]
+default = { level = "allow", priority = -1 }
 implicit_minimum_version_req = "warn"
 "#,
         )
@@ -1095,17 +1109,6 @@ workspace = true
     p.cargo("fetch -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unused workspace dependency
- --> Cargo.toml:7:1
-  |
-7 | dep = "1"
-  | ^^^
-  |
-  = [NOTE] `cargo::unused_workspace_dependencies` is set to `warn` by default
-[HELP] consider removing the unused dependency
-  |
-7 - dep = "1"
-  |
 [WARNING] dependency version requirement without an explicit minimum version
  --> Cargo.toml:7:7
   |
@@ -1117,7 +1120,7 @@ workspace = true
   |
 7 | dep = "1.0.0"
   |         ++++
-[WARNING] workspace (manifest) generated 2 warnings
+[WARNING] workspace (manifest) generated 1 warning
 [WARNING] dependency version requirement without an explicit minimum version
  --> member/Cargo.toml:7:7
   |
@@ -1155,6 +1158,7 @@ edition = "2021"
 dep = "1"
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 implicit_minimum_version_req = "deny"
 "#,
         )

--- a/tests/testsuite/lints/missing_lints_inheritance.rs
+++ b/tests/testsuite/lints/missing_lints_inheritance.rs
@@ -41,6 +41,7 @@ fn ws_lints() {
 members = ["bar"]
 
 [workspace.lints.cargo]
+default = { level = "allow", priority = -1 }
 missing_lints_inheritance = "warn"
 "#,
         )
@@ -90,6 +91,7 @@ fn empty_pkg_lints() {
 members = ["bar"]
 
 [workspace.lints.cargo]
+default = { level = "allow", priority = -1 }
 missing_lints_inheritance = "warn"
 "#,
         )
@@ -124,6 +126,7 @@ fn inherit_lints() {
 members = ["bar"]
 
 [workspace.lints.cargo]
+default = { level = "allow", priority = -1 }
 missing_lints_inheritance = "warn"
 "#,
         )

--- a/tests/testsuite/lints/non_kebab_case_bins.rs
+++ b/tests/testsuite/lints/non_kebab_case_bins.rs
@@ -19,6 +19,7 @@ name = "foo_bar"
 path = "src/main.rs"
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 non_kebab_case_bins = "warn"
 "#,
         )
@@ -59,6 +60,7 @@ edition = "2015"
 authors = []
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 non_kebab_case_bins = "warn"
 "#,
         )
@@ -81,12 +83,12 @@ non_kebab_case_bins = "warn"
  3 + name = "foo-bar"
    |
 [HELP] to change the binary name to kebab case, specify `bin.name`
-  --> Cargo.toml:9:30
+  --> Cargo.toml:10:30
    |
- 9 ~ non_kebab_case_bins = "warn"
-10 + [[bin]]
-11 + name = "foo-bar"
-12 + path = "src/main.rs"
+10 ~ non_kebab_case_bins = "warn"
+11 + [[bin]]
+12 + name = "foo-bar"
+13 + path = "src/main.rs"
    |
 [WARNING] `foo_bar` (manifest) generated 1 warning
 
@@ -107,6 +109,7 @@ edition = "2015"
 authors = []
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 non_kebab_case_bins = "warn"
 "#,
         )
@@ -141,6 +144,7 @@ fn bin_name_from_script_name() {
             r#"
 ---
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 non_kebab_case_bins = "warn"
 ---
 fn main() {}"#,

--- a/tests/testsuite/lints/non_kebab_case_features.rs
+++ b/tests/testsuite/lints/non_kebab_case_features.rs
@@ -19,6 +19,7 @@ authors = []
 foo_bar = []
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 non_kebab_case_features = "warn"
             "#,
         )
@@ -64,6 +65,7 @@ authors = []
 foo_bar = { version = "0.0.1", optional = true }
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 non_kebab_case_features = "warn"
             "#,
         )

--- a/tests/testsuite/lints/non_kebab_case_packages.rs
+++ b/tests/testsuite/lints/non_kebab_case_packages.rs
@@ -15,6 +15,7 @@ edition = "2015"
 authors = []
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 non_kebab_case_packages = "warn"
             "#,
         )
@@ -50,6 +51,7 @@ fn package_name_from_script_name() {
             r#"
 ---
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 non_kebab_case_packages = "warn"
 ---
 fn main() {}"#,
@@ -61,17 +63,6 @@ fn main() {}"#,
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
 [HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/foo_bar`
-[WARNING] binaries should have a kebab-case name
-  |
-1 | [ROOT]/home/.cargo/build/[HASH]/target/.../foo_bar[EXE]
-  |                                        [..]^^^^^^^
-  |
-  = [NOTE] `cargo::non_kebab_case_bins` is set to `warn` by default
-[HELP] to change the binary name to kebab case, convert the file stem
-  |
-1 - foo_bar
-1 + foo-bar
-  |
 [WARNING] packages should have a kebab-case name
  --> foo_bar
   = [NOTE] `cargo::non_kebab_case_packages` is set to `warn` in `[lints]`
@@ -80,7 +71,7 @@ fn main() {}"#,
 1 - [ROOT]/foo/foo_bar
 1 + [ROOT]/foo/foo-bar
   |
-[WARNING] `foo_bar` (manifest) generated 2 warnings
+[WARNING] `foo_bar` (manifest) generated 1 warning
 
 "#]])
         .run();

--- a/tests/testsuite/lints/non_snake_case_features.rs
+++ b/tests/testsuite/lints/non_snake_case_features.rs
@@ -19,6 +19,7 @@ authors = []
 foo-bar = []
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 non_snake_case_features = "warn"
             "#,
         )
@@ -64,6 +65,7 @@ authors = []
 foo-bar = { version = "0.0.1", optional = true }
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 non_snake_case_features = "warn"
             "#,
         )

--- a/tests/testsuite/lints/non_snake_case_packages.rs
+++ b/tests/testsuite/lints/non_snake_case_packages.rs
@@ -15,6 +15,7 @@ edition = "2015"
 authors = []
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 non_snake_case_packages = "warn"
             "#,
         )
@@ -50,6 +51,7 @@ fn package_name_from_script_name() {
             r#"
 ---
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 non_snake_case_packages = "warn"
 ---
 fn main() {}"#,

--- a/tests/testsuite/lints/redundant_homepage.rs
+++ b/tests/testsuite/lints/redundant_homepage.rs
@@ -16,6 +16,7 @@ repository = "https://github.com/rust-lang/cargo/"
 homepage = "https://github.com/rust-lang/cargo/"
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 redundant_homepage = "warn"
 "#,
         )
@@ -59,6 +60,7 @@ documentation = "https://docs.rs/cargo/latest/cargo/"
 homepage = "https://docs.rs/cargo/latest/cargo/"
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 redundant_homepage = "warn"
 "#,
         )
@@ -106,6 +108,7 @@ documentation.workspace = true
 homepage.workspace = true
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 redundant_homepage = "warn"
 "#,
         )

--- a/tests/testsuite/lints/redundant_readme.rs
+++ b/tests/testsuite/lints/redundant_readme.rs
@@ -16,6 +16,7 @@ authors = []
 readme = "README.md"
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 redundant_readme = "warn"
 "#,
         )
@@ -56,6 +57,7 @@ edition = "2015"
 authors = []
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 redundant_readme = "warn"
 "#,
         )
@@ -83,6 +85,7 @@ authors = []
 readme = "FOO.md"
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 redundant_readme = "warn"
 "#,
         )
@@ -110,6 +113,7 @@ authors = []
 readme = "src/README.md"
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 redundant_readme = "warn"
 "#,
         )
@@ -140,6 +144,7 @@ authors = []
 readme.workspace = true
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
 redundant_readme = "warn"
 "#,
         )

--- a/tests/testsuite/lints/text_direction_codepoint.rs
+++ b/tests/testsuite/lints/text_direction_codepoint.rs
@@ -19,6 +19,7 @@ fn bidi_comments_warn() {
 {BIDI_MANIFEST}
 
 [lints.cargo]
+default = {{ level = \"allow\", priority = -1 }}
 text_direction_codepoint_in_comment = \"warn\"
 text_direction_codepoint_in_literal = \"allow\"
 "
@@ -74,6 +75,7 @@ fn bidi_literals_warn() {
 {BIDI_MANIFEST}
 
 [lints.cargo]
+default = {{ level = \"allow\", priority = -1 }}
 text_direction_codepoint_in_comment = \"allow\"
 text_direction_codepoint_in_literal = \"warn\"
 "
@@ -149,6 +151,7 @@ members = [\"bar\"]
 {BIDI_MANIFEST}
 
 [lints.cargo]
+default = {{ level = \"allow\", priority = -1 }}
 text_direction_codepoint_in_comment = \"warn\"
 text_direction_codepoint_in_literal = \"warn\"
 "
@@ -267,6 +270,7 @@ homepage = \"a \u{202e}homepage\u{202a} there\"  # this is a \u{202b}tricky\u{20
 repository = \"a \u{202e}repository\u{202a} everywhere\"  # this is a \u{202b}tricky\u{202c} comment
 
 [workspace.lints.cargo]
+default = {{ level = \"allow\", priority = -1 }}
 text_direction_codepoint_in_comment = \"warn\"
 text_direction_codepoint_in_literal = \"warn\"
 "

--- a/tests/testsuite/lints/unknown_lints.rs
+++ b/tests/testsuite/lints/unknown_lints.rs
@@ -15,6 +15,8 @@ edition = "2015"
 authors = []
 
 [lints.cargo]
+default = { level = "allow", priority = -1 }
+unknown_lints = "warn"
 this-lint-does-not-exist = "warn"
 "#,
         )
@@ -25,12 +27,12 @@ this-lint-does-not-exist = "warn"
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [WARNING] unknown lint: `this-lint-does-not-exist`
- --> Cargo.toml:9:1
-  |
-9 | this-lint-does-not-exist = "warn"
-  | ^^^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+  --> Cargo.toml:11:1
+   |
+11 | this-lint-does-not-exist = "warn"
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = [NOTE] `cargo::unknown_lints` is set to `warn` in `[lints]`
 [WARNING] `foo` (manifest) generated 1 warning
 
 "#]])
@@ -47,6 +49,8 @@ fn inherited() {
 members = ["foo"]
 
 [workspace.lints.cargo]
+default = { level = "allow", priority = -1 }
+unknown_lints = "warn"
 this-lint-does-not-exist = "warn"
 "#,
         )
@@ -70,12 +74,12 @@ workspace = true
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [WARNING] unknown lint: `this-lint-does-not-exist`
- --> Cargo.toml:6:1
+ --> Cargo.toml:8:1
   |
-6 | this-lint-does-not-exist = "warn"
+8 | this-lint-does-not-exist = "warn"
   | ^^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+  = [NOTE] `cargo::unknown_lints` is set to `warn` in `[lints]`
 [WARNING] workspace (manifest) generated 1 warning
 
 "#]])
@@ -92,6 +96,8 @@ fn not_inherited() {
 members = ["foo"]
 
 [workspace.lints.cargo]
+default = { level = "allow", priority = -1 }
+unknown_lints = "warn"
 this-lint-does-not-exist = "warn"
 "#,
         )
@@ -112,12 +118,12 @@ authors = []
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [WARNING] unknown lint: `this-lint-does-not-exist`
- --> Cargo.toml:6:1
+ --> Cargo.toml:8:1
   |
-6 | this-lint-does-not-exist = "warn"
+8 | this-lint-does-not-exist = "warn"
   | ^^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = [NOTE] `cargo::unknown_lints` is set to `warn` by default
+  = [NOTE] `cargo::unknown_lints` is set to `warn` in `[lints]`
 [WARNING] workspace (manifest) generated 1 warning
 [WARNING] missing `[lints]` to inherit `[workspace.lints]`
  --> foo/Cargo.toml

--- a/tests/testsuite/lints/unused_dependencies.rs
+++ b/tests/testsuite/lints/unused_dependencies.rs
@@ -22,6 +22,7 @@ fn unused_dep_normal() {
             unused = "0.1.0"
 
             [lints.cargo]
+            default = { level = "allow", priority = -1 }
             unused_dependencies = "warn"
         "#,
         )
@@ -77,6 +78,7 @@ fn unused_dep_build() {
             unused = "0.1.0"
 
             [lints.cargo]
+            default = { level = "allow", priority = -1 }
             unused_dependencies = "warn"
         "#,
         )
@@ -138,6 +140,7 @@ fn unused_dep_build_no_build_rs() {
             unused = "0.1.0"
 
             [lints.cargo]
+            default = { level = "allow", priority = -1 }
             unused_dependencies = "warn"
         "#,
         )
@@ -198,6 +201,7 @@ fn unused_dep_lib_bins() {
             bins_used = "0.1.0"
 
             [lints.cargo]
+            default = { level = "allow", priority = -1 }
             unused_dependencies = "warn"
         "#,
         )
@@ -303,6 +307,7 @@ fn unused_dep_build_with_used_dep_normal() {
             unused_build = "0.1.0"
 
             [lints.cargo]
+            default = { level = "allow", priority = -1 }
             unused_dependencies = "warn"
         "#,
         )
@@ -365,6 +370,7 @@ fn unused_dep_normal_but_implicit_used_dep_dev() {
             used_dev = "0.1.0"
 
             [lints.cargo]
+            default = { level = "allow", priority = -1 }
             unused_dependencies = "warn"
         "#,
         )
@@ -454,6 +460,7 @@ fn unused_dep_normal_but_explicit_used_dep_dev() {
             used_once = "0.1.0"
 
             [lints.cargo]
+            default = { level = "allow", priority = -1 }
             unused_dependencies = "warn"
         "#,
         )
@@ -521,6 +528,7 @@ fn unused_dep_dev_but_explicit_used_dep_normal() {
             used_once = "0.1.0"
 
             [lints.cargo]
+            default = { level = "allow", priority = -1 }
             unused_dependencies = "warn"
         "#,
         )
@@ -579,6 +587,7 @@ fn optional_dependency() {
             used = { version = "0.1.0", optional = true }
 
             [lints.cargo]
+            default = { level = "allow", priority = -1 }
             unused_dependencies = "warn"
         "#,
         )
@@ -654,6 +663,7 @@ fn unused_dep_renamed() {
             bar = { package = "baz", version = "0.2.0" }
 
             [lints.cargo]
+            default = { level = "allow", priority = -1 }
             unused_dependencies = "warn"
         "#,
         )
@@ -716,6 +726,7 @@ fn warning_replay() {
             unused = "0.1.0"
 
             [lints.cargo]
+            default = { level = "allow", priority = -1 }
             unused_dependencies = "warn"
         "#,
         )
@@ -796,6 +807,7 @@ fn unused_dep_target() {
             used = "0.1.0"
 
             [lints.cargo]
+            default = {{ level = "allow", priority = -1 }}
             unused_dependencies = "warn"
         "#
             ),
@@ -869,6 +881,7 @@ fn unused_dev_deps() {
             unused = "0.1.0"
 
             [lints.cargo]
+            default = { level = "allow", priority = -1 }
             unused_dependencies = "warn"
         "#,
         )
@@ -1030,6 +1043,7 @@ fn package_selection() {
             external.path = "../external"
 
             [lints.cargo]
+            default = { level = "allow", priority = -1 }
             unused_dependencies = "warn"
             "#,
         )
@@ -1053,6 +1067,7 @@ fn package_selection() {
             used_bar = "0.1.0"
 
             [lints.cargo]
+            default = { level = "allow", priority = -1 }
             unused_dependencies = "warn"
             "#,
         )
@@ -1076,6 +1091,7 @@ fn package_selection() {
             used_external = "0.1.0"
 
             [lints.cargo]
+            default = { level = "allow", priority = -1 }
             unused_dependencies = "warn"
             "#,
         )
@@ -1261,6 +1277,7 @@ fn pinned_transitive_dep() {
             transitive = "=0.1.1"
 
             [lints.cargo]
+            default = { level = "allow", priority = -1 }
             unused_dependencies = "warn"
         "#,
         )
@@ -1335,6 +1352,7 @@ pub fn fun() -> &'static str {
             transitive = { version = "0.1.1", features = ["a"] }
 
             [lints.cargo]
+            default = { level = "allow", priority = -1 }
             unused_dependencies = "warn"
         "#,
         )
@@ -1384,6 +1402,7 @@ fn allow_rustflags() {
             unused = "0.1.0"
 
             [lints.cargo]
+            default = { level = "allow", priority = -1 }
             unused_dependencies = "warn"
         "#,
         )
@@ -1441,6 +1460,7 @@ fn allow_attribute() {
             unused = "0.1.0"
 
             [lints.cargo]
+            default = { level = "allow", priority = -1 }
             unused_dependencies = "warn"
         "#,
         )
@@ -1554,6 +1574,7 @@ fn deny_rustflags() {
             unused = "0.1.0"
 
             [lints.cargo]
+            default = { level = "allow", priority = -1 }
             unused_dependencies = "warn"
         "#,
         )
@@ -1611,6 +1632,7 @@ fn deny_attribute() {
             unused = "0.1.0"
 
             [lints.cargo]
+            default = { level = "allow", priority = -1 }
             unused_dependencies = "warn"
         "#,
         )
@@ -1668,6 +1690,7 @@ fn forbid_rustflags() {
             unused = "0.1.0"
 
             [lints.cargo]
+            default = { level = "allow", priority = -1 }
             unused_dependencies = "warn"
         "#,
         )
@@ -1725,6 +1748,7 @@ fn forbid_attribute() {
             unused = "0.1.0"
 
             [lints.cargo]
+            default = { level = "allow", priority = -1 }
             unused_dependencies = "warn"
         "#,
         )

--- a/tests/testsuite/lints/unused_workspace_dependencies.rs
+++ b/tests/testsuite/lints/unused_workspace_dependencies.rs
@@ -30,6 +30,7 @@ unused = "1"
 not-inherited = "1"
 
 [workspace.lints.cargo]
+default = { level = "allow", priority = -1 }
 unused_workspace_dependencies = "warn"
 
 [package]
@@ -100,19 +101,6 @@ workspace = true
 11 - unused = "1"
    |
 [WARNING] workspace (manifest) generated 2 warnings
-[WARNING] unused dependency
- --> bar/Cargo.toml:9:1
-  |
-9 | build-dep.workspace = true
-  | ^^^^^^^^^
-  |
-  = [NOTE] `cargo::unused_dependencies` is set to `warn` by default
-[HELP] remove the dependency
-  |
-9 - build-dep.workspace = true
-9 + .workspace = true
-  |
-[WARNING] `bar` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
 [LOCKING] 6 packages to latest compatible versions
 [DOWNLOADING] crates ...

--- a/tests/testsuite/lints/unused_workspace_package_fields.rs
+++ b/tests/testsuite/lints/unused_workspace_package_fields.rs
@@ -18,6 +18,7 @@ rust-version = "1.0"
 unknown = "foo"
 
 [workspace.lints.cargo]
+default = { level = "allow", priority = -1 }
 unused_workspace_package_fields = "warn"
 
 [package]


### PR DESCRIPTION
### What does this PR try to resolve?

Adds a "visible by default" lint group to mirror `clippy::all` which should gain a `clippy::default` alias.

Personally, my motivation is to reduce noise in tests by making it easy to disable all lints except those under tests.

### How to test and review this PR?
