### PR TITLE
Allow multiple artifact dependencies on the same package

### DIFF
--- a/doc/book/src/reference/unstable.md
+++ b/doc/book/src/reference/unstable.md
@@ -1021,6 +1021,15 @@ Artifact-dependencies adds the following keys to a dependency declaration in `Ca
   zoo = { version = "1.0", artifact = ["bin:cat", "bin:dog"]}
   ```
 
+  To build artifacts from the same package for multiple target platforms,
+  declare each alias separately:
+
+  ```toml
+  [build-dependencies]
+  firmware-x86 = { package = "firmware", version = "1.0", artifact = "bin", target = "x86_64-unknown-none" }
+  firmware-arm = { package = "firmware", version = "1.0", artifact = "bin", target = "thumbv7em-none-eabihf" }
+  ```
+
 - `lib` --- This is a Boolean value which indicates whether or not to also build the dependency's library as a normal Rust `lib` dependency.
   This field can only be specified when `artifact` is specified.
 

--- a/src/compiler/unit_dependencies.rs
+++ b/src/compiler/unit_dependencies.rs
@@ -338,6 +338,7 @@ fn compute_deps(
                 dep_pkg,
                 dep_lib,
                 Some(manifest_deps.clone()),
+                None,
                 dep_unit_for,
                 unit.kind,
                 mode,
@@ -350,6 +351,7 @@ fn compute_deps(
                 dep_pkg,
                 dep_lib,
                 Some(manifest_deps),
+                None,
                 dep_unit_for,
                 CompileKind::Host,
                 mode,
@@ -363,6 +365,7 @@ fn compute_deps(
                 dep_pkg,
                 dep_lib,
                 Some(manifest_deps),
+                None,
                 dep_unit_for,
                 unit.kind.for_target(dep_lib),
                 mode,
@@ -442,6 +445,7 @@ fn compute_deps(
                         &unit.pkg,
                         t,
                         None, // artificial
+                        None,
                         UnitFor::new_normal(unit_for.root_compile_kind()),
                         unit.kind.for_target(t),
                         CompileMode::Build,
@@ -538,6 +542,7 @@ fn compute_deps_custom_build(
         &unit.pkg,
         &unit.target,
         None, // artificial
+        None,
         script_unit_for,
         // Build scripts always compiled for the host.
         CompileKind::Host,
@@ -624,14 +629,17 @@ fn artifact_targets_to_unit_deps(
                                 _ => false,
                             })
                             .map(|target_kind| {
+                                let mut target = target.clone();
+                                target.set_kind(TargetKind::Lib(vec![target_kind.clone()]));
+                                let artifact_name =
+                                    Some(Resolve::artifact_dependency_name(dep, &target));
                                 new_unit_dep(
                                     state,
                                     parent,
                                     artifact_pkg,
-                                    target
-                                        .clone()
-                                        .set_kind(TargetKind::Lib(vec![target_kind.clone()])),
+                                    &target,
                                     None, // TBD
+                                    artifact_name,
                                     parent_unit_for,
                                     compile_kind,
                                     CompileMode::Build,
@@ -639,17 +647,21 @@ fn artifact_targets_to_unit_deps(
                                 )
                             }),
                     ) as Box<dyn Iterator<Item = _>>,
-                    _ => Box::new(std::iter::once(new_unit_dep(
-                        state,
-                        parent,
-                        artifact_pkg,
-                        target,
-                        None, // TBD
-                        parent_unit_for,
-                        compile_kind,
-                        CompileMode::Build,
-                        dep.artifact(),
-                    ))),
+                    _ => {
+                        let artifact_name = Some(Resolve::artifact_dependency_name(dep, target));
+                        Box::new(std::iter::once(new_unit_dep(
+                            state,
+                            parent,
+                            artifact_pkg,
+                            target,
+                            None, // TBD
+                            artifact_name,
+                            parent_unit_for,
+                            compile_kind,
+                            CompileMode::Build,
+                            dep.artifact(),
+                        )))
+                    }
                 }
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -681,6 +693,7 @@ fn compute_deps_doc(
             dep_pkg,
             dep_lib,
             None, // not checking unused deps
+            None,
             dep_unit_for,
             unit.kind.for_target(dep_lib),
             mode,
@@ -695,6 +708,7 @@ fn compute_deps_doc(
                 dep_pkg,
                 dep_lib,
                 None, // not checking unused deps
+                None,
                 dep_unit_for,
                 unit.kind.for_target(dep_lib),
                 unit.mode,
@@ -729,6 +743,7 @@ fn compute_deps_doc(
                 &unit.pkg,
                 lib,
                 None, // not checking unused deps
+                None,
                 dep_unit_for,
                 unit.kind.for_target(lib),
                 unit.mode,
@@ -749,6 +764,7 @@ fn compute_deps_doc(
                 &scrape_unit.pkg,
                 &scrape_unit.target,
                 None, // not checking unused deps
+                None,
                 scrape_unit_for,
                 scrape_unit.kind,
                 scrape_unit.mode,
@@ -777,6 +793,7 @@ fn maybe_lib(
                 unit,
                 &unit.pkg,
                 t,
+                None,
                 None,
                 dep_unit_for,
                 unit.kind.for_target(t),
@@ -840,6 +857,7 @@ fn dep_build_script(
                     &unit.pkg,
                     t,
                     None, // artificial
+                    None,
                     script_unit_for,
                     unit.kind,
                     CompileMode::RunCustomBuild,
@@ -877,6 +895,7 @@ fn new_unit_dep(
     pkg: &Package,
     target: &Target,
     manifest_deps: Option<Vec<Dependency>>,
+    artifact_name: Option<(InternedString, Option<InternedString>)>,
     unit_for: UnitFor,
     kind: CompileKind,
     mode: CompileMode,
@@ -896,6 +915,7 @@ fn new_unit_dep(
         pkg,
         target,
         manifest_deps,
+        artifact_name,
         unit_for,
         kind,
         mode,
@@ -910,17 +930,21 @@ fn new_unit_dep_with_profile(
     pkg: &Package,
     target: &Target,
     manifest_deps: Option<Vec<Dependency>>,
+    artifact_name: Option<(InternedString, Option<InternedString>)>,
     unit_for: UnitFor,
     kind: CompileKind,
     mode: CompileMode,
     profile: Profile,
     artifact: Option<&Artifact>,
 ) -> CargoResult<UnitDep> {
-    let (extern_crate_name, dep_name) = state.resolve().extern_crate_name_and_dep_name(
-        parent.pkg.package_id(),
-        pkg.package_id(),
-        target,
-    )?;
+    let (extern_crate_name, dep_name) = match artifact_name {
+        Some(name) => name,
+        None => state.resolve().lib_dependency_name(
+            parent.pkg.package_id(),
+            pkg.package_id(),
+            target,
+        )?,
+    };
     let public = state
         .resolve()
         .is_public_dep(parent.pkg.package_id(), pkg.package_id());

--- a/src/ops/cargo_metadata.rs
+++ b/src/ops/cargo_metadata.rs
@@ -91,8 +91,8 @@ struct MetadataResolveNode {
 
 #[derive(Serialize)]
 struct Dep {
-    // TODO(bindeps): after -Zbindeps gets stabilized,
-    // mark this field as deprecated in the help manual of cargo-metadata
+    // Metadata v1 defines `name` as the library dependency name. Artifact
+    // dependency names are recorded in `DepKindInfo::extern_name`. See #17350.
     name: InternedString,
     pkg: PackageIdSpec,
     #[serde(skip)]
@@ -246,14 +246,12 @@ fn build_resolve_graph_r(
 
             let targets = package_map[&dep_id].targets();
 
-            // Try to get the extern name for lib, or crate name for bins.
-            let extern_name = |target| {
-                resolve
-                    .extern_crate_name_and_dep_name(pkg_id, dep_id, target)
-                    .map(|(ext_crate_name, _)| ext_crate_name)
-            };
-
             let lib_target = targets.iter().find(|t| t.is_lib());
+            let lib_dep_name = lib_target
+                .filter(|_| deps.iter().any(|dep| dep.maybe_lib()))
+                .map(|target| resolve.lib_dependency_name(pkg_id, dep_id, target))
+                .transpose()?
+                .map(|(name, _)| name);
 
             for dep in deps.iter() {
                 if let Some(target) = lib_target {
@@ -269,7 +267,7 @@ fn build_resolve_graph_r(
                     // if the user is not using -Zbindeps.
                     // Remove this condition ` after -Zbindeps gets stabilized.
                     let extern_name = if dep.artifact().is_some() {
-                        Some(extern_name(target)?)
+                        Some(Resolve::artifact_dependency_name(dep, target).0)
                     } else {
                         None
                     };
@@ -308,7 +306,7 @@ fn build_resolve_graph_r(
                     dep_kinds.push(DepKindInfo {
                         kind: dep.kind(),
                         target: dep.platform().cloned(),
-                        extern_name: extern_name(target).ok(),
+                        extern_name: Some(Resolve::artifact_dependency_name(dep, target).0),
                         artifact: Some(kind.crate_type()),
                         compile_target,
                         bin_name: target.is_bin().then(|| target.name().to_string()),
@@ -320,23 +318,16 @@ fn build_resolve_graph_r(
 
             let pkg_id = normalize_id(dep_id);
 
-            let dep = match (lib_target, dep_kinds.len()) {
-                (Some(target), _) => Dep {
-                    name: extern_name(target)?,
-                    pkg: pkg_id.to_spec(),
-                    pkg_id,
-                    dep_kinds,
-                },
-                // No lib target exists but contains artifact deps.
-                (None, 1..) => Dep {
-                    name: "".into(),
-                    pkg: pkg_id.to_spec(),
-                    pkg_id,
-                    dep_kinds,
-                },
-                // No lib or artifact dep exists.
-                // Usually this mean parent depending on non-lib bin crate.
-                (None, _) => continue,
+            let name = match lib_dep_name {
+                Some(name) => name,
+                None if dep_kinds.is_empty() => continue,
+                None => "".into(),
+            };
+            let dep = Dep {
+                name,
+                pkg: pkg_id.to_spec(),
+                pkg_id,
+                dep_kinds,
             };
 
             dep_metadatas.push(dep)

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -406,31 +406,12 @@ unable to verify that `{0}` is the same as when the lockfile was generated
         &self.metadata
     }
 
-    pub fn extern_crate_name_and_dep_name(
-        &self,
-        from: PackageId,
-        to: PackageId,
-        to_target: &Target,
-    ) -> CargoResult<(InternedString, Option<InternedString>)> {
-        self.dependency_name_matching(from, to, to_target, |_| true)
-    }
-
     /// Returns the library name after ignoring artifact-only declarations.
     pub(crate) fn lib_dependency_name(
         &self,
         from: PackageId,
         to: PackageId,
         to_target: &Target,
-    ) -> CargoResult<(InternedString, Option<InternedString>)> {
-        self.dependency_name_matching(from, to, to_target, Dependency::maybe_lib)
-    }
-
-    fn dependency_name_matching(
-        &self,
-        from: PackageId,
-        to: PackageId,
-        to_target: &Target,
-        include: impl Fn(&Dependency) -> bool,
     ) -> CargoResult<(InternedString, Option<InternedString>)> {
         let empty_set: HashSet<Dependency> = HashSet::default();
         let deps = if from == to {
@@ -442,7 +423,7 @@ unable to verify that `{0}` is the same as when the lockfile was generated
         let target_crate_name = || (to_target.crate_name().into(), None);
         let mut name_pairs = deps
             .iter()
-            .filter(|dep| include(dep))
+            .filter(|dep| dep.maybe_lib())
             .map(|dep| Self::dep_extern_crate_name_and_dep_name(dep, to_target));
         let (extern_crate_name, dep_name) = name_pairs.next().unwrap_or_else(target_crate_name);
         for (n, _) in name_pairs {

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -419,12 +419,10 @@ unable to verify that `{0}` is the same as when the lockfile was generated
             self.dependencies_listed(from, to)
         };
 
-        let target_crate_name = || (to_target.crate_name(), None);
-        let mut name_pairs = deps.iter().map(|d| {
-            d.explicit_name_in_toml()
-                .map(|s| (s.as_str().replace("-", "_"), Some(s)))
-                .unwrap_or_else(target_crate_name)
-        });
+        let target_crate_name = || (to_target.crate_name().into(), None);
+        let mut name_pairs = deps
+            .iter()
+            .map(|d| Self::dep_extern_crate_name_and_dep_name(d, to_target));
         let (extern_crate_name, dep_name) = name_pairs.next().unwrap_or_else(target_crate_name);
         for (n, _) in name_pairs {
             anyhow::ensure!(
@@ -434,7 +432,16 @@ unable to verify that `{0}` is the same as when the lockfile was generated
                 to,
             );
         }
-        Ok((extern_crate_name.into(), dep_name))
+        Ok((extern_crate_name, dep_name))
+    }
+
+    fn dep_extern_crate_name_and_dep_name(
+        dep: &Dependency,
+        to_target: &Target,
+    ) -> (InternedString, Option<InternedString>) {
+        dep.explicit_name_in_toml()
+            .map(|name| (name.as_str().replace('-', "_").into(), Some(name)))
+            .unwrap_or_else(|| (to_target.crate_name().into(), None))
     }
 
     fn dependencies_listed(&self, from: PackageId, to: PackageId) -> &HashSet<Dependency> {

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -412,6 +412,26 @@ unable to verify that `{0}` is the same as when the lockfile was generated
         to: PackageId,
         to_target: &Target,
     ) -> CargoResult<(InternedString, Option<InternedString>)> {
+        self.dependency_name_matching(from, to, to_target, |_| true)
+    }
+
+    /// Returns the library name after ignoring artifact-only declarations.
+    pub(crate) fn lib_dependency_name(
+        &self,
+        from: PackageId,
+        to: PackageId,
+        to_target: &Target,
+    ) -> CargoResult<(InternedString, Option<InternedString>)> {
+        self.dependency_name_matching(from, to, to_target, Dependency::maybe_lib)
+    }
+
+    fn dependency_name_matching(
+        &self,
+        from: PackageId,
+        to: PackageId,
+        to_target: &Target,
+        include: impl Fn(&Dependency) -> bool,
+    ) -> CargoResult<(InternedString, Option<InternedString>)> {
         let empty_set: HashSet<Dependency> = HashSet::default();
         let deps = if from == to {
             &empty_set
@@ -422,7 +442,8 @@ unable to verify that `{0}` is the same as when the lockfile was generated
         let target_crate_name = || (to_target.crate_name().into(), None);
         let mut name_pairs = deps
             .iter()
-            .map(|d| Self::dep_extern_crate_name_and_dep_name(d, to_target));
+            .filter(|dep| include(dep))
+            .map(|dep| Self::dep_extern_crate_name_and_dep_name(dep, to_target));
         let (extern_crate_name, dep_name) = name_pairs.next().unwrap_or_else(target_crate_name);
         for (n, _) in name_pairs {
             anyhow::ensure!(
@@ -433,6 +454,14 @@ unable to verify that `{0}` is the same as when the lockfile was generated
             );
         }
         Ok((extern_crate_name, dep_name))
+    }
+
+    /// Returns the artifact name contributed by one dependency declaration.
+    pub(crate) fn artifact_dependency_name(
+        dep: &Dependency,
+        to_target: &Target,
+    ) -> (InternedString, Option<InternedString>) {
+        Self::dep_extern_crate_name_and_dep_name(dep, to_target)
     }
 
     fn dep_extern_crate_name_and_dep_name(

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -212,12 +212,38 @@ fn disallow_artifact_and_no_artifact_dep_to_same_package_within_the_same_dep_cat
                 resolver = "2"
 
                 [dependencies]
-                bar = { path = "bar/", artifact = "bin" }
-                bar_stable = { path = "bar/", package = "bar" }
+                bar-codegen = { path = "bar/", package = "bar", artifact = "bin" }
+                bar-runtime = { path = "bar/", package = "bar" }
             "#,
         )
-        .file("src/lib.rs", "")
-        .file("bar/Cargo.toml", &basic_bin_manifest("bar"))
+        .file(
+            "src/lib.rs",
+            r#"
+                extern crate bar_runtime;
+
+                pub fn f() {
+                    bar_runtime::f();
+                    let codegen = include_bytes!(env!("CARGO_BIN_FILE_BAR_CODEGEN_bar"));
+                    assert!(!codegen.is_empty());
+                }
+            "#,
+        )
+        .file(
+            "bar/Cargo.toml",
+            r#"
+                [package]
+                name = "bar"
+                version = "0.5.0"
+                edition = "2015"
+
+                [lib]
+                name = "bar"
+
+                [[bin]]
+                name = "bar"
+            "#,
+        )
+        .file("bar/src/lib.rs", "pub fn f() {}")
         .file("bar/src/main.rs", "fn main() {}")
         .build();
     p.cargo("check")
@@ -226,7 +252,55 @@ fn disallow_artifact_and_no_artifact_dep_to_same_package_within_the_same_dep_cat
         .with_status(101)
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
-[WARNING] foo v0.0.0 ([ROOT]/foo) ignoring invalid dependency `bar_stable` which is missing a lib target
+[ERROR] the crate `foo v0.0.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn disallow_artifact_lib_and_no_artifact_dep_to_same_package_within_the_same_dep_category() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                edition = "2015"
+                authors = []
+                resolver = "2"
+
+                [dependencies]
+                bar = { path = "bar/", artifact = "bin", lib = true }
+                bar_stable = { path = "bar/", package = "bar" }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file(
+            "bar/Cargo.toml",
+            r#"
+                [package]
+                name = "bar"
+                version = "0.5.0"
+                edition = "2015"
+
+                [lib]
+                name = "bar"
+
+                [[bin]]
+                name = "bar"
+            "#,
+        )
+        .file("bar/src/lib.rs", "")
+        .file("bar/src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("check -Z bindeps")
+        .masquerade_as_nightly_cargo(&["bindeps"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[LOCKING] 1 package to highest compatible version
 [ERROR] the crate `foo v0.0.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
 
 "#]])
@@ -964,6 +1038,48 @@ fn allow_artifact_and_no_artifact_dep_to_same_package_within_different_dep_categ
 }
 
 #[cargo_test]
+fn artifact_only_alias_and_ordinary_alias_across_dependency_kinds_rejected() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                edition = "2015"
+
+                [dependencies]
+                bar-runtime = { package = "bar", path = "bar" }
+
+                [build-dependencies]
+                bar-codegen = { package = "bar", path = "bar", artifact = "bin" }
+            "#,
+        )
+        .file(
+            "build.rs",
+            r#"fn main() {
+                let bin = std::env::var_os("CARGO_BIN_FILE_BAR_CODEGEN_bar").unwrap();
+                assert!(std::path::Path::new(&bin).is_file());
+            }"#,
+        )
+        .file("src/lib.rs", "pub fn f() { bar_runtime::f(); }")
+        .file("bar/Cargo.toml", &basic_bin_manifest("bar"))
+        .file("bar/src/lib.rs", "pub fn f() {}")
+        .file("bar/src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("check -Z bindeps")
+        .masquerade_as_nightly_cargo(&["bindeps"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[LOCKING] 1 package to highest compatible version
+[ERROR] the crate `foo v0.0.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn normal_build_deps_are_picked_up_in_presence_of_an_artifact_build_dep_to_the_same_package() {
     let p = project()
         .file(
@@ -1150,7 +1266,6 @@ fn build_script_deps_adopt_specified_target_unconditionally() {
         .run();
 }
 
-/// inverse RFC-3176
 #[cargo_test]
 fn build_script_deps_adopt_do_not_allow_multiple_targets_under_different_name_and_same_version() {
     if cross_compile_disabled() {
@@ -1201,6 +1316,428 @@ fn build_script_deps_adopt_do_not_allow_multiple_targets_under_different_name_an
 
     p.cargo("check -v")
         .arg("-Zbindeps")
+        .masquerade_as_nightly_cargo(&["bindeps"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[LOCKING] 1 package to highest compatible version
+[ERROR] the crate `foo v0.0.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn non_build_deps_do_not_allow_multiple_targets_under_different_names() {
+    if cross_compile_disabled() {
+        return;
+    }
+
+    let alternate = cross_compile::alternate();
+    let native = cross_compile::native();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            &format!(
+                r#"
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                edition = "2015"
+                authors = []
+                resolver = "2"
+
+                [dependencies]
+                bar = {{ path = "bar/", artifact = "bin", target = "{alternate}" }}
+                bar-native = {{ package = "bar", path = "bar/", artifact = "bin", target = "{native}" }}
+            "#
+            ),
+        )
+        .file(
+            "src/lib.rs",
+            r#"
+                pub fn f() {
+                    let _alternate = include_bytes!(env!("CARGO_BIN_FILE_BAR_bar"));
+                    let _native = include_bytes!(env!("CARGO_BIN_FILE_BAR_NATIVE_bar"));
+                }
+            "#,
+        )
+        .file("bar/Cargo.toml", &basic_bin_manifest("bar"))
+        .file("bar/src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("check -Z bindeps")
+        .masquerade_as_nightly_cargo(&["bindeps"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[LOCKING] 1 package to highest compatible version
+[ERROR] the crate `foo v0.0.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn build_script_deps_do_not_allow_same_target_under_different_names() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                edition = "2015"
+                authors = []
+                resolver = "2"
+
+                [build-dependencies]
+                bar = { path = "bar/", artifact = "bin" }
+                bar-alt = { package = "bar", path = "bar/", artifact = "bin" }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file(
+            "build.rs",
+            r#"
+                fn main() {
+                    let bar: std::path::PathBuf = std::env::var("CARGO_BIN_FILE_BAR").expect("CARGO_BIN_FILE_BAR").into();
+                    assert!(bar.is_file());
+                    let bar_alt: std::path::PathBuf = std::env::var("CARGO_BIN_FILE_BAR_ALT_bar").expect("CARGO_BIN_FILE_BAR_ALT_bar").into();
+                    assert!(bar_alt.is_file());
+                    assert_eq!(bar_alt, bar, "same-target aliases should share the artifact path");
+                }
+            "#,
+        )
+        .file("bar/Cargo.toml", &basic_bin_manifest("bar"))
+        .file("bar/src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("check -Z bindeps")
+        .masquerade_as_nightly_cargo(&["bindeps"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[LOCKING] 1 package to highest compatible version
+[ERROR] the crate `foo v0.0.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn build_script_deps_do_not_allow_staticlib_aliases() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                edition = "2015"
+                authors = []
+                resolver = "2"
+
+                [build-dependencies]
+                bar = { path = "bar/", artifact = "staticlib" }
+                bar-alt = { package = "bar", path = "bar/", artifact = "staticlib" }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file(
+            "build.rs",
+            r#"
+                fn main() {
+                    let bar: std::path::PathBuf = std::env::var("CARGO_STATICLIB_FILE_BAR").expect("CARGO_STATICLIB_FILE_BAR").into();
+                    assert!(bar.is_file());
+                    let bar_alt: std::path::PathBuf = std::env::var("CARGO_STATICLIB_FILE_BAR_ALT_bar").expect("CARGO_STATICLIB_FILE_BAR_ALT_bar").into();
+                    assert!(bar_alt.is_file());
+                    assert_eq!(bar_alt, bar, "same-target aliases should share the artifact path");
+                }
+            "#,
+        )
+        .file(
+            "bar/Cargo.toml",
+            r#"
+                [package]
+                name = "bar"
+                version = "0.5.0"
+                edition = "2015"
+
+                [lib]
+                name = "bar"
+                crate-type = ["staticlib"]
+            "#,
+        )
+        .file("bar/src/lib.rs", "pub fn f() {}")
+        .build();
+
+    p.cargo("check -Z bindeps")
+        .masquerade_as_nightly_cargo(&["bindeps"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[LOCKING] 1 package to highest compatible version
+[ERROR] the crate `foo v0.0.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn artifact_output_only_dep_cannot_coexist_with_one_artifact_lib_dep() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                edition = "2015"
+                authors = []
+                resolver = "2"
+
+                [build-dependencies]
+                bar-lib = { package = "bar", path = "bar/", artifact = "bin", lib = true }
+                bar-bin = { package = "bar", path = "bar/", artifact = "bin" }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file(
+            "build.rs",
+            r#"
+                extern crate bar_lib;
+
+                fn main() {
+                    bar_lib::f();
+                    let bar_lib_bin: std::path::PathBuf = std::env::var("CARGO_BIN_FILE_BAR_LIB_bar").expect("CARGO_BIN_FILE_BAR_LIB_bar").into();
+                    assert!(bar_lib_bin.is_file());
+                    let bar_bin: std::path::PathBuf = std::env::var("CARGO_BIN_FILE_BAR_BIN_bar").expect("CARGO_BIN_FILE_BAR_BIN_bar").into();
+                    assert!(bar_bin.is_file());
+                }
+            "#,
+        )
+        .file(
+            "bar/Cargo.toml",
+            r#"
+                [package]
+                name = "bar"
+                version = "0.5.0"
+                edition = "2015"
+
+                [lib]
+                name = "bar"
+
+                [[bin]]
+                name = "bar"
+            "#,
+        )
+        .file("bar/src/lib.rs", "pub fn f() {}")
+        .file("bar/src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("check -Z bindeps")
+        .masquerade_as_nightly_cargo(&["bindeps"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[LOCKING] 1 package to highest compatible version
+[ERROR] the crate `foo v0.0.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn multiple_artifact_lib_deps_to_same_package_still_error() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                edition = "2015"
+                authors = []
+                resolver = "2"
+
+                [dependencies]
+                bar-a = { package = "bar", path = "bar/", artifact = "bin", lib = true }
+                bar-b = { package = "bar", path = "bar/", artifact = "bin", lib = true }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file(
+            "bar/Cargo.toml",
+            r#"
+                [package]
+                name = "bar"
+                version = "0.5.0"
+                edition = "2015"
+
+                [lib]
+                name = "bar"
+
+                [[bin]]
+                name = "bar"
+            "#,
+        )
+        .file("bar/src/lib.rs", "")
+        .file("bar/src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("check -Z bindeps")
+        .masquerade_as_nightly_cargo(&["bindeps"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[LOCKING] 1 package to highest compatible version
+[ERROR] the crate `foo v0.0.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn artifact_lib_aliases_across_dependency_kinds_rejected() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                edition = "2015"
+                authors = []
+                resolver = "2"
+
+                [dependencies]
+                bar = { path = "bar/", artifact = "bin", lib = true }
+
+                [build-dependencies]
+                bar-alt = { package = "bar", path = "bar/", artifact = "bin", lib = true }
+            "#,
+        )
+        .file(
+            "src/lib.rs",
+            r#"
+                extern crate bar;
+
+                pub fn f() {
+                    bar::f();
+                }
+            "#,
+        )
+        .file(
+            "build.rs",
+            r#"
+                extern crate bar_alt;
+
+                fn main() {
+                    bar_alt::f();
+                }
+            "#,
+        )
+        .file(
+            "bar/Cargo.toml",
+            r#"
+                [package]
+                name = "bar"
+                version = "0.5.0"
+                edition = "2015"
+
+                [lib]
+                name = "bar"
+
+                [[bin]]
+                name = "bar"
+            "#,
+        )
+        .file("bar/src/lib.rs", "pub fn f() {}")
+        .file("bar/src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("check -Z bindeps")
+        .masquerade_as_nightly_cargo(&["bindeps"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[LOCKING] 1 package to highest compatible version
+[ERROR] the crate `foo v0.0.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn multiple_artifact_lib_deps_with_different_artifact_targets_still_error() {
+    if cross_compile_disabled() {
+        return;
+    }
+
+    let alternate = cross_compile::alternate();
+    let native = cross_compile::native();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            &format!(
+                r#"
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                edition = "2015"
+                authors = []
+                resolver = "2"
+
+                [dependencies]
+                bar = {{ path = "bar/", artifact = "bin", lib = true, target = "{alternate}" }}
+                bar-native = {{ package = "bar", path = "bar/", artifact = "bin", lib = true, target = "{native}" }}
+            "#
+            ),
+        )
+        .file("src/lib.rs", "")
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.5.0"))
+        .file("bar/src/lib.rs", "pub fn doit() {}")
+        .file("bar/src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("check -Z bindeps")
+        .masquerade_as_nightly_cargo(&["bindeps"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[LOCKING] 1 package to highest compatible version
+[ERROR] the crate `foo v0.0.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn multiple_artifact_aliases_no_op_rebuild() {
+    if cross_compile_disabled() {
+        return;
+    }
+
+    let alternate = cross_compile::alternate();
+    let native = cross_compile::native();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            &format!(
+                r#"
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                edition = "2015"
+                authors = []
+                resolver = "2"
+
+                [build-dependencies]
+                bar = {{ path = "bar/", artifact = "bin", target = "{alternate}" }}
+                bar-native = {{ package = "bar", path = "bar/", artifact = "bin", target = "{native}" }}
+            "#
+            ),
+        )
+        .file("src/lib.rs", "")
+        .file("build.rs", "fn main() {}")
+        .file("bar/Cargo.toml", &basic_bin_manifest("bar"))
+        .file("bar/src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("check -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
         .with_stderr_data(str![[r#"

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -199,7 +199,7 @@ Caused by:
 }
 
 #[cargo_test]
-fn disallow_artifact_and_no_artifact_dep_to_same_package_within_the_same_dep_category() {
+fn allow_artifact_and_no_artifact_dep_to_same_package_within_the_same_dep_category() {
     let p = project()
         .file(
             "Cargo.toml",
@@ -249,10 +249,11 @@ fn disallow_artifact_and_no_artifact_dep_to_same_package_within_the_same_dep_cat
     p.cargo("check")
         .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
-        .with_status(101)
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
-[ERROR] the crate `foo v0.0.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
+[COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
+[CHECKING] foo v0.0.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
         .run();
@@ -1038,7 +1039,7 @@ fn allow_artifact_and_no_artifact_dep_to_same_package_within_different_dep_categ
 }
 
 #[cargo_test]
-fn artifact_only_alias_and_ordinary_alias_across_dependency_kinds_rejected() {
+fn artifact_only_alias_and_ordinary_alias_across_dependency_kinds_allowed() {
     let p = project()
         .file(
             "Cargo.toml",
@@ -1070,12 +1071,6 @@ fn artifact_only_alias_and_ordinary_alias_across_dependency_kinds_rejected() {
 
     p.cargo("check -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
-        .with_status(101)
-        .with_stderr_data(str![[r#"
-[LOCKING] 1 package to highest compatible version
-[ERROR] the crate `foo v0.0.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
-
-"#]])
         .run();
 }
 
@@ -1267,7 +1262,7 @@ fn build_script_deps_adopt_specified_target_unconditionally() {
 }
 
 #[cargo_test]
-fn build_script_deps_adopt_do_not_allow_multiple_targets_under_different_name_and_same_version() {
+fn build_script_deps_allow_multiple_targets_under_different_names() {
     if cross_compile_disabled() {
         return;
     }
@@ -1317,17 +1312,26 @@ fn build_script_deps_adopt_do_not_allow_multiple_targets_under_different_name_an
     p.cargo("check -v")
         .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
-        .with_status(101)
-        .with_stderr_data(str![[r#"
+        .with_stderr_data(
+            str![[r#"
 [LOCKING] 1 package to highest compatible version
-[ERROR] the crate `foo v0.0.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
+[COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
+[COMPILING] foo v0.0.0 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name build_script_build [..]`
+[RUNNING] `rustc --crate-name bar [..]--out-dir [ROOT]/foo/target/[ALT_TARGET]/debug/build/bar/[HASH]/artifact/bin --target [ALT_TARGET] [..]`
+[RUNNING] `rustc --crate-name bar [..]--out-dir [ROOT]/foo/target/debug/build/bar/[HASH]/artifact/bin [..]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `rustc --crate-name foo [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
-"#]])
+"#]]
+            .unordered(),
+        )
         .run();
 }
 
 #[cargo_test]
-fn non_build_deps_do_not_allow_multiple_targets_under_different_names() {
+fn non_build_deps_allow_multiple_targets_under_different_names() {
     if cross_compile_disabled() {
         return;
     }
@@ -1365,19 +1369,26 @@ fn non_build_deps_do_not_allow_multiple_targets_under_different_names() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("check -Z bindeps")
+    p.cargo("check -v -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
-        .with_status(101)
-        .with_stderr_data(str![[r#"
+        .with_stderr_data(
+            str![[r#"
 [LOCKING] 1 package to highest compatible version
-[ERROR] the crate `foo v0.0.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
+[COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
+[RUNNING] `rustc --crate-name bar [..]--out-dir [ROOT]/foo/target/debug/build/bar/[HASH]/artifact/bin [..]`
+[RUNNING] `rustc --crate-name bar [..]--out-dir [ROOT]/foo/target/[ALT_TARGET]/debug/build/bar/[HASH]/artifact/bin --target [ALT_TARGET] [..]`
+[CHECKING] foo v0.0.0 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
-"#]])
+"#]]
+            .unordered(),
+        )
         .run();
 }
 
 #[cargo_test]
-fn build_script_deps_do_not_allow_same_target_under_different_names() {
+fn build_script_deps_allow_same_target_under_different_names() {
     let p = project()
         .file(
             "Cargo.toml",
@@ -1413,17 +1424,21 @@ fn build_script_deps_do_not_allow_same_target_under_different_names() {
 
     p.cargo("check -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
-        .with_status(101)
-        .with_stderr_data(str![[r#"
+        .with_stderr_data(
+            str![[r#"
 [LOCKING] 1 package to highest compatible version
-[ERROR] the crate `foo v0.0.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
+[COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
+[COMPILING] foo v0.0.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
-"#]])
+"#]]
+            .unordered(),
+        )
         .run();
 }
 
 #[cargo_test]
-fn build_script_deps_do_not_allow_staticlib_aliases() {
+fn build_script_deps_allow_staticlib_aliases() {
     let p = project()
         .file(
             "Cargo.toml",
@@ -1471,17 +1486,11 @@ fn build_script_deps_do_not_allow_staticlib_aliases() {
 
     p.cargo("check -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
-        .with_status(101)
-        .with_stderr_data(str![[r#"
-[LOCKING] 1 package to highest compatible version
-[ERROR] the crate `foo v0.0.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
-
-"#]])
         .run();
 }
 
 #[cargo_test]
-fn artifact_output_only_dep_cannot_coexist_with_one_artifact_lib_dep() {
+fn artifact_output_only_dep_can_coexist_with_one_artifact_lib_dep() {
     let p = project()
         .file(
             "Cargo.toml",
@@ -1534,12 +1543,6 @@ fn artifact_output_only_dep_cannot_coexist_with_one_artifact_lib_dep() {
 
     p.cargo("check -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
-        .with_status(101)
-        .with_stderr_data(str![[r#"
-[LOCKING] 1 package to highest compatible version
-[ERROR] the crate `foo v0.0.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
-
-"#]])
         .run();
 }
 
@@ -1739,10 +1742,11 @@ fn multiple_artifact_aliases_no_op_rebuild() {
 
     p.cargo("check -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
-        .with_status(101)
+        .run();
+    p.cargo("check -Z bindeps")
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to highest compatible version
-[ERROR] the crate `foo v0.0.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
         .run();

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -2186,7 +2186,7 @@ fn cargo_metadata_with_one_artifact_only_alias_to_lib_package() {
                 "target": null
               }
             ],
-            "name": "bar_alias",
+            "name": "",
             "pkg": "path+[ROOTURL]/foo/bar#0.5.0"
           }
         ],
@@ -2254,7 +2254,7 @@ fn cargo_metadata_rejects_artifact_lib_aliases_across_dependency_kinds() {
 }
 
 #[cargo_test]
-fn cargo_metadata_rejects_one_artifact_lib_alias_to_same_package() {
+fn cargo_metadata_with_one_artifact_lib_alias_to_same_package() {
     let p = project()
         .file(
             "Cargo.toml",
@@ -2287,20 +2287,59 @@ fn cargo_metadata_rejects_one_artifact_lib_alias_to_same_package() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("metadata -Z bindeps")
+    p.cargo("metadata --format-version 1 -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
-        .with_status(101)
-        .with_stderr_data(str![[r#"
-[WARNING] please specify `--format-version` flag explicitly to avoid compatibility problems
-[LOCKING] 1 package to highest compatible version
-[ERROR] the crate `foo v0.5.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
-
-"#]])
+        .with_stdout_data(
+            str![[r#"
+{
+  "packages": "{...}",
+  "resolve": {
+    "nodes": [
+      "{...}",
+      {
+        "deps": [
+          {
+            "dep_kinds": [
+              {
+                "artifact": "bin",
+                "bin_name": "bar",
+                "extern_name": "bar_bin",
+                "kind": null,
+                "target": null
+              },
+              {
+                "extern_name": "bar_lib",
+                "kind": null,
+                "target": null
+              },
+              {
+                "artifact": "bin",
+                "bin_name": "bar",
+                "extern_name": "bar_lib",
+                "kind": null,
+                "target": null
+              }
+            ],
+            "name": "bar_lib",
+            "pkg": "path+[ROOTURL]/foo/bar#0.5.0"
+          }
+        ],
+        "id": "path+[ROOTURL]/foo#0.5.0",
+        "...": "{...}"
+      }
+    ],
+    "root": "path+[ROOTURL]/foo#0.5.0"
+  },
+  "...": "{...}"
+}
+"#]]
+            .is_json(),
+        )
         .run();
 }
 
 #[cargo_test]
-fn cargo_metadata_rejects_multiple_bin_only_artifact_aliases_to_lib_package() {
+fn cargo_metadata_with_multiple_bin_only_artifact_aliases_to_lib_package() {
     let p = project()
         .file(
             "Cargo.toml",
@@ -2333,20 +2372,54 @@ fn cargo_metadata_rejects_multiple_bin_only_artifact_aliases_to_lib_package() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("metadata -Z bindeps")
+    p.cargo("metadata --format-version 1 -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
-        .with_status(101)
-        .with_stderr_data(str![[r#"
-[WARNING] please specify `--format-version` flag explicitly to avoid compatibility problems
-[LOCKING] 1 package to highest compatible version
-[ERROR] the crate `foo v0.5.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
-
-"#]])
+        .with_stdout_data(
+            str![[r#"
+{
+  "packages": "{...}",
+  "resolve": {
+    "nodes": [
+      "{...}",
+      {
+        "deps": [
+          {
+            "dep_kinds": [
+              {
+                "artifact": "bin",
+                "bin_name": "bar",
+                "extern_name": "bar_a",
+                "kind": null,
+                "target": null
+              },
+              {
+                "artifact": "bin",
+                "bin_name": "bar",
+                "extern_name": "bar_b",
+                "kind": null,
+                "target": null
+              }
+            ],
+            "name": "",
+            "pkg": "path+[ROOTURL]/foo/bar#0.5.0"
+          }
+        ],
+        "id": "path+[ROOTURL]/foo#0.5.0",
+        "...": "{...}"
+      }
+    ],
+    "root": "path+[ROOTURL]/foo#0.5.0"
+  },
+  "...": "{...}"
+}
+"#]]
+            .is_json(),
+        )
         .run();
 }
 
 #[cargo_test]
-fn cargo_metadata_rejects_mixed_artifact_and_no_artifact_dep_to_same_package() {
+fn cargo_metadata_allows_mixed_artifact_and_no_artifact_dep_to_same_package() {
     let p = project()
         .file(
             "Cargo.toml",
@@ -2379,15 +2452,46 @@ fn cargo_metadata_rejects_mixed_artifact_and_no_artifact_dep_to_same_package() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("metadata -Z bindeps")
+    p.cargo("metadata --format-version 1 -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
-        .with_status(101)
-        .with_stderr_data(str![[r#"
-[WARNING] please specify `--format-version` flag explicitly to avoid compatibility problems
-[LOCKING] 1 package to highest compatible version
-[ERROR] the crate `foo v0.5.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
-
-"#]])
+        .with_stdout_data(
+            str![[r#"
+{
+  "packages": "{...}",
+  "resolve": {
+    "nodes": [
+      "{...}",
+      {
+        "deps": [
+          {
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": null
+              },
+              {
+                "artifact": "bin",
+                "bin_name": "bar",
+                "extern_name": "bar",
+                "kind": null,
+                "target": null
+              }
+            ],
+            "name": "bar_stable",
+            "pkg": "path+[ROOTURL]/foo/bar#0.5.0"
+          }
+        ],
+        "id": "path+[ROOTURL]/foo#0.5.0",
+        "...": "{...}"
+      }
+    ],
+    "root": "path+[ROOTURL]/foo#0.5.0"
+  },
+  "...": "{...}"
+}
+"#]]
+            .is_json(),
+        )
         .run();
 }
 
@@ -2427,6 +2531,7 @@ fn cargo_metadata_allows_mixed_artifact_and_no_artifact_dep_to_bin_only_package(
               {
                 "artifact": "bin",
                 "bin_name": "bar",
+                "extern_name": "bar",
                 "kind": null,
                 "target": null
               }

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -2133,6 +2133,323 @@ fn cargo_metadata_with_invalid_artifact_deps() {
 }
 
 #[cargo_test]
+fn cargo_metadata_with_one_artifact_only_alias_to_lib_package() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.5.0"
+
+                [dependencies]
+                bar-alias = { package = "bar", path = "bar", artifact = "bin" }
+           "#,
+        )
+        .file("src/lib.rs", "")
+        .file(
+            "bar/Cargo.toml",
+            r#"
+                [package]
+                name = "bar"
+                version = "0.5.0"
+
+                [lib]
+                name = "bar"
+
+                [[bin]]
+                name = "bar"
+           "#,
+        )
+        .file("bar/src/lib.rs", "")
+        .file("bar/src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("metadata --format-version 1 -Z bindeps")
+        .masquerade_as_nightly_cargo(&["bindeps"])
+        .with_stdout_data(
+            str![[r#"
+{
+  "packages": "{...}",
+  "resolve": {
+    "nodes": [
+      "{...}",
+      {
+        "deps": [
+          {
+            "dep_kinds": [
+              {
+                "artifact": "bin",
+                "bin_name": "bar",
+                "extern_name": "bar_alias",
+                "kind": null,
+                "target": null
+              }
+            ],
+            "name": "bar_alias",
+            "pkg": "path+[ROOTURL]/foo/bar#0.5.0"
+          }
+        ],
+        "id": "path+[ROOTURL]/foo#0.5.0",
+        "...": "{...}"
+      }
+    ],
+    "root": "path+[ROOTURL]/foo#0.5.0"
+  },
+  "...": "{...}"
+}
+"#]]
+            .is_json(),
+        )
+        .run();
+}
+
+#[cargo_test]
+fn cargo_metadata_rejects_artifact_lib_aliases_across_dependency_kinds() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.5.0"
+
+                [dependencies]
+                bar = { path = "bar", artifact = "bin", lib = true }
+
+                [build-dependencies]
+                bar-alt = { package = "bar", path = "bar", artifact = "bin", lib = true }
+           "#,
+        )
+        .file("src/lib.rs", "")
+        .file("build.rs", "fn main() {}")
+        .file(
+            "bar/Cargo.toml",
+            r#"
+                [package]
+                name = "bar"
+                version = "0.5.0"
+
+                [lib]
+                name = "bar"
+
+                [[bin]]
+                name = "bar"
+           "#,
+        )
+        .file("bar/src/lib.rs", "")
+        .file("bar/src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("metadata -Z bindeps")
+        .masquerade_as_nightly_cargo(&["bindeps"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[WARNING] please specify `--format-version` flag explicitly to avoid compatibility problems
+[LOCKING] 1 package to highest compatible version
+[ERROR] the crate `foo v0.5.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn cargo_metadata_rejects_one_artifact_lib_alias_to_same_package() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.5.0"
+
+                [dependencies]
+                bar-lib = { package = "bar", path = "bar", artifact = "bin", lib = true }
+                bar-bin = { package = "bar", path = "bar", artifact = "bin" }
+           "#,
+        )
+        .file("src/lib.rs", "")
+        .file(
+            "bar/Cargo.toml",
+            r#"
+                [package]
+                name = "bar"
+                version = "0.5.0"
+
+                [lib]
+                name = "bar"
+
+                [[bin]]
+                name = "bar"
+           "#,
+        )
+        .file("bar/src/lib.rs", "")
+        .file("bar/src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("metadata -Z bindeps")
+        .masquerade_as_nightly_cargo(&["bindeps"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[WARNING] please specify `--format-version` flag explicitly to avoid compatibility problems
+[LOCKING] 1 package to highest compatible version
+[ERROR] the crate `foo v0.5.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn cargo_metadata_rejects_multiple_bin_only_artifact_aliases_to_lib_package() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.5.0"
+
+                [dependencies]
+                bar-a = { package = "bar", path = "bar", artifact = "bin" }
+                bar-b = { package = "bar", path = "bar", artifact = "bin" }
+           "#,
+        )
+        .file("src/lib.rs", "")
+        .file(
+            "bar/Cargo.toml",
+            r#"
+                [package]
+                name = "bar"
+                version = "0.5.0"
+
+                [lib]
+                name = "bar"
+
+                [[bin]]
+                name = "bar"
+           "#,
+        )
+        .file("bar/src/lib.rs", "")
+        .file("bar/src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("metadata -Z bindeps")
+        .masquerade_as_nightly_cargo(&["bindeps"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[WARNING] please specify `--format-version` flag explicitly to avoid compatibility problems
+[LOCKING] 1 package to highest compatible version
+[ERROR] the crate `foo v0.5.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn cargo_metadata_rejects_mixed_artifact_and_no_artifact_dep_to_same_package() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.5.0"
+
+                [dependencies]
+                bar = { path = "bar", artifact = "bin" }
+                bar_stable = { path = "bar", package = "bar" }
+           "#,
+        )
+        .file("src/lib.rs", "")
+        .file(
+            "bar/Cargo.toml",
+            r#"
+                [package]
+                name = "bar"
+                version = "0.5.0"
+
+                [lib]
+                name = "bar"
+
+                [[bin]]
+                name = "bar"
+           "#,
+        )
+        .file("bar/src/lib.rs", "")
+        .file("bar/src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("metadata -Z bindeps")
+        .masquerade_as_nightly_cargo(&["bindeps"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[WARNING] please specify `--format-version` flag explicitly to avoid compatibility problems
+[LOCKING] 1 package to highest compatible version
+[ERROR] the crate `foo v0.5.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn cargo_metadata_allows_mixed_artifact_and_no_artifact_dep_to_bin_only_package() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.5.0"
+
+                [dependencies]
+                bar = { path = "bar", artifact = "bin" }
+                bar_stable = { path = "bar", package = "bar" }
+           "#,
+        )
+        .file("src/lib.rs", "")
+        .file("bar/Cargo.toml", &basic_bin_manifest("bar"))
+        .file("bar/src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("metadata --format-version 1 -Z bindeps")
+        .masquerade_as_nightly_cargo(&["bindeps"])
+        .with_stdout_data(
+            str![[r#"
+{
+  "packages": "{...}",
+  "resolve": {
+    "nodes": [
+      "{...}",
+      {
+        "deps": [
+          {
+            "dep_kinds": [
+              {
+                "artifact": "bin",
+                "bin_name": "bar",
+                "kind": null,
+                "target": null
+              }
+            ],
+            "name": "",
+            "pkg": "path+[ROOTURL]/foo/bar#0.5.0"
+          }
+        ],
+        "id": "path+[ROOTURL]/foo#0.5.0",
+        "...": "{...}"
+      }
+    ],
+    "root": "path+[ROOTURL]/foo#0.5.0"
+  },
+  "...": "{...}"
+}
+"#]]
+            .is_json(),
+        )
+        .run();
+}
+
+#[cargo_test]
 fn cargo_metadata_with_invalid_duplicate_renamed_deps() {
     let p = project()
         .file(
@@ -2145,6 +2462,39 @@ fn cargo_metadata_with_invalid_duplicate_renamed_deps() {
                 [dependencies]
                 bar = { path = "bar" }
                 baz = { path = "bar", package = "bar" }
+           "#,
+        )
+        .file("src/lib.rs", "")
+        .file("bar/Cargo.toml", &basic_lib_manifest("bar"))
+        .file("bar/src/lib.rs", "")
+        .build();
+
+    p.cargo("metadata")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[WARNING] please specify `--format-version` flag explicitly to avoid compatibility problems
+[LOCKING] 1 package to highest compatible version
+[ERROR] the crate `foo v0.5.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn cargo_metadata_with_invalid_cross_kind_renamed_deps() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.5.0"
+
+                [dependencies]
+                bar-normal = { path = "bar", package = "bar" }
+
+                [build-dependencies]
+                bar-build = { path = "bar", package = "bar" }
            "#,
         )
         .file("src/lib.rs", "")

--- a/tests/testsuite/unit_graph.rs
+++ b/tests/testsuite/unit_graph.rs
@@ -240,7 +240,7 @@ fn simple() {
 }
 
 #[cargo_test]
-fn unit_graph_rejects_artifact_alias_edges_to_same_package() {
+fn artifact_alias_edges() {
     let p = project()
         .file(
             "Cargo.toml",
@@ -263,11 +263,105 @@ fn unit_graph_rejects_artifact_alias_edges_to_same_package() {
 
     p.cargo("build --unit-graph -Zunstable-options -Z bindeps")
         .masquerade_as_nightly_cargo(&["unit-graph", "bindeps"])
-        .with_status(101)
-        .with_stderr_data(str![[r#"
-[LOCKING] 1 package to highest compatible version
-[ERROR] the crate `foo v0.1.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
-
-"#]])
+        .with_stdout_data(
+            str![[r#"
+{
+  "roots": [
+    1
+  ],
+  "units": [
+    {
+      "dependencies": [],
+      "features": [],
+      "mode": "build",
+      "pkg_id": "path+[ROOTURL]/foo/bar#0.5.0",
+      "platform": null,
+      "profile": {
+        "codegen_backend": null,
+        "codegen_units": null,
+        "debug_assertions": true,
+        "debuginfo": 2,
+        "incremental": false,
+        "lto": "false",
+        "name": "dev",
+        "opt_level": "0",
+        "overflow_checks": true,
+        "panic": "unwind",
+        "rpath": false,
+        "split_debuginfo": "{...}",
+        "strip": "{...}"
+      },
+      "target": {
+        "crate_types": [
+          "bin"
+        ],
+        "doc": true,
+        "doctest": false,
+        "edition": "2015",
+        "kind": [
+          "bin"
+        ],
+        "name": "bar",
+        "src_path": "[ROOT]/foo/bar/src/main.rs",
+        "test": true
+      }
+    },
+    {
+      "dependencies": [
+        {
+          "extern_crate_name": "bar",
+          "index": 0,
+          "noprelude": false,
+          "nounused": false,
+          "public": false
+        },
+        {
+          "extern_crate_name": "bar_alt",
+          "index": 0,
+          "noprelude": false,
+          "nounused": false,
+          "public": false
+        }
+      ],
+      "features": [],
+      "mode": "build",
+      "pkg_id": "path+[ROOTURL]/foo#0.1.0",
+      "platform": null,
+      "profile": {
+        "codegen_backend": null,
+        "codegen_units": null,
+        "debug_assertions": true,
+        "debuginfo": 2,
+        "incremental": false,
+        "lto": "false",
+        "name": "dev",
+        "opt_level": "0",
+        "overflow_checks": true,
+        "panic": "unwind",
+        "rpath": false,
+        "split_debuginfo": "{...}",
+        "strip": "{...}"
+      },
+      "target": {
+        "crate_types": [
+          "lib"
+        ],
+        "doc": true,
+        "doctest": true,
+        "edition": "2015",
+        "kind": [
+          "lib"
+        ],
+        "name": "foo",
+        "src_path": "[ROOT]/foo/src/lib.rs",
+        "test": true
+      }
+    }
+  ],
+  "version": 1
+}
+"#]]
+            .is_json(),
+        )
         .run();
 }

--- a/tests/testsuite/unit_graph.rs
+++ b/tests/testsuite/unit_graph.rs
@@ -1,9 +1,9 @@
 //! Tests for --unit-graph option.
 
 use crate::prelude::*;
-use cargo_test_support::project;
 use cargo_test_support::registry::Package;
 use cargo_test_support::str;
+use cargo_test_support::{basic_bin_manifest, project};
 
 #[cargo_test]
 fn gated() {
@@ -236,5 +236,38 @@ fn simple() {
 "#]]
             .is_json(),
         )
+        .run();
+}
+
+#[cargo_test]
+fn unit_graph_rejects_artifact_alias_edges_to_same_package() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            edition = "2015"
+            authors = []
+
+            [dependencies]
+            bar = { path = "bar/", artifact = "bin" }
+            bar-alt = { package = "bar", path = "bar/", artifact = "bin" }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file("bar/Cargo.toml", &basic_bin_manifest("bar"))
+        .file("bar/src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build --unit-graph -Zunstable-options -Z bindeps")
+        .masquerade_as_nightly_cargo(&["unit-graph", "bindeps"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[LOCKING] 1 package to highest compatible version
+[ERROR] the crate `foo v0.1.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
+
+"#]])
         .run();
 }


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/cargo/pull/17067)*

This implements the multiple-dependency case described by [RFC 3176](https://rust-lang.github.io/rfcs/3176-cargo-multi-dep-artifacts.html).

A package may need to build the same tool for more than one target:

```toml
[build-dependencies]
firmware-x86 = { package = "firmware", version = "1.0", artifact = "bin", target = "x86_64-unknown-none" }
firmware-arm = { package = "firmware", version = "1.0", artifact = "bin", target = "aarch64-unknown-none" }
```

Cargo currently rejects this because the two dependencies refer to the same package but have different names.

This PR lets each artifact dependency keep its declared name. Cargo uses that name for the environment variables that expose the built artifact.

`cargo metadata --format-version=1` groups declarations resolving to the same package into one dependency entry. Its `name` field is the logically optional library dependency name, encoded as a required string for format-version compatibility. This PR leaves `name` empty when no declaration requests the library—even if the package provides an unrequested library target—and reports every artifact name through `extern_name`.

This intentionally changes unstable `-Z bindeps` metadata output. Existing nightly behavior can populate `name` from an artifact-only declaration when the package happens to provide a library. Removing that behavior makes the result depend only on the targets actually requested.

Metadata is included because it is the machine-readable representation of these resolved dependencies. Accepting artifact aliases during a build without reporting those aliases would make Cargo’s two interfaces disagree. The metadata invariant and remaining stabilization work are recorded in [#17350](https://github.com/rust-lang/cargo/issues/17350).

The rules for Rust libraries do not change. If the package is also used as a library, all declarations that build the library must still agree on its name. This includes ordinary dependencies and artifact dependencies with `lib = true`.

## Scope

This PR only changes how dependency names are represented when artifact dependencies are present. It does not change feature selection, dependency graphs, or `lib = true`.

Opaque dependencies and any changes to feature resolution remain separate design questions.

## Commit structure

1. Record the existing build behavior.
2. Record the existing metadata behavior.
3. Extract the shared name calculation.
4. Allow the build to use each artifact name.
5. Separate library and artifact names in metadata.
6. Document the new usage.

The first two commits contain the complete test setup. Later commits primarily show the behavior changing from rejection to success.

Closes https://github.com/rust-lang/cargo/issues/12374

FYI @joshtriplett @Byron
