### PR TITLE
fix(publish): avoid false deadlock when to_confirm is non-empty

### DIFF
--- a/src/cargo/ops/registry/publish.rs
+++ b/src/cargo/ops/registry/publish.rs
@@ -210,9 +210,8 @@ pub fn publish(ws: &Workspace<'_>, opts: &PublishOpts<'_>) -> CargoResult<()> {
         // upload.
         let mut ready = plan.take_ready();
 
-        if ready.is_empty() {
-            // Circular dependencies are caught above, so this indicates a failure
-            // to progress, potentially due to a timeout while waiting for confirmations.
+        if ready.is_empty() && to_confirm.is_empty() {
+            // Cycles are caught above; reaching here means an unexpected stall.
             return Err(crate::util::internal(format!(
                 "no packages ready to publish but {} packages remain in plan with {} awaiting confirmation: {}",
                 plan.len(),

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -3485,7 +3485,7 @@ fn wait_for_workspace_publish() {
 
     p.cargo("publish --workspace --no-verify")
         .replace_crates_io(registry.index_url())
-        .with_status(101)
+        .with_status(0)
         .with_stderr_data(str![[r#"
 [UPDATING] crates.io index
 [PACKAGING] b v1.0.0 ([ROOT]/foo/b)
@@ -3502,10 +3502,14 @@ fn wait_for_workspace_publish() {
 [NOTE] waiting for b v1.0.0 or c v1.0.0 to be available at registry `crates-io`.
       1 remaining crate to be published
 [PUBLISHED] b v1.0.0 at registry `crates-io`
-[ERROR] no packages ready to publish but 1 packages remain in plan with 1 awaiting confirmation: a v1.0.0
-[NOTE] this is an unexpected cargo internal error
-[NOTE] we would appreciate a bug report: https://github.com/rust-lang/cargo/issues/
-[NOTE] cargo [..]
+[NOTE] waiting for c v1.0.0 to be available at registry `crates-io`.
+      1 remaining crate to be published
+[PUBLISHED] c v1.0.0 at registry `crates-io`
+[UPLOADING] a v1.0.0 ([ROOT]/foo/a)
+[UPLOADED] a v1.0.0 to registry `crates-io`
+[NOTE] waiting for a v1.0.0 to be available at registry `crates-io`
+[HELP] you may press ctrl-c to skip waiting; the crate should be available shortly
+[PUBLISHED] a v1.0.0 at registry `crates-io`
 
 "#]])
         .run();

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -3410,6 +3410,108 @@ fn timeout_waiting_for_publish() {
 }
 
 #[cargo_test]
+fn wait_for_workspace_publish() {
+    let arc: Arc<Mutex<u32>> = Arc::new(Mutex::new(0));
+
+    let registry = registry::RegistryBuilder::new()
+        .http_api()
+        .http_index()
+        .add_responder("/index/1/c", move |req, server| {
+            let mut lock = arc.lock().unwrap();
+            *lock += 1;
+            // 3 queries come from resolving `c` during packaging of `a`
+            // 3 more from the wait loop while `b` and `c` are being confirmed
+            // `c` becomes available on the 7th query, unblocking `a`
+            if *lock <= 6 {
+                server.not_found(req)
+            } else {
+                server.index(req)
+            }
+        })
+        .build();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["a", "b", "c"]
+            "#,
+        )
+        .file(
+            "a/Cargo.toml",
+            r#"
+            [package]
+            name = "a"
+            version = "1.0.0"
+            edition = "2015"
+            license = "MIT"
+            description = "a"
+            repository = "a"
+
+            [dependencies]
+            b = { version = "1.0", path = "../b" }
+            c = { version = "1.0", path = "../c" }
+            "#,
+        )
+        .file("a/src/lib.rs", "")
+        .file(
+            "b/Cargo.toml",
+            r#"
+            [package]
+            name = "b"
+            version = "1.0.0"
+            edition = "2015"
+            license = "MIT"
+            description = "b"
+            repository = "b"
+            "#,
+        )
+        .file("b/src/lib.rs", "")
+        .file(
+            "c/Cargo.toml",
+            r#"
+            [package]
+            name = "c"
+            version = "1.0.0"
+            edition = "2015"
+            license = "MIT"
+            description = "c"
+            repository = "c"
+            "#,
+        )
+        .file("c/src/lib.rs", "")
+        .build();
+
+    p.cargo("publish --workspace --no-verify")
+        .replace_crates_io(registry.index_url())
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[UPDATING] crates.io index
+[PACKAGING] b v1.0.0 ([ROOT]/foo/b)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGING] c v1.0.0 ([ROOT]/foo/c)
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[PACKAGING] a v1.0.0 ([ROOT]/foo/a)
+[UPDATING] crates.io index
+[PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[UPLOADING] b v1.0.0 ([ROOT]/foo/b)
+[UPLOADED] b v1.0.0 to registry `crates-io`
+[UPLOADING] c v1.0.0 ([ROOT]/foo/c)
+[UPLOADED] c v1.0.0 to registry `crates-io`
+[NOTE] waiting for b v1.0.0 or c v1.0.0 to be available at registry `crates-io`.
+      1 remaining crate to be published
+[PUBLISHED] b v1.0.0 at registry `crates-io`
+[ERROR] no packages ready to publish but 1 packages remain in plan with 1 awaiting confirmation: a v1.0.0
+[NOTE] this is an unexpected cargo internal error
+[NOTE] we would appreciate a bug report: https://github.com/rust-lang/cargo/issues/
+[NOTE] cargo [..]
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn timeout_waiting_for_dependency_publish() {
     // Publish doesn't happen within the timeout window.
     let registry = registry::RegistryBuilder::new()


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/cargo/pull/17071)*

Fixes #17028

PR #16722 introduced a check that fires an internal error when `ready` is empty inside the publish loop. It fired even when packages were still legitimately waiting for registry confirmation in `to_confirm`, causing valid workspace publishes to fail with a false deadlock error. A true deadlock only exists when both `ready` and `to_confirm` are empty.