### PR TITLE
fix(clean): clarify why 'cargo clean' default != 'release' artifact set (#17129)

### DIFF
--- a/src/bin/cargo/commands/clean.rs
+++ b/src/bin/cargo/commands/clean.rs
@@ -26,8 +26,8 @@ pub fn cli() -> Command {
             flag("workspace", "Clean artifacts of the workspace members")
                 .help_heading(heading::PACKAGE_SELECTION),
         )
-        .arg_release("Whether or not to clean release artifacts")
-        .arg_profile("Clean artifacts of the specified profile")
+        .arg_release("Clean only release artifacts")
+        .arg_profile("Clean only artifacts of the specified profile")
         .arg_target_triple("Target triple to clean output for")
         .arg_target_dir()
         .arg_manifest_path()

--- a/src/doc/man/cargo-clean.md
+++ b/src/doc/man/cargo-clean.md
@@ -53,13 +53,11 @@ the target directory.
 {{/option}}
 
 {{#option "`--release`" }}
-Remove artifacts in the `release` directory only (instead of the default,
-which removes all artifacts).
+Remove artifacts in the `release` directory only.
 {{/option}}
 
 {{#option "`--profile` _name_" }}
-Remove artifacts only in the directory with the given profile name (instead
-of the default, which removes all artifacts).
+Remove artifacts only in the directory with the given profile name.
 {{/option}}
 
 {{> options-target-dir }}

--- a/src/doc/man/cargo-clean.md
+++ b/src/doc/man/cargo-clean.md
@@ -53,11 +53,13 @@ the target directory.
 {{/option}}
 
 {{#option "`--release`" }}
-Remove all artifacts in the `release` directory.
+Remove artifacts in the `release` directory only (instead of the default,
+which removes all artifacts).
 {{/option}}
 
 {{#option "`--profile` _name_" }}
-Remove all artifacts in the directory with the given profile name.
+Remove artifacts only in the directory with the given profile name (instead
+of the default, which removes all artifacts).
 {{/option}}
 
 {{> options-target-dir }}

--- a/src/doc/man/generated_txt/cargo-clean.txt
+++ b/src/doc/man/generated_txt/cargo-clean.txt
@@ -35,12 +35,10 @@ OPTIONS
            in the target directory.
 
        --release
-           Remove artifacts in the release directory only (instead of the
-           default, which removes all artifacts).
+           Remove artifacts in the release directory only.
 
        --profile name
-           Remove artifacts only in the directory with the given profile name
-           (instead of the default, which removes all artifacts).
+           Remove artifacts only in the directory with the given profile name.
 
        --target-dir directory
            Directory for all generated artifacts and intermediate files. May

--- a/src/doc/man/generated_txt/cargo-clean.txt
+++ b/src/doc/man/generated_txt/cargo-clean.txt
@@ -35,10 +35,12 @@ OPTIONS
            in the target directory.
 
        --release
-           Remove all artifacts in the release directory.
+           Remove artifacts in the release directory only (instead of the
+           default, which removes all artifacts).
 
        --profile name
-           Remove all artifacts in the directory with the given profile name.
+           Remove artifacts only in the directory with the given profile name
+           (instead of the default, which removes all artifacts).
 
        --target-dir directory
            Directory for all generated artifacts and intermediate files. May

--- a/src/doc/src/commands/cargo-clean.md
+++ b/src/doc/src/commands/cargo-clean.md
@@ -54,12 +54,14 @@ the target directory.</p>
 
 
 <dt class="option-term" id="option-cargo-clean---release"><a class="option-anchor" href="#option-cargo-clean---release"><code>--release</code></a></dt>
-<dd class="option-desc"><p>Remove all artifacts in the <code>release</code> directory.</p>
+<dd class="option-desc"><p>Remove artifacts in the <code>release</code> directory only (instead of the
+default, which removes all artifacts).</p>
 </dd>
 
 
 <dt class="option-term" id="option-cargo-clean---profile"><a class="option-anchor" href="#option-cargo-clean---profile"><code>--profile</code> <em>name</em></a></dt>
-<dd class="option-desc"><p>Remove all artifacts in the directory with the given profile name.</p>
+<dd class="option-desc"><p>Remove artifacts only in the directory with the given profile name
+(instead of the default, which removes all artifacts).</p>
 </dd>
 
 

--- a/src/doc/src/commands/cargo-clean.md
+++ b/src/doc/src/commands/cargo-clean.md
@@ -54,14 +54,12 @@ the target directory.</p>
 
 
 <dt class="option-term" id="option-cargo-clean---release"><a class="option-anchor" href="#option-cargo-clean---release"><code>--release</code></a></dt>
-<dd class="option-desc"><p>Remove artifacts in the <code>release</code> directory only (instead of the
-default, which removes all artifacts).</p>
+<dd class="option-desc"><p>Remove artifacts in the <code>release</code> directory only.</p>
 </dd>
 
 
 <dt class="option-term" id="option-cargo-clean---profile"><a class="option-anchor" href="#option-cargo-clean---profile"><code>--profile</code> <em>name</em></a></dt>
-<dd class="option-desc"><p>Remove artifacts only in the directory with the given profile name
-(instead of the default, which removes all artifacts).</p>
+<dd class="option-desc"><p>Remove artifacts only in the directory with the given profile name.</p>
 </dd>
 
 

--- a/src/etc/man/cargo-clean.1
+++ b/src/etc/man/cargo-clean.1
@@ -44,12 +44,12 @@ the target directory.
 .sp
 \fB\-\-release\fR
 .RS 4
-Remove all artifacts in the \fBrelease\fR directory.
+Remove artifacts in the \fBrelease\fR directory only.
 .RE
 .sp
 \fB\-\-profile\fR \fIname\fR
 .RS 4
-Remove all artifacts in the directory with the given profile name.
+Remove artifacts only in the directory with the given profile name.
 .RE
 .sp
 \fB\-\-target\-dir\fR \fIdirectory\fR

--- a/tests/testsuite/cargo_clean/help/stdout.term.svg
+++ b/tests/testsuite/cargo_clean/help/stdout.term.svg
@@ -60,9 +60,9 @@
 </tspan>
     <tspan x="10px" y="370px"><tspan class="fg-bright-green bold">Compilation Options:</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-r</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--release</tspan><tspan>                 Whether or not to clean release artifacts</tspan>
+    <tspan x="10px" y="388px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-r</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--release</tspan><tspan>                 Clean only release artifacts</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Clean artifacts of the specified profile</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Clean only artifacts of the specified profile</tspan>
 </tspan>
     <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Target triple to clean output for</tspan>
 </tspan>


### PR DESCRIPTION
Fixes #17129

## Summary
This rewords the `--release` and `--profile` argument descriptions for `cargo clean`. The existing phrasing ("Whether or not to clean release artifacts") reads as if `--release` is the **affirmative** form of an opt-in (and the default behaviour is "clean only non-release"). In fact:
- Without `--release`, `cargo clean` removes **all** artifacts.
- With `--release`, it removes **only** release artifacts.

The new wording ("Clean only release artifacts" / "Clean only artifacts of the specified profile") makes the restrictive semantics explicit and matches the requested change from @LeandroVandari.

## Test plan
- `cargo run -- clean --help` — both flags' short help should read "Clean only … artifacts".

Signed-off-by: Dodothereal <129273127+Dodothereal@users.noreply.github.com>

## AI assistance
Used an AI assistant to draft the commit message; the source change is a one-line mechanical edit on the clap argument descriptions and was hand-verified against `arg_release` / `arg_profile` semantics in `src/cargo/util/context/cargo_cli.rs`.
