### PR TITLE
feat: Add edition for scripts anytime we mutate the manifest

### DIFF
--- a/src/cargo/ops/cargo_add/mod.rs
+++ b/src/cargo/ops/cargo_add/mod.rs
@@ -278,6 +278,8 @@ pub fn add(workspace: &Workspace<'_>, options: &AddOptions<'_>) -> CargoResult<(
         }
     }
 
+    manifest.ensure_edition();
+
     if let Some(locked_flag) = options.gctx.locked_flag() {
         let new_raw_manifest = manifest.to_string();
         if original_raw_manifest != new_raw_manifest {

--- a/src/cargo/ops/cargo_remove.rs
+++ b/src/cargo/ops/cargo_remove.rs
@@ -106,6 +106,8 @@ pub fn remove(options: &RemoveOptions<'_>) -> CargoResult<()> {
         manifest.gc_dep(dep);
     }
 
+    manifest.ensure_edition();
+
     if options.dry_run {
         options
             .gctx

--- a/src/cargo/ops/fix/mod.rs
+++ b/src/cargo/ops/fix/mod.rs
@@ -309,20 +309,10 @@ fn fix_manifests(ws: &Workspace<'_>, pkgs: &[&Package]) -> CargoResult<()> {
         let file = file.display();
 
         let mut manifest_mut = LocalManifest::try_new(pkg.manifest_path())?;
-        let document = &mut manifest_mut.data;
         let mut fixes = 0;
 
-        let root = document.as_table_mut();
-
         fixes += 1;
-        root.entry("package").or_insert_with(|| {
-            let mut t = toml_edit::Table::new();
-            t.set_position(Some(-1));
-            t.into()
-        });
-        root["package"]["edition"] = crate::core::features::Edition::LATEST_STABLE
-            .to_string()
-            .into();
+        manifest_mut.ensure_edition();
 
         if 0 < fixes {
             let verb = if fixes == 1 { "fix" } else { "fixes" };

--- a/src/cargo/ops/fix/mod.rs
+++ b/src/cargo/ops/fix/mod.rs
@@ -294,27 +294,17 @@ fn check_version_control(gctx: &GlobalContext, opts: &FixOptions) -> CargoResult
 
 fn fix_manifests(ws: &Workspace<'_>, pkgs: &[&Package]) -> CargoResult<()> {
     for pkg in pkgs {
-        if !pkg.manifest().is_embedded()
-            || pkg
-                .manifest()
-                .original_toml()
-                .and_then(|m| m.package())
-                .map(|pkg| pkg.edition.is_some())
-                .unwrap_or(false)
-        {
-            continue;
-        }
-        let file = pkg.manifest_path();
-        let file = file.strip_prefix(ws.root()).unwrap_or(file);
-        let file = file.display();
-
         let mut manifest_mut = LocalManifest::try_new(pkg.manifest_path())?;
         let mut fixes = 0;
 
-        fixes += 1;
-        manifest_mut.ensure_edition();
+        if manifest_mut.ensure_edition() {
+            fixes += 1;
+        }
 
         if 0 < fixes {
+            let file = pkg.manifest_path();
+            let file = file.strip_prefix(ws.root()).unwrap_or(file);
+            let file = file.display();
             let verb = if fixes == 1 { "fix" } else { "fixes" };
             let msg = format!("{file} ({fixes} {verb})");
             ws.gctx().shell().status("Fixed", msg)?;

--- a/src/cargo/util/toml_mut/manifest.rs
+++ b/src/cargo/util/toml_mut/manifest.rs
@@ -353,6 +353,32 @@ impl LocalManifest {
             })
     }
 
+    pub fn ensure_edition(&mut self) -> bool {
+        if self.embedded.is_none() {
+            return false;
+        }
+
+        let root = self.data.as_table_mut();
+        let package = root.entry("package").or_insert_with(|| {
+            let mut t = toml_edit::Table::new();
+            t.set_position(Some(-1));
+            t.into()
+        });
+        let Some(package) = package.as_table_like_mut() else {
+            return false;
+        };
+
+        let mut changed = false;
+        package.entry("edition").or_insert_with(|| {
+            changed = true;
+            crate::core::features::Edition::LATEST_STABLE
+                .to_string()
+                .into()
+        });
+
+        changed
+    }
+
     /// Add entry to a Cargo.toml.
     pub fn insert_into_table(
         &mut self,

--- a/tests/testsuite/cargo_add/script_bare/out/cargo-test-fixture.rs
+++ b/tests/testsuite/cargo_add/script_bare/out/cargo-test-fixture.rs
@@ -1,4 +1,7 @@
 ---
+[package]
+edition = "2024"
+
 [dependencies]
 my-package = "99999.0.0"
 ---

--- a/tests/testsuite/cargo_add/script_bare/stderr.term.svg
+++ b/tests/testsuite/cargo_add/script_bare/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="1465px" height="164px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1465px" height="128px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -28,13 +28,9 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-bright-cyan bold">help</tspan><tspan>: to pin the edition, run `cargo fix --manifest-path [ROOT]/case/cargo-test-fixture.rs`</tspan>
-</tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
-</tspan>
-    <tspan x="10px" y="154px">
+    <tspan x="10px" y="118px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_add/script_frontmatter_empty/out/cargo-test-fixture.rs
+++ b/tests/testsuite/cargo_add/script_frontmatter_empty/out/cargo-test-fixture.rs
@@ -1,4 +1,7 @@
 ---
+[package]
+edition = "2024"
+
 [dependencies]
 my-package = "99999.0.0"
 ---

--- a/tests/testsuite/cargo_add/script_frontmatter_empty/stderr.term.svg
+++ b/tests/testsuite/cargo_add/script_frontmatter_empty/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="1574px" height="164px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1574px" height="128px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -28,13 +28,9 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-bright-cyan bold">help</tspan><tspan>: to pin the edition, run `cargo fix --manifest-path [ROOT]/case/cargo-test-fixture.rs`</tspan>
-</tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
-</tspan>
-    <tspan x="10px" y="154px">
+    <tspan x="10px" y="118px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_add/script_shebang/out/cargo-test-fixture.rs
+++ b/tests/testsuite/cargo_add/script_shebang/out/cargo-test-fixture.rs
@@ -1,5 +1,8 @@
 #!/usr/bin/env cargo
 ---
+[package]
+edition = "2024"
+
 [dependencies]
 my-package = "99999.0.0"
 ---

--- a/tests/testsuite/cargo_add/script_shebang/stderr.term.svg
+++ b/tests/testsuite/cargo_add/script_shebang/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="1490px" height="164px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1490px" height="128px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -28,13 +28,9 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-bright-cyan bold">help</tspan><tspan>: to pin the edition, run `cargo fix --manifest-path [ROOT]/case/cargo-test-fixture.rs`</tspan>
-</tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
-</tspan>
-    <tspan x="10px" y="154px">
+    <tspan x="10px" y="118px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_remove/script/in/cargo-remove-test-fixture.rs
+++ b/tests/testsuite/cargo_remove/script/in/cargo-remove-test-fixture.rs
@@ -1,4 +1,5 @@
 ---
+[package]
 edition = "2015"
 
 [dependencies]

--- a/tests/testsuite/cargo_remove/script/out/cargo-remove-test-fixture.rs
+++ b/tests/testsuite/cargo_remove/script/out/cargo-remove-test-fixture.rs
@@ -1,4 +1,5 @@
 ---
+[package]
 edition = "2015"
 
 [dependencies]

--- a/tests/testsuite/cargo_remove/script/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/script/stderr.term.svg
@@ -1,10 +1,8 @@
-<svg width="1507px" height="128px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
-    .fg-bright-cyan { fill: #55FFFF }
     .fg-bright-green { fill: #55FF55 }
-    .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -20,17 +18,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> docopt from dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-cyan bold">help</tspan><tspan>: to pin the edition, run `cargo fix --manifest-path [ROOT]/case/cargo-remove-test-fixture.rs`</tspan>
-</tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> docopt from dependencies</tspan>
-</tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)</tspan>
-</tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-bright-cyan bold">help</tspan><tspan>: to pin the edition, run `cargo fix --manifest-path [ROOT]/case/cargo-remove-test-fixture.rs`</tspan>
-</tspan>
-    <tspan x="10px" y="118px">
+    <tspan x="10px" y="46px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_remove/script_last/out/cargo-remove-test-fixture.rs
+++ b/tests/testsuite/cargo_remove/script_last/out/cargo-remove-test-fixture.rs
@@ -1,5 +1,6 @@
 ---
-
+[package]
+edition = "2024"
 ---
 
 fn main() {

--- a/tests/testsuite/cargo_remove/script_last/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/script_last/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="1549px" height="128px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1549px" height="92px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -26,11 +26,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">    Removing</tspan><tspan> docopt from dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-yellow bold">warning</tspan><tspan>: `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)</tspan>
-</tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-bright-cyan bold">help</tspan><tspan>: to pin the edition, run `cargo fix --manifest-path [ROOT]/case/cargo-remove-test-fixture.rs`</tspan>
-</tspan>
-    <tspan x="10px" y="118px">
+    <tspan x="10px" y="82px">
 </tspan>
   </text>
 


### PR DESCRIPTION
### What does this PR try to resolve?

This is an experiment in finding a middle ground between two opposite perspectives
- `cargo fix` resolves the no-edition warning by setting it
- `cargo` automatically injects the edition whenever running a cargo script

This is instead "if we're already doing edits, we might as well inject the edition". This is still limited because (1) people or IDEs can do direct edits and (2) `cargo add -M script.rs serde` is a big more cumbersome than `cargo add serde`.

We could possibly take this a step further to "all mutations" and include `cargo update` and `cargo generate-lockfile`.

This does not include a "pinning" status message at this time.

### How to test and review this PR?

