### PR TITLE
fix(test): skip dwp uplift test without packed debuginfo

### DIFF
--- a/crates/cargo-test-macro/src/lib.rs
+++ b/crates/cargo-test-macro/src/lib.rs
@@ -38,6 +38,8 @@ use std::sync::LazyLock;
 ///   For example, `requires = "rustfmt"` means the test will only run if the executable `rustfmt` is installed.
 ///   These tests are *always* run on CI.
 ///   This is mainly used to avoid requiring contributors from having every dependency installed.
+/// * `requires_host_split_debuginfo = "<value>"` --- This indicates a `-Csplit-debuginfo` value
+///   that is required to be supported by the host `rustc`.
 /// * `build_std_real` --- This is a "real" `-Zbuild-std` test (in the `build_std` integration test).
 ///   This only runs on nightly, and only if the environment variable `CARGO_RUN_BUILD_STD_TESTS` is set (these tests on run on Linux).
 /// * `build_std_mock` --- This is a "mock" `-Zbuild-std` test (which uses a mock standard library).
@@ -146,6 +148,23 @@ pub fn cargo_test(attr: TokenStream, item: TokenStream) -> TokenStream {
                     panic!("expect a quoted string literal, found: {literal}");
                 };
                 set_ignore!(!has_command(command), "{command} not installed");
+            }
+            s if s.starts_with("requires_host_split_debuginfo=") => {
+                let split_debuginfo = &s[30..];
+                let Ok(literal) = split_debuginfo.parse::<Literal>() else {
+                    panic!("expect a string literal, found: {split_debuginfo}");
+                };
+                let literal = literal.to_string();
+                let Some(split_debuginfo) = literal
+                    .strip_prefix('"')
+                    .and_then(|lit| lit.strip_suffix('"'))
+                else {
+                    panic!("expect a quoted string literal, found: {literal}");
+                };
+                set_ignore!(
+                    !host_supports_split_debuginfo(split_debuginfo),
+                    "host rustc does not support -Csplit-debuginfo={split_debuginfo}"
+                );
             }
             s if s.starts_with(">=1.") => {
                 requires_reason = true;
@@ -319,6 +338,33 @@ static VERSION: std::sync::LazyLock<(u32, bool)> = LazyLock::new(|| {
 
 fn version() -> (u32, bool) {
     LazyLock::force(&VERSION).clone()
+}
+
+fn host_supports_split_debuginfo(split_debuginfo: &str) -> bool {
+    static SPLIT_DEBUGINFO: LazyLock<Vec<String>> = LazyLock::new(|| {
+        let output = Command::new("rustc")
+            .arg("--print=split-debuginfo")
+            .output()
+            .expect("rustc should run");
+
+        let exit_code = output.status.code();
+        if exit_code != Some(0) {
+            let stdout = std::str::from_utf8(&output.stdout).unwrap_or("<invalid utf8>");
+            let stderr = std::str::from_utf8(&output.stderr).unwrap_or("<invalid utf8>");
+            panic!(
+                "'rustc --print=split-debuginfo' exited with non-zero exit code: {exit_code:?}\n\
+                stdout: {stdout}\n\
+                stderr: {stderr}",
+            );
+        }
+
+        let stdout = std::str::from_utf8(&output.stdout).expect("utf8");
+        stdout.lines().map(str::to_owned).collect()
+    });
+
+    SPLIT_DEBUGINFO
+        .iter()
+        .any(|supported| supported == split_debuginfo)
 }
 
 fn check_command(command_path: &Path, args: &[&str]) -> bool {

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -5241,7 +5241,7 @@ fn uplift_pdb_of_bin_on_windows() {
     assert!(!p.target_debug_dir().join("d.pdb").exists());
 }
 
-#[cargo_test]
+#[cargo_test(requires_host_split_debuginfo = "packed")]
 #[cfg(target_os = "linux")]
 fn uplift_dwp_of_bin_on_linux() {
     let p = project()


### PR DESCRIPTION
### What does this PR try to resolve?

Fix: https://github.com/rust-lang/rust/issues/158213.

`uplift_dwp_of_bin_on_linux` assumes all Linux hosts can produce `.dwp` files by requesting `-Csplit-debuginfo=packed`. That is not true for every Linux target. For example, `riscv64gc-unknown-linux-gnu` currently reports only `off` from `rustc --print=split-debuginfo`.

When Cargo sees that `packed` is unsupported, it correctly avoids passing `-Csplit-debuginfo=packed`, so rustc does not emit `.dwp` files. The test then fails because it still unconditionally expects those files.

This PR adds a `requires_host_split_debuginfo = "packed"` option to the `cargo_test` macro and uses it for the `.dwp` uplift test, so unsupported hosts show the test as ignored instead of silently returning.

### How to test and review this PR?

The main behavior to review is that the test still runs on Linux hosts that support `packed`, while being marked ignored on Linux hosts like RISC-V where Cargo cannot request packed split debuginfo.

Tested with:

```console
build/x86_64-unknown-linux-gnu/rustfmt/bin/rustfmt --check src/tools/cargo/crates/cargo-test-macro/src/lib.rs src/tools/cargo/tests/testsuite/build.rs
RUST_BACKTRACE=1 ./x test --stage 2 src/tools/cargo --test-args "build::uplift_dwp_of_bin_on_linux --exact --nocapture"
```