### PR TITLE
fix: strip CR from `cargo:token-from-stdout`

### DIFF
--- a/src/cargo/util/credential/adaptor.rs
+++ b/src/cargo/util/credential/adaptor.rs
@@ -51,6 +51,10 @@ impl Credential for BasicProcessCredential {
                         .into());
                     }
                     buffer.truncate(end);
+                    // Strip also a preceding `\r` from CRLF
+                    if buffer.ends_with('\r') {
+                        buffer.pop();
+                    }
                 }
                 let status = child.wait().context("credential process never started")?;
                 if !status.success() {

--- a/tests/testsuite/credential_process.rs
+++ b/tests/testsuite/credential_process.rs
@@ -728,19 +728,14 @@ fn basic_provider_crlf() {
     Package::new("bar", "0.0.1").alternative(true).publish();
 
     p.cargo("check")
-        .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[ERROR] failed to get `bar` as a dependency of package `foo v0.0.1 ([ROOT]/foo)`
-
-Caused by:
-  failed to load source for dependency `bar`
-
-Caused by:
-  unable to update registry `alternative`
-
-Caused by:
-  failed to parse header value
+[LOCKING] 1 package to latest compatible version
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v0.0.1 (registry `alternative`)
+[CHECKING] bar v0.0.1 (registry `alternative`)
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
         .run();

--- a/tests/testsuite/credential_process.rs
+++ b/tests/testsuite/credential_process.rs
@@ -685,6 +685,68 @@ CARGO_REGISTRY_INDEX_URL=Some("[ROOTURL]/alternative-registry")
 }
 
 #[cargo_test]
+fn basic_provider_crlf() {
+    // Helpers on Windows commonly emit a token terminated by `\r\n`.
+    let cred_proj = project()
+        .at("cred_proj")
+        .file("Cargo.toml", &basic_manifest("test-cred", "1.0.0"))
+        .file("src/main.rs", r#"fn main() { print!("sekrit\r\n"); }"#)
+        .build();
+    cred_proj.cargo("build").run();
+
+    let _server = registry::RegistryBuilder::new()
+        .no_configure_token()
+        .credential_provider(&[
+            "cargo:token-from-stdout",
+            &toml_bin(&cred_proj, "test-cred"),
+        ])
+        .token(cargo_test_support::registry::Token::Plaintext(
+            "sekrit".to_string(),
+        ))
+        .alternative()
+        .http_api()
+        .http_index()
+        .auth_required()
+        .build();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                edition = "2015"
+                authors = []
+                [dependencies.bar]
+                version = "0.0.1"
+                registry = "alternative"
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+    Package::new("bar", "0.0.1").alternative(true).publish();
+
+    p.cargo("check")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[UPDATING] `alternative` index
+[ERROR] failed to get `bar` as a dependency of package `foo v0.0.1 ([ROOT]/foo)`
+
+Caused by:
+  failed to load source for dependency `bar`
+
+Caused by:
+  unable to update registry `alternative`
+
+Caused by:
+  failed to parse header value
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn unsupported_version() {
     let cred_proj = project()
         .at("new-vers")


### PR DESCRIPTION
### What does this PR try to resolve?

Helpers on Windows commonly emit a token terminated by `\r\n`.
The adaptor only strips `\n` and leaves leaving a trailing `\r`.
In 1.96 the registry network refactor started using `http::HeaderValue`,
and it rejects trailing `\r` when constructing the request.
So, users see a confusing "failed to parse header value" message.
They are stuck and cannot send the request.

This fix simply trims trailing `\r` after trimming `\n`.

I have no idea how AWS CodeArtifact works with trailing `\r` before.
Perhaps it trims those as well.

Fixes rust-lang/cargo#14073
Fixes rust-lang/cargo#17072

### How to test and review this PR?

One regression test is added.

Also, before <https://github.com/rust-lang/cargo/pull/16745> Cargo constructed request as-is and didn't reject invalid headers (and libcurl doesn't seem to check it?). Since `http::HeaderValue` started doing a stricter validation, probably we should take the advantage and apply [`check_token`](https://github.com/rust-lang/cargo/blob/71b70c095bb15e278ab9f0f808397c8033079888/crates/crates-io/lib.rs?plain=1#L496-L516) to all alternate registries?


