### PR TITLE
fix(util): constant type for Redox OS 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util"
-version = "0.2.30"
+version = "0.2.31"
 dependencies = [
  "anyhow",
  "core-foundation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ cargo-credential-wincred = { version = "0.4.23", path = "credential/cargo-creden
 cargo-platform = { path = "crates/cargo-platform", version = "0.3.3" }
 cargo-test-macro = { version = "0.4.12", path = "crates/cargo-test-macro" }
 cargo-test-support = { version = "0.11.3", path = "crates/cargo-test-support" }
-cargo-util = { version = "0.2.30", path = "crates/cargo-util" }
+cargo-util = { version = "0.2.31", path = "crates/cargo-util" }
 cargo-util-schemas = { version = "0.14.2", path = "crates/cargo-util-schemas" }
 cargo-util-terminal = { version = "0.1.0", path = "crates/cargo-util-terminal" }
 cargo_metadata = "0.23.1"

--- a/crates/cargo-util/Cargo.toml
+++ b/crates/cargo-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-util"
-version = "0.2.30"
+version = "0.2.31"
 rust-version = "1.95"  # MSRV:1
 edition.workspace = true
 license.workspace = true

--- a/crates/cargo-util/src/paths.rs
+++ b/crates/cargo-util/src/paths.rs
@@ -211,8 +211,8 @@ pub fn write_atomic<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> Res
     let perms = path.metadata().ok().map(|meta| {
         use std::os::unix::fs::PermissionsExt;
 
-        // these constants are u16 on macOS
-        let mask = u32::from(libc::S_IRWXU | libc::S_IRWXG | libc::S_IRWXO);
+        // these constants are u16 on macOS and i32 on Redox
+        let mask = (libc::S_IRWXU | libc::S_IRWXG | libc::S_IRWXO) as u32;
         let mode = meta.permissions().mode() & mask;
 
         std::fs::Permissions::from_mode(mode)
@@ -947,9 +947,9 @@ mod tests {
     fn write_atomic_permissions() {
         use std::os::unix::fs::PermissionsExt;
 
-        let original_perms = std::fs::Permissions::from_mode(u32::from(
-            libc::S_IRWXU | libc::S_IRGRP | libc::S_IWGRP | libc::S_IROTH,
-        ));
+        let original_perms = std::fs::Permissions::from_mode(
+            (libc::S_IRWXU | libc::S_IRGRP | libc::S_IWGRP | libc::S_IROTH) as u32,
+        );
 
         let tmp = tempfile::Builder::new().tempfile().unwrap();
 
@@ -964,7 +964,7 @@ mod tests {
 
         let new_perms = std::fs::metadata(tmp.path()).unwrap().permissions();
 
-        let mask = u32::from(libc::S_IRWXU | libc::S_IRWXG | libc::S_IRWXO);
+        let mask = (libc::S_IRWXU | libc::S_IRWXG | libc::S_IRWXO) as u32;
         assert_eq!(original_perms.mode(), new_perms.mode() & mask);
     }
 


### PR DESCRIPTION
### What does this PR try to resolve?

This fixes compilation to Redox platform due to `mode_t` being `i32`. This patch has been used in Redox cargo fork downstream for years.

+ [mode_t](https://github.com/rust-lang/libc/blob/main/src/unix/redox/mod.rs#L13) and [constants](https://github.com/rust-lang/libc/blob/main/src/unix/redox/mod.rs#L722) in libc
+ [downstream patch](https://gitlab.redox-os.org/redox-os/cargo/-/merge_requests/2)

### How to test and review this PR?

```
cargo install --git https://gitlab.redox-os.org/redox-os/redoxer.git
redoxer pkg curl
redoxer build --release
```
