### PR TITLE
fix(install): copy dylib dependencies alongside binaries (#17055)

### DIFF
--- a/src/cargo/core/compiler/build_runner/mod.rs
+++ b/src/cargo/core/compiler/build_runner/mod.rs
@@ -339,6 +339,12 @@ impl<'a, 'gctx> BuildRunner<'a, 'gctx> {
                 self.compilation
                     .cdylibs
                     .push(self.unit_output(unit, bindst)?);
+            } else if unit.target.is_dylib()
+                && !self.compilation.dylibs.iter().any(|uo| uo.unit == *unit)
+            {
+                self.compilation
+                    .dylibs
+                    .push(self.unit_output(unit, bindst)?);
             }
         }
         Ok(())

--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -80,6 +80,9 @@ pub struct Compilation<'gctx> {
     /// An array of all cdylibs created.
     pub cdylibs: Vec<UnitOutput>,
 
+    /// An array of all dylibs created.
+    pub dylibs: Vec<UnitOutput>,
+
     /// The crate names of the root units specified on the command-line.
     pub root_crate_names: Vec<String>,
 
@@ -99,7 +102,7 @@ pub struct Compilation<'gctx> {
     pub deps_output: HashMap<CompileKind, PathBuf>,
 
     /// The path to libstd for each target
-    sysroot_target_libdir: HashMap<CompileKind, PathBuf>,
+    pub(crate) sysroot_target_libdir: HashMap<CompileKind, PathBuf>,
 
     /// Extra environment variables that were passed to compilations and should
     /// be passed to future invocations of programs.
@@ -186,6 +189,7 @@ impl<'gctx> Compilation<'gctx> {
             tests: Vec::new(),
             binaries: Vec::new(),
             cdylibs: Vec::new(),
+            dylibs: Vec::new(),
             root_crate_names: Vec::new(),
             extra_env: HashMap::new(),
             to_doc_test: Vec::new(),

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -27,11 +27,13 @@ use tracing::debug;
 
 struct Transaction {
     bins: Vec<PathBuf>,
+    cdylibs: Vec<PathBuf>,
 }
 
 impl Transaction {
     fn success(mut self) {
         self.bins.clear();
+        self.cdylibs.clear();
     }
 }
 
@@ -39,6 +41,9 @@ impl Drop for Transaction {
     fn drop(&mut self) {
         for bin in self.bins.iter() {
             let _ = paths::remove_file(bin);
+        }
+        for lib in self.cdylibs.iter() {
+            let _ = paths::remove_file(lib);
         }
     }
 }
@@ -506,7 +511,10 @@ impl<'gctx> InstallablePackage<'gctx> {
             .map(|&(bin, _)| bin)
             .partition(|&bin| duplicates.contains_key(bin));
 
-        let mut installed = Transaction { bins: Vec::new() };
+        let mut installed = Transaction {
+            bins: Vec::new(),
+            cdylibs: Vec::new(),
+        };
         let mut successful_bins = BTreeSet::new();
 
         // Move the temporary copies into `dst` starting with new binaries.
@@ -575,6 +583,16 @@ impl<'gctx> InstallablePackage<'gctx> {
 
         // Reaching here means all actions have succeeded. Clean up.
         installed.success();
+
+        // See https://github.com/rust-lang/cargo/issues/17055
+        if !dry_run && (!compile.cdylibs.is_empty() || !compile.dylibs.is_empty()) {
+            let kind = self.opts.build_config.single_requested_kind()?;
+            install_dylibs(self.gctx, &compile, kind, &dst)?;
+            for &(bin_name, _) in &binaries {
+                fix_rpath_for_install(self.gctx, &dst.join(bin_name));
+            }
+        }
+
         if needs_cleanup {
             // Don't bother grabbing a lock as we're going to blow it all away
             // anyway.
@@ -1005,6 +1023,115 @@ fn remove_orphaned_bins(
                 if !dry_run {
                     paths::remove_file(&full_path)
                         .with_context(|| format!("failed to remove {:?}", full_path))?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn fix_rpath_for_install(gctx: &GlobalContext, bin_path: &Path) {
+    #[cfg(target_os = "linux")]
+    {
+        if std::process::Command::new("patchelf")
+            .arg("--add-rpath")
+            .arg("$ORIGIN")
+            .arg(bin_path)
+            .output()
+            .is_err()
+        {
+            let _ = gctx.shell().warn(format!(
+                "`patchelf` is not installed; the installed binary `{}`\n\
+                 may not be able to find its dynamic libraries at runtime.\n\
+                 consider installing `patchelf` or setting `LD_LIBRARY_PATH`.",
+                bin_path.display(),
+            ));
+        }
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let _ = std::process::Command::new("install_name_tool")
+            .arg("-add_rpath")
+            .arg("@loader_path")
+            .arg(bin_path)
+            .output();
+        let _ = gctx;
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        let _ = (gctx, bin_path);
+    }
+}
+
+fn install_dylibs(
+    gctx: &GlobalContext,
+    compile: &crate::core::compiler::Compilation<'_>,
+    kind: CompileKind,
+    dst: &Path,
+) -> CargoResult<()> {
+    for cdylib in &compile.cdylibs {
+        let Some(name) = cdylib.path.file_name() else {
+            bail!("cdylib path has no filename: {}", cdylib.path.display());
+        };
+        let dest = dst.join(name);
+        if !dest.exists() {
+            gctx.shell().status("Installing", dest.display())?;
+            paths::copy(&cdylib.path, &dest)?;
+        }
+    }
+
+    for dylib in &compile.dylibs {
+        let Some(name) = dylib.path.file_name() else {
+            bail!("dylib path has no filename: {}", dylib.path.display());
+        };
+        let dest = dst.join(name);
+        if !dest.exists() {
+            gctx.shell().status("Installing", dest.display())?;
+            paths::copy(&dylib.path, &dest)?;
+        }
+    }
+
+    for dir in compile
+        .root_output
+        .values()
+        .chain(compile.deps_output.values())
+    {
+        if !dir.is_dir() {
+            continue;
+        }
+        for entry in std::fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            let ext = path.extension().and_then(|e| e.to_str());
+            if !matches!(ext, Some("so" | "dylib")) {
+                continue;
+            }
+            let Some(name) = path.file_name() else {
+                continue;
+            };
+            let dest = dst.join(name);
+            if !dest.exists() {
+                gctx.shell().status("Installing", dest.display())?;
+                paths::copy(&path, &dest)?;
+            }
+        }
+    }
+
+    if let Some(sysroot_libdir) = compile.sysroot_target_libdir.get(&kind) {
+        if sysroot_libdir.is_dir() {
+            for entry in std::fs::read_dir(sysroot_libdir)? {
+                let entry = entry?;
+                let path = entry.path();
+                let ext = path.extension().and_then(|e| e.to_str());
+                if matches!(ext, Some("so" | "dylib")) {
+                    let Some(name) = path.file_name() else {
+                        bail!("sysroot file path has no filename: {}", path.display());
+                    };
+                    let dest = dst.join(name);
+                    if !dest.exists() {
+                        gctx.shell().status("Installing", dest.display())?;
+                        paths::copy(&path, &dest)?;
+                    }
                 }
             }
         }


### PR DESCRIPTION
### What does this PR try to resolve?
Fixes #17055.

When a crate depends on a dylib or cdylib, rustc implicitly enables -C prefer-dynamic, which causes libstd to be linked as a shared library. cargo install only copies the binary to ~/.cargo/bin/, leaving the required .so files behind, so the binary fails at runtime.

This PR addresses the issue with two changes:

1. Copy shared libraries alongside the binary — a new install_dylibs() function collects .so/.dylib files from three sources: root-unit cdylib/dylib targets, a directory scan of root_output and deps_output (for dependency crates), and the sysroot target libdir (for libstd).

2. Fix rpath after install — fix_rpath_for_install() adds $ORIGIN (Linux, via patchelf) or @loader_path (macOS, via install_name_tool) to the installed binary's rpath, so it can find the shared libraries in its own directory. If the tool is not available, a warning is emitted.

### How to test and review this PR?

`cargo build --bin cargo`
`./target/debug/cargo install --force cargo_install_dylib_bug`

libstd and project dylibs should be installed alongside the binary
`ls ~/.cargo/bin/*.so`

If patchelf is installed, the binary should work:
`cargo_install_dylib_bug`

if patchelf is not installed:
`LD_LIBRARY_PATH=~/.cargo/bin cargo_install_dylib_bug`
