### PR TITLE
[stable 1.96 backport] Backport portable-atomics to 1.96 branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,6 +563,7 @@ dependencies = [
  "jobserver",
  "libc",
  "miow",
+ "portable-atomic",
  "same-file",
  "sha2 0.11.0",
  "shell-escape",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,6 +419,7 @@ dependencies = [
  "os_info",
  "pasetors",
  "pathdiff",
+ "portable-atomic",
  "rand 0.10.0",
  "regex",
  "rusqlite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util"
-version = "0.2.29"
+version = "0.2.30"
 dependencies = [
  "anyhow",
  "core-foundation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,7 @@ all = { level = "allow", priority = -2 }
 correctness = { level = "warn", priority = -1 }
 dbg_macro = "warn"
 disallowed_methods = "warn"
+disallowed_types = "warn"
 print_stderr = "warn"
 print_stdout = "warn"
 self_named_module_files = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ openssl-src = "=300.5.4"
 os_info = { version = "3.14.0", default-features = false }
 pasetors = { version = "0.7.8", features = ["v3", "paserk", "std", "serde"] }
 pathdiff = "0.2.3"
+portable-atomic = "1.13.1"
 percent-encoding = "2.3.2"
 proptest = "1.11.0"
 pulldown-cmark = { version = "0.13.3", default-features = false, features = ["html"] }
@@ -204,6 +205,7 @@ opener.workspace = true
 os_info.workspace = true
 pasetors.workspace = true
 pathdiff.workspace = true
+portable-atomic.workspace = true
 rand.workspace = true
 regex.workspace = true
 rusqlite = { workspace = true, features = ["fallible_uint"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,6 +227,7 @@ time.workspace = true
 toml = { workspace = true, features = ["std", "serde", "parse", "display", "preserve_order"] }
 toml_edit.workspace = true
 tracing = { workspace = true, features = ["attributes"] }
+tracing-chrome.workspace = true
 tracing-subscriber.workspace = true
 unicase.workspace = true
 unicode-width.workspace = true
@@ -234,9 +235,6 @@ unicode-ident.workspace = true
 url.workspace = true
 walkdir.workspace = true
 winnow.workspace = true
-
-[target.'cfg(target_has_atomic = "64")'.dependencies]
-tracing-chrome.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true

--- a/clippy.toml
+++ b/clippy.toml
@@ -7,5 +7,6 @@ disallowed-methods = [
     { path = "std::env::vars_os", reason = "not recommended to use in Cargo. See rust-lang/cargo#11588" },
 ]
 disallowed-types = [
-    { path = "std::sync::atomic::AtomicU64", reason = "not portable. See rust-lang/cargo#12988" },
+    { path = "std::sync::atomic::AtomicU64", reason = "not portable; See rust-lang/cargo#12988", replacement = "portable_atomic::AtomicU64" },
+    { path = "std::sync::atomic::AtomicI64", reason = "not portable; See rust-lang/cargo#12988", replacement = "portable_atomic::AtomicI64" },
 ]

--- a/crates/cargo-util/Cargo.toml
+++ b/crates/cargo-util/Cargo.toml
@@ -12,6 +12,7 @@ anyhow.workspace = true
 filetime.workspace = true
 hex.workspace = true
 ignore.workspace = true
+portable-atomic.workspace = true
 jobserver.workspace = true
 same-file.workspace = true
 sha2.workspace = true

--- a/crates/cargo-util/Cargo.toml
+++ b/crates/cargo-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-util"
-version = "0.2.29"
+version = "0.2.30"
 rust-version = "1.94"  # MSRV:1
 edition.workspace = true
 license.workspace = true

--- a/crates/cargo-util/src/du.rs
+++ b/crates/cargo-util/src/du.rs
@@ -1,10 +1,13 @@
 //! A simple disk usage estimator.
 
+use std::path::Path;
+use std::sync::atomic::Ordering;
+use std::sync::{Arc, Mutex};
+
 use anyhow::{Context, Result};
 use ignore::overrides::OverrideBuilder;
 use ignore::{WalkBuilder, WalkState};
-use std::path::Path;
-use std::sync::{Arc, Mutex};
+use portable_atomic::AtomicU64;
 
 /// Determines the disk usage of all files in the given directory.
 ///
@@ -40,12 +43,7 @@ fn du_inner(path: &Path, patterns: &[&str]) -> Result<u64> {
         .git_exclude(false);
     let walker = builder.build_parallel();
 
-    // Platforms like PowerPC don't support AtomicU64, so we use a Mutex instead.
-    //
-    // See:
-    // - https://github.com/rust-lang/cargo/pull/12981
-    // - https://github.com/rust-lang/rust/pull/117916#issuecomment-1812635848
-    let total = Arc::new(Mutex::new(0u64));
+    let total = Arc::new(AtomicU64::new(0));
 
     // A slot used to indicate there was an error while walking.
     //
@@ -58,8 +56,7 @@ fn du_inner(path: &Path, patterns: &[&str]) -> Result<u64> {
                 Ok(entry) => match entry.metadata() {
                     Ok(meta) => {
                         if meta.is_file() {
-                            let mut lock = total.lock().unwrap();
-                            *lock += meta.len();
+                            total.fetch_add(meta.len(), Ordering::Relaxed);
                         }
                     }
                     Err(e) => {
@@ -80,6 +77,5 @@ fn du_inner(path: &Path, patterns: &[&str]) -> Result<u64> {
         return Err(e);
     }
 
-    let total = *total.lock().unwrap();
-    Ok(total)
+    Ok(total.load(Ordering::Relaxed))
 }

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -61,7 +61,7 @@ fn main() {
     }
 }
 
-fn setup_logger() -> Option<ChromeFlushGuard> {
+fn setup_logger() -> Option<tracing_chrome::FlushGuard> {
     use tracing_subscriber::prelude::*;
 
     let env = tracing_subscriber::EnvFilter::from_env("CARGO_LOG");
@@ -81,12 +81,9 @@ fn setup_logger() -> Option<ChromeFlushGuard> {
     profile_guard
 }
 
-#[cfg(target_has_atomic = "64")]
-type ChromeFlushGuard = tracing_chrome::FlushGuard;
-#[cfg(target_has_atomic = "64")]
 fn chrome_layer<S>() -> (
     Option<tracing_chrome::ChromeLayer<S>>,
-    Option<ChromeFlushGuard>,
+    Option<tracing_chrome::FlushGuard>,
 )
 where
     S: tracing::Subscriber
@@ -95,7 +92,6 @@ where
         + Sync,
 {
     #![expect(clippy::disallowed_methods, reason = "runs before config is loaded")]
-
     if env_to_bool(std::env::var_os("CARGO_LOG_PROFILE").as_deref()) {
         let capture_args =
             env_to_bool(std::env::var_os("CARGO_LOG_PROFILE_CAPTURE_ARGS").as_deref());
@@ -108,17 +104,6 @@ where
     }
 }
 
-#[cfg(not(target_has_atomic = "64"))]
-type ChromeFlushGuard = ();
-#[cfg(not(target_has_atomic = "64"))]
-fn chrome_layer() -> (
-    Option<tracing_subscriber::layer::Identity>,
-    Option<ChromeFlushGuard>,
-) {
-    (None, None)
-}
-
-#[cfg(target_has_atomic = "64")]
 fn env_to_bool(os: Option<&OsStr>) -> bool {
     match os.and_then(|os| os.to_str()) {
         Some("1") | Some("true") => true,

--- a/src/cargo/util/network/http_async.rs
+++ b/src/cargo/util/network/http_async.rs
@@ -8,8 +8,6 @@ use std::io::Cursor;
 use std::io::Read;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::sync::atomic::AtomicI64;
-use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::mpsc;
 use std::sync::mpsc::Receiver;
@@ -25,6 +23,8 @@ use curl::easy::WriteError;
 use curl::multi::Easy2Handle;
 use curl::multi::Multi;
 use futures::channel::oneshot;
+use portable_atomic::AtomicI64;
+use portable_atomic::AtomicU64;
 use tracing::{debug, error, trace, warn};
 
 use crate::util::network::http::HandleConfiguration;


### PR DESCRIPTION
This backports https://github.com/rust-lang/cargo/pull/16906/ (all commits) to the 1.96 branch, which is needed for compilation to certain tier 2 platforms; see failure here: https://github.com/rust-lang/rust/pull/158331#issuecomment-4786964666