### PR TITLE
feat(cli): add trustpub subcommand

### DIFF
--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -161,6 +161,24 @@ pub struct GitHubConfig {
 struct GitHubConfigs {
     github_configs: Vec<GitHubConfig>,
 }
+#[derive(Deserialize)]
+struct GitHubConfigResponse {
+    github_config: GitHubConfig,
+}
+#[derive(Serialize)]
+struct NewGitHubConfig<'a> {
+    #[serde(rename = "crate")]
+    krate: &'a str,
+    repository_owner: &'a str,
+    repository_name: &'a str,
+    workflow_filename: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    environment: Option<&'a str>,
+}
+#[derive(Serialize)]
+struct NewGitHubConfigReq<'a> {
+    github_config: NewGitHubConfig<'a>,
+}
 
 /// Error returned when interacting with a registry.
 #[derive(Debug, thiserror::Error)]
@@ -303,6 +321,27 @@ impl<T: HttpClient> Registry<T> {
         Ok(serde_json::from_str::<GitHubConfigs>(&body)?.github_configs)
     }
 
+    pub fn add_github_trustpub_config(
+        &mut self,
+        krate: &str,
+        repository_owner: &str,
+        repository_name: &str,
+        workflow_filename: &str,
+        environment: Option<&str>,
+    ) -> RegistryResult<GitHubConfig, T::Error> {
+        let body = serde_json::to_string(&NewGitHubConfigReq {
+            github_config: NewGitHubConfig {
+                krate,
+                repository_owner,
+                repository_name,
+                workflow_filename,
+                environment,
+            },
+        })?;
+        let body = self.post("/trusted_publishing/github_configs", Some(body.as_bytes()))?;
+        Ok(serde_json::from_str::<GitHubConfigResponse>(&body)?.github_config)
+    }
+
     pub fn publish(
         &mut self,
         krate: &NewCrate,
@@ -417,6 +456,10 @@ impl<T: HttpClient> Registry<T> {
 
     fn put(&mut self, path: &str, b: Option<&[u8]>) -> RegistryResult<String, T::Error> {
         self.req(Method::PUT, path, b, Auth::Authorized)
+    }
+
+    fn post(&mut self, path: &str, b: Option<&[u8]>) -> RegistryResult<String, T::Error> {
+        self.req(Method::POST, path, b, Auth::Authorized)
     }
 
     fn get(&mut self, path: &str) -> RegistryResult<String, T::Error> {

--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -145,6 +145,23 @@ struct Crates {
     meta: TotalCrates,
 }
 
+#[derive(Deserialize)]
+pub struct GitHubConfig {
+    pub id: u32,
+    #[serde(rename = "crate")]
+    pub krate: String,
+    pub repository_owner: String,
+    pub repository_owner_id: Option<u32>,
+    pub repository_name: String,
+    pub workflow_filename: String,
+    pub environment: Option<String>,
+    pub created_at: Option<String>,
+}
+#[derive(Deserialize)]
+struct GitHubConfigs {
+    github_configs: Vec<GitHubConfig>,
+}
+
 /// Error returned when interacting with a registry.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
@@ -272,6 +289,18 @@ impl<T: HttpClient> Registry<T> {
     pub fn list_owners(&mut self, krate: &str) -> RegistryResult<Vec<User>, T::Error> {
         let body = self.get(&format!("/crates/{}/owners", krate))?;
         Ok(serde_json::from_str::<Users>(&body)?.users)
+    }
+
+    pub fn list_github_trustpub_configs(
+        &mut self,
+        krate: &str,
+    ) -> RegistryResult<Vec<GitHubConfig>, T::Error> {
+        let krate = percent_encode(krate.as_bytes(), NON_ALPHANUMERIC);
+        let body = self.get(&format!(
+            "/trusted_publishing/github_configs?crate={}",
+            krate
+        ))?;
+        Ok(serde_json::from_str::<GitHubConfigs>(&body)?.github_configs)
     }
 
     pub fn publish(

--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -179,6 +179,15 @@ struct NewGitHubConfig<'a> {
 struct NewGitHubConfigReq<'a> {
     github_config: NewGitHubConfig<'a>,
 }
+#[derive(Serialize)]
+struct CrateUpdate {
+    trustpub_only: bool,
+}
+#[derive(Serialize)]
+struct CrateUpdateReq {
+    #[serde(rename = "crate")]
+    krate: CrateUpdate,
+}
 
 /// Error returned when interacting with a registry.
 #[derive(Debug, thiserror::Error)]
@@ -350,6 +359,18 @@ impl<T: HttpClient> Registry<T> {
         Ok(())
     }
 
+    pub fn set_trustpub_only(
+        &mut self,
+        krate: &str,
+        trustpub_only: bool,
+    ) -> RegistryResult<(), T::Error> {
+        let body = serde_json::to_string(&CrateUpdateReq {
+            krate: CrateUpdate { trustpub_only },
+        })?;
+        self.patch(&format!("/crates/{}", krate), Some(body.as_bytes()))?;
+        Ok(())
+    }
+
     pub fn publish(
         &mut self,
         krate: &NewCrate,
@@ -468,6 +489,10 @@ impl<T: HttpClient> Registry<T> {
 
     fn post(&mut self, path: &str, b: Option<&[u8]>) -> RegistryResult<String, T::Error> {
         self.req(Method::POST, path, b, Auth::Authorized)
+    }
+
+    fn patch(&mut self, path: &str, b: Option<&[u8]>) -> RegistryResult<String, T::Error> {
+        self.req(Method::PATCH, path, b, Auth::Authorized)
     }
 
     fn get(&mut self, path: &str) -> RegistryResult<String, T::Error> {

--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -352,10 +352,7 @@ impl<T: HttpClient> Registry<T> {
     }
 
     pub fn remove_github_trustpub_config(&mut self, id: u32) -> RegistryResult<(), T::Error> {
-        self.delete(
-            &format!("/trusted_publishing/github_configs/{}", id),
-            None,
-        )?;
+        self.delete(&format!("/trusted_publishing/github_configs/{}", id), None)?;
         Ok(())
     }
 

--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -342,6 +342,14 @@ impl<T: HttpClient> Registry<T> {
         Ok(serde_json::from_str::<GitHubConfigResponse>(&body)?.github_config)
     }
 
+    pub fn remove_github_trustpub_config(&mut self, id: u32) -> RegistryResult<(), T::Error> {
+        self.delete(
+            &format!("/trusted_publishing/github_configs/{}", id),
+            None,
+        )?;
+        Ok(())
+    }
+
     pub fn publish(
         &mut self,
         krate: &NewCrate,

--- a/src/bin/cargo/commands/mod.rs
+++ b/src/bin/cargo/commands/mod.rs
@@ -35,6 +35,7 @@ pub fn builtin() -> Vec<Command> {
         search::cli(),
         test::cli(),
         tree::cli(),
+        trustpub::cli(),
         uninstall::cli(),
         update::cli(),
         vendor::cli(),
@@ -81,6 +82,7 @@ pub fn builtin_exec(cmd: &str) -> Option<Exec> {
         "search" => search::exec,
         "test" => test::exec,
         "tree" => tree::exec,
+        "trustpub" => trustpub::exec,
         "uninstall" => uninstall::exec,
         "update" => update::exec,
         "vendor" => vendor::exec,
@@ -125,6 +127,7 @@ pub mod rustdoc;
 pub mod search;
 pub mod test;
 pub mod tree;
+pub mod trustpub;
 pub mod uninstall;
 pub mod update;
 pub mod vendor;

--- a/src/bin/cargo/commands/trustpub.rs
+++ b/src/bin/cargo/commands/trustpub.rs
@@ -1,0 +1,39 @@
+use crate::command_prelude::*;
+
+use cargo::ops::{self, TrustpubCommand, TrustpubOptions};
+use cargo_credential::Secret;
+
+pub fn cli() -> Command {
+    subcommand("trustpub")
+        .about("Manage Trusted Publishing configuration for a crate on the registry")
+        .subcommand_required(true)
+        .arg_required_else_help(true)
+        .arg(
+            opt("crate", "Crate to operate on")
+                .value_name("CRATE")
+                .global(true),
+        )
+        .arg(
+            opt("token", "API token to use when authenticating")
+                .value_name("TOKEN")
+                .global(true),
+        )
+        .arg_silent_suggestion()
+        .subcommand(subcommand("list").about("List the Trusted Publishing configs for a crate"))
+}
+
+pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
+    let command = match args.subcommand() {
+        Some(("list", _)) => TrustpubCommand::List,
+        Some((cmd, _)) => unreachable!("unexpected command {}", cmd),
+        None => unreachable!("unexpected command"),
+    };
+
+    let opts = TrustpubOptions {
+        krate: args.get_one::<String>("crate").cloned(),
+        token: args.get_one::<String>("token").cloned().map(Secret::from),
+        command,
+    };
+    ops::trusted_publish(gctx, &opts)?;
+    Ok(())
+}

--- a/src/bin/cargo/commands/trustpub.rs
+++ b/src/bin/cargo/commands/trustpub.rs
@@ -43,6 +43,16 @@ pub fn cli() -> Command {
                         .value_name("ENV"),
                 ),
         )
+        .subcommand(
+            subcommand("remove")
+                .about("Remove a Trusted Publishing config from a crate")
+                .arg(
+                    opt("id", "Id of the config to remove (see `cargo trustpub list`)")
+                        .value_name("ID")
+                        .value_parser(value_parser!(u32))
+                        .required(true),
+                ),
+        )
 }
 
 pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
@@ -53,6 +63,9 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
             repository_name: sub.get_one::<String>("repo").cloned().unwrap(),
             workflow_filename: sub.get_one::<String>("pipeline").cloned().unwrap(),
             environment: sub.get_one::<String>("env").cloned(),
+        },
+        Some(("remove", sub)) => TrustpubCommand::Remove {
+            id: *sub.get_one::<u32>("id").unwrap(),
         },
         Some((cmd, _)) => unreachable!("unexpected command {}", cmd),
         None => unreachable!("unexpected command"),

--- a/src/bin/cargo/commands/trustpub.rs
+++ b/src/bin/cargo/commands/trustpub.rs
@@ -53,6 +53,19 @@ pub fn cli() -> Command {
                         .required(true),
                 ),
         )
+        .subcommand(
+            subcommand("set")
+                .about("Control whether new versions must be published via Trusted Publishing")
+                .arg(
+                    opt(
+                        "trustpub-only",
+                        "Require Trusted Publishing for new versions of the crate",
+                    )
+                    .value_name("BOOL")
+                    .value_parser(value_parser!(bool))
+                    .required(true),
+                ),
+        )
 }
 
 pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
@@ -66,6 +79,9 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
         },
         Some(("remove", sub)) => TrustpubCommand::Remove {
             id: *sub.get_one::<u32>("id").unwrap(),
+        },
+        Some(("set", sub)) => TrustpubCommand::Set {
+            trustpub_only: *sub.get_one::<bool>("trustpub-only").unwrap(),
         },
         Some((cmd, _)) => unreachable!("unexpected command {}", cmd),
         None => unreachable!("unexpected command"),

--- a/src/bin/cargo/commands/trustpub.rs
+++ b/src/bin/cargo/commands/trustpub.rs
@@ -20,11 +20,40 @@ pub fn cli() -> Command {
         )
         .arg_silent_suggestion()
         .subcommand(subcommand("list").about("List the Trusted Publishing configs for a crate"))
+        .subcommand(
+            subcommand("add")
+                .about("Add a GitHub Actions Trusted Publishing config to a crate")
+                .arg(
+                    opt("owner", "GitHub repository owner (user or organization)")
+                        .value_name("OWNER")
+                        .required(true),
+                )
+                .arg(
+                    opt("repo", "GitHub repository name")
+                        .value_name("REPO")
+                        .required(true),
+                )
+                .arg(
+                    opt("pipeline", "GitHub Actions workflow filename (e.g. `ci.yml`)")
+                        .value_name("PIPELINE")
+                        .required(true),
+                )
+                .arg(
+                    opt("env", "GitHub Actions environment the workflow must run in")
+                        .value_name("ENV"),
+                ),
+        )
 }
 
 pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
     let command = match args.subcommand() {
         Some(("list", _)) => TrustpubCommand::List,
+        Some(("add", sub)) => TrustpubCommand::Add {
+            repository_owner: sub.get_one::<String>("owner").cloned().unwrap(),
+            repository_name: sub.get_one::<String>("repo").cloned().unwrap(),
+            workflow_filename: sub.get_one::<String>("pipeline").cloned().unwrap(),
+            environment: sub.get_one::<String>("env").cloned(),
+        },
         Some((cmd, _)) => unreachable!("unexpected command {}", cmd),
         None => unreachable!("unexpected command"),
     };

--- a/src/bin/cargo/commands/trustpub.rs
+++ b/src/bin/cargo/commands/trustpub.rs
@@ -34,9 +34,12 @@ pub fn cli() -> Command {
                         .required(true),
                 )
                 .arg(
-                    opt("pipeline", "GitHub Actions workflow filename (e.g. `ci.yml`)")
-                        .value_name("PIPELINE")
-                        .required(true),
+                    opt(
+                        "pipeline",
+                        "GitHub Actions workflow filename (e.g. `ci.yml`)",
+                    )
+                    .value_name("PIPELINE")
+                    .required(true),
                 )
                 .arg(
                     opt("env", "GitHub Actions environment the workflow must run in")
@@ -47,10 +50,13 @@ pub fn cli() -> Command {
             subcommand("remove")
                 .about("Remove a Trusted Publishing config from a crate")
                 .arg(
-                    opt("id", "Id of the config to remove (see `cargo trustpub list`)")
-                        .value_name("ID")
-                        .value_parser(value_parser!(u32))
-                        .required(true),
+                    opt(
+                        "id",
+                        "Id of the config to remove (see `cargo trustpub list`)",
+                    )
+                    .value_name("ID")
+                    .value_parser(value_parser!(u32))
+                    .required(true),
                 ),
         )
         .subcommand(

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -39,10 +39,10 @@ pub use self::fix::{
 pub use self::lockfile::{load_pkg_lockfile, resolve_to_string, write_pkg_lockfile};
 pub use self::registry::OwnersOptions;
 pub use self::registry::PublishOpts;
-pub use self::registry::TrustpubCommand;
-pub use self::registry::TrustpubOptions;
 pub use self::registry::RegistryCredentialConfig;
 pub use self::registry::RegistryOrIndex;
+pub use self::registry::TrustpubCommand;
+pub use self::registry::TrustpubOptions;
 pub use self::registry::info;
 pub use self::registry::modify_owners;
 pub use self::registry::publish;

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -39,6 +39,8 @@ pub use self::fix::{
 pub use self::lockfile::{load_pkg_lockfile, resolve_to_string, write_pkg_lockfile};
 pub use self::registry::OwnersOptions;
 pub use self::registry::PublishOpts;
+pub use self::registry::TrustpubCommand;
+pub use self::registry::TrustpubOptions;
 pub use self::registry::RegistryCredentialConfig;
 pub use self::registry::RegistryOrIndex;
 pub use self::registry::info;
@@ -47,6 +49,7 @@ pub use self::registry::publish;
 pub use self::registry::registry_login;
 pub use self::registry::registry_logout;
 pub use self::registry::search;
+pub use self::registry::trusted_publish;
 pub use self::registry::yank;
 pub use self::resolve::{
     WorkspaceResolve, add_overrides, get_resolved_packages, resolve_with_previous, resolve_ws,

--- a/src/cargo/ops/registry/mod.rs
+++ b/src/cargo/ops/registry/mod.rs
@@ -8,6 +8,7 @@ mod logout;
 mod owner;
 mod publish;
 mod search;
+mod trustpub;
 mod yank;
 
 use std::collections::HashSet;
@@ -35,6 +36,9 @@ pub use self::owner::modify_owners;
 pub use self::publish::PublishOpts;
 pub use self::publish::publish;
 pub use self::search::search;
+pub use self::trustpub::TrustpubCommand;
+pub use self::trustpub::TrustpubOptions;
+pub use self::trustpub::trusted_publish;
 pub use self::yank::yank;
 
 pub(crate) use self::publish::prepare_transmit;

--- a/src/cargo/ops/registry/trustpub.rs
+++ b/src/cargo/ops/registry/trustpub.rs
@@ -20,6 +20,9 @@ pub enum TrustpubCommand {
     Remove {
         id: u32,
     },
+    Set {
+        trustpub_only: bool,
+    },
 }
 
 pub struct TrustpubOptions {
@@ -132,6 +135,21 @@ pub fn trusted_publish(gctx: &GlobalContext, opts: &TrustpubOptions) -> CargoRes
             gctx.shell().status(
                 "Removed",
                 format!("trusted publishing config {} for crate `{}`", id, name),
+            )?;
+        }
+        TrustpubCommand::Set { trustpub_only } => {
+            registry
+                .set_trustpub_only(&name, *trustpub_only)
+                .with_context(|| {
+                    format!(
+                        "failed to update `trustpub_only` for crate `{}` on registry at {}",
+                        name,
+                        registry.host()
+                    )
+                })?;
+            gctx.shell().status(
+                "Updated",
+                format!("`trustpub_only` for crate `{}` to {}", name, trustpub_only),
             )?;
         }
     }

--- a/src/cargo/ops/registry/trustpub.rs
+++ b/src/cargo/ops/registry/trustpub.rs
@@ -1,0 +1,77 @@
+use anyhow::Context as _;
+use cargo_credential::Operation;
+use cargo_credential::Secret;
+
+use crate::CargoResult;
+use crate::GlobalContext;
+use crate::core::Workspace;
+use crate::drop_print;
+use crate::drop_println;
+use crate::util::important_paths::find_root_manifest_for_wd;
+
+pub enum TrustpubCommand {
+    List,
+}
+
+pub struct TrustpubOptions {
+    pub krate: Option<String>,
+    pub token: Option<Secret<String>>,
+    pub command: TrustpubCommand,
+}
+
+pub fn trusted_publish(gctx: &GlobalContext, opts: &TrustpubOptions) -> CargoResult<()> {
+    let name = match opts.krate {
+        Some(ref name) => name.clone(),
+        None => {
+            let manifest_path = find_root_manifest_for_wd(gctx.cwd())?;
+            let ws = Workspace::new(&manifest_path, gctx)?;
+            ws.current()?.package_id().name().to_string()
+        }
+    };
+
+    let operation = Operation::Owners { name: &name };
+    let source_ids = super::get_source_id(gctx, None)?;
+    let (mut registry, _) = super::registry(
+        gctx,
+        &source_ids,
+        opts.token.as_ref().map(Secret::as_deref),
+        None,
+        true,
+        Some(operation),
+    )?;
+
+    match opts.command {
+        TrustpubCommand::List => {
+            let configs = registry.list_github_trustpub_configs(&name).with_context(|| {
+                format!(
+                    "failed to list trusted publishing configs for crate `{}` on registry at {}",
+                    name,
+                    registry.host()
+                )
+            })?;
+            if configs.is_empty() {
+                drop_println!(
+                    gctx,
+                    "no trusted publishing configs found for crate `{}`",
+                    name
+                );
+            }
+            for config in configs.iter() {
+                drop_print!(
+                    gctx,
+                    "{}: github {}/{} workflow={}",
+                    config.id,
+                    config.repository_owner,
+                    config.repository_name,
+                    config.workflow_filename,
+                );
+                match config.environment.as_ref() {
+                    Some(env) => drop_println!(gctx, " environment={}", env),
+                    None => drop_println!(gctx),
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/cargo/ops/registry/trustpub.rs
+++ b/src/cargo/ops/registry/trustpub.rs
@@ -17,6 +17,9 @@ pub enum TrustpubCommand {
         workflow_filename: String,
         environment: Option<String>,
     },
+    Remove {
+        id: u32,
+    },
 }
 
 pub struct TrustpubOptions {
@@ -113,6 +116,22 @@ pub fn trusted_publish(gctx: &GlobalContext, opts: &TrustpubOptions) -> CargoRes
                     environment,
                     name,
                 ),
+            )?;
+        }
+        TrustpubCommand::Remove { id } => {
+            registry
+                .remove_github_trustpub_config(*id)
+                .with_context(|| {
+                    format!(
+                        "failed to remove trusted publishing config {} from crate `{}` on registry at {}",
+                        id,
+                        name,
+                        registry.host()
+                    )
+                })?;
+            gctx.shell().status(
+                "Removed",
+                format!("trusted publishing config {} for crate `{}`", id, name),
             )?;
         }
     }

--- a/src/cargo/ops/registry/trustpub.rs
+++ b/src/cargo/ops/registry/trustpub.rs
@@ -11,6 +11,12 @@ use crate::util::important_paths::find_root_manifest_for_wd;
 
 pub enum TrustpubCommand {
     List,
+    Add {
+        repository_owner: String,
+        repository_name: String,
+        workflow_filename: String,
+        environment: Option<String>,
+    },
 }
 
 pub struct TrustpubOptions {
@@ -40,7 +46,7 @@ pub fn trusted_publish(gctx: &GlobalContext, opts: &TrustpubOptions) -> CargoRes
         Some(operation),
     )?;
 
-    match opts.command {
+    match &opts.command {
         TrustpubCommand::List => {
             let configs = registry.list_github_trustpub_configs(&name).with_context(|| {
                 format!(
@@ -70,6 +76,44 @@ pub fn trusted_publish(gctx: &GlobalContext, opts: &TrustpubOptions) -> CargoRes
                     None => drop_println!(gctx),
                 }
             }
+        }
+        TrustpubCommand::Add {
+            repository_owner,
+            repository_name,
+            workflow_filename,
+            environment,
+        } => {
+            let config = registry
+                .add_github_trustpub_config(
+                    &name,
+                    repository_owner,
+                    repository_name,
+                    workflow_filename,
+                    environment.as_deref(),
+                )
+                .with_context(|| {
+                    format!(
+                        "failed to add trusted publishing config to crate `{}` on registry at {}",
+                        name,
+                        registry.host()
+                    )
+                })?;
+            let environment = match config.environment.as_ref() {
+                Some(env) => format!(" environment={}", env),
+                None => String::new(),
+            };
+            gctx.shell().status(
+                "Added",
+                format!(
+                    "trusted publishing config {} ({}/{} workflow={}{}) for crate `{}`",
+                    config.id,
+                    config.repository_owner,
+                    config.repository_name,
+                    config.workflow_filename,
+                    environment,
+                    name,
+                ),
+            )?;
         }
     }
 


### PR DESCRIPTION
### What does this PR try to resolve?

It already supports the trusted publishing token scope and API, but it looks like Cargo doesn't support it yet.

### How to test and review this PR?

I used the `owner` command as a template and added this new command.

| Command | API Call |
|----------|----------|
| `cargo trustpub list [--crate foo]` | `GET /api/v1/trusted_publishing/github_configs?crate=foo` |
| `cargo trustpub add --owner O --repo R --pipeline ci.yml [--env E]` | `POST /api/v1/trusted_publishing/github_configs` |
| `cargo trustpub remove --id 42` | `DELETE /api/v1/trusted_publishing/github_configs/42` |
| `cargo trustpub set --trustpub-only true` | `PATCH /api/v1/crates/foo {"crate":{"trustpub_only":true}}` |

there are 2 global args
- crate (falls back to the current package)
- token

below is what these commands look like with some use cases

  <details>
  <summary><code>cargo trustpub --help</code></summary>

```
  Manage Trusted Publishing configuration for a crate on the registry

  Usage: cargo trustpub [OPTIONS] <COMMAND>

  Commands:
    list    List the Trusted Publishing configs for a crate
    add     Add a GitHub Actions Trusted Publishing config to a crate
    remove  Remove a Trusted Publishing config from a crate
    set     Control whether new versions must be published via Trusted Publishing

  Options:
        --crate <CRATE>            Crate to operate on
        --token <TOKEN>            API token to use when authenticating
    -v, --verbose...               Use verbose output (-vv very verbose/build.rs output)
    -q, --quiet                    Do not print cargo log messages
        --color <WHEN>             Coloring [possible values: auto, always, never]
        --config <KEY=VALUE|PATH>  Override a configuration value
    -Z <FLAG>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
                                   details
    -h, --help                     Print help

  Manifest Options:
        --locked   Assert that `Cargo.lock` will remain unchanged
        --offline  Run without accessing the network
        --frozen   Equivalent to specifying both --locked and --offline
```

  </details>

  <details>
  <summary><code>cargo trustpub list --help</code></summary>

```
  List the Trusted Publishing configs for a crate

  Usage: cargo trustpub list [OPTIONS]

  Options:
        --crate <CRATE>            Crate to operate on
        --token <TOKEN>            API token to use when authenticating
    -v, --verbose...               Use verbose output (-vv very verbose/build.rs output)
    -q, --quiet                    Do not print cargo log messages
        --color <WHEN>             Coloring [possible values: auto, always, never]
        --config <KEY=VALUE|PATH>  Override a configuration value
    -Z <FLAG>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
                                   details
    -h, --help                     Print help

  Manifest Options:
        --locked   Assert that `Cargo.lock` will remain unchanged
        --offline  Run without accessing the network
        --frozen   Equivalent to specifying both --locked and --offline
```

  </details>

  <details>
  <summary><code>cargo trustpub --token _TOKEN_ list [--crate ruleset-playground] </code></summary>

```
    Updating crates.io index
10684: github org101org101/ruleset-playground workflow=release.yml environment=prod
10685: github org101org101/ruleset-playground workflow=release.yml
```

  </details>

  <details>
  <summary><code>cargo trustpub add --help</code></summary>

```
  Add a GitHub Actions Trusted Publishing config to a crate

  Usage: cargo trustpub add [OPTIONS] --owner <OWNER> --repo <REPO> --pipeline <PIPELINE>

  Options:
        --crate <CRATE>            Crate to operate on
        --owner <OWNER>            GitHub repository owner (user or organization)
        --repo <REPO>              GitHub repository name
        --token <TOKEN>            API token to use when authenticating
        --pipeline <PIPELINE>      GitHub Actions workflow filename (e.g. `ci.yml`)
        --env <ENV>                GitHub Actions environment the workflow must run in
    -v, --verbose...               Use verbose output (-vv very verbose/build.rs output)
    -q, --quiet                    Do not print cargo log messages
        --color <WHEN>             Coloring [possible values: auto, always, never]
        --config <KEY=VALUE|PATH>  Override a configuration value
    -Z <FLAG>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
                                   details
    -h, --help                     Print help

  Manifest Options:
        --locked   Assert that `Cargo.lock` will remain unchanged
        --offline  Run without accessing the network
        --frozen   Equivalent to specifying both --locked and --offline
```

  </details>

  <details>
  <summary><code>cargo trustpub --token _TOKEN_ add [--crate ruleset-playground] --owner org101org101 --repo ruleset-playground --pipeline release.yml</code></summary>

```
    Updating crates.io index
       Added trusted publishing config 10690 (org101org101/ruleset-playground workflow=release.yml) for crate `ruleset-playground`
```

  </details>

  <details>
  <summary><code>cargo trustpub --token _TOKEN_ add [--crate ruleset-playground] --owner org101org101 --repo ruleset-playground --pipeline release.yml --env prod</code></summary>

```
    Updating crates.io index
       Added trusted publishing config 10715 (org101org101/ruleset-playground workflow=release.yml environment=prod) for crate `ruleset-playground`
```

  </details>


  <details>
  <summary><code>cargo trustpub remove --help</code></summary>

```
  Remove a Trusted Publishing config from a crate

  Usage: cargo trustpub remove [OPTIONS] --id <ID>

  Options:
        --crate <CRATE>            Crate to operate on
        --id <ID>                  Id of the config to remove (see `cargo trustpub list`)
        --token <TOKEN>            API token to use when authenticating
    -v, --verbose...               Use verbose output (-vv very verbose/build.rs output)
    -q, --quiet                    Do not print cargo log messages
        --color <WHEN>             Coloring [possible values: auto, always, never]
        --config <KEY=VALUE|PATH>  Override a configuration value
    -Z <FLAG>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
                                   details
    -h, --help                     Print help

  Manifest Options:
        --locked   Assert that `Cargo.lock` will remain unchanged
        --offline  Run without accessing the network
        --frozen   Equivalent to specifying both --locked and --offline
```

  </details>

  <details>
  <summary><code>cargo trustpub --token _TOKEN_ remove --id 10691</code></summary>

```
    Updating crates.io index
     Removed trusted publishing config 10691 for crate `ruleset-playground`
```

  </details>


  <details>
  <summary><code>cargo trustpub set --help</code></summary>

```
  Control whether new versions must be published via Trusted Publishing

  Usage: cargo trustpub set [OPTIONS] --trustpub-only <BOOL>

  Options:
        --crate <CRATE>            Crate to operate on
        --trustpub-only <BOOL>     Require Trusted Publishing for new versions of the crate [possible
                                   values: true, false]
        --token <TOKEN>            API token to use when authenticating
    -v, --verbose...               Use verbose output (-vv very verbose/build.rs output)
    -q, --quiet                    Do not print cargo log messages
        --color <WHEN>             Coloring [possible values: auto, always, never]
        --config <KEY=VALUE|PATH>  Override a configuration value
    -Z <FLAG>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
                                   details
    -h, --help                     Print help

  Manifest Options:
        --locked   Assert that `Cargo.lock` will remain unchanged
        --offline  Run without accessing the network
        --frozen   Equivalent to specifying both --locked and --offline
```

  </details>

  <details>
  <summary><code>cargo trustpub --token _TOKEN_ set --trustpub-only true</code></summary>

```
    Updating crates.io index
     Updated `trustpub_only` for crate `ruleset-playground` to true
```

  </details>