### PR TITLE
fix(diag): Report summaries for unused_deps

### DIFF
--- a/src/cargo/core/compiler/build_runner/mod.rs
+++ b/src/cargo/core/compiler/build_runner/mod.rs
@@ -24,6 +24,7 @@ use super::job_queue::JobQueue;
 use super::layout::Layout;
 use super::lto::Lto;
 use super::unit_graph::UnitDep;
+use super::unused_deps::UnusedDepState;
 use super::{BuildContext, Compilation, CompileKind, CompileMode, Executor, FileFlavor};
 
 mod compilation_files;
@@ -89,6 +90,8 @@ pub struct BuildRunner<'a, 'gctx> {
     /// because it is continuously updated as the job progresses.
     pub failed_scrape_units: Arc<Mutex<HashSet<UnitHash>>>,
 
+    pub unused_dep_state: UnusedDepState,
+
     /// Manages locks for build units when fine grain locking is enabled.
     pub lock_manager: Arc<LockManager>,
 }
@@ -130,6 +133,7 @@ impl<'a, 'gctx> BuildRunner<'a, 'gctx> {
             lto: HashMap::new(),
             metadata_for_doc_units: HashMap::new(),
             failed_scrape_units: Arc::new(Mutex::new(HashSet::new())),
+            unused_dep_state: UnusedDepState::new(bcx),
             lock_manager: Arc::new(LockManager::new()),
         })
     }

--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -850,7 +850,6 @@ impl<'gctx> DrainState<'gctx> {
                 &mut stats,
             ));
             errors.count += stats.error_count();
-            build_runner.compilation.lint_warning_count += stats.lint_warning_count();
         }
 
         let profile_name = build_runner.bcx.build_config.requested_profile;

--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -138,6 +138,7 @@ use super::UnitIndex;
 use super::custom_build::Severity;
 use super::timings::SectionTiming;
 use super::timings::Timings;
+use super::unused_deps::emit_unused_warnings;
 use crate::core::compiler::descriptive_pkg_name;
 use crate::core::compiler::future_incompat::{
     self, FutureBreakageItem, FutureIncompatReportPackage,
@@ -844,9 +845,10 @@ impl<'gctx> DrainState<'gctx> {
         if build_runner.bcx.gctx.cli_unstable().cargo_lints {
             let mut warn_count = 0;
             let mut error_count = 0;
-            drop(build_runner.unused_dep_state.emit_unused_warnings(
+            drop(emit_unused_warnings(
                 &mut warn_count,
                 &mut error_count,
+                &build_runner.unused_dep_state,
                 build_runner.bcx,
             ));
             errors.count += error_count;

--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -844,12 +844,12 @@ impl<'gctx> DrainState<'gctx> {
         self.progress.clear();
 
         if build_runner.bcx.gctx.cli_unstable().cargo_lints {
-            let mut stats = DiagnosticStats::new();
+            let mut global_stats = DiagnosticStats::new();
             drop(unused_dependencies::lint_build_results(
                 build_runner,
-                &mut stats,
+                &mut global_stats,
             ));
-            errors.count += stats.error_count();
+            errors.count += global_stats.error_count();
         }
 
         let profile_name = build_runner.bcx.build_config.requested_profile;

--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -850,7 +850,7 @@ impl<'gctx> DrainState<'gctx> {
                 &mut stats,
             ));
             errors.count += stats.error_count();
-            build_runner.compilation.lint_warning_count += stats.warning_count();
+            build_runner.compilation.lint_warning_count += stats.lint_warning_count();
         }
 
         let profile_name = build_runner.bcx.build_config.requested_profile;

--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -138,13 +138,13 @@ use super::UnitIndex;
 use super::custom_build::Severity;
 use super::timings::SectionTiming;
 use super::timings::Timings;
-use super::unused_deps;
 use crate::core::compiler::descriptive_pkg_name;
 use crate::core::compiler::future_incompat::{
     self, FutureBreakageItem, FutureIncompatReportPackage,
 };
 use crate::core::resolver::ResolveBehavior;
 use crate::core::{PackageId, TargetKind};
+use crate::diagnostics::rules::unused_dependencies;
 use crate::util::CargoResult;
 use crate::util::context::WarningHandling;
 use crate::util::diagnostic_server::{self, DiagnosticPrinter};
@@ -845,7 +845,7 @@ impl<'gctx> DrainState<'gctx> {
         if build_runner.bcx.gctx.cli_unstable().cargo_lints {
             let mut warn_count = 0;
             let mut error_count = 0;
-            drop(unused_deps::lint_build_results(
+            drop(unused_dependencies::lint_build_results(
                 build_runner,
                 &mut warn_count,
                 &mut error_count,

--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -138,7 +138,7 @@ use super::UnitIndex;
 use super::custom_build::Severity;
 use super::timings::SectionTiming;
 use super::timings::Timings;
-use super::unused_deps::emit_unused_warnings;
+use super::unused_deps;
 use crate::core::compiler::descriptive_pkg_name;
 use crate::core::compiler::future_incompat::{
     self, FutureBreakageItem, FutureIncompatReportPackage,
@@ -845,7 +845,7 @@ impl<'gctx> DrainState<'gctx> {
         if build_runner.bcx.gctx.cli_unstable().cargo_lints {
             let mut warn_count = 0;
             let mut error_count = 0;
-            drop(emit_unused_warnings(
+            drop(unused_deps::lint_build_results(
                 &mut warn_count,
                 &mut error_count,
                 &build_runner.unused_dep_state,

--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -508,7 +508,7 @@ impl<'gctx> JobQueue<'gctx> {
             progress,
             next_id: 0,
             timings: self.timings,
-            unused_dep_state: UnusedDepState::new(build_runner),
+            unused_dep_state: UnusedDepState::new(build_runner.bcx),
             index_to_unit: build_runner
                 .bcx
                 .unit_to_index
@@ -849,7 +849,7 @@ impl<'gctx> DrainState<'gctx> {
             drop(self.unused_dep_state.emit_unused_warnings(
                 &mut warn_count,
                 &mut error_count,
-                build_runner,
+                build_runner.bcx,
             ));
             errors.count += error_count;
             build_runner.compilation.lint_warning_count += warn_count;

--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -846,10 +846,9 @@ impl<'gctx> DrainState<'gctx> {
             let mut warn_count = 0;
             let mut error_count = 0;
             drop(unused_deps::lint_build_results(
+                build_runner,
                 &mut warn_count,
                 &mut error_count,
-                &build_runner.unused_dep_state,
-                build_runner.bcx,
             ));
             errors.count += error_count;
             build_runner.compilation.lint_warning_count += warn_count;

--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -138,7 +138,6 @@ use super::UnitIndex;
 use super::custom_build::Severity;
 use super::timings::SectionTiming;
 use super::timings::Timings;
-use super::unused_deps::UnusedDepState;
 use crate::core::compiler::descriptive_pkg_name;
 use crate::core::compiler::future_incompat::{
     self, FutureBreakageItem, FutureIncompatReportPackage,
@@ -189,7 +188,6 @@ struct DrainState<'gctx> {
     progress: Progress<'gctx>,
     next_id: u32,
     timings: Timings<'gctx>,
-    unused_dep_state: UnusedDepState,
 
     /// Map from unit index to unit, for looking up dependency information.
     index_to_unit: HashMap<UnitIndex, Unit>,
@@ -508,7 +506,6 @@ impl<'gctx> JobQueue<'gctx> {
             progress,
             next_id: 0,
             timings: self.timings,
-            unused_dep_state: UnusedDepState::new(build_runner.bcx),
             index_to_unit: build_runner
                 .bcx
                 .unit_to_index
@@ -748,7 +745,8 @@ impl<'gctx> DrainState<'gctx> {
             }
             Message::UnusedExterns(id, unused_externs) => {
                 let unit = &self.active[&id];
-                self.unused_dep_state
+                build_runner
+                    .unused_dep_state
                     .record_unused_externs_for_unit(unit, unused_externs);
             }
             Message::Token(acquired_token) => {
@@ -846,7 +844,7 @@ impl<'gctx> DrainState<'gctx> {
         if build_runner.bcx.gctx.cli_unstable().cargo_lints {
             let mut warn_count = 0;
             let mut error_count = 0;
-            drop(self.unused_dep_state.emit_unused_warnings(
+            drop(build_runner.unused_dep_state.emit_unused_warnings(
                 &mut warn_count,
                 &mut error_count,
                 build_runner.bcx,

--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -144,6 +144,7 @@ use crate::core::compiler::future_incompat::{
 };
 use crate::core::resolver::ResolveBehavior;
 use crate::core::{PackageId, TargetKind};
+use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::rules::unused_dependencies;
 use crate::util::CargoResult;
 use crate::util::context::WarningHandling;
@@ -843,15 +844,13 @@ impl<'gctx> DrainState<'gctx> {
         self.progress.clear();
 
         if build_runner.bcx.gctx.cli_unstable().cargo_lints {
-            let mut warn_count = 0;
-            let mut error_count = 0;
+            let mut stats = DiagnosticStats::new();
             drop(unused_dependencies::lint_build_results(
                 build_runner,
-                &mut warn_count,
-                &mut error_count,
+                &mut stats,
             ));
-            errors.count += error_count;
-            build_runner.compilation.lint_warning_count += warn_count;
+            errors.count += stats.error_count();
+            build_runner.compilation.lint_warning_count += stats.warning_count();
         }
 
         let profile_name = build_runner.bcx.build_config.requested_profile;

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -51,7 +51,7 @@ pub mod timings;
 mod unit;
 pub mod unit_dependencies;
 pub mod unit_graph;
-mod unused_deps;
+pub mod unused_deps;
 
 use std::borrow::Cow;
 use std::cell::OnceCell;

--- a/src/cargo/core/compiler/unused_deps.rs
+++ b/src/cargo/core/compiler/unused_deps.rs
@@ -139,7 +139,7 @@ impl UnusedDepState {
 }
 
 #[instrument(skip_all)]
-pub fn emit_unused_warnings(
+pub fn lint_build_results(
     warn_count: &mut usize,
     error_count: &mut usize,
     unused_dep_state: &UnusedDepState,

--- a/src/cargo/core/compiler/unused_deps.rs
+++ b/src/cargo/core/compiler/unused_deps.rs
@@ -12,6 +12,7 @@ use indexmap::IndexSet;
 use tracing::{debug, instrument, trace};
 
 use super::BuildContext;
+use super::BuildRunner;
 use super::unit::Unit;
 use crate::core::Dependency;
 use crate::core::Package;
@@ -140,13 +141,12 @@ impl UnusedDepState {
 
 #[instrument(skip_all)]
 pub fn lint_build_results(
+    build_runner: &BuildRunner<'_, '_>,
     warn_count: &mut usize,
     error_count: &mut usize,
-    unused_dep_state: &UnusedDepState,
-    bcx: &BuildContext<'_, '_>,
 ) -> CargoResult<()> {
-    for (pkg_id, states) in &unused_dep_state.states {
-        let Some(pkg) = get_package(unused_dep_state, pkg_id) else {
+    for (pkg_id, states) in &build_runner.unused_dep_state.states {
+        let Some(pkg) = get_package(&build_runner.unused_dep_state, pkg_id) else {
             continue;
         };
         let toml_lints = pkg
@@ -182,7 +182,7 @@ pub fn lint_build_results(
             continue;
         }
 
-        let manifest_path = rel_cwd_manifest_path(pkg.manifest_path(), bcx.gctx);
+        let manifest_path = rel_cwd_manifest_path(pkg.manifest_path(), build_runner.bcx.gctx);
         let mut lint_count = 0;
         for (dep_kind, state) in states.iter() {
             for ext in state.unused_externs.iter().flatten() {
@@ -234,7 +234,7 @@ pub fn lint_build_results(
                     );
                     continue;
                 }
-                if is_transitive_dep(&extern_state.unit, &state.seen_units, bcx) {
+                if is_transitive_dep(&extern_state.unit, &state.seen_units, build_runner.bcx) {
                     debug!(
                         "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, may be activating features",
                         pkg_id.name(),
@@ -303,7 +303,11 @@ pub fn lint_build_results(
                     if lint_level.is_error() {
                         *error_count += 1;
                     }
-                    bcx.gctx.shell().print_report(&report, lint_level.force())?;
+                    build_runner
+                        .bcx
+                        .gctx
+                        .shell()
+                        .print_report(&report, lint_level.force())?;
                 }
             }
         }

--- a/src/cargo/core/compiler/unused_deps.rs
+++ b/src/cargo/core/compiler/unused_deps.rs
@@ -11,7 +11,7 @@ use indexmap::IndexMap;
 use indexmap::IndexSet;
 use tracing::{debug, instrument, trace};
 
-use super::BuildRunner;
+use super::BuildContext;
 use super::unit::Unit;
 use crate::core::Dependency;
 use crate::core::Package;
@@ -34,18 +34,18 @@ pub struct UnusedDepState {
 
 impl UnusedDepState {
     #[instrument(name = "UnusedDepState::new", skip_all)]
-    pub fn new(build_runner: &mut BuildRunner<'_, '_>) -> Self {
+    pub fn new(bcx: &BuildContext<'_, '_>) -> Self {
         // Find all units for a package that can report unused externs
         let mut root_build_script_builds = IndexSet::new();
-        let roots = &build_runner.bcx.roots;
+        let roots = &bcx.roots;
         for root in roots.iter() {
-            for build_script_run in build_runner.unit_deps(root).iter() {
+            for build_script_run in bcx.unit_graph[root].iter() {
                 if !build_script_run.unit.target.is_custom_build()
                     && build_script_run.unit.pkg.package_id() != root.pkg.package_id()
                 {
                     continue;
                 }
-                for build_script_build in build_runner.unit_deps(&build_script_run.unit).iter() {
+                for build_script_build in bcx.unit_graph[&build_script_run.unit].iter() {
                     if !build_script_build.unit.target.is_custom_build()
                         && build_script_build.unit.pkg.package_id() != root.pkg.package_id()
                     {
@@ -59,15 +59,12 @@ impl UnusedDepState {
             }
         }
 
-        trace!(
-            "selected dep kinds: {:?}",
-            build_runner.bcx.selected_dep_kinds
-        );
+        trace!("selected dep kinds: {:?}", bcx.selected_dep_kinds);
         let mut states = IndexMap::<_, IndexMap<_, DependenciesState>>::new();
         for root in roots.iter().chain(root_build_script_builds.iter()) {
             let pkg_id = root.pkg.package_id();
             let dep_kind = dep_kind_of(root);
-            if !build_runner.bcx.selected_dep_kinds.contains(dep_kind) {
+            if !bcx.selected_dep_kinds.contains(dep_kind) {
                 trace!(
                     "pkg {} v{} ({dep_kind:?}): ignoring unused deps due to non-exhaustive units",
                     pkg_id.name(),
@@ -88,7 +85,7 @@ impl UnusedDepState {
                 .entry(dep_kind)
                 .or_default();
             state.needed_units += 1;
-            for dep in build_runner.unit_deps(root).iter() {
+            for dep in bcx.unit_graph[root].iter() {
                 trace!(
                     "    => {} (deps={})",
                     dep.unit.pkg.name(),
@@ -145,7 +142,7 @@ impl UnusedDepState {
         &self,
         warn_count: &mut usize,
         error_count: &mut usize,
-        build_runner: &mut BuildRunner<'_, '_>,
+        bcx: &BuildContext<'_, '_>,
     ) -> CargoResult<()> {
         for (pkg_id, states) in &self.states {
             let Some(pkg) = self.get_package(pkg_id) else {
@@ -184,7 +181,7 @@ impl UnusedDepState {
                 continue;
             }
 
-            let manifest_path = rel_cwd_manifest_path(pkg.manifest_path(), build_runner.bcx.gctx);
+            let manifest_path = rel_cwd_manifest_path(pkg.manifest_path(), bcx.gctx);
             let mut lint_count = 0;
             for (dep_kind, state) in states.iter() {
                 for ext in state.unused_externs.iter().flatten() {
@@ -240,7 +237,7 @@ impl UnusedDepState {
                         );
                         continue;
                     }
-                    if is_transitive_dep(&extern_state.unit, &state.seen_units, build_runner) {
+                    if is_transitive_dep(&extern_state.unit, &state.seen_units, bcx) {
                         debug!(
                             "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, may be activating features",
                             pkg_id.name(),
@@ -310,11 +307,7 @@ impl UnusedDepState {
                         if lint_level.is_error() {
                             *error_count += 1;
                         }
-                        build_runner
-                            .bcx
-                            .gctx
-                            .shell()
-                            .print_report(&report, lint_level.force())?;
+                        bcx.gctx.shell().print_report(&report, lint_level.force())?;
                     }
                 }
             }
@@ -383,11 +376,11 @@ fn unit_desc(unit: &Unit) -> String {
 fn is_transitive_dep(
     direct_dep_unit: &Unit,
     seen_units: &Vec<Unit>,
-    build_runner: &mut BuildRunner<'_, '_>,
+    bcx: &BuildContext<'_, '_>,
 ) -> bool {
     let mut queue = std::collections::VecDeque::new();
     for root_unit in seen_units {
-        for unit_dep in build_runner.unit_deps(root_unit) {
+        for unit_dep in &bcx.unit_graph[root_unit] {
             if root_unit.pkg.package_id() == unit_dep.unit.pkg.package_id() {
                 continue;
             }
@@ -399,7 +392,7 @@ fn is_transitive_dep(
     }
 
     while let Some(dep_unit) = queue.pop_front() {
-        for unit_dep in build_runner.unit_deps(dep_unit) {
+        for unit_dep in &bcx.unit_graph[dep_unit] {
             if unit_dep.unit == *direct_dep_unit {
                 return true;
             }

--- a/src/cargo/core/compiler/unused_deps.rs
+++ b/src/cargo/core/compiler/unused_deps.rs
@@ -136,193 +136,191 @@ impl UnusedDepState {
             state.unused_externs = Some(unused_externs);
         }
     }
+}
 
-    #[instrument(skip_all)]
-    pub fn emit_unused_warnings(
-        &self,
-        warn_count: &mut usize,
-        error_count: &mut usize,
-        bcx: &BuildContext<'_, '_>,
-    ) -> CargoResult<()> {
-        for (pkg_id, states) in &self.states {
-            let Some(pkg) = self.get_package(pkg_id) else {
-                continue;
-            };
-            let toml_lints = pkg
-                .manifest()
-                .normalized_toml()
-                .lints
-                .clone()
-                .map(|lints| lints.lints)
-                .unwrap_or(manifest::TomlLints::default());
-            let cargo_lints = toml_lints
-                .get("cargo")
-                .cloned()
-                .unwrap_or(manifest::TomlToolLints::default());
-            let LintLevelProduct {
-                level: lint_level,
-                source,
-            } = LINT.level(
-                &cargo_lints,
-                pkg.rust_version(),
-                pkg.manifest().unstable_features(),
-            );
+#[instrument(skip_all)]
+pub fn emit_unused_warnings(
+    warn_count: &mut usize,
+    error_count: &mut usize,
+    unused_dep_state: &UnusedDepState,
+    bcx: &BuildContext<'_, '_>,
+) -> CargoResult<()> {
+    for (pkg_id, states) in &unused_dep_state.states {
+        let Some(pkg) = get_package(unused_dep_state, pkg_id) else {
+            continue;
+        };
+        let toml_lints = pkg
+            .manifest()
+            .normalized_toml()
+            .lints
+            .clone()
+            .map(|lints| lints.lints)
+            .unwrap_or(manifest::TomlLints::default());
+        let cargo_lints = toml_lints
+            .get("cargo")
+            .cloned()
+            .unwrap_or(manifest::TomlToolLints::default());
+        let LintLevelProduct {
+            level: lint_level,
+            source,
+        } = LINT.level(
+            &cargo_lints,
+            pkg.rust_version(),
+            pkg.manifest().unstable_features(),
+        );
 
-            if lint_level == LintLevel::Allow {
-                for (dep_kind, state) in states.iter() {
-                    for ext in state.unused_externs.iter().flatten() {
-                        debug!(
-                            "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, lint is allowed",
-                            pkg_id.name(),
-                            pkg_id.version(),
-                        );
-                    }
-                }
-                continue;
-            }
-
-            let manifest_path = rel_cwd_manifest_path(pkg.manifest_path(), bcx.gctx);
-            let mut lint_count = 0;
+        if lint_level == LintLevel::Allow {
             for (dep_kind, state) in states.iter() {
                 for ext in state.unused_externs.iter().flatten() {
-                    let mut used_in_dev = false;
-                    match dep_kind {
-                        DepKind::Normal => {
-                            if let Some(state) = states.get(&DepKind::Development)
-                                && state
-                                    .unused_externs
-                                    .as_ref()
-                                    .is_some_and(|ue| !ue.contains(ext))
-                            {
-                                used_in_dev = true;
-                            }
-                        }
-                        DepKind::Development => {
-                            if let Some(state) = states.get(&DepKind::Normal)
-                                && state.externs.contains_key(ext)
-                            {
-                                trace!(
-                                    "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, inherited from normal dependency",
-                                    pkg_id.name(),
-                                    pkg_id.version(),
-                                );
-                                continue;
-                            }
-                        }
-                        DepKind::Build => {}
-                    }
-                    let Some(extern_state) = state.externs.get(ext) else {
-                        // not one we care to report
-                        debug!(
-                            "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, untracked dependent",
-                            pkg_id.name(),
-                            pkg_id.version(),
-                        );
-                        continue;
-                    };
-                    if state.seen_units.len() != state.needed_units {
-                        debug_assert_ne!(
-                            state.externs.len(),
-                            0,
-                            "assumes tracked is checked first"
-                        );
-                        // Some compilations errored without printing the unused externs.
-                        // Don't print the warning in order to reduce false positive
-                        // spam during errors.
-                        debug!(
-                            "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, {} outstanding units",
-                            pkg_id.name(),
-                            pkg_id.version(),
-                            state.needed_units - state.seen_units.len()
-                        );
-                        continue;
-                    }
-                    if is_transitive_dep(&extern_state.unit, &state.seen_units, bcx) {
-                        debug!(
-                            "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, may be activating features",
-                            pkg_id.name(),
-                            pkg_id.version(),
-                        );
-                        continue;
-                    }
+                    debug!(
+                        "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, lint is allowed",
+                        pkg_id.name(),
+                        pkg_id.version(),
+                    );
+                }
+            }
+            continue;
+        }
 
-                    // Implicitly added dependencies (in the same crate) aren't interesting
-                    let dependency = if let Some(dependency) = &extern_state.manifest_deps {
-                        dependency
+        let manifest_path = rel_cwd_manifest_path(pkg.manifest_path(), bcx.gctx);
+        let mut lint_count = 0;
+        for (dep_kind, state) in states.iter() {
+            for ext in state.unused_externs.iter().flatten() {
+                let mut used_in_dev = false;
+                match dep_kind {
+                    DepKind::Normal => {
+                        if let Some(state) = states.get(&DepKind::Development)
+                            && state
+                                .unused_externs
+                                .as_ref()
+                                .is_some_and(|ue| !ue.contains(ext))
+                        {
+                            used_in_dev = true;
+                        }
+                    }
+                    DepKind::Development => {
+                        if let Some(state) = states.get(&DepKind::Normal)
+                            && state.externs.contains_key(ext)
+                        {
+                            trace!(
+                                "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, inherited from normal dependency",
+                                pkg_id.name(),
+                                pkg_id.version(),
+                            );
+                            continue;
+                        }
+                    }
+                    DepKind::Build => {}
+                }
+                let Some(extern_state) = state.externs.get(ext) else {
+                    // not one we care to report
+                    debug!(
+                        "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, untracked dependent",
+                        pkg_id.name(),
+                        pkg_id.version(),
+                    );
+                    continue;
+                };
+                if state.seen_units.len() != state.needed_units {
+                    debug_assert_ne!(state.externs.len(), 0, "assumes tracked is checked first");
+                    // Some compilations errored without printing the unused externs.
+                    // Don't print the warning in order to reduce false positive
+                    // spam during errors.
+                    debug!(
+                        "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, {} outstanding units",
+                        pkg_id.name(),
+                        pkg_id.version(),
+                        state.needed_units - state.seen_units.len()
+                    );
+                    continue;
+                }
+                if is_transitive_dep(&extern_state.unit, &state.seen_units, bcx) {
+                    debug!(
+                        "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, may be activating features",
+                        pkg_id.name(),
+                        pkg_id.version(),
+                    );
+                    continue;
+                }
+
+                // Implicitly added dependencies (in the same crate) aren't interesting
+                let dependency = if let Some(dependency) = &extern_state.manifest_deps {
+                    dependency
+                } else {
+                    continue;
+                };
+                for dependency in dependency {
+                    let manifest = pkg.manifest();
+                    let document = manifest.document();
+                    let contents = manifest.contents();
+                    let level = lint_level.to_diagnostic_level();
+                    let emitted_source = LINT.emitted_source(lint_level, source);
+                    let toml_path = dependency.toml_path();
+
+                    let mut primary = Group::with_title(level.primary_title(LINT.desc));
+                    if let Some(document) = document
+                        && let Some(contents) = contents
+                        && let Some(span) = get_key_value_span(document, &toml_path)
+                    {
+                        let span = span.key.start..span.value.end;
+                        primary = primary.element(
+                            Snippet::source(contents)
+                                .path(&manifest_path)
+                                .annotation(AnnotationKind::Primary.span(span)),
+                        );
                     } else {
-                        continue;
-                    };
-                    for dependency in dependency {
-                        let manifest = pkg.manifest();
-                        let document = manifest.document();
-                        let contents = manifest.contents();
-                        let level = lint_level.to_diagnostic_level();
-                        let emitted_source = LINT.emitted_source(lint_level, source);
-                        let toml_path = dependency.toml_path();
-
-                        let mut primary = Group::with_title(level.primary_title(LINT.desc));
-                        if let Some(document) = document
-                            && let Some(contents) = contents
-                            && let Some(span) = get_key_value_span(document, &toml_path)
-                        {
-                            let span = span.key.start..span.value.end;
-                            primary = primary.element(
-                                Snippet::source(contents)
-                                    .path(&manifest_path)
-                                    .annotation(AnnotationKind::Primary.span(span)),
-                            );
-                        } else {
-                            primary = primary.element(Origin::path(&manifest_path));
-                        }
-                        if lint_count == 0 {
-                            primary = primary.element(Level::NOTE.message(emitted_source));
-                        }
-                        lint_count += 1;
-                        let mut report = vec![primary];
-                        if let Some(document) = document
-                            && let Some(contents) = contents
-                            && let Some(span) = get_key_value_span(document, &toml_path)
-                        {
-                            let span = span.key.start..span.value.end;
-                            let mut help = Group::with_title(
-                                Level::HELP.secondary_title("remove the dependency"),
-                            );
-                            help = help.element(
-                                Snippet::source(contents)
-                                    .path(&manifest_path)
-                                    .patch(Patch::new(span, "")),
-                            );
-                            report.push(help);
-                        }
-                        if used_in_dev {
-                            let help = Group::with_title(Level::HELP.secondary_title(
-                                "to still use for development builds, move to `dev-dependencies`",
-                            ));
-                            report.push(help);
-                        }
-
-                        if lint_level.is_warn() {
-                            *warn_count += 1;
-                        }
-                        if lint_level.is_error() {
-                            *error_count += 1;
-                        }
-                        bcx.gctx.shell().print_report(&report, lint_level.force())?;
+                        primary = primary.element(Origin::path(&manifest_path));
                     }
+                    if lint_count == 0 {
+                        primary = primary.element(Level::NOTE.message(emitted_source));
+                    }
+                    lint_count += 1;
+                    let mut report = vec![primary];
+                    if let Some(document) = document
+                        && let Some(contents) = contents
+                        && let Some(span) = get_key_value_span(document, &toml_path)
+                    {
+                        let span = span.key.start..span.value.end;
+                        let mut help =
+                            Group::with_title(Level::HELP.secondary_title("remove the dependency"));
+                        help = help.element(
+                            Snippet::source(contents)
+                                .path(&manifest_path)
+                                .patch(Patch::new(span, "")),
+                        );
+                        report.push(help);
+                    }
+                    if used_in_dev {
+                        let help = Group::with_title(Level::HELP.secondary_title(
+                            "to still use for development builds, move to `dev-dependencies`",
+                        ));
+                        report.push(help);
+                    }
+
+                    if lint_level.is_warn() {
+                        *warn_count += 1;
+                    }
+                    if lint_level.is_error() {
+                        *error_count += 1;
+                    }
+                    bcx.gctx.shell().print_report(&report, lint_level.force())?;
                 }
             }
         }
-        Ok(())
     }
+    Ok(())
+}
 
-    fn get_package(&self, pkg_id: &PackageId) -> Option<&Package> {
-        let state = self.states.get(pkg_id)?;
-        let mut iter = state.values();
-        let state = iter.next()?;
-        let mut iter = state.seen_units.iter();
-        let unit = iter.next()?;
-        Some(&unit.pkg)
-    }
+fn get_package<'s>(
+    unused_dep_state: &'s UnusedDepState,
+    pkg_id: &PackageId,
+) -> Option<&'s Package> {
+    let state = unused_dep_state.states.get(pkg_id)?;
+    let mut iter = state.values();
+    let state = iter.next()?;
+    let mut iter = state.seen_units.iter();
+    let unit = iter.next()?;
+    Some(&unit.pkg)
 }
 
 /// Track a package's [`DepKind`]

--- a/src/cargo/core/compiler/unused_deps.rs
+++ b/src/cargo/core/compiler/unused_deps.rs
@@ -1,36 +1,21 @@
 use std::collections::BTreeSet;
 
-use cargo_util_schemas::manifest;
-use cargo_util_terminal::report::AnnotationKind;
-use cargo_util_terminal::report::Group;
-use cargo_util_terminal::report::Level;
-use cargo_util_terminal::report::Origin;
-use cargo_util_terminal::report::Patch;
-use cargo_util_terminal::report::Snippet;
 use indexmap::IndexMap;
 use indexmap::IndexSet;
-use tracing::{debug, instrument, trace};
+use tracing::{instrument, trace};
 
 use super::BuildContext;
-use super::BuildRunner;
 use super::unit::Unit;
 use crate::core::Dependency;
-use crate::core::Package;
 use crate::core::PackageId;
 use crate::core::compiler::build_config::CompileMode;
 use crate::core::dependency::DepKind;
 use crate::core::manifest::TargetKind;
-use crate::diagnostics::LintLevel;
-use crate::diagnostics::LintLevelProduct;
-use crate::diagnostics::get_key_value_span;
-use crate::diagnostics::rel_cwd_manifest_path;
-use crate::diagnostics::rules::unused_dependencies::LINT;
-use crate::util::errors::CargoResult;
 use crate::util::interning::InternedString;
 
 /// Track and translate `unused_externs` to `unused_dependencies`
 pub struct UnusedDepState {
-    states: IndexMap<PackageId, IndexMap<DepKind, DependenciesState>>,
+    pub states: IndexMap<PackageId, IndexMap<DepKind, DependenciesState>>,
 }
 
 impl UnusedDepState {
@@ -139,214 +124,26 @@ impl UnusedDepState {
     }
 }
 
-#[instrument(skip_all)]
-pub fn lint_build_results(
-    build_runner: &BuildRunner<'_, '_>,
-    warn_count: &mut usize,
-    error_count: &mut usize,
-) -> CargoResult<()> {
-    for (pkg_id, states) in &build_runner.unused_dep_state.states {
-        let Some(pkg) = get_package(&build_runner.unused_dep_state, pkg_id) else {
-            continue;
-        };
-        let toml_lints = pkg
-            .manifest()
-            .normalized_toml()
-            .lints
-            .clone()
-            .map(|lints| lints.lints)
-            .unwrap_or(manifest::TomlLints::default());
-        let cargo_lints = toml_lints
-            .get("cargo")
-            .cloned()
-            .unwrap_or(manifest::TomlToolLints::default());
-        let LintLevelProduct {
-            level: lint_level,
-            source,
-        } = LINT.level(
-            &cargo_lints,
-            pkg.rust_version(),
-            pkg.manifest().unstable_features(),
-        );
-
-        if lint_level == LintLevel::Allow {
-            for (dep_kind, state) in states.iter() {
-                for ext in state.unused_externs.iter().flatten() {
-                    debug!(
-                        "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, lint is allowed",
-                        pkg_id.name(),
-                        pkg_id.version(),
-                    );
-                }
-            }
-            continue;
-        }
-
-        let manifest_path = rel_cwd_manifest_path(pkg.manifest_path(), build_runner.bcx.gctx);
-        let mut lint_count = 0;
-        for (dep_kind, state) in states.iter() {
-            for ext in state.unused_externs.iter().flatten() {
-                let mut used_in_dev = false;
-                match dep_kind {
-                    DepKind::Normal => {
-                        if let Some(state) = states.get(&DepKind::Development)
-                            && state
-                                .unused_externs
-                                .as_ref()
-                                .is_some_and(|ue| !ue.contains(ext))
-                        {
-                            used_in_dev = true;
-                        }
-                    }
-                    DepKind::Development => {
-                        if let Some(state) = states.get(&DepKind::Normal)
-                            && state.externs.contains_key(ext)
-                        {
-                            trace!(
-                                "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, inherited from normal dependency",
-                                pkg_id.name(),
-                                pkg_id.version(),
-                            );
-                            continue;
-                        }
-                    }
-                    DepKind::Build => {}
-                }
-                let Some(extern_state) = state.externs.get(ext) else {
-                    // not one we care to report
-                    debug!(
-                        "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, untracked dependent",
-                        pkg_id.name(),
-                        pkg_id.version(),
-                    );
-                    continue;
-                };
-                if state.seen_units.len() != state.needed_units {
-                    debug_assert_ne!(state.externs.len(), 0, "assumes tracked is checked first");
-                    // Some compilations errored without printing the unused externs.
-                    // Don't print the warning in order to reduce false positive
-                    // spam during errors.
-                    debug!(
-                        "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, {} outstanding units",
-                        pkg_id.name(),
-                        pkg_id.version(),
-                        state.needed_units - state.seen_units.len()
-                    );
-                    continue;
-                }
-                if is_transitive_dep(&extern_state.unit, &state.seen_units, build_runner.bcx) {
-                    debug!(
-                        "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, may be activating features",
-                        pkg_id.name(),
-                        pkg_id.version(),
-                    );
-                    continue;
-                }
-
-                // Implicitly added dependencies (in the same crate) aren't interesting
-                let dependency = if let Some(dependency) = &extern_state.manifest_deps {
-                    dependency
-                } else {
-                    continue;
-                };
-                for dependency in dependency {
-                    let manifest = pkg.manifest();
-                    let document = manifest.document();
-                    let contents = manifest.contents();
-                    let level = lint_level.to_diagnostic_level();
-                    let emitted_source = LINT.emitted_source(lint_level, source);
-                    let toml_path = dependency.toml_path();
-
-                    let mut primary = Group::with_title(level.primary_title(LINT.desc));
-                    if let Some(document) = document
-                        && let Some(contents) = contents
-                        && let Some(span) = get_key_value_span(document, &toml_path)
-                    {
-                        let span = span.key.start..span.value.end;
-                        primary = primary.element(
-                            Snippet::source(contents)
-                                .path(&manifest_path)
-                                .annotation(AnnotationKind::Primary.span(span)),
-                        );
-                    } else {
-                        primary = primary.element(Origin::path(&manifest_path));
-                    }
-                    if lint_count == 0 {
-                        primary = primary.element(Level::NOTE.message(emitted_source));
-                    }
-                    lint_count += 1;
-                    let mut report = vec![primary];
-                    if let Some(document) = document
-                        && let Some(contents) = contents
-                        && let Some(span) = get_key_value_span(document, &toml_path)
-                    {
-                        let span = span.key.start..span.value.end;
-                        let mut help =
-                            Group::with_title(Level::HELP.secondary_title("remove the dependency"));
-                        help = help.element(
-                            Snippet::source(contents)
-                                .path(&manifest_path)
-                                .patch(Patch::new(span, "")),
-                        );
-                        report.push(help);
-                    }
-                    if used_in_dev {
-                        let help = Group::with_title(Level::HELP.secondary_title(
-                            "to still use for development builds, move to `dev-dependencies`",
-                        ));
-                        report.push(help);
-                    }
-
-                    if lint_level.is_warn() {
-                        *warn_count += 1;
-                    }
-                    if lint_level.is_error() {
-                        *error_count += 1;
-                    }
-                    build_runner
-                        .bcx
-                        .gctx
-                        .shell()
-                        .print_report(&report, lint_level.force())?;
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
-fn get_package<'s>(
-    unused_dep_state: &'s UnusedDepState,
-    pkg_id: &PackageId,
-) -> Option<&'s Package> {
-    let state = unused_dep_state.states.get(pkg_id)?;
-    let mut iter = state.values();
-    let state = iter.next()?;
-    let mut iter = state.seen_units.iter();
-    let unit = iter.next()?;
-    Some(&unit.pkg)
-}
-
 /// Track a package's [`DepKind`]
 #[derive(Default)]
-struct DependenciesState {
+pub struct DependenciesState {
     /// All declared dependencies
-    externs: IndexMap<InternedString, ExternState>,
+    pub externs: IndexMap<InternedString, ExternState>,
     /// Expected [`Self::seen_units`] entries to know we've received them all
     ///
     /// To avoid warning in cases where we didn't,
     /// e.g. if a [`Unit`] errored and didn't report unused externs.
-    needed_units: usize,
+    pub needed_units: usize,
     /// Units that have reported their unused externs
-    seen_units: Vec<Unit>,
+    pub seen_units: Vec<Unit>,
     /// Intersection of unused externs across all [`Self::seen_units`]
-    unused_externs: Option<BTreeSet<InternedString>>,
+    pub unused_externs: Option<BTreeSet<InternedString>>,
 }
 
 #[derive(Clone)]
-struct ExternState {
-    unit: Unit,
-    manifest_deps: Option<Vec<Dependency>>,
+pub struct ExternState {
+    pub unit: Unit,
+    pub manifest_deps: Option<Vec<Dependency>>,
 }
 
 fn dep_kind_of(unit: &Unit) -> DepKind {
@@ -372,35 +169,4 @@ fn unit_desc(unit: &Unit) -> String {
         unit.target.kind().description(),
         unit.mode,
     )
-}
-
-#[instrument(skip_all)]
-fn is_transitive_dep(
-    direct_dep_unit: &Unit,
-    seen_units: &Vec<Unit>,
-    bcx: &BuildContext<'_, '_>,
-) -> bool {
-    let mut queue = std::collections::VecDeque::new();
-    for root_unit in seen_units {
-        for unit_dep in &bcx.unit_graph[root_unit] {
-            if root_unit.pkg.package_id() == unit_dep.unit.pkg.package_id() {
-                continue;
-            }
-            if unit_dep.unit == *direct_dep_unit {
-                continue;
-            }
-            queue.push_back(&unit_dep.unit);
-        }
-    }
-
-    while let Some(dep_unit) = queue.pop_front() {
-        for unit_dep in &bcx.unit_graph[dep_unit] {
-            if unit_dep.unit == *direct_dep_unit {
-                return true;
-            }
-            queue.push_back(&unit_dep.unit);
-        }
-    }
-
-    false
 }

--- a/src/cargo/diagnostics/mod.rs
+++ b/src/cargo/diagnostics/mod.rs
@@ -97,6 +97,28 @@ impl DiagnosticStats {
     }
 }
 
+impl std::ops::Add for DiagnosticStats {
+    type Output = DiagnosticStats;
+
+    fn add(mut self, rhs: Self) -> Self::Output {
+        self += rhs;
+        self
+    }
+}
+
+impl std::ops::AddAssign for DiagnosticStats {
+    fn add_assign(&mut self, rhs: Self) {
+        let DiagnosticStats {
+            warning_count,
+            lint_warning_count,
+            error_count,
+        } = rhs;
+        self.warning_count += warning_count;
+        self.lint_warning_count += lint_warning_count;
+        self.error_count += error_count;
+    }
+}
+
 /// Scope at which a lint runs: package-level or workspace-level.
 pub enum ManifestFor<'a> {
     /// Lint runs for a specific package.

--- a/src/cargo/diagnostics/mod.rs
+++ b/src/cargo/diagnostics/mod.rs
@@ -19,6 +19,7 @@ pub use rules::{LINT_GROUPS, LINTS};
 
 pub struct DiagnosticStats {
     warning_count: usize,
+    lint_warning_count: usize,
     error_count: usize,
 }
 
@@ -26,8 +27,13 @@ impl DiagnosticStats {
     pub fn new() -> Self {
         Self {
             warning_count: 0,
+            lint_warning_count: 0,
             error_count: 0,
         }
+    }
+
+    pub fn lint_warning_count(&self) -> usize {
+        self.lint_warning_count
     }
 
     pub fn warning_count(&self) -> usize {
@@ -52,6 +58,7 @@ impl DiagnosticStats {
                 self.record_error();
             }
             LintLevel::Warn => {
+                self.lint_warning_count += 1;
                 self.record_warning();
             }
             LintLevel::Allow => {}

--- a/src/cargo/diagnostics/mod.rs
+++ b/src/cargo/diagnostics/mod.rs
@@ -30,6 +30,14 @@ impl DiagnosticStats {
         }
     }
 
+    pub fn warning_count(&self) -> usize {
+        self.warning_count
+    }
+
+    pub fn error_count(&self) -> usize {
+        self.error_count
+    }
+
     pub fn record_warning(&mut self) {
         self.warning_count += 1;
     }

--- a/src/cargo/diagnostics/passes.rs
+++ b/src/cargo/diagnostics/passes.rs
@@ -112,7 +112,7 @@ fn emit_parse_pkg_diagnostics(
     path: &Path,
     rules: &[ParsePassRule<'_>],
 ) -> CargoResult<()> {
-    let mut stats = DiagnosticStats::new();
+    let mut pkg_stats = DiagnosticStats::new();
 
     let toml_lints = pkg
         .manifest()
@@ -130,20 +130,20 @@ fn emit_parse_pkg_diagnostics(
         match rule {
             ParsePassRule::DiagnosticManifest { rule } => {
                 let manifest = pkg.into();
-                rule(manifest, &path, &mut stats, workspace.gctx())?;
+                rule(manifest, &path, &mut pkg_stats, workspace.gctx())?;
             }
             ParsePassRule::LintManifest { rule, lint } => {
                 if workspace.gctx().cli_unstable().cargo_lints {
                     let manifest: ManifestFor<'_> = pkg.into();
                     let level = manifest.lint_level(&cargo_lints, lint);
                     if level.level != LintLevel::Allow {
-                        rule(manifest, &path, level, &mut stats, workspace.gctx())?;
+                        rule(manifest, &path, level, &mut pkg_stats, workspace.gctx())?;
                     }
                 }
             }
             ParsePassRule::DiagnosticWorkspace { .. } | ParsePassRule::LintWorkspace { .. } => {}
             ParsePassRule::DiagnosticPackage { rule } => {
-                rule(workspace, pkg, &path, &mut stats, workspace.gctx())?;
+                rule(workspace, pkg, &path, &mut pkg_stats, workspace.gctx())?;
             }
             ParsePassRule::LintPackage { rule, lint } => {
                 if workspace.gctx().cli_unstable().cargo_lints {
@@ -154,14 +154,21 @@ fn emit_parse_pkg_diagnostics(
                     );
 
                     if level.level != LintLevel::Allow {
-                        rule(workspace, pkg, &path, level, &mut stats, workspace.gctx())?;
+                        rule(
+                            workspace,
+                            pkg,
+                            &path,
+                            level,
+                            &mut pkg_stats,
+                            workspace.gctx(),
+                        )?;
                     }
                 }
             }
         }
     }
 
-    stats.report_summary("parse", Some(&*pkg.name()), workspace.gctx())?;
+    pkg_stats.report_summary("parse", Some(&*pkg.name()), workspace.gctx())?;
 
     Ok(())
 }
@@ -170,7 +177,7 @@ fn emit_parse_ws_diagnostics(
     workspace: &Workspace<'_>,
     rules: &[ParsePassRule<'_>],
 ) -> CargoResult<()> {
-    let mut stats = DiagnosticStats::new();
+    let mut pkg_stats = DiagnosticStats::new();
 
     let cargo_lints = match workspace.root_maybe() {
         MaybePackage::Package(pkg) => {
@@ -200,7 +207,7 @@ fn emit_parse_ws_diagnostics(
                 rule(
                     manifest,
                     workspace.root_manifest(),
-                    &mut stats,
+                    &mut pkg_stats,
                     workspace.gctx(),
                 )?;
             }
@@ -213,7 +220,7 @@ fn emit_parse_ws_diagnostics(
                             manifest,
                             workspace.root_manifest(),
                             level,
-                            &mut stats,
+                            &mut pkg_stats,
                             workspace.gctx(),
                         )?;
                     }
@@ -224,7 +231,7 @@ fn emit_parse_ws_diagnostics(
                     workspace,
                     workspace.root_maybe(),
                     workspace.root_manifest(),
-                    &mut stats,
+                    &mut pkg_stats,
                     workspace.gctx(),
                 )?;
             }
@@ -241,7 +248,7 @@ fn emit_parse_ws_diagnostics(
                             workspace.root_maybe(),
                             workspace.root_manifest(),
                             level,
-                            &mut stats,
+                            &mut pkg_stats,
                             workspace.gctx(),
                         )?;
                     }
@@ -251,6 +258,6 @@ fn emit_parse_ws_diagnostics(
         }
     }
 
-    stats.report_summary("parse", None, workspace.gctx())?;
+    pkg_stats.report_summary("parse", None, workspace.gctx())?;
     Ok(())
 }

--- a/src/cargo/diagnostics/rules/blanket_hint_mostly_unused.rs
+++ b/src/cargo/diagnostics/rules/blanket_hint_mostly_unused.rs
@@ -61,7 +61,7 @@ pub(crate) fn lint_workspace(
     maybe_pkg: &MaybePackage,
     path: &Path,
     level: LintLevelProduct,
-    stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -169,7 +169,7 @@ pub(crate) fn lint_workspace(
         // The primary group should always be first
         report.insert(0, primary_group);
 
-        stats.record_lint(lint_level);
+        pkg_stats.record_lint(lint_level);
         gctx.shell().print_report(&report, lint_level.force())?;
     }
 

--- a/src/cargo/diagnostics/rules/deferred_parse_diagnostics.rs
+++ b/src/cargo/diagnostics/rules/deferred_parse_diagnostics.rs
@@ -13,7 +13,7 @@ use crate::diagnostics::rel_cwd_manifest_path;
 pub(crate) fn diagnose_manifest(
     manifest: ManifestFor<'_>,
     manifest_path: &Path,
-    stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let warnings = match &manifest {
@@ -35,10 +35,10 @@ pub(crate) fn diagnose_manifest(
     for warning in warnings {
         let msg = format!("{manifest_path}: {}", warning.message);
         if warning.is_critical {
-            stats.record_error();
+            pkg_stats.record_error();
             gctx.shell().error(msg)?
         } else {
-            stats.record_warning();
+            pkg_stats.record_warning();
             gctx.shell().warn(msg)?
         }
     }

--- a/src/cargo/diagnostics/rules/im_a_teapot.rs
+++ b/src/cargo/diagnostics/rules/im_a_teapot.rs
@@ -35,7 +35,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     path: &Path,
     level: LintLevelProduct,
-    stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let manifest = pkg.manifest();
@@ -71,7 +71,7 @@ pub(crate) fn lint_package(
 
         let report = &[desc.element(Level::NOTE.message(&emitted_source))];
 
-        stats.record_lint(lint_level);
+        pkg_stats.record_lint(lint_level);
         gctx.shell().print_report(report, lint_level.force())?;
     }
     Ok(())

--- a/src/cargo/diagnostics/rules/implicit_minimum_version_req.rs
+++ b/src/cargo/diagnostics/rules/implicit_minimum_version_req.rs
@@ -90,7 +90,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     manifest_path: &Path,
     level: LintLevelProduct,
-    stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -138,7 +138,7 @@ pub(crate) fn lint_package(
             emit_source = false;
         }
 
-        stats.record_lint(lint_level);
+        pkg_stats.record_lint(lint_level);
         gctx.shell().print_report(&report, lint_level.force())?;
     }
 
@@ -151,7 +151,7 @@ pub(crate) fn lint_workspace(
     maybe_pkg: &MaybePackage,
     manifest_path: &Path,
     level: LintLevelProduct,
-    stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -215,7 +215,7 @@ pub(crate) fn lint_workspace(
             emit_source = false;
         }
 
-        stats.record_lint(lint_level);
+        pkg_stats.record_lint(lint_level);
         gctx.shell().print_report(&report, lint_level.force())?;
     }
 

--- a/src/cargo/diagnostics/rules/missing_lints_features.rs
+++ b/src/cargo/diagnostics/rules/missing_lints_features.rs
@@ -21,7 +21,7 @@ use crate::diagnostics::rel_cwd_manifest_path;
 pub(crate) fn diagnose_manifest(
     manifest: ManifestFor<'_>,
     manifest_path: &Path,
-    stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let normalized_toml = match &manifest {
@@ -51,10 +51,10 @@ pub(crate) fn diagnose_manifest(
         .and_then(|lints| lints.get("cargo"));
 
     if let Some(cargo_lints) = ws_lints {
-        diagnose_manifest_inner(&manifest, manifest_path, cargo_lints, stats, gctx)?;
+        diagnose_manifest_inner(&manifest, manifest_path, cargo_lints, pkg_stats, gctx)?;
     }
     if let Some(cargo_lints) = pkg_lints {
-        diagnose_manifest_inner(&manifest, manifest_path, cargo_lints, stats, gctx)?;
+        diagnose_manifest_inner(&manifest, manifest_path, cargo_lints, pkg_stats, gctx)?;
     }
 
     Ok(())
@@ -64,7 +64,7 @@ fn diagnose_manifest_inner(
     manifest: &ManifestFor<'_>,
     manifest_path: &Path,
     cargo_lints: &manifest::TomlToolLints,
-    stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
@@ -85,7 +85,14 @@ fn diagnose_manifest_inner(
         if let Some(feature_gate) = feature_gate
             && !manifest.unstable_features().is_enabled(feature_gate)
         {
-            report_feature_not_enabled(name, feature_gate, &manifest, &manifest_path, stats, gctx)?;
+            report_feature_not_enabled(
+                name,
+                feature_gate,
+                &manifest,
+                &manifest_path,
+                pkg_stats,
+                gctx,
+            )?;
         }
     }
 
@@ -97,7 +104,7 @@ fn report_feature_not_enabled(
     feature_gate: &Feature,
     manifest: &ManifestFor<'_>,
     manifest_path: &str,
-    stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let dash_feature_name = feature_gate.name().replace("_", "-");
@@ -129,7 +136,7 @@ fn report_feature_not_enabled(
         "consider adding `cargo-features = [\"{dash_feature_name}\"]` to the top of the manifest"
     )))];
 
-    stats.record_error();
+    pkg_stats.record_error();
     gctx.shell().print_report(&report, true)?;
 
     Ok(())

--- a/src/cargo/diagnostics/rules/missing_lints_inheritance.rs
+++ b/src/cargo/diagnostics/rules/missing_lints_inheritance.rs
@@ -59,7 +59,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     manifest_path: &Path,
     level: LintLevelProduct,
-    stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -114,7 +114,7 @@ pub(crate) fn lint_package(
         report.push(help);
     }
 
-    stats.record_lint(lint_level);
+    pkg_stats.record_lint(lint_level);
     gctx.shell().print_report(&report, lint_level.force())?;
 
     Ok(())

--- a/src/cargo/diagnostics/rules/non_kebab_case_bins.rs
+++ b/src/cargo/diagnostics/rules/non_kebab_case_bins.rs
@@ -69,7 +69,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     manifest_path: &Path,
     level: LintLevelProduct,
-    stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -79,7 +79,7 @@ pub(crate) fn lint_package(
 
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
 
-    lint_package_inner(ws, pkg, &manifest_path, lint_level, source, stats, gctx)
+    lint_package_inner(ws, pkg, &manifest_path, lint_level, source, pkg_stats, gctx)
 }
 
 fn lint_package_inner(
@@ -88,7 +88,7 @@ fn lint_package_inner(
     manifest_path: &str,
     lint_level: LintLevel,
     source: LintLevelSource,
-    stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let manifest = pkg.manifest();
@@ -235,7 +235,7 @@ path = "src/main.rs""#
             report.push(help);
         }
 
-        stats.record_lint(lint_level);
+        pkg_stats.record_lint(lint_level);
         gctx.shell().print_report(&report, lint_level.force())?;
     }
 

--- a/src/cargo/diagnostics/rules/non_kebab_case_features.rs
+++ b/src/cargo/diagnostics/rules/non_kebab_case_features.rs
@@ -64,7 +64,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     manifest_path: &Path,
     level: LintLevelProduct,
-    stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -74,7 +74,7 @@ pub(crate) fn lint_package(
 
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
 
-    lint_package_inner(pkg, &manifest_path, lint_level, source, stats, gctx)
+    lint_package_inner(pkg, &manifest_path, lint_level, source, pkg_stats, gctx)
 }
 
 fn lint_package_inner(
@@ -82,7 +82,7 @@ fn lint_package_inner(
     manifest_path: &str,
     lint_level: LintLevel,
     source: LintLevelSource,
-    stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     for original_name in pkg.summary().features().keys() {
@@ -144,7 +144,7 @@ fn lint_package_inner(
             report.push(help);
         }
 
-        stats.record_lint(lint_level);
+        pkg_stats.record_lint(lint_level);
         gctx.shell().print_report(&report, lint_level.force())?;
     }
 

--- a/src/cargo/diagnostics/rules/non_kebab_case_packages.rs
+++ b/src/cargo/diagnostics/rules/non_kebab_case_packages.rs
@@ -64,7 +64,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     manifest_path: &Path,
     level: LintLevelProduct,
-    stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -74,7 +74,7 @@ pub(crate) fn lint_package(
 
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
 
-    lint_package_inner(pkg, &manifest_path, lint_level, source, stats, gctx)
+    lint_package_inner(pkg, &manifest_path, lint_level, source, pkg_stats, gctx)
 }
 
 fn lint_package_inner(
@@ -82,7 +82,7 @@ fn lint_package_inner(
     manifest_path: &str,
     lint_level: LintLevel,
     source: LintLevelSource,
-    stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let manifest = pkg.manifest();
@@ -145,7 +145,7 @@ fn lint_package_inner(
         report.push(help);
     }
 
-    stats.record_lint(lint_level);
+    pkg_stats.record_lint(lint_level);
     gctx.shell().print_report(&report, lint_level.force())?;
 
     Ok(())

--- a/src/cargo/diagnostics/rules/non_snake_case_features.rs
+++ b/src/cargo/diagnostics/rules/non_snake_case_features.rs
@@ -64,7 +64,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     manifest_path: &Path,
     level: LintLevelProduct,
-    stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -74,7 +74,7 @@ pub(crate) fn lint_package(
 
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
 
-    lint_package_inner(pkg, &manifest_path, lint_level, source, stats, gctx)
+    lint_package_inner(pkg, &manifest_path, lint_level, source, pkg_stats, gctx)
 }
 
 fn lint_package_inner(
@@ -82,7 +82,7 @@ fn lint_package_inner(
     manifest_path: &str,
     lint_level: LintLevel,
     source: LintLevelSource,
-    stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     for original_name in pkg.summary().features().keys() {
@@ -144,7 +144,7 @@ fn lint_package_inner(
             report.push(help);
         }
 
-        stats.record_lint(lint_level);
+        pkg_stats.record_lint(lint_level);
         gctx.shell().print_report(&report, lint_level.force())?;
     }
 

--- a/src/cargo/diagnostics/rules/non_snake_case_packages.rs
+++ b/src/cargo/diagnostics/rules/non_snake_case_packages.rs
@@ -64,7 +64,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     manifest_path: &Path,
     level: LintLevelProduct,
-    stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -74,7 +74,7 @@ pub(crate) fn lint_package(
 
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
 
-    lint_package_inner(pkg, &manifest_path, lint_level, source, stats, gctx)
+    lint_package_inner(pkg, &manifest_path, lint_level, source, pkg_stats, gctx)
 }
 
 fn lint_package_inner(
@@ -82,7 +82,7 @@ fn lint_package_inner(
     manifest_path: &str,
     lint_level: LintLevel,
     source: LintLevelSource,
-    stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let manifest = pkg.manifest();
@@ -145,7 +145,7 @@ fn lint_package_inner(
         report.push(help);
     }
 
-    stats.record_lint(lint_level);
+    pkg_stats.record_lint(lint_level);
     gctx.shell().print_report(&report, lint_level.force())?;
 
     Ok(())

--- a/src/cargo/diagnostics/rules/redundant_homepage.rs
+++ b/src/cargo/diagnostics/rules/redundant_homepage.rs
@@ -68,7 +68,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     manifest_path: &Path,
     level: LintLevelProduct,
-    stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -78,7 +78,7 @@ pub(crate) fn lint_package(
 
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
 
-    lint_package_inner(pkg, &manifest_path, lint_level, source, stats, gctx)
+    lint_package_inner(pkg, &manifest_path, lint_level, source, pkg_stats, gctx)
 }
 
 fn lint_package_inner(
@@ -86,7 +86,7 @@ fn lint_package_inner(
     manifest_path: &str,
     lint_level: LintLevel,
     source: LintLevelSource,
-    stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let manifest = pkg.manifest();
@@ -153,7 +153,7 @@ fn lint_package_inner(
         report.push(help);
     }
 
-    stats.record_lint(lint_level);
+    pkg_stats.record_lint(lint_level);
     gctx.shell().print_report(&report, lint_level.force())?;
 
     Ok(())

--- a/src/cargo/diagnostics/rules/redundant_readme.rs
+++ b/src/cargo/diagnostics/rules/redundant_readme.rs
@@ -70,7 +70,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     manifest_path: &Path,
     level: LintLevelProduct,
-    stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -80,7 +80,7 @@ pub(crate) fn lint_package(
 
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
 
-    lint_package_inner(pkg, &manifest_path, lint_level, source, stats, gctx)
+    lint_package_inner(pkg, &manifest_path, lint_level, source, pkg_stats, gctx)
 }
 
 fn lint_package_inner(
@@ -88,7 +88,7 @@ fn lint_package_inner(
     manifest_path: &str,
     lint_level: LintLevel,
     source: LintLevelSource,
-    stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let manifest = pkg.manifest();
@@ -156,7 +156,7 @@ fn lint_package_inner(
         report.push(help);
     }
 
-    stats.record_lint(lint_level);
+    pkg_stats.record_lint(lint_level);
     gctx.shell().print_report(&report, lint_level.force())?;
 
     Ok(())

--- a/src/cargo/diagnostics/rules/text_direction_codepoint_in_comment.rs
+++ b/src/cargo/diagnostics/rules/text_direction_codepoint_in_comment.rs
@@ -51,7 +51,7 @@ pub(crate) fn lint_manifest(
     manifest: ManifestFor<'_>,
     manifest_path: &Path,
     level: LintLevelProduct,
-    stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -113,7 +113,7 @@ pub(crate) fn lint_manifest(
 
         let report = [primary];
 
-        stats.record_lint(lint_level);
+        pkg_stats.record_lint(lint_level);
         gctx.shell().print_report(&report, lint_level.force())?;
     }
 

--- a/src/cargo/diagnostics/rules/text_direction_codepoint_in_literal.rs
+++ b/src/cargo/diagnostics/rules/text_direction_codepoint_in_literal.rs
@@ -52,7 +52,7 @@ pub(crate) fn lint_manifest(
     manifest: ManifestFor<'_>,
     manifest_path: &Path,
     level: LintLevelProduct,
-    stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -156,7 +156,7 @@ pub(crate) fn lint_manifest(
 
         let report = [primary, help];
 
-        stats.record_lint(lint_level);
+        pkg_stats.record_lint(lint_level);
         gctx.shell().print_report(&report, lint_level.force())?;
     }
 

--- a/src/cargo/diagnostics/rules/unknown_lints.rs
+++ b/src/cargo/diagnostics/rules/unknown_lints.rs
@@ -53,7 +53,7 @@ pub(crate) fn lint_manifest(
     manifest: ManifestFor<'_>,
     manifest_path: &Path,
     level: LintLevelProduct,
-    stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let normalized_toml = match &manifest {
@@ -83,10 +83,24 @@ pub(crate) fn lint_manifest(
         .and_then(|lints| lints.get("cargo"));
 
     if let Some(cargo_lints) = ws_lints {
-        lint_manifest_inner(&manifest, manifest_path, &level, cargo_lints, stats, gctx)?;
+        lint_manifest_inner(
+            &manifest,
+            manifest_path,
+            &level,
+            cargo_lints,
+            pkg_stats,
+            gctx,
+        )?;
     }
     if let Some(cargo_lints) = pkg_lints {
-        lint_manifest_inner(&manifest, manifest_path, &level, cargo_lints, stats, gctx)?;
+        lint_manifest_inner(
+            &manifest,
+            manifest_path,
+            &level,
+            cargo_lints,
+            pkg_stats,
+            gctx,
+        )?;
     }
 
     Ok(())
@@ -97,7 +111,7 @@ fn lint_manifest_inner(
     manifest_path: &Path,
     level: &LintLevelProduct,
     cargo_lints: &TomlToolLints,
-    stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -162,7 +176,7 @@ fn lint_manifest_inner(
         }
         report.push(group);
 
-        stats.record_lint(*lint_level);
+        pkg_stats.record_lint(*lint_level);
         gctx.shell().print_report(&report, lint_level.force())?;
     }
 

--- a/src/cargo/diagnostics/rules/unused_dependencies.rs
+++ b/src/cargo/diagnostics/rules/unused_dependencies.rs
@@ -170,8 +170,7 @@ pub(crate) fn lint_package(
 #[instrument(skip_all)]
 pub fn lint_build_results(
     build_runner: &BuildRunner<'_, '_>,
-    warn_count: &mut usize,
-    error_count: &mut usize,
+    stats: &mut DiagnosticStats,
 ) -> CargoResult<()> {
     for (pkg_id, states) in &build_runner.unused_dep_state.states {
         let Some(pkg) = get_package(&build_runner.unused_dep_state, pkg_id) else {
@@ -325,12 +324,7 @@ pub fn lint_build_results(
                         report.push(help);
                     }
 
-                    if lint_level.is_warn() {
-                        *warn_count += 1;
-                    }
-                    if lint_level.is_error() {
-                        *error_count += 1;
-                    }
+                    stats.record_lint(lint_level);
                     build_runner
                         .bcx
                         .gctx

--- a/src/cargo/diagnostics/rules/unused_dependencies.rs
+++ b/src/cargo/diagnostics/rules/unused_dependencies.rs
@@ -8,6 +8,7 @@ use cargo_util_terminal::report::Level;
 use cargo_util_terminal::report::Origin;
 use cargo_util_terminal::report::Patch;
 use cargo_util_terminal::report::Snippet;
+use indexmap::IndexMap;
 use tracing::{debug, instrument, trace};
 
 use super::STYLE;
@@ -19,6 +20,7 @@ use crate::core::Workspace;
 use crate::core::compiler::BuildContext;
 use crate::core::compiler::BuildRunner;
 use crate::core::compiler::Unit;
+use crate::core::compiler::unused_deps::DependenciesState;
 use crate::core::compiler::unused_deps::UnusedDepState;
 use crate::core::dependency::DepKind;
 use crate::diagnostics::DiagnosticStats;
@@ -187,16 +189,12 @@ pub fn lint_build_results(
             .get("cargo")
             .cloned()
             .unwrap_or(manifest::TomlToolLints::default());
-        let LintLevelProduct {
-            level: lint_level,
-            source,
-        } = LINT.level(
+        let level = LINT.level(
             &cargo_lints,
             pkg.rust_version(),
             pkg.manifest().unstable_features(),
         );
-
-        if lint_level == LintLevel::Allow {
+        if level.level == LintLevel::Allow {
             for (dep_kind, state) in states.iter() {
                 for ext in state.unused_externs.iter().flatten() {
                     debug!(
@@ -209,128 +207,144 @@ pub fn lint_build_results(
             continue;
         }
 
-        let manifest_path = rel_cwd_manifest_path(pkg.manifest_path(), build_runner.bcx.gctx);
-        let mut lint_count = 0;
-        for (dep_kind, state) in states.iter() {
-            for ext in state.unused_externs.iter().flatten() {
-                let mut used_in_dev = false;
-                match dep_kind {
-                    DepKind::Normal => {
-                        if let Some(state) = states.get(&DepKind::Development)
-                            && state
-                                .unused_externs
-                                .as_ref()
-                                .is_some_and(|ue| !ue.contains(ext))
-                        {
-                            used_in_dev = true;
-                        }
-                    }
-                    DepKind::Development => {
-                        if let Some(state) = states.get(&DepKind::Normal)
-                            && state.externs.contains_key(ext)
-                        {
-                            trace!(
-                                "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, inherited from normal dependency",
-                                pkg_id.name(),
-                                pkg_id.version(),
-                            );
-                            continue;
-                        }
-                    }
-                    DepKind::Build => {}
-                }
-                let Some(extern_state) = state.externs.get(ext) else {
-                    // not one we care to report
-                    debug!(
-                        "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, untracked dependent",
-                        pkg_id.name(),
-                        pkg_id.version(),
-                    );
-                    continue;
-                };
-                if state.seen_units.len() != state.needed_units {
-                    debug_assert_ne!(state.externs.len(), 0, "assumes tracked is checked first");
-                    // Some compilations errored without printing the unused externs.
-                    // Don't print the warning in order to reduce false positive
-                    // spam during errors.
-                    debug!(
-                        "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, {} outstanding units",
-                        pkg_id.name(),
-                        pkg_id.version(),
-                        state.needed_units - state.seen_units.len()
-                    );
-                    continue;
-                }
-                if is_transitive_dep(&extern_state.unit, &state.seen_units, build_runner.bcx) {
-                    debug!(
-                        "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, may be activating features",
-                        pkg_id.name(),
-                        pkg_id.version(),
-                    );
-                    continue;
-                }
+        lint_package_build_results(build_runner, pkg, states, level, stats)?;
+    }
+    Ok(())
+}
 
-                // Implicitly added dependencies (in the same crate) aren't interesting
-                let dependency = if let Some(dependency) = &extern_state.manifest_deps {
-                    dependency
+fn lint_package_build_results(
+    build_runner: &BuildRunner<'_, '_>,
+    pkg: &Package,
+    states: &IndexMap<DepKind, DependenciesState>,
+    level: LintLevelProduct,
+    stats: &mut DiagnosticStats,
+) -> CargoResult<()> {
+    let mut lint_count = 0;
+    let LintLevelProduct {
+        level: lint_level,
+        source,
+    } = level;
+    let manifest_path = rel_cwd_manifest_path(pkg.manifest_path(), build_runner.bcx.gctx);
+    let pkg_id = pkg.package_id();
+    for (dep_kind, state) in states.iter() {
+        for ext in state.unused_externs.iter().flatten() {
+            let mut used_in_dev = false;
+            match dep_kind {
+                DepKind::Normal => {
+                    if let Some(state) = states.get(&DepKind::Development)
+                        && state
+                            .unused_externs
+                            .as_ref()
+                            .is_some_and(|ue| !ue.contains(ext))
+                    {
+                        used_in_dev = true;
+                    }
+                }
+                DepKind::Development => {
+                    if let Some(state) = states.get(&DepKind::Normal)
+                        && state.externs.contains_key(ext)
+                    {
+                        trace!(
+                            "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, inherited from normal dependency",
+                            pkg_id.name(),
+                            pkg_id.version(),
+                        );
+                        continue;
+                    }
+                }
+                DepKind::Build => {}
+            }
+            let Some(extern_state) = state.externs.get(ext) else {
+                // not one we care to report
+                debug!(
+                    "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, untracked dependent",
+                    pkg_id.name(),
+                    pkg_id.version(),
+                );
+                continue;
+            };
+            if state.seen_units.len() != state.needed_units {
+                debug_assert_ne!(state.externs.len(), 0, "assumes tracked is checked first");
+                // Some compilations errored without printing the unused externs.
+                // Don't print the warning in order to reduce false positive
+                // spam during errors.
+                debug!(
+                    "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, {} outstanding units",
+                    pkg_id.name(),
+                    pkg_id.version(),
+                    state.needed_units - state.seen_units.len()
+                );
+                continue;
+            }
+            if is_transitive_dep(&extern_state.unit, &state.seen_units, build_runner.bcx) {
+                debug!(
+                    "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, may be activating features",
+                    pkg_id.name(),
+                    pkg_id.version(),
+                );
+                continue;
+            }
+
+            // Implicitly added dependencies (in the same crate) aren't interesting
+            let dependency = if let Some(dependency) = &extern_state.manifest_deps {
+                dependency
+            } else {
+                continue;
+            };
+            for dependency in dependency {
+                let manifest = pkg.manifest();
+                let document = manifest.document();
+                let contents = manifest.contents();
+                let level = lint_level.to_diagnostic_level();
+                let emitted_source = LINT.emitted_source(lint_level, source);
+                let toml_path = dependency.toml_path();
+
+                let mut primary = Group::with_title(level.primary_title(LINT.desc));
+                if let Some(document) = document
+                    && let Some(contents) = contents
+                    && let Some(span) = get_key_value_span(document, &toml_path)
+                {
+                    let span = span.key.start..span.value.end;
+                    primary = primary.element(
+                        Snippet::source(contents)
+                            .path(&manifest_path)
+                            .annotation(AnnotationKind::Primary.span(span)),
+                    );
                 } else {
-                    continue;
-                };
-                for dependency in dependency {
-                    let manifest = pkg.manifest();
-                    let document = manifest.document();
-                    let contents = manifest.contents();
-                    let level = lint_level.to_diagnostic_level();
-                    let emitted_source = LINT.emitted_source(lint_level, source);
-                    let toml_path = dependency.toml_path();
-
-                    let mut primary = Group::with_title(level.primary_title(LINT.desc));
-                    if let Some(document) = document
-                        && let Some(contents) = contents
-                        && let Some(span) = get_key_value_span(document, &toml_path)
-                    {
-                        let span = span.key.start..span.value.end;
-                        primary = primary.element(
-                            Snippet::source(contents)
-                                .path(&manifest_path)
-                                .annotation(AnnotationKind::Primary.span(span)),
-                        );
-                    } else {
-                        primary = primary.element(Origin::path(&manifest_path));
-                    }
-                    if lint_count == 0 {
-                        primary = primary.element(Level::NOTE.message(emitted_source));
-                    }
-                    lint_count += 1;
-                    let mut report = vec![primary];
-                    if let Some(document) = document
-                        && let Some(contents) = contents
-                        && let Some(span) = get_key_value_span(document, &toml_path)
-                    {
-                        let span = span.key.start..span.value.end;
-                        let mut help =
-                            Group::with_title(Level::HELP.secondary_title("remove the dependency"));
-                        help = help.element(
-                            Snippet::source(contents)
-                                .path(&manifest_path)
-                                .patch(Patch::new(span, "")),
-                        );
-                        report.push(help);
-                    }
-                    if used_in_dev {
-                        let help = Group::with_title(Level::HELP.secondary_title(
-                            "to still use for development builds, move to `dev-dependencies`",
-                        ));
-                        report.push(help);
-                    }
-
-                    stats.record_lint(lint_level);
-                    build_runner
-                        .bcx
-                        .gctx
-                        .shell()
-                        .print_report(&report, lint_level.force())?;
+                    primary = primary.element(Origin::path(&manifest_path));
                 }
+                if lint_count == 0 {
+                    primary = primary.element(Level::NOTE.message(emitted_source));
+                }
+                lint_count += 1;
+                let mut report = vec![primary];
+                if let Some(document) = document
+                    && let Some(contents) = contents
+                    && let Some(span) = get_key_value_span(document, &toml_path)
+                {
+                    let span = span.key.start..span.value.end;
+                    let mut help =
+                        Group::with_title(Level::HELP.secondary_title("remove the dependency"));
+                    help = help.element(
+                        Snippet::source(contents)
+                            .path(&manifest_path)
+                            .patch(Patch::new(span, "")),
+                    );
+                    report.push(help);
+                }
+                if used_in_dev {
+                    let help = Group::with_title(Level::HELP.secondary_title(
+                        "to still use for development builds, move to `dev-dependencies`",
+                    ));
+                    report.push(help);
+                }
+
+                stats.record_lint(lint_level);
+                build_runner
+                    .bcx
+                    .gctx
+                    .shell()
+                    .print_report(&report, lint_level.force())?;
             }
         }
     }

--- a/src/cargo/diagnostics/rules/unused_dependencies.rs
+++ b/src/cargo/diagnostics/rules/unused_dependencies.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use cargo_util_schemas::manifest;
 use cargo_util_schemas::manifest::TomlPackageBuild;
 use cargo_util_terminal::report::AnnotationKind;
 use cargo_util_terminal::report::Group;
@@ -7,15 +8,22 @@ use cargo_util_terminal::report::Level;
 use cargo_util_terminal::report::Origin;
 use cargo_util_terminal::report::Patch;
 use cargo_util_terminal::report::Snippet;
-use tracing::instrument;
+use tracing::{debug, instrument, trace};
 
 use super::STYLE;
 use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::Package;
+use crate::core::PackageId;
 use crate::core::Workspace;
+use crate::core::compiler::BuildContext;
+use crate::core::compiler::BuildRunner;
+use crate::core::compiler::Unit;
+use crate::core::compiler::unused_deps::UnusedDepState;
+use crate::core::dependency::DepKind;
 use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
+use crate::diagnostics::LintLevel;
 use crate::diagnostics::LintLevelProduct;
 use crate::diagnostics::get_key_value_span;
 use crate::diagnostics::rel_cwd_manifest_path;
@@ -157,4 +165,223 @@ pub(crate) fn lint_package(
     }
 
     Ok(())
+}
+
+#[instrument(skip_all)]
+pub fn lint_build_results(
+    build_runner: &BuildRunner<'_, '_>,
+    warn_count: &mut usize,
+    error_count: &mut usize,
+) -> CargoResult<()> {
+    for (pkg_id, states) in &build_runner.unused_dep_state.states {
+        let Some(pkg) = get_package(&build_runner.unused_dep_state, pkg_id) else {
+            continue;
+        };
+        let toml_lints = pkg
+            .manifest()
+            .normalized_toml()
+            .lints
+            .clone()
+            .map(|lints| lints.lints)
+            .unwrap_or(manifest::TomlLints::default());
+        let cargo_lints = toml_lints
+            .get("cargo")
+            .cloned()
+            .unwrap_or(manifest::TomlToolLints::default());
+        let LintLevelProduct {
+            level: lint_level,
+            source,
+        } = LINT.level(
+            &cargo_lints,
+            pkg.rust_version(),
+            pkg.manifest().unstable_features(),
+        );
+
+        if lint_level == LintLevel::Allow {
+            for (dep_kind, state) in states.iter() {
+                for ext in state.unused_externs.iter().flatten() {
+                    debug!(
+                        "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, lint is allowed",
+                        pkg_id.name(),
+                        pkg_id.version(),
+                    );
+                }
+            }
+            continue;
+        }
+
+        let manifest_path = rel_cwd_manifest_path(pkg.manifest_path(), build_runner.bcx.gctx);
+        let mut lint_count = 0;
+        for (dep_kind, state) in states.iter() {
+            for ext in state.unused_externs.iter().flatten() {
+                let mut used_in_dev = false;
+                match dep_kind {
+                    DepKind::Normal => {
+                        if let Some(state) = states.get(&DepKind::Development)
+                            && state
+                                .unused_externs
+                                .as_ref()
+                                .is_some_and(|ue| !ue.contains(ext))
+                        {
+                            used_in_dev = true;
+                        }
+                    }
+                    DepKind::Development => {
+                        if let Some(state) = states.get(&DepKind::Normal)
+                            && state.externs.contains_key(ext)
+                        {
+                            trace!(
+                                "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, inherited from normal dependency",
+                                pkg_id.name(),
+                                pkg_id.version(),
+                            );
+                            continue;
+                        }
+                    }
+                    DepKind::Build => {}
+                }
+                let Some(extern_state) = state.externs.get(ext) else {
+                    // not one we care to report
+                    debug!(
+                        "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, untracked dependent",
+                        pkg_id.name(),
+                        pkg_id.version(),
+                    );
+                    continue;
+                };
+                if state.seen_units.len() != state.needed_units {
+                    debug_assert_ne!(state.externs.len(), 0, "assumes tracked is checked first");
+                    // Some compilations errored without printing the unused externs.
+                    // Don't print the warning in order to reduce false positive
+                    // spam during errors.
+                    debug!(
+                        "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, {} outstanding units",
+                        pkg_id.name(),
+                        pkg_id.version(),
+                        state.needed_units - state.seen_units.len()
+                    );
+                    continue;
+                }
+                if is_transitive_dep(&extern_state.unit, &state.seen_units, build_runner.bcx) {
+                    debug!(
+                        "pkg {} v{} ({dep_kind:?}): ignoring unused extern `{ext}`, may be activating features",
+                        pkg_id.name(),
+                        pkg_id.version(),
+                    );
+                    continue;
+                }
+
+                // Implicitly added dependencies (in the same crate) aren't interesting
+                let dependency = if let Some(dependency) = &extern_state.manifest_deps {
+                    dependency
+                } else {
+                    continue;
+                };
+                for dependency in dependency {
+                    let manifest = pkg.manifest();
+                    let document = manifest.document();
+                    let contents = manifest.contents();
+                    let level = lint_level.to_diagnostic_level();
+                    let emitted_source = LINT.emitted_source(lint_level, source);
+                    let toml_path = dependency.toml_path();
+
+                    let mut primary = Group::with_title(level.primary_title(LINT.desc));
+                    if let Some(document) = document
+                        && let Some(contents) = contents
+                        && let Some(span) = get_key_value_span(document, &toml_path)
+                    {
+                        let span = span.key.start..span.value.end;
+                        primary = primary.element(
+                            Snippet::source(contents)
+                                .path(&manifest_path)
+                                .annotation(AnnotationKind::Primary.span(span)),
+                        );
+                    } else {
+                        primary = primary.element(Origin::path(&manifest_path));
+                    }
+                    if lint_count == 0 {
+                        primary = primary.element(Level::NOTE.message(emitted_source));
+                    }
+                    lint_count += 1;
+                    let mut report = vec![primary];
+                    if let Some(document) = document
+                        && let Some(contents) = contents
+                        && let Some(span) = get_key_value_span(document, &toml_path)
+                    {
+                        let span = span.key.start..span.value.end;
+                        let mut help =
+                            Group::with_title(Level::HELP.secondary_title("remove the dependency"));
+                        help = help.element(
+                            Snippet::source(contents)
+                                .path(&manifest_path)
+                                .patch(Patch::new(span, "")),
+                        );
+                        report.push(help);
+                    }
+                    if used_in_dev {
+                        let help = Group::with_title(Level::HELP.secondary_title(
+                            "to still use for development builds, move to `dev-dependencies`",
+                        ));
+                        report.push(help);
+                    }
+
+                    if lint_level.is_warn() {
+                        *warn_count += 1;
+                    }
+                    if lint_level.is_error() {
+                        *error_count += 1;
+                    }
+                    build_runner
+                        .bcx
+                        .gctx
+                        .shell()
+                        .print_report(&report, lint_level.force())?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn get_package<'s>(
+    unused_dep_state: &'s UnusedDepState,
+    pkg_id: &PackageId,
+) -> Option<&'s Package> {
+    let state = unused_dep_state.states.get(pkg_id)?;
+    let mut iter = state.values();
+    let state = iter.next()?;
+    let mut iter = state.seen_units.iter();
+    let unit = iter.next()?;
+    Some(&unit.pkg)
+}
+
+#[instrument(skip_all)]
+fn is_transitive_dep(
+    direct_dep_unit: &Unit,
+    seen_units: &Vec<Unit>,
+    bcx: &BuildContext<'_, '_>,
+) -> bool {
+    let mut queue = std::collections::VecDeque::new();
+    for root_unit in seen_units {
+        for unit_dep in &bcx.unit_graph[root_unit] {
+            if root_unit.pkg.package_id() == unit_dep.unit.pkg.package_id() {
+                continue;
+            }
+            if unit_dep.unit == *direct_dep_unit {
+                continue;
+            }
+            queue.push_back(&unit_dep.unit);
+        }
+    }
+
+    while let Some(dep_unit) = queue.pop_front() {
+        for unit_dep in &bcx.unit_graph[dep_unit] {
+            if unit_dep.unit == *direct_dep_unit {
+                return true;
+            }
+            queue.push_back(&unit_dep.unit);
+        }
+    }
+
+    false
 }

--- a/src/cargo/diagnostics/rules/unused_dependencies.rs
+++ b/src/cargo/diagnostics/rules/unused_dependencies.rs
@@ -209,6 +209,12 @@ pub fn lint_build_results(
 
         let mut pkg_stats = DiagnosticStats::new();
         lint_package_build_results(build_runner, pkg, states, level, &mut pkg_stats)?;
+        // HACK: as other rules are added to this pass, this needs to move up into the pass
+        if let Err(error) =
+            pkg_stats.report_summary("finalize", Some(&*pkg.name()), build_runner.bcx.gctx)
+        {
+            build_runner.bcx.gctx.shell().error(error)?;
+        }
         *global_stats += pkg_stats;
     }
     Ok(())

--- a/src/cargo/diagnostics/rules/unused_dependencies.rs
+++ b/src/cargo/diagnostics/rules/unused_dependencies.rs
@@ -207,7 +207,9 @@ pub fn lint_build_results(
             continue;
         }
 
-        lint_package_build_results(build_runner, pkg, states, level, global_stats)?;
+        let mut pkg_stats = DiagnosticStats::new();
+        lint_package_build_results(build_runner, pkg, states, level, &mut pkg_stats)?;
+        *global_stats += pkg_stats;
     }
     Ok(())
 }
@@ -217,7 +219,7 @@ fn lint_package_build_results(
     pkg: &Package,
     states: &IndexMap<DepKind, DependenciesState>,
     level: LintLevelProduct,
-    global_stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
 ) -> CargoResult<()> {
     let mut lint_count = 0;
     let LintLevelProduct {
@@ -339,7 +341,7 @@ fn lint_package_build_results(
                     report.push(help);
                 }
 
-                global_stats.record_lint(lint_level);
+                pkg_stats.record_lint(lint_level);
                 build_runner
                     .bcx
                     .gctx

--- a/src/cargo/diagnostics/rules/unused_dependencies.rs
+++ b/src/cargo/diagnostics/rules/unused_dependencies.rs
@@ -99,7 +99,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     manifest_path: &Path,
     level: LintLevelProduct,
-    stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -162,7 +162,7 @@ pub(crate) fn lint_package(
             report.push(help);
         }
 
-        stats.record_lint(lint_level);
+        pkg_stats.record_lint(lint_level);
         gctx.shell().print_report(&report, lint_level.force())?;
     }
 
@@ -172,7 +172,7 @@ pub(crate) fn lint_package(
 #[instrument(skip_all)]
 pub fn lint_build_results(
     build_runner: &BuildRunner<'_, '_>,
-    stats: &mut DiagnosticStats,
+    global_stats: &mut DiagnosticStats,
 ) -> CargoResult<()> {
     for (pkg_id, states) in &build_runner.unused_dep_state.states {
         let Some(pkg) = get_package(&build_runner.unused_dep_state, pkg_id) else {
@@ -207,7 +207,7 @@ pub fn lint_build_results(
             continue;
         }
 
-        lint_package_build_results(build_runner, pkg, states, level, stats)?;
+        lint_package_build_results(build_runner, pkg, states, level, global_stats)?;
     }
     Ok(())
 }
@@ -217,7 +217,7 @@ fn lint_package_build_results(
     pkg: &Package,
     states: &IndexMap<DepKind, DependenciesState>,
     level: LintLevelProduct,
-    stats: &mut DiagnosticStats,
+    global_stats: &mut DiagnosticStats,
 ) -> CargoResult<()> {
     let mut lint_count = 0;
     let LintLevelProduct {
@@ -339,7 +339,7 @@ fn lint_package_build_results(
                     report.push(help);
                 }
 
-                stats.record_lint(lint_level);
+                global_stats.record_lint(lint_level);
                 build_runner
                     .bcx
                     .gctx

--- a/src/cargo/diagnostics/rules/unused_workspace_dependencies.rs
+++ b/src/cargo/diagnostics/rules/unused_workspace_dependencies.rs
@@ -52,7 +52,7 @@ pub(crate) fn lint_workspace(
     maybe_pkg: &MaybePackage,
     manifest_path: &Path,
     level: LintLevelProduct,
-    stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -166,7 +166,7 @@ pub(crate) fn lint_workspace(
             report.push(help);
         }
 
-        stats.record_lint(lint_level);
+        pkg_stats.record_lint(lint_level);
         gctx.shell().print_report(&report, lint_level.force())?;
     }
 

--- a/src/cargo/diagnostics/rules/unused_workspace_package_fields.rs
+++ b/src/cargo/diagnostics/rules/unused_workspace_package_fields.rs
@@ -52,7 +52,7 @@ pub(crate) fn lint_workspace(
     maybe_pkg: &MaybePackage,
     manifest_path: &Path,
     level: LintLevelProduct,
-    stats: &mut DiagnosticStats,
+    pkg_stats: &mut DiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -135,7 +135,7 @@ pub(crate) fn lint_workspace(
             report.push(help);
         }
 
-        stats.record_lint(lint_level);
+        pkg_stats.record_lint(lint_level);
         gctx.shell().print_report(&report, lint_level.force())?;
     }
 

--- a/src/doc/src/guide/build-performance.md
+++ b/src/doc/src/guide/build-performance.md
@@ -160,7 +160,7 @@ This may have false positives from:
 
 Also, periodically review hidden [`cargo::unused_dependencies`] results:
 ```console
-$ CARGO_LOG=cargo::core::compiler::unused_deps=debug cargo +nightly check -Zcargo-lints --workspace --all-targets
+$ CARGO_LOG=cargo::diagnostics::rules::unused_dependencies=debug cargo +nightly check -Zcargo-lints --workspace --all-targets
 ```
 This will show potential unused dependencies for
 - registry and git dependencies

--- a/tests/testsuite/lints/unused_dependencies.rs
+++ b/tests/testsuite/lints/unused_dependencies.rs
@@ -53,6 +53,7 @@ fn unused_dep_normal() {
   |
 9 -             unused = "0.1.0"
   |
+[WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -113,6 +114,7 @@ fn unused_dep_build() {
   |
 9 -             unused = "0.1.0"
   |
+[WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -247,6 +249,7 @@ fn unused_dep_lib_bins() {
   |
 9 -             unused = "0.1.0"
   |
+[WARNING] `foo` (manifest) generated 1 warning
 
 "#]]
             .unordered(),
@@ -338,6 +341,7 @@ fn unused_dep_build_with_used_dep_normal() {
   |
 9 -             unused_build = "0.1.0"
   |
+[WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -401,6 +405,7 @@ fn unused_dep_normal_but_implicit_used_dep_dev() {
   |
 9 -             used_dev = "0.1.0"
   |
+[WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -422,6 +427,7 @@ fn unused_dep_normal_but_implicit_used_dep_dev() {
 9 -             used_dev = "0.1.0"
   |
 [HELP] to still use for development builds, move to `dev-dependencies`
+[WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -488,6 +494,7 @@ fn unused_dep_normal_but_explicit_used_dep_dev() {
   |
 9 -             used_once = "0.1.0"
   |
+[WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -619,6 +626,7 @@ fn optional_dependency() {
   |
 9 -             unused = { version = "0.1.0", optional = true }
   |
+[WARNING] `foo` (manifest) generated 1 warning
 
 "#]]
             .unordered(),
@@ -682,6 +690,7 @@ fn unused_dep_renamed() {
   |
 9 -             baz = { package = "bar", version = "0.1.0" }
   |
+[WARNING] `foo` (manifest) generated 1 warning
 
 "#]]
             .unordered(),
@@ -738,6 +747,7 @@ fn warning_replay() {
   |
 9 -             unused = "0.1.0"
   |
+[WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -757,6 +767,7 @@ fn warning_replay() {
   |
 9 -             unused = "0.1.0"
   |
+[WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -822,6 +833,7 @@ fn unused_dep_target() {
   |
 9 -             unused = "0.1.0"
   |
+[WARNING] `foo` (manifest) generated 1 warning
 
 "#]]
             .unordered(),
@@ -1141,6 +1153,8 @@ fn package_selection() {
   |
 9 -             unused_foo = "0.1.0"
   |
+[WARNING] `bar` (manifest) generated 1 warning
+[WARNING] `foo` (manifest) generated 3 warnings
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]]
@@ -1185,6 +1199,7 @@ fn package_selection() {
   |
 9 -             unused_foo = "0.1.0"
   |
+[WARNING] `foo` (manifest) generated 3 warnings
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]]
@@ -1207,6 +1222,7 @@ fn package_selection() {
   |
 9 -             unused_bar = "0.1.0"
   |
+[WARNING] `bar` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]]
@@ -1400,6 +1416,7 @@ fn allow_rustflags() {
   |
 9 -             unused = "0.1.0"
   |
+[WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -1456,6 +1473,7 @@ fn allow_attribute() {
   |
 9 -             unused = "0.1.0"
   |
+[WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -1512,6 +1530,7 @@ fn deny_in_manifest() {
   |
 9 -             unused = "0.1.0"
   |
+[ERROR] could not finalize `foo` (manifest) due to 1 previous error
 
 "#]])
         .run();
@@ -1567,6 +1586,7 @@ fn deny_rustflags() {
   |
 9 -             unused = "0.1.0"
   |
+[WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -1623,6 +1643,7 @@ fn deny_attribute() {
   |
 9 -             unused = "0.1.0"
   |
+[WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -1679,6 +1700,7 @@ fn forbid_rustflags() {
   |
 9 -             unused = "0.1.0"
   |
+[WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -1735,6 +1757,7 @@ fn forbid_attribute() {
   |
 9 -             unused = "0.1.0"
   |
+[WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])

--- a/tests/testsuite/lints/unused_dependencies.rs
+++ b/tests/testsuite/lints/unused_dependencies.rs
@@ -1463,6 +1463,61 @@ fn allow_attribute() {
 }
 
 #[cargo_test]
+fn deny_in_manifest() {
+    // The most basic case where there is an unused dependency
+    Package::new("unused", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dependencies]
+            unused = "0.1.0"
+
+            [lints.cargo]
+            unused_dependencies = "deny"
+        "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+            fn main() {}
+            "#,
+        )
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
+[LOCKING] 1 package to latest compatible version
+[DOWNLOADING] crates ...
+[DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
+[CHECKING] unused v0.1.0
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[ERROR] unused dependency
+ --> Cargo.toml:9:13
+  |
+9 |             unused = "0.1.0"
+  |             ^^^^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::unused_dependencies` is set to `deny` in `[lints]`
+[HELP] remove the dependency
+  |
+9 -             unused = "0.1.0"
+  |
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn deny_rustflags() {
     // The most basic case where there is an unused dependency
     Package::new("unused", "0.1.0").publish();


### PR DESCRIPTION
### What does this PR try to resolve?

This aims to bring unused dependencies more inline with parse pass lints in terms of
- handling of `build.warnings`
- lint summary reporting
- code structure

### How to test and review this PR?

It doesn't create a formal pass function yet but that helps highlight that there are more structural things that will need to be changed (e.g. summary reports) that is best left for when we have a better idea of what else will be run in that pass.