### PR TITLE
fix: flaky test: sparse_blocking_count

### DIFF
--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -3587,7 +3587,7 @@ internal server error
    [..] DEBUG cargo::core::resolver::restarting: pending=[..]
    [..] DEBUG cargo::core::resolver::restarting: pending=0
 [LOCKING] 3 packages to latest compatible versions
-   [..] DEBUG cargo::core::resolver::restarting: pending=0
+...
 [DOWNLOADING] crates ...
    [..] DEBUG network::fetch: url="[..]/dl/bar/0.0.1/download"
    [..] DEBUG network::fetch: url="[..]/dl/dep1/0.0.1/download"


### PR DESCRIPTION
The sparse_blocking_count test is occasionally failing in rust-lang/rust CI with final `::restarting` line missing.

This behavior is possible if the async `http_async::Client::request` function returns immediately (without a `Pending` for network operations).

Since the HTTP requests *can* finish faster than the thread that's awaiting them, there is more non-determinism now that we're using async for registry network operations. This is not an observable difference for Cargo users unless this debug logging is turned on.

This change makes the additional line optional with a `...`.

Even with this change, the test likely still has some value to prevent regressions with the number of resolver restarts, though it's value is less than it was with fully-deterministic debug output. In the future, it may be possible to avoid resolver restarts altogether, and then this test could be removed.

Fixes https://github.com/rust-lang/rust/issues/157295