### PR TITLE
fix(add): list too-new versions and how to override

### DIFF
--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -258,11 +258,10 @@ pub(super) fn activation_error(
             match candidate {
                 IndexSummary::Candidate(summary) => {
                     if let Some(violation) = version_prefs.too_new(&summary) {
-                        let version_age = violation.age_label();
-                        let config = violation.config();
+                        let note = violation.note();
                         let _ = writeln!(
                             &mut msg,
-                            "  version {} is too new (published {version_age}, minimum age {config})",
+                            "  version {} is too new ({note})",
                             summary.version(),
                         );
                     } else {

--- a/src/cargo/core/resolver/version_prefs.rs
+++ b/src/cargo/core/resolver/version_prefs.rs
@@ -334,6 +334,14 @@ impl PublishAgeViolation {
     pub fn config(&self) -> &str {
         &self.config
     }
+
+    /// A human-readable note describing the violation,
+    /// like `published 2 days ago, minimum age 7 days`.
+    pub fn note(&self) -> String {
+        let age = self.age_label();
+        let config = self.config();
+        format!("published {age}, minimum age {config}",)
+    }
 }
 
 /// Formats an age as a single, friendly-spelled unit, never is multi-unit noise.

--- a/src/cargo/ops/cargo_add/mod.rs
+++ b/src/cargo/ops/cargo_add/mod.rs
@@ -851,11 +851,29 @@ fn get_latest_dependency(
             // so the `min-publish-age` policy must be applied here too.
             let publish_age = PublishAgePolicy::new(gctx)?;
             if let Some(publish_age) = &publish_age {
-                possibilities.retain(|s| publish_age.too_new(s).is_none());
+                let mut too_new = Vec::new();
+                possibilities.retain(|s| match publish_age.too_new(s) {
+                    Some(violation) => {
+                        too_new.push((s.version().clone(), violation));
+                        false
+                    }
+                    None => true,
+                });
                 if possibilities.is_empty() && has_candidates {
-                    anyhow::bail!(
+                    too_new.sort_by(|(a, _), (b, _)| a.cmp(b));
+                    let mut msg = format!(
                         "all versions of crate `{dependency}` are too new per `min-publish-age`"
                     );
+                    for (version, violation) in &too_new {
+                        let note = violation.note();
+                        let _ = write!(&mut msg, "\n  version {version} is too new ({note})",);
+                    }
+                    let _ = write!(
+                        &mut msg,
+                        "\nhelp: to add the latest version anyways, \
+                         re-run with `CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow`"
+                    );
+                    anyhow::bail!(msg);
                 }
             }
 

--- a/src/cargo/ops/cargo_update.rs
+++ b/src/cargo/ops/cargo_update.rs
@@ -824,13 +824,9 @@ fn report_too_new(
 ) -> Option<String> {
     let summary = resolve.summary(change.package_id);
     let violation = publish_age?.too_new(summary)?;
-    let age = violation.age_label();
-    let config = violation.config();
 
     let warn = style::WARN;
-    Some(format!(
-        " {warn}(published {age}, minimum age {config}){warn:#}"
-    ))
+    Some(format!(" {warn}({}){warn:#}", violation.note()))
 }
 
 fn report_latest(

--- a/src/cargo/ops/cargo_update.rs
+++ b/src/cargo/ops/cargo_update.rs
@@ -823,10 +823,10 @@ fn report_too_new(
     publish_age: Option<&PublishAgePolicy>,
 ) -> Option<String> {
     let summary = resolve.summary(change.package_id);
-    let violation = publish_age?.too_new(summary)?;
+    let note = publish_age?.too_new(summary)?.note();
 
     let warn = style::WARN;
-    Some(format!(" {warn}({}){warn:#}", violation.note()))
+    Some(format!(" {warn}({note}){warn:#}"))
 }
 
 fn report_latest(

--- a/tests/testsuite/min_publish_age.rs
+++ b/tests/testsuite/min_publish_age.rs
@@ -2001,6 +2001,12 @@ fn cargo_add_all_versions_too_new() {
     Package::new("bar", "1.1.0")
         .pubtime("2006-08-06T00:00:00Z")
         .publish();
+    Package::new("bar", "1.2.0")
+        .pubtime("2006-08-07T00:00:00Z")
+        .publish();
+    Package::new("bar", "1.3.0")
+        .pubtime("2006-08-08T00:00:20Z") // a future version (clock drift)
+        .publish();
 
     let p = project()
         .file(

--- a/tests/testsuite/min_publish_age.rs
+++ b/tests/testsuite/min_publish_age.rs
@@ -2034,6 +2034,10 @@ fn cargo_add_all_versions_too_new() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [ERROR] all versions of crate `bar` are too new per `min-publish-age`
+  version 1.1.0 is too new (published 2 days ago, minimum age 7 days)
+  version 1.2.0 is too new (published 24 hours ago, minimum age 7 days)
+  version 1.3.0 is too new (published moments ago, minimum age 7 days)
+[HELP] to add the latest version anyways, re-run with `CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow`
 
 "#]])
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

When every candidate is filtered out by `min-publish-age`,
`cargo add` now list each rejected version with its publish age,
with a hint of env var override.

This matches the resolver's diagnostic style.

cc https://github.com/rust-lang/cargo/issues/17009