### PR TITLE
Detect Fossil repositories in cargo --fix

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -570,7 +570,9 @@ pub fn init(opts: &NewOptions, gctx: &GlobalContext) -> CargoResult<NewProjectKi
             num_detected_vcses += 1;
         }
 
-        if path.join(".fossil").exists() {
+        // .fslckout tracks your active, local work.
+        // ~/.fossil is the Configuration Database
+        if path.join(".fslckout").exists() {
             version_control = Some(VersionControl::Fossil);
             num_detected_vcses += 1;
         }

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -581,7 +581,7 @@ pub fn init(opts: &NewOptions, gctx: &GlobalContext) -> CargoResult<NewProjectKi
 
         if num_detected_vcses > 1 {
             anyhow::bail!(
-                "more than one of .hg, .git, .pijul, .fossil configurations \
+                "more than one of .hg, .git, .pijul, .fslckout configurations \
                  found and the ignore file can't be filled in as \
                  a result. specify --vcs to override detection"
             );

--- a/src/cargo/util/vcs.rs
+++ b/src/cargo/util/vcs.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 // 1. We are in a git repo and the path to the new package is not an ignored
 //    path in that repo.
 // 2. We are in an HG repo.
+// 3. We are in a fossil repo.
 pub fn existing_vcs_repo(path: &Path, cwd: &Path) -> bool {
     fn in_git_repo(path: &Path, cwd: &Path) -> bool {
         if let Ok(repo) = GitRepo::discover(path, cwd) {
@@ -22,7 +23,9 @@ pub fn existing_vcs_repo(path: &Path, cwd: &Path) -> bool {
         }
     }
 
-    in_git_repo(path, cwd) || HgRepo::discover(path, cwd).is_ok()
+    in_git_repo(path, cwd)
+        || HgRepo::discover(path, cwd).is_ok()
+        || FossilRepo::discover(path, cwd).is_ok()
 }
 
 pub struct HgRepo;
@@ -100,5 +103,19 @@ impl FossilRepo {
             .exec()?;
 
         Ok(FossilRepo)
+    }
+
+    pub fn discover(_path: &Path, cwd: &Path) -> CargoResult<FossilRepo> {
+        let output = ProcessBuilder::new("fossil")
+            .cwd(cwd)
+            .arg("info")
+            .output()?;
+        let stdout = String::from_utf8(output.stdout)?;
+        let has_local_root = stdout.lines().any(|line| line.starts_with("local-root:"));
+        if has_local_root {
+            Ok(FossilRepo)
+        } else {
+            anyhow::bail!("not in a fossil repository")
+        }
     }
 }

--- a/src/cargo/util/vcs.rs
+++ b/src/cargo/util/vcs.rs
@@ -96,10 +96,10 @@ impl FossilRepo {
 
         // open it in that new directory
         ProcessBuilder::new("fossil")
-            .cwd(&path)
+            .cwd(cwd)
             .arg("open")
             .arg("--")
-            .arg(db_fname)
+            .arg(db_path)
             .exec()?;
 
         Ok(FossilRepo)

--- a/tests/testsuite/cargo_init/fossil_autodetect/mod.rs
+++ b/tests/testsuite/cargo_init/fossil_autodetect/mod.rs
@@ -18,6 +18,6 @@ fn case() {
         .stdout_eq(str![""])
         .stderr_eq(file!["stderr.term.svg"]);
 
-    assert_ui().subset_matches(current_dir!().join("out"), project_root);
-    assert!(!project_root.join(".git").is_dir());
+    assert_ui().subset_matches(current_dir!().join("in"), project_root);
+    assert!(!project_root.join(".fslckout").is_file());
 }


### PR DESCRIPTION
### What does this PR try to resolve?

Fix <https://github.com/rust-lang/cargo/issues/12721>

`cargo --fix` does not detect a Fossil checkout and aborts execution of `--fix`.

### How to test and review this PR?

The current behaviour is to emit an error when inside a Fossil repository (not a git repo), like below:

```
cargo fix --bin "lazyfossil" -p lazyfossil
error: no VCS found for this package and `cargo fix` can potentially perform destructive changes;
if you'd like to suppress this error pass `--allow-no-vcs`
```

With this fix `cargo`  performs as expected:

```
/home/geraldo/git/geraldolsribeiro/cargo/target/release/cargo fix --bin "lazyfossil" -p lazyfossil
   Compiling libc v0.2.186
   Compiling proc-macro2 v1.0.106
...
warning: `lazyfossil` (bin "lazyfossil") generated 2 warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.05s
```
