### PR TITLE
Expose resolved lint flags in unit graph

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1632,7 +1632,7 @@ fn build_dir_remap(build_runner: &BuildRunner<'_, '_>) -> OsString {
 }
 
 /// Generates the `--check-cfg` arguments for the `unit`.
-fn check_cfg_args(unit: &Unit) -> Vec<OsString> {
+pub(crate) fn check_cfg_args(unit: &Unit) -> Vec<OsString> {
     // The routine below generates the --check-cfg arguments. Our goals here are to
     // enable the checking of conditionals and pass the list of declared features.
     //

--- a/src/cargo/core/compiler/unit_graph.rs
+++ b/src/cargo/core/compiler/unit_graph.rs
@@ -6,7 +6,7 @@ use cargo_util_schemas::core::PackageIdSpec;
 
 use crate::GlobalContext;
 use crate::core::Target;
-use crate::core::compiler::Unit;
+use crate::core::compiler::{self, Unit};
 use crate::core::compiler::{CompileKind, CompileMode};
 use crate::core::dependency::Dependency;
 use crate::core::profiles::{Profile, UnitFor};
@@ -67,6 +67,10 @@ struct SerializedUnit<'a> {
     platform: CompileKind,
     mode: CompileMode,
     features: &'a Vec<InternedString>,
+    /// Resolved rustc flags from the package's `[lints]` table.
+    #[serde(skip_serializing_if = "<[_]>::is_empty")]
+    lint_rustflags: &'a [String],
+    check_cfg_args: Vec<String>,
     #[serde(skip_serializing_if = "std::ops::Not::not")] // hide for unstable build-std
     is_std: bool,
     dependencies: Vec<SerializedUnitDep>,
@@ -137,6 +141,11 @@ pub fn emit_serialized_unit_graph(
                 platform: unit.kind,
                 mode: unit.mode,
                 features: &unit.features,
+                lint_rustflags: unit.pkg.manifest().lint_rustflags(),
+                check_cfg_args: compiler::check_cfg_args(unit)
+                    .into_iter()
+                    .map(|arg| arg.to_string_lossy().into_owned())
+                    .collect(),
                 is_std: unit.is_std,
                 dependencies,
             }

--- a/tests/testsuite/unit_graph.rs
+++ b/tests/testsuite/unit_graph.rs
@@ -4,6 +4,7 @@ use crate::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::registry::Package;
 use cargo_test_support::str;
+use serde_json::Value;
 
 #[cargo_test]
 fn gated() {
@@ -56,6 +57,12 @@ fn simple() {
   ],
   "units": [
     {
+      "check_cfg_args": [
+        "--check-cfg",
+        "cfg(docsrs,test)",
+        "--check-cfg",
+        "cfg(feature, values(\"feata\"))"
+      ],
       "dependencies": [
         {
           "extern_crate_name": "b",
@@ -102,6 +109,12 @@ fn simple() {
       }
     },
     {
+      "check_cfg_args": [
+        "--check-cfg",
+        "cfg(docsrs,test)",
+        "--check-cfg",
+        "cfg(feature, values(\"featb\"))"
+      ],
       "dependencies": [
         {
           "extern_crate_name": "c",
@@ -148,6 +161,12 @@ fn simple() {
       }
     },
     {
+      "check_cfg_args": [
+        "--check-cfg",
+        "cfg(docsrs,test)",
+        "--check-cfg",
+        "cfg(feature, values(\"featc\"))"
+      ],
       "dependencies": [],
       "features": [
         "featc"
@@ -186,6 +205,12 @@ fn simple() {
       }
     },
     {
+      "check_cfg_args": [
+        "--check-cfg",
+        "cfg(docsrs,test)",
+        "--check-cfg",
+        "cfg(feature, values())"
+      ],
       "dependencies": [
         {
           "extern_crate_name": "a",
@@ -236,4 +261,76 @@ fn simple() {
             .is_json(),
         )
         .run();
+}
+
+#[cargo_test]
+fn includes_resolved_lint_rustflags() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["app"]
+
+            [workspace.lints.rust]
+            unsafe_code = "forbid"
+            unexpected_cfgs = { level = "warn", check-cfg = ["cfg(ix_test)"] }
+
+            [workspace.lints.clippy]
+            all = { level = "deny", priority = -1 }
+            pedantic = "warn"
+            "#,
+        )
+        .file(
+            "app/Cargo.toml",
+            r#"
+            [package]
+            name = "app"
+            version = "0.1.0"
+            edition = "2024"
+
+            [features]
+            alpha = []
+            beta = []
+
+            [lints]
+            workspace = true
+            "#,
+        )
+        .file("app/src/lib.rs", "")
+        .build();
+
+    let output = p
+        .cargo("build --unit-graph -Zunstable-options")
+        .masquerade_as_nightly_cargo(&["unit-graph"])
+        .exec_with_output()
+        .unwrap();
+    let graph: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let app = graph["units"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|unit| unit["target"]["name"] == "app")
+        .unwrap();
+
+    assert_eq!(
+        app["lint_rustflags"],
+        serde_json::json!([
+            "--deny=clippy::all",
+            "--forbid=unsafe_code",
+            "--warn=unexpected_cfgs",
+            "--warn=clippy::pedantic",
+            "--check-cfg",
+            "cfg(ix_test)"
+        ])
+    );
+    assert_eq!(
+        app["check_cfg_args"],
+        serde_json::json!([
+            "--check-cfg",
+            "cfg(docsrs,test)",
+            "--check-cfg",
+            "cfg(feature, values(\"alpha\", \"beta\"))"
+        ])
+    );
 }


### PR DESCRIPTION
Expose resolved lint-related rustc arguments in `cargo --unit-graph` so external build planners can invoke rustc with the same package lint configuration Cargo would use.

This adds two fields per serialized unit:

- `lint_rustflags`: the resolved flags from the package manifest's `[lints]` table, including workspace inheritance and manifest `check-cfg` entries.
- `check_cfg_args`: Cargo's generated `--check-cfg` arguments for `docsrs`, `test`, and package features.

The fields let consumers avoid reimplementing Cargo's lint inheritance, priority sorting, and generated check-cfg logic.

Tests cover workspace lint inheritance, Clippy tool lints, manifest `check-cfg`, and generated feature `check-cfg` values.
