### PR TITLE
Bump cargo-util-schemas to 0.14.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util-schemas"
-version = "0.13.2"
+version = "0.14.2"
 dependencies = [
  "jiff",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ cargo-platform = { path = "crates/cargo-platform", version = "0.3.3" }
 cargo-test-macro = { version = "0.4.12", path = "crates/cargo-test-macro" }
 cargo-test-support = { version = "0.11.3", path = "crates/cargo-test-support" }
 cargo-util = { version = "0.2.30", path = "crates/cargo-util" }
-cargo-util-schemas = { version = "0.13.2", path = "crates/cargo-util-schemas" }
+cargo-util-schemas = { version = "0.14.2", path = "crates/cargo-util-schemas" }
 cargo-util-terminal = { version = "0.1.0", path = "crates/cargo-util-terminal" }
 cargo_metadata = "0.23.1"
 clap = "4.6.0"

--- a/crates/cargo-util-schemas/Cargo.toml
+++ b/crates/cargo-util-schemas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-util-schemas"
-version = "0.13.2"
+version = "0.14.2"
 rust-version = "1.95"  # MSRV:1
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Bumps cargo-util-schemas to 0.14.2 due to the bump of toml 0.9 to toml 1.0 which was a semver-breaking change.
