### PR TITLE
refactor(source): drop `Source::is_yanked`

### DIFF
--- a/src/cargo/ops/cargo_package/mod.rs
+++ b/src/cargo/ops/cargo_package/mod.rs
@@ -6,6 +6,7 @@ use std::io::SeekFrom;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 
+use crate::core::Dependency;
 use crate::core::PackageIdSpecQuery;
 use crate::core::Workspace;
 use crate::core::dependency::DepKind;
@@ -16,12 +17,14 @@ use crate::core::{Package, PackageId, PackageSet, Resolve, SourceId};
 use crate::ops::lockfile::LOCKFILE_NAME;
 use crate::ops::registry::{RegistryOrIndex, infer_registry};
 use crate::sources::path::PathEntry;
+use crate::sources::source::QueryKind;
 use crate::sources::{CRATES_IO_REGISTRY, PathSource};
 use crate::util::FileLock;
 use crate::util::Filesystem;
 use crate::util::GlobalContext;
 use crate::util::Graph;
 use crate::util::HumanBytes;
+use crate::util::OptVersionReq;
 use crate::util::cache_lock::CacheLockMode;
 use crate::util::context::JobsConfig;
 use crate::util::errors::CargoResult;
@@ -1040,12 +1043,26 @@ pub fn check_yanked(
         source.invalidate_cache();
     }
 
+    let sources = &pkg_set.sources();
     let mut futures = resolve
         .iter()
         .map(|pkg_id| async move {
-            if let Some(source) = pkg_set.sources().get(pkg_id.source_id())
-                && source.is_yanked(pkg_id).await?
-            {
+            let Some(source) = sources.get(pkg_id.source_id()) else {
+                return CargoResult::Ok(());
+            };
+
+            let mut dep = Dependency::new_override(pkg_id.name(), pkg_id.source_id());
+            dep.set_version_req(OptVersionReq::lock_to_exact(pkg_id.version()));
+            let mut yanked = false;
+            source
+                .query(&dep, QueryKind::Exact, &mut |s| {
+                    if s.is_yanked() {
+                        yanked = true;
+                    }
+                })
+                .await?;
+
+            if yanked {
                 gctx.shell().warn(format!(
                     "package `{}` in Cargo.lock is yanked in registry `{}`, {}",
                     pkg_id,

--- a/src/cargo/ops/cargo_package/mod.rs
+++ b/src/cargo/ops/cargo_package/mod.rs
@@ -1063,12 +1063,15 @@ pub fn check_yanked(
                 .await?;
 
             if yanked {
-                gctx.shell().warn(format!(
-                    "package `{}` in Cargo.lock is yanked in registry `{}`, {}",
-                    pkg_id,
-                    pkg_id.source_id().display_registry_name(),
-                    hint
-                ))?;
+                gctx.shell().print_report(
+                    &[Level::WARNING
+                        .secondary_title(format!(
+                            "package `{pkg_id}` in Cargo.lock is yanked in registry `{}`",
+                            pkg_id.source_id().display_registry_name(),
+                        ))
+                        .element(Level::HELP.message(hint))],
+                    false,
+                )?;
             }
             CargoResult::Ok(())
         })

--- a/src/cargo/sources/directory.rs
+++ b/src/cargo/sources/directory.rs
@@ -267,10 +267,6 @@ impl<'gctx> Source for DirectorySource<'gctx> {
         format!("directory source `{}`", self.root.display())
     }
 
-    async fn is_yanked(&self, _pkg: PackageId) -> CargoResult<bool> {
-        Ok(false)
-    }
-
     fn invalidate_cache(&self) {
         // Directory source has no local cache.
     }

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -442,10 +442,6 @@ impl<'gctx> Source for GitSource<'gctx> {
         format!("Git repository {}", self.source_id.borrow())
     }
 
-    async fn is_yanked(&self, _pkg: PackageId) -> CargoResult<bool> {
-        Ok(false)
-    }
-
     fn invalidate_cache(&self) {}
 
     fn set_quiet(&mut self, quiet: bool) {

--- a/src/cargo/sources/overlay.rs
+++ b/src/cargo/sources/overlay.rs
@@ -126,8 +126,4 @@ impl<'gctx> Source for DependencyConfusionThreatOverlaySource<'gctx> {
     fn describe(&self) -> String {
         self.remote.describe()
     }
-
-    async fn is_yanked(&self, pkg: crate::core::PackageId) -> crate::CargoResult<bool> {
-        self.remote.is_yanked(pkg).await
-    }
 }

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -201,10 +201,6 @@ impl<'gctx> Source for PathSource<'gctx> {
         }
     }
 
-    async fn is_yanked(&self, _pkg: PackageId) -> CargoResult<bool> {
-        Ok(false)
-    }
-
     fn invalidate_cache(&self) {
         // Path source has no local cache.
     }
@@ -398,10 +394,6 @@ impl<'gctx> Source for RecursivePathSource<'gctx> {
             Ok(path) => path.display().to_string(),
             Err(_) => self.source_id.to_string(),
         }
-    }
-
-    async fn is_yanked(&self, _pkg: PackageId) -> CargoResult<bool> {
-        Ok(false)
     }
 
     fn invalidate_cache(&self) {

--- a/src/cargo/sources/registry/index/mod.rs
+++ b/src/cargo/sources/registry/index/mod.rs
@@ -504,16 +504,6 @@ impl<'gctx> RegistryIndex<'gctx> {
             .for_each(f);
         Ok(())
     }
-
-    /// Looks into the summaries to check if a package has been yanked.
-    pub async fn is_yanked(&self, pkg: PackageId, load: &dyn RegistryData) -> CargoResult<bool> {
-        let req = OptVersionReq::lock_to_exact(pkg.version());
-        let found = self
-            .summaries(pkg.name(), &req, load)
-            .await?
-            .any(|s| matches!(s, IndexSummary::Yanked(_)));
-        Ok(found)
-    }
 }
 
 impl Summaries {

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -880,10 +880,6 @@ impl<'gctx> Source for RegistrySource<'gctx> {
     fn describe(&self) -> String {
         self.source_id.display_index()
     }
-
-    async fn is_yanked(&self, pkg: PackageId) -> CargoResult<bool> {
-        self.index.is_yanked(pkg, &*self.ops).await
-    }
 }
 
 /// Get the maximum unpack size that Cargo permits

--- a/src/cargo/sources/replaced.rs
+++ b/src/cargo/sources/replaced.rs
@@ -155,8 +155,4 @@ impl<'gctx> Source for ReplacedSource<'gctx> {
     fn is_replaced(&self) -> bool {
         !self.is_builtin_replacement()
     }
-
-    async fn is_yanked(&self, pkg: PackageId) -> CargoResult<bool> {
-        self.inner.is_yanked(pkg).await
-    }
 }

--- a/src/cargo/sources/source.rs
+++ b/src/cargo/sources/source.rs
@@ -124,10 +124,6 @@ pub trait Source {
     fn is_replaced(&self) -> bool {
         false
     }
-
-    /// Query if a package is yanked. Only registry sources can mark packages
-    /// as yanked.
-    async fn is_yanked(&self, pkg: PackageId) -> CargoResult<bool>;
 }
 
 /// Defines how a dependency query will be performed for a [`Source`].
@@ -231,10 +227,6 @@ impl<'a, T: Source + ?Sized + 'a> Source for &'a mut T {
 
     fn is_replaced(&self) -> bool {
         (**self).is_replaced()
-    }
-
-    async fn is_yanked(&self, pkg: PackageId) -> CargoResult<bool> {
-        (**self).is_yanked(pkg).await
     }
 }
 

--- a/tests/testsuite/publish_lockfile.rs
+++ b/tests/testsuite/publish_lockfile.rs
@@ -417,6 +417,45 @@ dependencies = [
 }
 
 #[cargo_test]
+fn warn_install_with_offline_warn_cache() {
+    Package::new("bar", "0.1.0").yanked(true).publish();
+    Package::new("bar", "0.1.1").publish();
+    Package::new("foo", "0.1.0")
+        .dep("bar", "0.1")
+        .file("src/main.rs", "fn main() {}")
+        .file(
+            "Cargo.lock",
+            r#"
+[[package]]
+name = "bar"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "foo"
+version = "0.1.0"
+dependencies = [
+ "bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+            "#,
+        )
+        .publish();
+
+    // Warm the registry index cache.
+    cargo_process("install --locked foo").run();
+
+    // Re-install and the yanked help works with offline.
+    // (no extra index query)
+    cargo_process("install --offline --locked --force foo")
+        .with_stderr_data(str![[r#"
+...
+[WARNING] package `bar v0.1.0` in Cargo.lock is yanked in registry `crates-io`, consider running without --locked
+...
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn ignore_lockfile() {
     // With an explicit `include` list, but Cargo.lock in .gitignore, don't
     // complain about `Cargo.lock` being ignored. Note that it is still

--- a/tests/testsuite/publish_lockfile.rs
+++ b/tests/testsuite/publish_lockfile.rs
@@ -346,7 +346,9 @@ fn warn_package_with_yanked() {
         .with_stderr_data(str![[r#"
 [PACKAGING] foo v0.0.1 ([ROOT]/foo)
 [UPDATING] `dummy-registry` index
-[WARNING] package `bar v0.1.0` in Cargo.lock is yanked in registry `crates-io`, consider updating to a version that is not yanked
+[WARNING] package `bar v0.1.0` in Cargo.lock is yanked in registry `crates-io`
+  |
+  = [HELP] consider updating to a version that is not yanked
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
 
 "#]])
@@ -384,7 +386,9 @@ dependencies = [
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.1.0 (registry `dummy-registry`)
 [INSTALLING] foo v0.1.0
-[WARNING] package `bar v0.1.0` in Cargo.lock is yanked in registry `crates-io`, consider running without --locked
+[WARNING] package `bar v0.1.0` in Cargo.lock is yanked in registry `crates-io`
+  |
+  = [HELP] consider running without --locked
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [COMPILING] bar v0.1.0
@@ -449,8 +453,11 @@ dependencies = [
     cargo_process("install --offline --locked --force foo")
         .with_stderr_data(str![[r#"
 ...
-[WARNING] package `bar v0.1.0` in Cargo.lock is yanked in registry `crates-io`, consider running without --locked
+[WARNING] package `bar v0.1.0` in Cargo.lock is yanked in registry `crates-io`
+  |
+  = [HELP] consider running without --locked
 ...
+
 "#]])
         .run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?

`cargo_package::check_yanked` is the only external caller.
Replace it with a direct `Source::query` instead
since we want `Source` to be yanked-naive.

This is an follow-up of https://github.com/rust-lang/cargo/pull/17083

### How to test and review this PR?

