### PR TITLE
fix(host-config): dont apply target config to host artifacts 

### DIFF
--- a/src/cargo/core/compiler/build_context/mod.rs
+++ b/src/cargo/core/compiler/build_context/mod.rs
@@ -21,6 +21,7 @@ pub use self::target_info::FileFlavor;
 pub use self::target_info::FileType;
 pub use self::target_info::RustcTargetData;
 pub use self::target_info::TargetInfo;
+pub(crate) use self::target_info::host_artifact_uses_only_host_config;
 
 /// The build context, containing complete information needed for a build task
 /// before it gets started.

--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -783,24 +783,8 @@ fn extra_args(
     kind: CompileKind,
     flags: Flags,
 ) -> CargoResult<Vec<String>> {
-    let target_applies_to_host = gctx.target_applies_to_host()?;
-
-    // Host artifacts should not generally pick up rustflags from anywhere except [host].
-    //
-    // The one exception to this is if `target-applies-to-host = true`, which opts into a
-    // particular (inconsistent) past Cargo behavior where host artifacts _do_ pick up rustflags
-    // set elsewhere when `--target` isn't passed.
-    if kind.is_host() {
-        if target_applies_to_host && requested_kinds == [CompileKind::Host] {
-            // This is the past Cargo behavior where we fall back to the same logic as for other
-            // artifacts without --target.
-        } else {
-            // In all other cases, host artifacts just get flags from [host], regardless of
-            // --target. Or, phrased differently, no `--target` behaves the same as `--target
-            // <host>`, and host artifacts are always "special" (they don't pick up `RUSTFLAGS` for
-            // example).
-            return Ok(rustflags_from_host(gctx, flags, host_triple)?.unwrap_or_else(Vec::new));
-        }
+    if host_artifact_uses_only_host_config(gctx, requested_kinds, kind)? {
+        return Ok(rustflags_from_host(gctx, flags, host_triple)?.unwrap_or_else(Vec::new));
     }
 
     // All other artifacts pick up the RUSTFLAGS, [target.*], and [build], in that order.
@@ -921,6 +905,35 @@ fn rustflags_from_build(gctx: &GlobalContext, flag: Flags) -> CargoResult<Option
         Flags::Rustdoc => &build.rustdocflags,
     };
     Ok(list.as_ref().map(|l| l.as_slice().to_vec()))
+}
+
+/// Whether a host artifact must take its configuration solely from `[host]` and ignore `[target]`.
+pub(crate) fn host_artifact_uses_only_host_config(
+    gctx: &GlobalContext,
+    requested_kinds: &[CompileKind],
+    kind: CompileKind,
+) -> CargoResult<bool> {
+    let target_applies_to_host = gctx.target_applies_to_host()?;
+
+    // Host artifacts should not generally pick up rustflags from anywhere except [host].
+    //
+    // The one exception to this is if `target-applies-to-host = true`, which opts into a
+    // particular (inconsistent) past Cargo behavior where host artifacts _do_ pick up rustflags
+    // set elsewhere when `--target` isn't passed.
+    if kind.is_host() {
+        if target_applies_to_host && requested_kinds == [CompileKind::Host] {
+            // This is the past Cargo behavior where we fall back to the same logic as for other
+            // artifacts without --target.
+        } else {
+            // In all other cases, host artifacts just get flags from [host], regardless of
+            // --target. Or, phrased differently, no `--target` behaves the same as `--target
+            // <host>`, and host artifacts are always "special" (they don't pick up `RUSTFLAGS` for
+            // example).
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
 }
 
 /// Collection of information about `rustc` and the host and target.

--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -13,6 +13,7 @@ use crate::core::compiler::BuildContext;
 use crate::core::compiler::CompileTarget;
 use crate::core::compiler::RustdocFingerprint;
 use crate::core::compiler::apply_env_config;
+use crate::core::compiler::build_context::host_artifact_uses_only_host_config;
 use crate::core::compiler::{CompileKind, Unit, UnitHash};
 use crate::util::{CargoResult, GlobalContext};
 
@@ -505,6 +506,11 @@ fn target_runner(
     if let Some(runner) = bcx.target_data.target_config(kind).runner.as_ref() {
         let path = runner.val.path.clone().resolve_program(bcx.gctx);
         return Ok(Some((path, runner.val.args.clone())));
+    }
+
+    // Host artifacts should not pick up a runner from `[target.'cfg(...)']`.
+    if host_artifact_uses_only_host_config(bcx.gctx, &bcx.build_config.requested_kinds, kind)? {
+        return Ok(None);
     }
 
     // try target.'cfg(...)'.runner

--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -554,6 +554,11 @@ fn target_linker(bcx: &BuildContext<'_, '_>, kind: CompileKind) -> CargoResult<O
         return Ok(Some(path));
     }
 
+    // Host artifacts should not pick up a linker from `[target.'cfg(...)']`.
+    if host_artifact_uses_only_host_config(bcx.gctx, &bcx.build_config.requested_kinds, kind)? {
+        return Ok(None);
+    }
+
     // Try target.'cfg(...)'.linker.
     let target_cfg = bcx.target_data.info(kind).cfg();
     let mut cfgs = bcx

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -6860,18 +6860,12 @@ fn target_linker_does_not_apply_to_build_script_with_host_config() {
 
     p.cargo("build -Z target-applies-to-host --verbose -Z host-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
-        .with_status(101)
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name build_script_build [..] -C linker=nonexistent-host-linker [..]`
-[ERROR] linker `nonexistent-host-linker` not found
-  |
-  = [NOTE] [NOT_FOUND]
-
-[ERROR] could not compile `foo` (build script) due to 1 previous error
-
-Caused by:
-  process didn't exit successfully: `rustc --crate-name build_script_build [..] -C linker=nonexistent-host-linker [..]` ([EXIT_STATUS]: 1)
+[RUNNING] `rustc --crate-name build_script_build [..]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `rustc --crate-name foo [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 
 "#]])
         .run();

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -6841,3 +6841,38 @@ fn target_runner_does_not_apply_to_build_script_with_host_config() {
 "#]])
         .run();
 }
+
+#[cargo_test]
+fn target_linker_does_not_apply_to_build_script_with_host_config() {
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            &format!(
+                r#"
+                [target.'cfg(r#true)']
+                linker = "nonexistent-host-linker"
+                "#,
+            ),
+        )
+        .file("build.rs", "fn main() {}")
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("build -Z target-applies-to-host --verbose -Z host-config")
+        .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name build_script_build [..] -C linker=nonexistent-host-linker [..]`
+[ERROR] linker `nonexistent-host-linker` not found
+  |
+  = [NOTE] [NOT_FOUND]
+
+[ERROR] could not compile `foo` (build script) due to 1 previous error
+
+Caused by:
+  process didn't exit successfully: `rustc --crate-name build_script_build [..] -C linker=nonexistent-host-linker [..]` ([EXIT_STATUS]: 1)
+
+"#]])
+        .run();
+}

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -6831,18 +6831,12 @@ fn target_runner_does_not_apply_to_build_script_with_host_config() {
 
     p.cargo("build -Z target-applies-to-host --verbose -Z host-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
-        .with_status(101)
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]`
-[RUNNING] `nonexistent-target-runner [ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
-[ERROR] failed to run custom build command for `foo v0.0.1 ([ROOT]/foo)`
-
-Caused by:
-  could not execute process `nonexistent-target-runner [ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build` (never executed)
-
-Caused by:
-  [NOT_FOUND]
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `rustc --crate-name foo [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 
 "#]])
         .run();

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -6812,3 +6812,38 @@ fn linker_search_path_preference() {
 ...
 "#]]).run();
 }
+
+#[cargo_test]
+fn target_runner_does_not_apply_to_build_script_with_host_config() {
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            &format!(
+                r#"
+                [target.'cfg(r#true)']
+                runner = "nonexistent-target-runner"
+                "#,
+            ),
+        )
+        .file("build.rs", "fn main() {}")
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("build -Z target-applies-to-host --verbose -Z host-config")
+        .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name build_script_build [..]`
+[RUNNING] `nonexistent-target-runner [ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[ERROR] failed to run custom build command for `foo v0.0.1 ([ROOT]/foo)`
+
+Caused by:
+  could not execute process `nonexistent-target-runner [ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build` (never executed)
+
+Caused by:
+  [NOT_FOUND]
+
+"#]])
+        .run();
+}


### PR DESCRIPTION
### What does this PR try to resolve?

With `-Zhost-config`,
a host artifact must only take its config from `[host]`
but never from `[target.'cfg(...)']`.

The bug is that the first branch of `target_{linker,runner}`
already routes `[host]` and `[target]` correctly.
However, later the cfg fallback read the global `target_cfgs()`
so a host artifact wrongly picked up the target's `cfg()` linker.

This patch follows the same pattern `extra_args` has used.

### How to test and review this PR?

Two regression tests are added.

Fixes rust-lang/miri#5101

To test against the repro <https://github.com/nazar-pc/miri-5101-reproduction>, run

```
RUSTFLAGS="-Znext-solver=globally" MIRIFLAGS="-Znext-solver=globally" \
  rustup run nightly /path/to/pr17123/cargo miri test \
  -Ztarget-applies-to-host -Zhost-config \
  --config 'host.rustflags=["-Znext-solver=globally"]' --lib
```

