### PR TITLE
docs: clarify on crate removal post RFC 3660

### DIFF
--- a/src/doc/src/reference/publishing.md
+++ b/src/doc/src/reference/publishing.md
@@ -4,9 +4,10 @@ Once you've got a library that you'd like to share with the world, it's time to
 publish it on [crates.io]! Publishing a crate is when a specific
 version is uploaded to be hosted on [crates.io].
 
-Take care when publishing a crate, because a publish is **permanent**. The
-version can never be overwritten, and the code cannot be deleted. There is no
-limit to the number of versions which can be published, however.
+Take care when publishing a crate, because a publish is
+[generally permanent](https://crates.io/policies#package-ownership).
+The version can never be overwritten, and the code cannot be deleted. There is
+no limit to the number of versions which can be published, however.
 
 ## Before your first publish
 


### PR DESCRIPTION
Crates can be removed soon after publishing or if they are not widely
used (impact is minimal)

- https://rust-lang.github.io/rfcs/3660-crates-io-crate-deletions.html
- https://blog.rust-lang.org/2025/02/05/crates-io-development-update/

_Thanks for the pull request 🎉!_
_Please read the contribution guide: <https://doc.crates.io/contrib/>._

### What does this PR try to resolve?

People are confusing when the actual behavior contradicts the documented one:

https://www.reddit.com/r/rust/comments/1towtbg/why_did_the_nagami_crate_disappear_from_cratesio/oo4k75j/

### How to test and review this PR?

No testing. Well, harper is still complaining about passive voice all over the place. But I checked the text carefully I guess.