### PR TITLE
fix(resolver): hint how to resolve too-new versions

### DIFF
--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -236,6 +236,8 @@ pub(super) fn activation_error(
     // give an error message that nothing was found.
     let mut msg = String::new();
     let mut hints = String::new();
+    // Whether any candidate was rejected for being newer than `min-publish-age`,
+    let mut has_too_new = false;
     if let Some(version_candidates) = rejected_versions(registry, dep) {
         let version_candidates = match version_candidates {
             Ok(c) => c,
@@ -258,6 +260,7 @@ pub(super) fn activation_error(
             match candidate {
                 IndexSummary::Candidate(summary) => {
                     if let Some(violation) = version_prefs.too_new(&summary) {
+                        has_too_new = true;
                         let note = violation.note();
                         let _ = writeln!(
                             &mut msg,
@@ -422,6 +425,30 @@ pub(super) fn activation_error(
         "required by {}",
         describe_path_in_context(resolver_ctx, &parent.package_id()),
     );
+
+    if has_too_new {
+        let downgrade_to =
+            alt_versions(registry, dep)
+                .and_then(|r| r.ok())
+                .and_then(|candidates| {
+                    candidates
+                        .into_iter()
+                        .find(|s| version_prefs.too_new(s).is_none())
+                });
+        if let Some(summary) = downgrade_to {
+            let _ = write!(
+                &mut hints,
+                "\nhelp: to preserve the min-publish-age, \
+                 downgrade the requirement to \"{}\"",
+                summary.version(),
+            );
+        }
+        let _ = write!(
+            &mut hints,
+            "\nhelp: to use too-new packages anyways, \
+             re-resolve with `CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow`",
+        );
+    }
 
     if let Some(gctx) = gctx {
         if let Some(offline_flag) = gctx.offline_flag() {

--- a/tests/testsuite/min_publish_age.rs
+++ b/tests/testsuite/min_publish_age.rs
@@ -418,6 +418,8 @@ fn no_candidates_error() {
   version 1.3.0 is too new (published moments ago, minimum age 7 days)
 location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.0.0 ([ROOT]/foo)`
+[HELP] to preserve the min-publish-age, downgrade the requirement to "0.2.0"
+[HELP] to use too-new packages anyways, re-resolve with `CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow`
 
 "#]])
         .run();
@@ -982,6 +984,7 @@ dependencies = [
   version 1.1.0 is too new (published 2 days ago, minimum age 7 days)
 location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `foo v0.0.0 ([ROOT]/foo)`
+[HELP] to use too-new packages anyways, re-resolve with `CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow`
 
 "#]])
         .run();

--- a/tests/testsuite/min_publish_age.rs
+++ b/tests/testsuite/min_publish_age.rs
@@ -368,6 +368,12 @@ dependencies = [
 
 #[cargo_test]
 fn no_candidates_error() {
+    Package::new("bar", "0.2.0")
+        .pubtime("2006-07-06T00:00:00Z") // ver-req not match, old enough
+        .publish();
+    Package::new("bar", "0.3.0")
+        .pubtime("2006-08-05T00:00:00Z") // ver-req not match, too-new
+        .publish();
     Package::new("bar", "1.1.0")
         .pubtime("2006-08-06T00:00:00Z")
         .publish();


### PR DESCRIPTION
### What does this PR try to resolve?

Emits two hints when every candidate matching the requirement
is newer than `min-publish-age`,
as the RFC suggests.

For `--precise` we don't emit the first hint as it is not useful.
The precise version is intended.