### PR TITLE
fix: LockManager use OS-aware flock shim

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -5,6 +5,11 @@ disallowed-methods = [
     { path = "std::env::var_os", reason = "use `Config::get_env_os` instead. See rust-lang/cargo#11588" },
     { path = "std::env::vars", reason = "not recommended to use in Cargo. See rust-lang/cargo#11588" },
     { path = "std::env::vars_os", reason = "not recommended to use in Cargo. See rust-lang/cargo#11588" },
+    { path = "std::fs::File::lock", reason = "see rust-lang/cargo#17084", replacement = "crate::util::flock::lock_exclusive" },
+    { path = "std::fs::File::lock_shared", reason = "see rust-lang/cargo#17084", replacement = "crate::util::flock::lock_shared" },
+    { path = "std::fs::File::try_lock", reason = "see rust-lang/cargo#17084", replacement = "crate::util::flock::try_lock_exclusive" },
+    { path = "std::fs::File::try_lock_shared", reason = "see rust-lang/cargo#17084", replacement = "crate::util::flock::try_lock_shared" },
+    { path = "std::fs::File::unlock", reason = "see rust-lang/cargo#17084", replacement = "crate::util::flock::unlock" },
 ]
 disallowed-types = [
     { path = "std::sync::atomic::AtomicU64", reason = "not portable; See rust-lang/cargo#12988", replacement = "portable_atomic::AtomicU64" },

--- a/src/cargo/core/compiler/locking.rs
+++ b/src/cargo/core/compiler/locking.rs
@@ -1,10 +1,12 @@
 //! This module handles the locking logic during compilation.
 
+use crate::util::flock;
 use crate::{
     CargoResult,
     core::compiler::{BuildRunner, Unit},
     util::{FileLock, Filesystem},
 };
+
 use anyhow::bail;
 use std::{
     collections::HashMap,
@@ -43,7 +45,7 @@ impl LockManager {
 
         let mut locks = self.locks.write().unwrap();
         if let Some(lock) = locks.get_mut(&key) {
-            lock.file().lock_shared()?;
+            flock::lock_shared(lock.file())?;
         } else {
             let fs = Filesystem::new(key.0.clone());
             let lock_msg = format!(
@@ -62,7 +64,7 @@ impl LockManager {
     pub fn lock(&self, key: &LockKey) -> CargoResult<()> {
         let locks = self.locks.read().unwrap();
         if let Some(lock) = locks.get(&key) {
-            lock.file().lock()?;
+            flock::lock_exclusive(lock.file())?;
         } else {
             bail!("lock was not found in lock manager: {key}");
         }
@@ -77,7 +79,7 @@ impl LockManager {
         let Some(lock) = locks.get(key) else {
             bail!("lock was not found in lock manager: {key}");
         };
-        lock.file().lock_shared()?;
+        flock::lock_shared(lock.file())?;
         Ok(())
     }
 
@@ -85,7 +87,7 @@ impl LockManager {
     pub fn unlock(&self, key: &LockKey) -> CargoResult<()> {
         let locks = self.locks.read().unwrap();
         if let Some(lock) = locks.get(key) {
-            lock.file().unlock()?;
+            flock::unlock(lock.file())?;
         };
 
         Ok(())

--- a/src/cargo/util/flock.rs
+++ b/src/cargo/util/flock.rs
@@ -19,6 +19,14 @@ use crate::util::style;
 use anyhow::Context as _;
 use cargo_util::paths;
 
+pub(crate) use self::imp::lock_exclusive;
+pub(crate) use self::imp::lock_shared;
+#[expect(unused_imports, reason = "for non-blocking lock callers")]
+pub(crate) use self::imp::try_lock_exclusive;
+#[expect(unused_imports, reason = "for non-blocking lock callers")]
+pub(crate) use self::imp::try_lock_shared;
+pub(crate) use self::imp::unlock;
+
 /// A locked file.
 ///
 /// This provides access to file while holding a lock on the file. This type

--- a/src/cargo/util/flock.rs
+++ b/src/cargo/util/flock.rs
@@ -486,7 +486,13 @@ fn error_unsupported(err: &std::io::Error) -> bool {
     }
 }
 
+// This is the one place allowed to call `std::fs::File` lock methods.
+// Everything else goes through this shim.
 #[cfg(not(target_os = "solaris"))]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "the OS doesn't need the fcntl shim"
+)]
 mod imp {
     use super::*;
 


### PR DESCRIPTION
### What does this PR try to resolve?


Address the last missing part in `-Zfine-grain-locking`: https://github.com/rust-lang/cargo/pull/17110#pullrequestreview-4548783322

Resolves https://github.com/rust-lang/cargo/issues/17084

### How to test and review this PR?

r? ehuss