### PR TITLE
[1.96] Bump cargo-util-schemas to 0.14.0 and cargo to 0.97.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "cargo"
-version = "0.97.0"
+version = "0.97.1"
 dependencies = [
  "annotate-snippets",
  "anstream",
@@ -573,7 +573,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util-schemas"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "jiff",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ cargo-platform = { path = "crates/cargo-platform", version = "0.3.3" }
 cargo-test-macro = { version = "0.4.10", path = "crates/cargo-test-macro" }
 cargo-test-support = { version = "0.11.2", path = "crates/cargo-test-support" }
 cargo-util = { version = "0.2.28", path = "crates/cargo-util" }
-cargo-util-schemas = { version = "0.13.0", path = "crates/cargo-util-schemas" }
+cargo-util-schemas = { version = "0.14.0", path = "crates/cargo-util-schemas" }
 cargo-util-terminal = { version = "0.1.0", path = "crates/cargo-util-terminal" }
 cargo_metadata = "0.23.1"
 clap = "4.6.0"
@@ -144,7 +144,7 @@ self_named_module_files = "warn"
 
 [package]
 name = "cargo"
-version = "0.97.0"
+version = "0.97.1"
 edition.workspace = true
 license.workspace = true
 rust-version = "1.94"  # MSRV:1

--- a/crates/cargo-util-schemas/Cargo.toml
+++ b/crates/cargo-util-schemas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-util-schemas"
-version = "0.13.1"
+version = "0.14.0"
 rust-version = "1.94"  # MSRV:1
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
0.13.1 included a bump from toml 0.9 to toml 1.0. This causes cargo 0.96.0 to fail to build because it is expecting toml 0.9. This bumps cargo-util-schema to 0.14.0 with the intent to yank 0.13.1 and publish cargo 0.97.1.
