### PR TITLE
fix(toml): warn on hyphenated lint names and duplicates

### DIFF
--- a/src/workspace/parser/mod.rs
+++ b/src/workspace/parser/mod.rs
@@ -2698,6 +2698,7 @@ supported tools: {}",
         if tool == "cargo" && !gctx.cli_unstable().cargo_lints {
             warn_for_cargo_lint_feature(gctx, warnings);
         }
+        let mut seen_normalized: HashMap<String, String> = HashMap::default();
         for (name, config) in lints {
             let normalized = name.replace('-', "_");
             if name.contains('-') {
@@ -2707,6 +2708,13 @@ supported tools: {}",
                      future edition"
                 ));
             }
+            if let Some(existing) = seen_normalized.get(&normalized) {
+                warnings.push(format!(
+                    "duplicate lint `{existing}` in `[lints.{tool}]`, \
+                     conflicts with `{name}` and will not work in a future edition"
+                ));
+            }
+            seen_normalized.insert(normalized.clone(), name.to_string());
             if let Some((prefix, suffix)) = name.split_once("::") {
                 if tool == prefix {
                     anyhow::bail!(

--- a/src/workspace/parser/mod.rs
+++ b/src/workspace/parser/mod.rs
@@ -2699,6 +2699,14 @@ supported tools: {}",
             warn_for_cargo_lint_feature(gctx, warnings);
         }
         for (name, config) in lints {
+            let normalized = name.replace('-', "_");
+            if name.contains('-') {
+                warnings.push(format!(
+                    "`lints.{tool}.{name}` is deprecated in favor of \
+                     `lints.{tool}.{normalized}` and will not work in a \
+                     future edition"
+                ));
+            }
             if let Some((prefix, suffix)) = name.split_once("::") {
                 if tool == prefix {
                     anyhow::bail!(

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -3273,7 +3273,7 @@ authors = []
 im-a-teapot = true
 
 [lints.cargo]
-im-a-teapot = "deny"
+im_a_teapot = "deny"
             "#,
         )
         .file("src/main.rs", "fn main() { let unused = 10; }")

--- a/tests/testsuite/lints/mod.rs
+++ b/tests/testsuite/lints/mod.rs
@@ -38,7 +38,7 @@ authors = []
 im-a-teapot = true
 
 [lints.cargo]
-im-a-teapot = "warn"
+im_a_teapot = "warn"
             "#,
         )
         .file("src/lib.rs", "")
@@ -47,14 +47,13 @@ im-a-teapot = "warn"
     foo.cargo("fetch -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints", "test-dummy-unstable"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `im-a-teapot`
-  --> Cargo.toml:12:1
-   |
-12 | im-a-teapot = "warn"
-   | ^^^^^^^^^^^
-   |
-   = [NOTE] `cargo::unknown_lints` is set to `warn` by default
-   = [HELP] there is a lint with a similar name: `im_a_teapot`
+[WARNING] `im_a_teapot` is specified
+ --> Cargo.toml:9:1
+  |
+9 | im-a-teapot = true
+  | ^^^^^^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::im_a_teapot` is set to `warn` in `[lints]`
 [WARNING] `foo` (manifest) generated 1 warning
 
 "#]])

--- a/tests/testsuite/lints/unknown_lints.rs
+++ b/tests/testsuite/lints/unknown_lints.rs
@@ -17,7 +17,7 @@ authors = []
 [lints.cargo]
 default = { level = "allow", priority = -1 }
 unknown_lints = "warn"
-this-lint-does-not-exist = "warn"
+this_lint_does_not_exist = "warn"
 "#,
         )
         .file("src/lib.rs", "")
@@ -26,10 +26,10 @@ this-lint-does-not-exist = "warn"
     p.cargo("fetch -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `this-lint-does-not-exist`
+[WARNING] unknown lint: `this_lint_does_not_exist`
   --> Cargo.toml:11:1
    |
-11 | this-lint-does-not-exist = "warn"
+11 | this_lint_does_not_exist = "warn"
    | ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = [NOTE] `cargo::unknown_lints` is set to `warn` in `[lints]`
@@ -51,7 +51,7 @@ members = ["foo"]
 [workspace.lints.cargo]
 default = { level = "allow", priority = -1 }
 unknown_lints = "warn"
-this-lint-does-not-exist = "warn"
+this_lint_does_not_exist = "warn"
 "#,
         )
         .file(
@@ -73,10 +73,10 @@ workspace = true
     p.cargo("fetch -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `this-lint-does-not-exist`
+[WARNING] unknown lint: `this_lint_does_not_exist`
  --> Cargo.toml:8:1
   |
-8 | this-lint-does-not-exist = "warn"
+8 | this_lint_does_not_exist = "warn"
   | ^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::unknown_lints` is set to `warn` in `[lints]`
@@ -98,7 +98,7 @@ members = ["foo"]
 [workspace.lints.cargo]
 default = { level = "allow", priority = -1 }
 unknown_lints = "warn"
-this-lint-does-not-exist = "warn"
+this_lint_does_not_exist = "warn"
 "#,
         )
         .file(
@@ -117,10 +117,10 @@ authors = []
     p.cargo("fetch -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
-[WARNING] unknown lint: `this-lint-does-not-exist`
+[WARNING] unknown lint: `this_lint_does_not_exist`
  --> Cargo.toml:8:1
   |
-8 | this-lint-does-not-exist = "warn"
+8 | this_lint_does_not_exist = "warn"
   | ^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::unknown_lints` is set to `warn` in `[lints]`

--- a/tests/testsuite/lints_table.rs
+++ b/tests/testsuite/lints_table.rs
@@ -864,6 +864,8 @@ fn hyphen_in_lint_name() {
 
     foo.cargo("check")
         .with_stderr_data(str![[r#"
+[WARNING] Cargo.toml: `lints.rust.unexpected-cfgs` is deprecated in favor of `lints.rust.unexpected_cfgs` and will not work in a future edition
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -892,6 +894,8 @@ fn duplicate_lint_name_hyphen_and_underscore() {
 
     foo.cargo("check")
         .with_stderr_data(str![[r#"
+[WARNING] Cargo.toml: `lints.rust.unexpected-cfgs` is deprecated in favor of `lints.rust.unexpected_cfgs` and will not work in a future edition
+[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/lints_table.rs
+++ b/tests/testsuite/lints_table.rs
@@ -843,3 +843,58 @@ im_a_teapot = "warn"
 "#]])
         .run();
 }
+
+#[cargo_test]
+fn hyphen_in_lint_name() {
+    let foo = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                edition = "2015"
+
+                [lints.rust]
+                unexpected-cfgs = "warn"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    foo.cargo("check")
+        .with_stderr_data(str![[r#"
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn duplicate_lint_name_hyphen_and_underscore() {
+    let foo = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                edition = "2015"
+
+                [lints.rust]
+                unexpected_cfgs = "warn"
+                unexpected-cfgs = "allow"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    foo.cargo("check")
+        .with_stderr_data(str![[r#"
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}

--- a/tests/testsuite/lints_table.rs
+++ b/tests/testsuite/lints_table.rs
@@ -895,7 +895,8 @@ fn duplicate_lint_name_hyphen_and_underscore() {
     foo.cargo("check")
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `lints.rust.unexpected-cfgs` is deprecated in favor of `lints.rust.unexpected_cfgs` and will not work in a future edition
-[WARNING] `foo` (manifest) generated 1 warning
+[WARNING] Cargo.toml: duplicate lint `unexpected-cfgs` in `[lints.rust]`, conflicts with `unexpected_cfgs` and will not work in a future edition
+[WARNING] `foo` (manifest) generated 2 warnings
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/lints_table.rs
+++ b/tests/testsuite/lints_table.rs
@@ -125,7 +125,7 @@ fn invalid_type_in_lint_value() {
                 edition = "2015"
 
                 [workspace.lints.rust]
-                rust-2018-idioms = -1
+                rust_2018_idioms = -1
             "#,
         )
         .file("src/lib.rs", "")
@@ -137,7 +137,7 @@ fn invalid_type_in_lint_value() {
 [ERROR] invalid type: integer `-1`, expected a string or map
  --> Cargo.toml:8:36
   |
-8 |                 rust-2018-idioms = -1
+8 |                 rust_2018_idioms = -1
   |                                    ^^
 
 "#]])
@@ -156,9 +156,9 @@ fn warn_on_unused_key() {
                 edition = "2015"
 
                 [workspace.lints.rust]
-                rust-2018-idioms = { level = "allow", unused = true }
+                rust_2018_idioms = { level = "allow", unused = true }
                 [lints.rust]
-                rust-2018-idioms = { level = "allow", unused = true }
+                rust_2018_idioms = { level = "allow", unused = true }
             "#,
         )
         .file("src/lib.rs", "")
@@ -166,8 +166,8 @@ fn warn_on_unused_key() {
 
     foo.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] Cargo.toml: unused manifest key: `lints.rust.rust-2018-idioms.unused`
-[WARNING] Cargo.toml: unused manifest key: `lints.rust.rust-2018-idioms.unused`
+[WARNING] Cargo.toml: unused manifest key: `lints.rust.rust_2018_idioms.unused`
+[WARNING] Cargo.toml: unused manifest key: `lints.rust.rust_2018_idioms.unused`
 [WARNING] `foo` (manifest) generated 2 warnings
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -697,7 +697,7 @@ fn doctest_respects_lints() {
                 authors = []
 
                 [lints.rust]
-                confusable-idents = 'allow'
+                confusable_idents = 'allow'
             "#,
         )
         .file(


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/cargo/pull/17051)*

Relates #13943

Changes:
- **Refactor:** Updated unrelated existing tests to use `_` instead of `-`.
- **Warn on Hyphens:** Emits a deprecation warning if a lint name uses `-` instead of `_`
- **Warn on Duplicates:** Emits a warning if two lint names conflict after normalization

*Note: Kept both as warnings for now since `Edition2027` isn't defined yet and 2024 has already shipped.*