### PR TITLE
Improve error message when 'cargo owner --add' fails with a GitHub team

### DIFF
--- a/src/cargo/ops/registry/owner.rs
+++ b/src/cargo/ops/registry/owner.rs
@@ -53,6 +53,14 @@ pub fn modify_owners(gctx: &GlobalContext, opts: &OwnersOptions) -> CargoResult<
                 name,
                 registry.host()
             )
+        }).map_err(|e| {
+            if format!("{e:#}").contains("could not find the github team") {
+                e.context("hint: crates.io may not have permission to access the GitHub organization. \
+                    Go to https://github.com/settings/applications, check that crates.io is \
+                    authorized, and ensure the organization has granted access")
+            } else {
+                e
+            }
         })?;
 
         gctx.shell().status("Owner", msg)?;


### PR DESCRIPTION
When running `cargo owner --add github:org:team` and the GitHub team cannot be found, the error message now includes a helpful hint directing users to check their GitHub OAuth application permissions.

### What does this PR do?

The underlying error from crates.io (`could not find the github team org/repo`) is often caused by crates.io not having permission to access the GitHub organization, not because the team doesn't exist. This PR adds a hint to the error message pointing users to:
- Go to https://github.com/settings/applications
- Check that crates.io is authorized
- Ensure the organization has granted access

### Before

```
error: failed to invite owners to crate `foo` on registry at https://crates.io

Caused by:
  the remote server responded with an error: could not find the github team org/repo
```

### After

```
error: failed to invite owners to crate `foo` on registry at https://crates.io

Caused by:
  the remote server responded with an error: could not find the github team org/repo
  hint: crates.io may not have permission to access the GitHub organization. Go to https://github.com/settings/applications, check that crates.io is authorized, and ensure the organization has granted access
```

Closes #11505
