### PR TITLE
fix(diag): Report all errors, in order

### DIFF
--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -144,7 +144,7 @@ use crate::core::compiler::future_incompat::{
 };
 use crate::core::resolver::ResolveBehavior;
 use crate::core::{PackageId, TargetKind};
-use crate::diagnostics::ScopedDiagnosticStats;
+use crate::diagnostics::GlobalDiagnosticStats;
 use crate::diagnostics::rules::unused_dependencies;
 use crate::util::CargoResult;
 use crate::util::context::WarningHandling;
@@ -844,7 +844,7 @@ impl<'gctx> DrainState<'gctx> {
         self.progress.clear();
 
         if build_runner.bcx.gctx.cli_unstable().cargo_lints {
-            let mut global_stats = ScopedDiagnosticStats::new();
+            let mut global_stats = GlobalDiagnosticStats::new();
             drop(unused_dependencies::lint_build_results(
                 build_runner,
                 &mut global_stats,

--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -144,7 +144,7 @@ use crate::core::compiler::future_incompat::{
 };
 use crate::core::resolver::ResolveBehavior;
 use crate::core::{PackageId, TargetKind};
-use crate::diagnostics::DiagnosticStats;
+use crate::diagnostics::ScopedDiagnosticStats;
 use crate::diagnostics::rules::unused_dependencies;
 use crate::util::CargoResult;
 use crate::util::context::WarningHandling;
@@ -844,7 +844,7 @@ impl<'gctx> DrainState<'gctx> {
         self.progress.clear();
 
         if build_runner.bcx.gctx.cli_unstable().cargo_lints {
-            let mut global_stats = DiagnosticStats::new();
+            let mut global_stats = ScopedDiagnosticStats::new();
             drop(unused_dependencies::lint_build_results(
                 build_runner,
                 &mut global_stats,

--- a/src/cargo/diagnostics/mod.rs
+++ b/src/cargo/diagnostics/mod.rs
@@ -44,7 +44,7 @@
 //! When a diagnostic requires adding a new pass, keep in mind:
 //! - Support for `build.warnings`
 //! - When errors should block further evaluation within the pass
-//! - Providing a summary at the end, like what is provided by [`DiagnosticStats::report_summary`]
+//! - Providing a summary at the end, like what is provided by [`ScopedDiagnosticStats::report_summary`]
 //! - Prefer data driven passes to simplify adding rules
 //!   - Ensure the pass' lints are in [`rules::LINTS`], e.g. `ensure_parse_passed_in_lints`
 //!   - Prefer evaluating the lint level within the pass
@@ -72,13 +72,13 @@ pub use lint::{Lint, LintGroup, LintLevel, LintLevelProduct, LintLevelSource};
 pub use report::{AsIndex, get_key_value, get_key_value_span, rel_cwd_manifest_path};
 pub use rules::{LINT_GROUPS, LINTS};
 
-pub struct DiagnosticStats {
+pub struct ScopedDiagnosticStats {
     warning_count: usize,
     lint_warning_count: usize,
     error_count: usize,
 }
 
-impl DiagnosticStats {
+impl ScopedDiagnosticStats {
     pub fn new() -> Self {
         Self {
             warning_count: 0,
@@ -152,8 +152,8 @@ impl DiagnosticStats {
     }
 }
 
-impl std::ops::Add for DiagnosticStats {
-    type Output = DiagnosticStats;
+impl std::ops::Add for ScopedDiagnosticStats {
+    type Output = ScopedDiagnosticStats;
 
     fn add(mut self, rhs: Self) -> Self::Output {
         self += rhs;
@@ -161,9 +161,9 @@ impl std::ops::Add for DiagnosticStats {
     }
 }
 
-impl std::ops::AddAssign for DiagnosticStats {
+impl std::ops::AddAssign for ScopedDiagnosticStats {
     fn add_assign(&mut self, rhs: Self) {
-        let DiagnosticStats {
+        let ScopedDiagnosticStats {
             warning_count,
             lint_warning_count,
             error_count,

--- a/src/cargo/diagnostics/mod.rs
+++ b/src/cargo/diagnostics/mod.rs
@@ -72,21 +72,37 @@ pub use lint::{Lint, LintGroup, LintLevel, LintLevelProduct, LintLevelSource};
 pub use report::{AsIndex, get_key_value, get_key_value_span, rel_cwd_manifest_path};
 pub use rules::{LINT_GROUPS, LINTS};
 
-pub struct ScopedDiagnosticStats {
-    warning_count: usize,
-    lint_warning_count: usize,
+pub struct GlobalDiagnosticStats {
     error_count: usize,
 }
 
-impl ScopedDiagnosticStats {
+impl GlobalDiagnosticStats {
     pub fn new() -> Self {
-        Self {
+        Self { error_count: 0 }
+    }
+
+    pub fn scope(&mut self) -> ScopedDiagnosticStats<'_> {
+        ScopedDiagnosticStats {
             warning_count: 0,
             lint_warning_count: 0,
             error_count: 0,
+            global: self,
         }
     }
 
+    pub fn error_count(&self) -> usize {
+        self.error_count
+    }
+}
+
+pub struct ScopedDiagnosticStats<'g> {
+    warning_count: usize,
+    lint_warning_count: usize,
+    error_count: usize,
+    global: &'g mut GlobalDiagnosticStats,
+}
+
+impl ScopedDiagnosticStats<'_> {
     pub fn lint_warning_count(&self) -> usize {
         self.lint_warning_count
     }
@@ -105,6 +121,7 @@ impl ScopedDiagnosticStats {
 
     pub fn record_error(&mut self) {
         self.error_count += 1;
+        self.global.error_count += 1;
     }
 
     pub fn record_lint(&mut self, lint: LintLevel) {
@@ -149,28 +166,6 @@ impl ScopedDiagnosticStats {
         }
 
         Ok(())
-    }
-}
-
-impl std::ops::Add for ScopedDiagnosticStats {
-    type Output = ScopedDiagnosticStats;
-
-    fn add(mut self, rhs: Self) -> Self::Output {
-        self += rhs;
-        self
-    }
-}
-
-impl std::ops::AddAssign for ScopedDiagnosticStats {
-    fn add_assign(&mut self, rhs: Self) {
-        let ScopedDiagnosticStats {
-            warning_count,
-            lint_warning_count,
-            error_count,
-        } = rhs;
-        self.warning_count += warning_count;
-        self.lint_warning_count += lint_warning_count;
-        self.error_count += error_count;
     }
 }
 

--- a/src/cargo/diagnostics/mod.rs
+++ b/src/cargo/diagnostics/mod.rs
@@ -53,7 +53,6 @@
 //!
 //! [future-incompat lint]: https://rustc-dev-guide.rust-lang.org/diagnostics.html#future-incompatible-lints
 
-use anyhow::bail;
 use cargo_util_schemas::manifest::RustVersion;
 use cargo_util_schemas::manifest::TomlToolLints;
 
@@ -92,6 +91,16 @@ impl GlobalDiagnosticStats {
 
     pub fn error_count(&self) -> usize {
         self.error_count
+    }
+
+    pub fn ok(&self) -> CargoResult<()> {
+        if 0 < self.error_count {
+            Err(crate::Error::new(crate::AlreadyPrintedError::new(
+                anyhow::format_err!("see above"),
+            )))
+        } else {
+            Ok(())
+        }
     }
 }
 
@@ -137,6 +146,9 @@ impl ScopedDiagnosticStats<'_> {
         }
     }
 
+    /// Print a summary to the user
+    ///
+    /// **Note:** be sure to call `GlobalDiagnosticStats::ok` or equivalent to fail the operation
     pub fn report_summary(
         &self,
         action: &str,
@@ -159,10 +171,10 @@ impl ScopedDiagnosticStats<'_> {
             let name = name
                 .map(|n| format!("`{n}`"))
                 .unwrap_or_else(|| "workspace".to_owned());
-            bail!(
+            gctx.shell().error(format!(
                 "could not {action} {name} (manifest) due to {} previous error{plural}",
                 self.error_count
-            )
+            ))?;
         }
 
         Ok(())

--- a/src/cargo/diagnostics/passes.rs
+++ b/src/cargo/diagnostics/passes.rs
@@ -7,6 +7,7 @@ use crate::GlobalContext;
 use crate::core::MaybePackage;
 use crate::core::Package;
 use crate::core::Workspace;
+use crate::diagnostics::GlobalDiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevel;
 use crate::diagnostics::LintLevelProduct;
@@ -39,13 +40,13 @@ pub enum ParsePassRule<'r> {
 }
 
 type FnDiagnosticManifest =
-    fn(ManifestFor<'_>, &Path, &mut ScopedDiagnosticStats, &GlobalContext) -> CargoResult<()>;
+    fn(ManifestFor<'_>, &Path, &mut ScopedDiagnosticStats<'_>, &GlobalContext) -> CargoResult<()>;
 
 type FnDiagnosticWorkspace = fn(
     &Workspace<'_>,
     &MaybePackage,
     &Path,
-    &mut ScopedDiagnosticStats,
+    &mut ScopedDiagnosticStats<'_>,
     &GlobalContext,
 ) -> CargoResult<()>;
 
@@ -53,7 +54,7 @@ type FnDiagnosticPackage = fn(
     &Workspace<'_>,
     &Package,
     &Path,
-    &mut ScopedDiagnosticStats,
+    &mut ScopedDiagnosticStats<'_>,
     &GlobalContext,
 ) -> CargoResult<()>;
 
@@ -61,7 +62,7 @@ type FnLintManifest = fn(
     manifest: ManifestFor<'_>,
     manifest_path: &Path,
     LintLevelProduct,
-    stats: &mut ScopedDiagnosticStats,
+    stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()>;
 
@@ -70,7 +71,7 @@ type FnLintWorkspace = fn(
     &MaybePackage,
     &Path,
     LintLevelProduct,
-    &mut ScopedDiagnosticStats,
+    &mut ScopedDiagnosticStats<'_>,
     &GlobalContext,
 ) -> CargoResult<()>;
 
@@ -79,7 +80,7 @@ type FnLintPackage = fn(
     &Package,
     &Path,
     LintLevelProduct,
-    &mut ScopedDiagnosticStats,
+    &mut ScopedDiagnosticStats<'_>,
     &GlobalContext,
 ) -> CargoResult<()>;
 
@@ -87,16 +88,17 @@ pub fn emit_parse_diagnostics(
     workspace: &Workspace<'_>,
     rules: &[ParsePassRule<'_>],
 ) -> CargoResult<()> {
+    let mut stats = GlobalDiagnosticStats::new();
     let mut first_emitted_error = None;
 
-    if let Err(e) = emit_parse_ws_diagnostics(workspace, rules) {
+    if let Err(e) = emit_parse_ws_diagnostics(workspace, rules, &mut stats) {
         first_emitted_error = Some(e);
     }
 
     for maybe_pkg in workspace.loaded_maybe() {
         if let MaybePackage::Package(pkg) = maybe_pkg {
             let path = pkg.manifest_path();
-            if let Err(e) = emit_parse_pkg_diagnostics(workspace, pkg, &path, rules)
+            if let Err(e) = emit_parse_pkg_diagnostics(workspace, pkg, &path, rules, &mut stats)
                 && first_emitted_error.is_none()
             {
                 first_emitted_error = Some(e);
@@ -116,8 +118,9 @@ fn emit_parse_pkg_diagnostics(
     pkg: &Package,
     path: &Path,
     rules: &[ParsePassRule<'_>],
+    global_stats: &mut GlobalDiagnosticStats,
 ) -> CargoResult<()> {
-    let mut pkg_stats = ScopedDiagnosticStats::new();
+    let mut pkg_stats = global_stats.scope();
 
     let toml_lints = pkg
         .manifest()
@@ -181,8 +184,9 @@ fn emit_parse_pkg_diagnostics(
 fn emit_parse_ws_diagnostics(
     workspace: &Workspace<'_>,
     rules: &[ParsePassRule<'_>],
+    global_stats: &mut GlobalDiagnosticStats,
 ) -> CargoResult<()> {
-    let mut pkg_stats = ScopedDiagnosticStats::new();
+    let mut pkg_stats = global_stats.scope();
 
     let cargo_lints = match workspace.root_maybe() {
         MaybePackage::Package(pkg) => {

--- a/src/cargo/diagnostics/passes.rs
+++ b/src/cargo/diagnostics/passes.rs
@@ -7,11 +7,11 @@ use crate::GlobalContext;
 use crate::core::MaybePackage;
 use crate::core::Package;
 use crate::core::Workspace;
-use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevel;
 use crate::diagnostics::LintLevelProduct;
 use crate::diagnostics::ManifestFor;
+use crate::diagnostics::ScopedDiagnosticStats;
 
 #[derive(Clone)]
 pub enum ParsePassRule<'r> {
@@ -39,24 +39,29 @@ pub enum ParsePassRule<'r> {
 }
 
 type FnDiagnosticManifest =
-    fn(ManifestFor<'_>, &Path, &mut DiagnosticStats, &GlobalContext) -> CargoResult<()>;
+    fn(ManifestFor<'_>, &Path, &mut ScopedDiagnosticStats, &GlobalContext) -> CargoResult<()>;
 
 type FnDiagnosticWorkspace = fn(
     &Workspace<'_>,
     &MaybePackage,
     &Path,
-    &mut DiagnosticStats,
+    &mut ScopedDiagnosticStats,
     &GlobalContext,
 ) -> CargoResult<()>;
 
-type FnDiagnosticPackage =
-    fn(&Workspace<'_>, &Package, &Path, &mut DiagnosticStats, &GlobalContext) -> CargoResult<()>;
+type FnDiagnosticPackage = fn(
+    &Workspace<'_>,
+    &Package,
+    &Path,
+    &mut ScopedDiagnosticStats,
+    &GlobalContext,
+) -> CargoResult<()>;
 
 type FnLintManifest = fn(
     manifest: ManifestFor<'_>,
     manifest_path: &Path,
     LintLevelProduct,
-    stats: &mut DiagnosticStats,
+    stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()>;
 
@@ -65,7 +70,7 @@ type FnLintWorkspace = fn(
     &MaybePackage,
     &Path,
     LintLevelProduct,
-    &mut DiagnosticStats,
+    &mut ScopedDiagnosticStats,
     &GlobalContext,
 ) -> CargoResult<()>;
 
@@ -74,7 +79,7 @@ type FnLintPackage = fn(
     &Package,
     &Path,
     LintLevelProduct,
-    &mut DiagnosticStats,
+    &mut ScopedDiagnosticStats,
     &GlobalContext,
 ) -> CargoResult<()>;
 
@@ -112,7 +117,7 @@ fn emit_parse_pkg_diagnostics(
     path: &Path,
     rules: &[ParsePassRule<'_>],
 ) -> CargoResult<()> {
-    let mut pkg_stats = DiagnosticStats::new();
+    let mut pkg_stats = ScopedDiagnosticStats::new();
 
     let toml_lints = pkg
         .manifest()
@@ -177,7 +182,7 @@ fn emit_parse_ws_diagnostics(
     workspace: &Workspace<'_>,
     rules: &[ParsePassRule<'_>],
 ) -> CargoResult<()> {
-    let mut pkg_stats = DiagnosticStats::new();
+    let mut pkg_stats = ScopedDiagnosticStats::new();
 
     let cargo_lints = match workspace.root_maybe() {
         MaybePackage::Package(pkg) => {

--- a/src/cargo/diagnostics/passes.rs
+++ b/src/cargo/diagnostics/passes.rs
@@ -89,28 +89,17 @@ pub fn emit_parse_diagnostics(
     rules: &[ParsePassRule<'_>],
 ) -> CargoResult<()> {
     let mut stats = GlobalDiagnosticStats::new();
-    let mut first_emitted_error = None;
 
-    if let Err(e) = emit_parse_ws_diagnostics(workspace, rules, &mut stats) {
-        first_emitted_error = Some(e);
-    }
+    emit_parse_ws_diagnostics(workspace, rules, &mut stats)?;
 
     for maybe_pkg in workspace.loaded_maybe() {
         if let MaybePackage::Package(pkg) = maybe_pkg {
             let path = pkg.manifest_path();
-            if let Err(e) = emit_parse_pkg_diagnostics(workspace, pkg, &path, rules, &mut stats)
-                && first_emitted_error.is_none()
-            {
-                first_emitted_error = Some(e);
-            }
+            emit_parse_pkg_diagnostics(workspace, pkg, &path, rules, &mut stats)?;
         }
     }
 
-    if let Some(error) = first_emitted_error {
-        Err(error)
-    } else {
-        Ok(())
-    }
+    stats.ok()
 }
 
 fn emit_parse_pkg_diagnostics(

--- a/src/cargo/diagnostics/rules/blanket_hint_mostly_unused.rs
+++ b/src/cargo/diagnostics/rules/blanket_hint_mostly_unused.rs
@@ -61,7 +61,7 @@ pub(crate) fn lint_workspace(
     maybe_pkg: &MaybePackage,
     path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {

--- a/src/cargo/diagnostics/rules/blanket_hint_mostly_unused.rs
+++ b/src/cargo/diagnostics/rules/blanket_hint_mostly_unused.rs
@@ -14,9 +14,9 @@ use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::MaybePackage;
 use crate::core::Workspace;
-use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevelProduct;
+use crate::diagnostics::ScopedDiagnosticStats;
 use crate::diagnostics::get_key_value_span;
 use crate::diagnostics::rel_cwd_manifest_path;
 
@@ -61,7 +61,7 @@ pub(crate) fn lint_workspace(
     maybe_pkg: &MaybePackage,
     path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {

--- a/src/cargo/diagnostics/rules/deferred_parse_diagnostics.rs
+++ b/src/cargo/diagnostics/rules/deferred_parse_diagnostics.rs
@@ -5,15 +5,15 @@ use tracing::instrument;
 use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::MaybePackage;
-use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::ManifestFor;
+use crate::diagnostics::ScopedDiagnosticStats;
 use crate::diagnostics::rel_cwd_manifest_path;
 
 #[instrument(skip_all)]
 pub(crate) fn diagnose_manifest(
     manifest: ManifestFor<'_>,
     manifest_path: &Path,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let warnings = match &manifest {

--- a/src/cargo/diagnostics/rules/deferred_parse_diagnostics.rs
+++ b/src/cargo/diagnostics/rules/deferred_parse_diagnostics.rs
@@ -13,7 +13,7 @@ use crate::diagnostics::rel_cwd_manifest_path;
 pub(crate) fn diagnose_manifest(
     manifest: ManifestFor<'_>,
     manifest_path: &Path,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let warnings = match &manifest {

--- a/src/cargo/diagnostics/rules/im_a_teapot.rs
+++ b/src/cargo/diagnostics/rules/im_a_teapot.rs
@@ -13,9 +13,9 @@ use crate::GlobalContext;
 use crate::core::Feature;
 use crate::core::Package;
 use crate::core::Workspace;
-use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevelProduct;
+use crate::diagnostics::ScopedDiagnosticStats;
 use crate::diagnostics::get_key_value_span;
 use crate::diagnostics::rel_cwd_manifest_path;
 
@@ -35,7 +35,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let manifest = pkg.manifest();

--- a/src/cargo/diagnostics/rules/im_a_teapot.rs
+++ b/src/cargo/diagnostics/rules/im_a_teapot.rs
@@ -35,7 +35,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let manifest = pkg.manifest();

--- a/src/cargo/diagnostics/rules/implicit_minimum_version_req.rs
+++ b/src/cargo/diagnostics/rules/implicit_minimum_version_req.rs
@@ -19,11 +19,11 @@ use crate::core::Manifest;
 use crate::core::MaybePackage;
 use crate::core::Package;
 use crate::core::Workspace;
-use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevel;
 use crate::diagnostics::LintLevelProduct;
 use crate::diagnostics::LintLevelSource;
+use crate::diagnostics::ScopedDiagnosticStats;
 use crate::diagnostics::get_key_value;
 use crate::diagnostics::rel_cwd_manifest_path;
 use crate::util::OptVersionReq;
@@ -90,7 +90,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -151,7 +151,7 @@ pub(crate) fn lint_workspace(
     maybe_pkg: &MaybePackage,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {

--- a/src/cargo/diagnostics/rules/implicit_minimum_version_req.rs
+++ b/src/cargo/diagnostics/rules/implicit_minimum_version_req.rs
@@ -90,7 +90,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -151,7 +151,7 @@ pub(crate) fn lint_workspace(
     maybe_pkg: &MaybePackage,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {

--- a/src/cargo/diagnostics/rules/missing_lints_features.rs
+++ b/src/cargo/diagnostics/rules/missing_lints_features.rs
@@ -21,7 +21,7 @@ use crate::diagnostics::rel_cwd_manifest_path;
 pub(crate) fn diagnose_manifest(
     manifest: ManifestFor<'_>,
     manifest_path: &Path,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let normalized_toml = match &manifest {
@@ -64,7 +64,7 @@ fn diagnose_manifest_inner(
     manifest: &ManifestFor<'_>,
     manifest_path: &Path,
     cargo_lints: &manifest::TomlToolLints,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
@@ -104,7 +104,7 @@ fn report_feature_not_enabled(
     feature_gate: &Feature,
     manifest: &ManifestFor<'_>,
     manifest_path: &str,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let dash_feature_name = feature_gate.name().replace("_", "-");

--- a/src/cargo/diagnostics/rules/missing_lints_features.rs
+++ b/src/cargo/diagnostics/rules/missing_lints_features.rs
@@ -12,8 +12,8 @@ use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::Feature;
 use crate::core::MaybePackage;
-use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::ManifestFor;
+use crate::diagnostics::ScopedDiagnosticStats;
 use crate::diagnostics::get_key_value_span;
 use crate::diagnostics::rel_cwd_manifest_path;
 
@@ -21,7 +21,7 @@ use crate::diagnostics::rel_cwd_manifest_path;
 pub(crate) fn diagnose_manifest(
     manifest: ManifestFor<'_>,
     manifest_path: &Path,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let normalized_toml = match &manifest {
@@ -64,7 +64,7 @@ fn diagnose_manifest_inner(
     manifest: &ManifestFor<'_>,
     manifest_path: &Path,
     cargo_lints: &manifest::TomlToolLints,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let manifest_path = rel_cwd_manifest_path(manifest_path, gctx);
@@ -104,7 +104,7 @@ fn report_feature_not_enabled(
     feature_gate: &Feature,
     manifest: &ManifestFor<'_>,
     manifest_path: &str,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let dash_feature_name = feature_gate.name().replace("_", "-");

--- a/src/cargo/diagnostics/rules/missing_lints_inheritance.rs
+++ b/src/cargo/diagnostics/rules/missing_lints_inheritance.rs
@@ -59,7 +59,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {

--- a/src/cargo/diagnostics/rules/missing_lints_inheritance.rs
+++ b/src/cargo/diagnostics/rules/missing_lints_inheritance.rs
@@ -12,9 +12,9 @@ use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::Package;
 use crate::core::Workspace;
-use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevelProduct;
+use crate::diagnostics::ScopedDiagnosticStats;
 use crate::diagnostics::rel_cwd_manifest_path;
 
 pub static LINT: &Lint = &Lint {
@@ -59,7 +59,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {

--- a/src/cargo/diagnostics/rules/non_kebab_case_bins.rs
+++ b/src/cargo/diagnostics/rules/non_kebab_case_bins.rs
@@ -69,7 +69,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -88,7 +88,7 @@ fn lint_package_inner(
     manifest_path: &str,
     lint_level: LintLevel,
     source: LintLevelSource,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let manifest = pkg.manifest();

--- a/src/cargo/diagnostics/rules/non_kebab_case_bins.rs
+++ b/src/cargo/diagnostics/rules/non_kebab_case_bins.rs
@@ -14,11 +14,11 @@ use crate::GlobalContext;
 use crate::core::Package;
 use crate::core::Workspace;
 use crate::diagnostics::AsIndex;
-use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevel;
 use crate::diagnostics::LintLevelProduct;
 use crate::diagnostics::LintLevelSource;
+use crate::diagnostics::ScopedDiagnosticStats;
 use crate::diagnostics::get_key_value_span;
 use crate::diagnostics::rel_cwd_manifest_path;
 
@@ -69,7 +69,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -88,7 +88,7 @@ fn lint_package_inner(
     manifest_path: &str,
     lint_level: LintLevel,
     source: LintLevelSource,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let manifest = pkg.manifest();

--- a/src/cargo/diagnostics/rules/non_kebab_case_features.rs
+++ b/src/cargo/diagnostics/rules/non_kebab_case_features.rs
@@ -64,7 +64,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -82,7 +82,7 @@ fn lint_package_inner(
     manifest_path: &str,
     lint_level: LintLevel,
     source: LintLevelSource,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     for original_name in pkg.summary().features().keys() {

--- a/src/cargo/diagnostics/rules/non_kebab_case_features.rs
+++ b/src/cargo/diagnostics/rules/non_kebab_case_features.rs
@@ -13,11 +13,11 @@ use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::Package;
 use crate::core::Workspace;
-use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevel;
 use crate::diagnostics::LintLevelProduct;
 use crate::diagnostics::LintLevelSource;
+use crate::diagnostics::ScopedDiagnosticStats;
 use crate::diagnostics::get_key_value_span;
 use crate::diagnostics::rel_cwd_manifest_path;
 
@@ -64,7 +64,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -82,7 +82,7 @@ fn lint_package_inner(
     manifest_path: &str,
     lint_level: LintLevel,
     source: LintLevelSource,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     for original_name in pkg.summary().features().keys() {

--- a/src/cargo/diagnostics/rules/non_kebab_case_packages.rs
+++ b/src/cargo/diagnostics/rules/non_kebab_case_packages.rs
@@ -64,7 +64,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -82,7 +82,7 @@ fn lint_package_inner(
     manifest_path: &str,
     lint_level: LintLevel,
     source: LintLevelSource,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let manifest = pkg.manifest();

--- a/src/cargo/diagnostics/rules/non_kebab_case_packages.rs
+++ b/src/cargo/diagnostics/rules/non_kebab_case_packages.rs
@@ -13,11 +13,11 @@ use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::Package;
 use crate::core::Workspace;
-use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevel;
 use crate::diagnostics::LintLevelProduct;
 use crate::diagnostics::LintLevelSource;
+use crate::diagnostics::ScopedDiagnosticStats;
 use crate::diagnostics::get_key_value_span;
 use crate::diagnostics::rel_cwd_manifest_path;
 
@@ -64,7 +64,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -82,7 +82,7 @@ fn lint_package_inner(
     manifest_path: &str,
     lint_level: LintLevel,
     source: LintLevelSource,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let manifest = pkg.manifest();

--- a/src/cargo/diagnostics/rules/non_snake_case_features.rs
+++ b/src/cargo/diagnostics/rules/non_snake_case_features.rs
@@ -64,7 +64,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -82,7 +82,7 @@ fn lint_package_inner(
     manifest_path: &str,
     lint_level: LintLevel,
     source: LintLevelSource,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     for original_name in pkg.summary().features().keys() {

--- a/src/cargo/diagnostics/rules/non_snake_case_features.rs
+++ b/src/cargo/diagnostics/rules/non_snake_case_features.rs
@@ -13,11 +13,11 @@ use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::Package;
 use crate::core::Workspace;
-use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevel;
 use crate::diagnostics::LintLevelProduct;
 use crate::diagnostics::LintLevelSource;
+use crate::diagnostics::ScopedDiagnosticStats;
 use crate::diagnostics::get_key_value_span;
 use crate::diagnostics::rel_cwd_manifest_path;
 
@@ -64,7 +64,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -82,7 +82,7 @@ fn lint_package_inner(
     manifest_path: &str,
     lint_level: LintLevel,
     source: LintLevelSource,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     for original_name in pkg.summary().features().keys() {

--- a/src/cargo/diagnostics/rules/non_snake_case_packages.rs
+++ b/src/cargo/diagnostics/rules/non_snake_case_packages.rs
@@ -64,7 +64,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -82,7 +82,7 @@ fn lint_package_inner(
     manifest_path: &str,
     lint_level: LintLevel,
     source: LintLevelSource,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let manifest = pkg.manifest();

--- a/src/cargo/diagnostics/rules/non_snake_case_packages.rs
+++ b/src/cargo/diagnostics/rules/non_snake_case_packages.rs
@@ -13,11 +13,11 @@ use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::Package;
 use crate::core::Workspace;
-use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevel;
 use crate::diagnostics::LintLevelProduct;
 use crate::diagnostics::LintLevelSource;
+use crate::diagnostics::ScopedDiagnosticStats;
 use crate::diagnostics::get_key_value_span;
 use crate::diagnostics::rel_cwd_manifest_path;
 
@@ -64,7 +64,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -82,7 +82,7 @@ fn lint_package_inner(
     manifest_path: &str,
     lint_level: LintLevel,
     source: LintLevelSource,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let manifest = pkg.manifest();

--- a/src/cargo/diagnostics/rules/redundant_homepage.rs
+++ b/src/cargo/diagnostics/rules/redundant_homepage.rs
@@ -68,7 +68,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -86,7 +86,7 @@ fn lint_package_inner(
     manifest_path: &str,
     lint_level: LintLevel,
     source: LintLevelSource,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let manifest = pkg.manifest();

--- a/src/cargo/diagnostics/rules/redundant_homepage.rs
+++ b/src/cargo/diagnostics/rules/redundant_homepage.rs
@@ -14,11 +14,11 @@ use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::Package;
 use crate::core::Workspace;
-use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevel;
 use crate::diagnostics::LintLevelProduct;
 use crate::diagnostics::LintLevelSource;
+use crate::diagnostics::ScopedDiagnosticStats;
 use crate::diagnostics::get_key_value_span;
 use crate::diagnostics::rel_cwd_manifest_path;
 
@@ -68,7 +68,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -86,7 +86,7 @@ fn lint_package_inner(
     manifest_path: &str,
     lint_level: LintLevel,
     source: LintLevelSource,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let manifest = pkg.manifest();

--- a/src/cargo/diagnostics/rules/redundant_readme.rs
+++ b/src/cargo/diagnostics/rules/redundant_readme.rs
@@ -70,7 +70,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -88,7 +88,7 @@ fn lint_package_inner(
     manifest_path: &str,
     lint_level: LintLevel,
     source: LintLevelSource,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let manifest = pkg.manifest();

--- a/src/cargo/diagnostics/rules/redundant_readme.rs
+++ b/src/cargo/diagnostics/rules/redundant_readme.rs
@@ -15,11 +15,11 @@ use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::Package;
 use crate::core::Workspace;
-use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevel;
 use crate::diagnostics::LintLevelProduct;
 use crate::diagnostics::LintLevelSource;
+use crate::diagnostics::ScopedDiagnosticStats;
 use crate::diagnostics::get_key_value_span;
 use crate::diagnostics::rel_cwd_manifest_path;
 use crate::util::toml::DEFAULT_README_FILES;
@@ -70,7 +70,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -88,7 +88,7 @@ fn lint_package_inner(
     manifest_path: &str,
     lint_level: LintLevel,
     source: LintLevelSource,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let manifest = pkg.manifest();

--- a/src/cargo/diagnostics/rules/text_direction_codepoint_in_comment.rs
+++ b/src/cargo/diagnostics/rules/text_direction_codepoint_in_comment.rs
@@ -51,7 +51,7 @@ pub(crate) fn lint_manifest(
     manifest: ManifestFor<'_>,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {

--- a/src/cargo/diagnostics/rules/text_direction_codepoint_in_comment.rs
+++ b/src/cargo/diagnostics/rules/text_direction_codepoint_in_comment.rs
@@ -16,10 +16,10 @@ use super::CORRECTNESS;
 use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::MaybePackage;
-use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevelProduct;
 use crate::diagnostics::ManifestFor;
+use crate::diagnostics::ScopedDiagnosticStats;
 use crate::diagnostics::rel_cwd_manifest_path;
 
 pub static LINT: &Lint = &Lint {
@@ -51,7 +51,7 @@ pub(crate) fn lint_manifest(
     manifest: ManifestFor<'_>,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {

--- a/src/cargo/diagnostics/rules/text_direction_codepoint_in_literal.rs
+++ b/src/cargo/diagnostics/rules/text_direction_codepoint_in_literal.rs
@@ -52,7 +52,7 @@ pub(crate) fn lint_manifest(
     manifest: ManifestFor<'_>,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {

--- a/src/cargo/diagnostics/rules/text_direction_codepoint_in_literal.rs
+++ b/src/cargo/diagnostics/rules/text_direction_codepoint_in_literal.rs
@@ -17,10 +17,10 @@ use super::CORRECTNESS;
 use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::MaybePackage;
-use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevelProduct;
 use crate::diagnostics::ManifestFor;
+use crate::diagnostics::ScopedDiagnosticStats;
 use crate::diagnostics::rel_cwd_manifest_path;
 
 pub static LINT: &Lint = &Lint {
@@ -52,7 +52,7 @@ pub(crate) fn lint_manifest(
     manifest: ManifestFor<'_>,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {

--- a/src/cargo/diagnostics/rules/unknown_lints.rs
+++ b/src/cargo/diagnostics/rules/unknown_lints.rs
@@ -53,7 +53,7 @@ pub(crate) fn lint_manifest(
     manifest: ManifestFor<'_>,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let normalized_toml = match &manifest {
@@ -111,7 +111,7 @@ fn lint_manifest_inner(
     manifest_path: &Path,
     level: &LintLevelProduct,
     cargo_lints: &TomlToolLints,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {

--- a/src/cargo/diagnostics/rules/unknown_lints.rs
+++ b/src/cargo/diagnostics/rules/unknown_lints.rs
@@ -15,10 +15,10 @@ use super::find_lint_or_group;
 use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::MaybePackage;
-use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevelProduct;
 use crate::diagnostics::ManifestFor;
+use crate::diagnostics::ScopedDiagnosticStats;
 use crate::diagnostics::get_key_value_span;
 use crate::diagnostics::rel_cwd_manifest_path;
 
@@ -53,7 +53,7 @@ pub(crate) fn lint_manifest(
     manifest: ManifestFor<'_>,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let normalized_toml = match &manifest {
@@ -111,7 +111,7 @@ fn lint_manifest_inner(
     manifest_path: &Path,
     level: &LintLevelProduct,
     cargo_lints: &TomlToolLints,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {

--- a/src/cargo/diagnostics/rules/unused_dependencies.rs
+++ b/src/cargo/diagnostics/rules/unused_dependencies.rs
@@ -23,10 +23,10 @@ use crate::core::compiler::Unit;
 use crate::core::compiler::unused_deps::DependenciesState;
 use crate::core::compiler::unused_deps::UnusedDepState;
 use crate::core::dependency::DepKind;
-use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevel;
 use crate::diagnostics::LintLevelProduct;
+use crate::diagnostics::ScopedDiagnosticStats;
 use crate::diagnostics::get_key_value_span;
 use crate::diagnostics::rel_cwd_manifest_path;
 
@@ -99,7 +99,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -172,7 +172,7 @@ pub(crate) fn lint_package(
 #[instrument(skip_all)]
 pub fn lint_build_results(
     build_runner: &BuildRunner<'_, '_>,
-    global_stats: &mut DiagnosticStats,
+    global_stats: &mut ScopedDiagnosticStats,
 ) -> CargoResult<()> {
     for (pkg_id, states) in &build_runner.unused_dep_state.states {
         let Some(pkg) = get_package(&build_runner.unused_dep_state, pkg_id) else {
@@ -207,7 +207,7 @@ pub fn lint_build_results(
             continue;
         }
 
-        let mut pkg_stats = DiagnosticStats::new();
+        let mut pkg_stats = ScopedDiagnosticStats::new();
         lint_package_build_results(build_runner, pkg, states, level, &mut pkg_stats)?;
         // HACK: as other rules are added to this pass, this needs to move up into the pass
         if let Err(error) =
@@ -225,7 +225,7 @@ fn lint_package_build_results(
     pkg: &Package,
     states: &IndexMap<DepKind, DependenciesState>,
     level: LintLevelProduct,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
 ) -> CargoResult<()> {
     let mut lint_count = 0;
     let LintLevelProduct {

--- a/src/cargo/diagnostics/rules/unused_dependencies.rs
+++ b/src/cargo/diagnostics/rules/unused_dependencies.rs
@@ -210,12 +210,7 @@ pub fn lint_build_results(
 
         let mut pkg_stats = global_stats.scope();
         lint_package_build_results(build_runner, pkg, states, level, &mut pkg_stats)?;
-        // HACK: as other rules are added to this pass, this needs to move up into the pass
-        if let Err(error) =
-            pkg_stats.report_summary("finalize", Some(&*pkg.name()), build_runner.bcx.gctx)
-        {
-            build_runner.bcx.gctx.shell().error(error)?;
-        }
+        pkg_stats.report_summary("finalize", Some(&*pkg.name()), build_runner.bcx.gctx)?;
     }
     Ok(())
 }

--- a/src/cargo/diagnostics/rules/unused_dependencies.rs
+++ b/src/cargo/diagnostics/rules/unused_dependencies.rs
@@ -23,6 +23,7 @@ use crate::core::compiler::Unit;
 use crate::core::compiler::unused_deps::DependenciesState;
 use crate::core::compiler::unused_deps::UnusedDepState;
 use crate::core::dependency::DepKind;
+use crate::diagnostics::GlobalDiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevel;
 use crate::diagnostics::LintLevelProduct;
@@ -99,7 +100,7 @@ pub(crate) fn lint_package(
     pkg: &Package,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {
@@ -172,7 +173,7 @@ pub(crate) fn lint_package(
 #[instrument(skip_all)]
 pub fn lint_build_results(
     build_runner: &BuildRunner<'_, '_>,
-    global_stats: &mut ScopedDiagnosticStats,
+    global_stats: &mut GlobalDiagnosticStats,
 ) -> CargoResult<()> {
     for (pkg_id, states) in &build_runner.unused_dep_state.states {
         let Some(pkg) = get_package(&build_runner.unused_dep_state, pkg_id) else {
@@ -207,7 +208,7 @@ pub fn lint_build_results(
             continue;
         }
 
-        let mut pkg_stats = ScopedDiagnosticStats::new();
+        let mut pkg_stats = global_stats.scope();
         lint_package_build_results(build_runner, pkg, states, level, &mut pkg_stats)?;
         // HACK: as other rules are added to this pass, this needs to move up into the pass
         if let Err(error) =
@@ -215,7 +216,6 @@ pub fn lint_build_results(
         {
             build_runner.bcx.gctx.shell().error(error)?;
         }
-        *global_stats += pkg_stats;
     }
     Ok(())
 }
@@ -225,7 +225,7 @@ fn lint_package_build_results(
     pkg: &Package,
     states: &IndexMap<DepKind, DependenciesState>,
     level: LintLevelProduct,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
 ) -> CargoResult<()> {
     let mut lint_count = 0;
     let LintLevelProduct {

--- a/src/cargo/diagnostics/rules/unused_workspace_dependencies.rs
+++ b/src/cargo/diagnostics/rules/unused_workspace_dependencies.rs
@@ -52,7 +52,7 @@ pub(crate) fn lint_workspace(
     maybe_pkg: &MaybePackage,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {

--- a/src/cargo/diagnostics/rules/unused_workspace_dependencies.rs
+++ b/src/cargo/diagnostics/rules/unused_workspace_dependencies.rs
@@ -15,9 +15,9 @@ use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::MaybePackage;
 use crate::core::Workspace;
-use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevelProduct;
+use crate::diagnostics::ScopedDiagnosticStats;
 use crate::diagnostics::get_key_value_span;
 use crate::diagnostics::rel_cwd_manifest_path;
 
@@ -52,7 +52,7 @@ pub(crate) fn lint_workspace(
     maybe_pkg: &MaybePackage,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {

--- a/src/cargo/diagnostics/rules/unused_workspace_package_fields.rs
+++ b/src/cargo/diagnostics/rules/unused_workspace_package_fields.rs
@@ -52,7 +52,7 @@ pub(crate) fn lint_workspace(
     maybe_pkg: &MaybePackage,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut ScopedDiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {

--- a/src/cargo/diagnostics/rules/unused_workspace_package_fields.rs
+++ b/src/cargo/diagnostics/rules/unused_workspace_package_fields.rs
@@ -14,9 +14,9 @@ use crate::CargoResult;
 use crate::GlobalContext;
 use crate::core::MaybePackage;
 use crate::core::Workspace;
-use crate::diagnostics::DiagnosticStats;
 use crate::diagnostics::Lint;
 use crate::diagnostics::LintLevelProduct;
+use crate::diagnostics::ScopedDiagnosticStats;
 use crate::diagnostics::get_key_value_span;
 use crate::diagnostics::rel_cwd_manifest_path;
 
@@ -52,7 +52,7 @@ pub(crate) fn lint_workspace(
     maybe_pkg: &MaybePackage,
     manifest_path: &Path,
     level: LintLevelProduct,
-    pkg_stats: &mut DiagnosticStats,
+    pkg_stats: &mut ScopedDiagnosticStats,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     let LintLevelProduct {

--- a/tests/testsuite/lints/mod.rs
+++ b/tests/testsuite/lints/mod.rs
@@ -385,6 +385,7 @@ authors = []
   | ^^^^^^^^^^^^^^^^^^^ this is behind `test-dummy-unstable`, which is not enabled
   |
   = [HELP] consider adding `cargo-features = ["test-dummy-unstable"]` to the top of the manifest
+[ERROR] could not parse workspace (manifest) due to 2 previous errors
 [WARNING] missing `[lints]` to inherit `[workspace.lints]`
  --> foo/Cargo.toml
   = [NOTE] `cargo::missing_lints_inheritance` is set to `warn` by default
@@ -400,7 +401,6 @@ authors = []
 8 + [lints]
   |
 [WARNING] `foo` (manifest) generated 1 warning
-[ERROR] could not parse workspace (manifest) due to 2 previous errors
 
 "#]])
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

This makes the two existing passes more consistent.
The downside is that if there is an error, that might not be the final message.
This is already the case with `--keep-going` (see [#t-cargo > &#96;--keep-going&#96; and compilation errors @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/.60--keep-going.60.20and.20compilation.20errors/near/595741468)).

We may want to iterate on this further and stop after the current manifest/package unless `--keep-going` is provided.

### How to test and review this PR?

