### PR TITLE
docs(diag): Provide jumping off points for writing diagnostics and passes

### DIFF
--- a/src/cargo/diagnostics/mod.rs
+++ b/src/cargo/diagnostics/mod.rs
@@ -1,3 +1,58 @@
+//! Hard-coded and user-controlled diagnostics
+//!
+//! Diagnostics are user messages, like warnings and errors.
+//! When they are named for setting a user-overridable level,
+//! they are called lints.
+//!
+//! # When should a diagnostic be a lint
+//!
+//! Lints are generally preferred because of the level of control for users.
+//!
+//! Use a hard-coded diagnostic when:
+//! - Critical errors
+//! - There is no associated package or workspace. The diagnostic must still be suppressible
+//!   somehow (e.g. a user explicitly opting in to a config field's default value)
+//! - The warning message is too important to allow a user to hide (rare)
+//!
+//! # Adding a diagnostic
+//!
+//! The mechanics of adding a diagnostic is dependent on the requirements:
+//! - TOML syntax or manifest schema: [`passes::emit_parse_diagnostics`], [`rules::PARSE_PASS_RULES`]
+//! - Lockfile
+//!   - May be overly broad for what dependencies are checked
+//! - Pre-build unit graph
+//!   - Tailored to a specific configuration (features, targets) but requires users to enumerate every configuration
+//! - Post-build unit graph: [`rules::unused_dependencies::lint_build_results`]
+//!   - Slow feedback cycle since a build needs to happen
+//! - Does not fit into any idea of a pass: directly call [`cargo_util_terminal::Shell::warn`] or [`crate::CargoResult::Err`]
+//!
+//! When evaluating a diagnostic:
+//! - Only evaluate and emit for local packages unless it is for a [future-incompat lint]
+//!
+//! When generating a diagnostic [report][cargo_util_terminal::report::Report]:
+//! - Try to keep the report succinct while ensuring a beginner can understand what is wrong and how to fix.
+//!   It is a difficult balance to hit; err on the side of providing extra information.
+//! - Messages should generally be a phrase, starting with a lowercase letter.
+//!   If multiple sentences are needed, consider if a [message][cargo_util_terminal::report::Message] or sub-diagnostic would be more
+//!   appropriate.
+//! - Only the first lint for a package should emit the [`lint::Lint::emitted_source`]
+//!
+//! See also [rustc's Errors and Lints](https://rustc-dev-guide.rust-lang.org/diagnostics.html)
+//!
+//! # Adding a pass
+//!
+//! When a diagnostic requires adding a new pass, keep in mind:
+//! - Support for `build.warnings`
+//! - When errors should block further evaluation within the pass
+//! - Providing a summary at the end, like what is provided by [`DiagnosticStats::report_summary`]
+//! - Prefer data driven passes to simplify adding rules
+//!   - Ensure the pass' lints are in [`rules::LINTS`], e.g. `ensure_parse_passed_in_lints`
+//!   - Prefer evaluating the lint level within the pass
+//!
+//! See [`passes::emit_parse_diagnostics`] as an example.
+//!
+//! [future-incompat lint]: https://rustc-dev-guide.rust-lang.org/diagnostics.html#future-incompatible-lints
+
 use anyhow::bail;
 use cargo_util_schemas::manifest::RustVersion;
 use cargo_util_schemas::manifest::TomlToolLints;

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -43,6 +43,8 @@
 //!   The [`sources::source::Source`] trait is an abstraction over different sources of packages.
 //!   Sources are uniquely identified by a [`core::SourceId`]. Sources are implemented in the [`sources`]
 //!   directory.
+//! - [`diagnostics`]: Home of diagnostic [passes][diagnostics::passes] and their
+//!   [rules][diagnostics::rules].
 //! - [`util`]:
 //!   This directory contains generally-useful utility modules.
 //! - [`util::context`]:

--- a/src/doc/contrib/src/implementation/console.md
+++ b/src/doc/contrib/src/implementation/console.md
@@ -16,6 +16,10 @@ Messages written during compilation should handle errors, and abort the build
 if they are unable to be displayed. This is generally automatically handled in
 the [`JobQueue`] as it processes each message.
 
+**Note:** keep the normal output brief.
+Cargo is already fairly noisy,
+so try to keep the output as brief and clean as possible.
+
 [`Shell`]: https://github.com/rust-lang/cargo/blob/master/src/cargo/core/shell.rs
 [`GlobalContext`]: https://github.com/rust-lang/cargo/blob/master/src/cargo/util/context/mod.rs
 [`drop_print`]: https://github.com/rust-lang/cargo/blob/e4b65bdc80f2a293447f2f6a808fa7c84bf9a357/src/cargo/util/config/mod.rs#L1820-L1848
@@ -23,13 +27,7 @@ the [`JobQueue`] as it processes each message.
 
 ## Diagnostics
 
-See rustc's [Errors and lints] for:
-- diagnostic structure
-- hard diagnostics vs lints
-- diagnostic style guide
-- lint naming
-- diagnostic levels
-- suggestion style guide
+See [`diagnostics`](https://doc.rust-lang.org/nightly/nightly-rustc/cargo/diagnostics/index.html) for how to write diagnostics and lints (including errors)
 
 ### Errors
 
@@ -45,25 +43,9 @@ The binary side of Cargo uses the `CliError` struct to wrap the process exit
 code. Usually Cargo exits with 101 for an error, but some commands like `cargo
 test` will exit with different codes.
 
-[`errors`]: https://github.com/rust-lang/cargo/blob/master/src/cargo/util/errors.rs
-
-## Style
-
-Some guidelines for Cargo's output:
-
-* Keep the normal output brief. Cargo is already fairly noisy, so try to keep
-  the output as brief and clean as possible.
-* Good error messages are very important! Try to keep them brief and to the
-  point, but good enough that a beginner can understand what is wrong and can
-  figure out how to fix. It is a difficult balance to hit! Err on the side of
-  providing extra information.
-* When using any low-level routines, such as `std::fs`, *always* add error
-  context about what it is doing. For example, reading from a file should
-  include context about which file is being read if there is an error.
-* Cargo's error style is usually a phrase, starting with a lowercase letter.
-  If there is a longer error message that needs multiple sentences, go ahead
-  and use multiple sentences. This should probably be improved sometime in the
-  future to be more structured.
+**Note:** When using any low-level routines,
+such as `std::fs`, *always* add error context about what it is doing.
+For example, reading from a file should include context about which file is being read if there is an error.
 
 [`anyhow`]: https://docs.rs/anyhow
 [Errors and lints]: https://rustc-dev-guide.rust-lang.org/diagnostics.html


### PR DESCRIPTION

### What does this PR try to resolve?

This delegates a lot of implementation details to the parse pass API, the parse pass as an example, existing rules as examples, and tests for style enforcement.

This is part of #12235

### How to test and review this PR?

I expect we'll iterate on this as we get more contributions