### PR TITLE
fix(bindeps): register transitive artifact targets

### DIFF
--- a/src/cargo/core/resolver/resolve.rs
+++ b/src/cargo/core/resolver/resolve.rs
@@ -329,6 +329,14 @@ unable to verify that `{0}` is the same as when the lockfile was generated
             .map(move |(id, deps)| (self.replacement(id).unwrap_or(id), deps))
     }
 
+    pub fn bindeps(&self, pkg: PackageId) -> impl Iterator<Item = (PackageId, &Dependency)> {
+        self.deps(pkg).flat_map(|(dep_id, deps)| {
+            deps.iter()
+                .filter(|dep| dep.artifact().is_some())
+                .map(move |dep| (dep_id, dep))
+        })
+    }
+
     pub fn deps_not_replaced(
         &self,
         pkg: PackageId,

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -272,6 +272,26 @@ pub fn resolve_ws_with_opts<'gctx>(
         .iter()
         .map(|(p, _fts)| p.package_id())
         .collect::<Vec<_>>();
+
+    // Artifact dependencies can introduce compile kinds (the artifact's
+    // `target`) beyond those gathered up front from the workspace members in
+    // `RustcTargetData::new`. When such an artifact dependency is reached only
+    // transitively through a non-member dependency, its target is otherwise
+    // unknown, and traversing the resolve graph below would panic looking the
+    // target info up (e.g. when evaluating a `cfg(..)` for that platform).
+    // Register those kinds now that the full graph is resolved.
+    for pkg_id in resolved_with_overrides.iter() {
+        for kind in resolved_with_overrides
+            .bindeps(pkg_id)
+            .filter_map(|(_dep_id, dep)| dep.artifact()?.target()?.to_compile_kind())
+        {
+            // Best effort: an invalid target triple is reported later,
+            // with proper context, while building the unit graph, so
+            // any error here is intentionally ignored.
+            let _ = target_data.merge_compile_kind(kind);
+        }
+    }
+
     pkg_set.download_accessible(
         &resolved_with_overrides,
         &member_ids,

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -3377,8 +3377,12 @@ fn transitive_artifact_dep_with_target_and_platform_specific_dep() {
 
     p.cargo("tree -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
-        .with_status(101)
-        .with_stderr_contains("[..]panicked[..]")
+        .with_stdout_data(str![[r#"
+foo v0.0.0 ([ROOT]/foo)
+└── bar v0.0.0 ([ROOT]/foo/bar)
+    └── baz v0.0.0 ([ROOT]/foo/bar/baz)
+
+"#]])
         .run();
 }
 
@@ -3459,8 +3463,7 @@ fn transitive_build_script_artifact_dep_with_target() {
 
     p.cargo("check -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
-        .with_status(101)
-        .with_stderr_contains("[..]panicked[..]")
+        .with_status(0)
         .run();
 }
 

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -9,7 +9,7 @@ use cargo_test_support::compare::assert_e2e;
 use cargo_test_support::registry::{Package, RegistryBuilder};
 use cargo_test_support::str;
 use cargo_test_support::{
-    Project, basic_bin_manifest, basic_manifest, cross_compile, project, publish, registry,
+    Project, basic_bin_manifest, basic_manifest, cross_compile, git, project, publish, registry,
     rustc_host,
 };
 
@@ -3315,6 +3315,152 @@ Caused by:
 
 "#]])
         .with_status(101)
+        .run();
+}
+
+#[cargo_test]
+fn transitive_artifact_dep_with_target_and_platform_specific_dep() {
+    // Regression test: an artifact dependency reached through a *non-member*
+    // dependency and built for a non-default `target` must not panic during
+    // resolution when the artifact's package has a platform-specific
+    // dependency.
+    //
+    // Target info is gathered up front only from workspace members, so a target
+    // introduced solely by a transitive artifact dependency is unknown. When
+    // such an artifact's package also has a `[target.'cfg(..)'.dependencies]`
+    // entry, collecting the downloadable deps for the artifact's target
+    // platform evaluates that `cfg` against the missing target info, which used
+    // to `unwrap()` a `None` and panic.
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                edition = "2015"
+
+                [dependencies]
+                bar = { path = "bar/" }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file(
+            "bar/Cargo.toml",
+            r#"
+                [package]
+                name = "bar"
+                version = "0.0.0"
+                edition = "2015"
+
+                [dependencies]
+                baz = { path = "baz/", artifact = "bin", target = "x86_64-unknown-none" }
+            "#,
+        )
+        .file("bar/src/lib.rs", "")
+        .file(
+            "bar/baz/Cargo.toml",
+            r#"
+                [package]
+                name = "baz"
+                version = "0.0.0"
+                edition = "2015"
+
+                [target.'cfg(unix)'.dependencies]
+                qux = { path = "qux/" }
+            "#,
+        )
+        .file("bar/baz/src/main.rs", "fn main() {}")
+        .file("bar/baz/qux/Cargo.toml", &basic_manifest("qux", "0.0.0"))
+        .file("bar/baz/qux/src/lib.rs", "")
+        .build();
+
+    p.cargo("tree -Z bindeps")
+        .masquerade_as_nightly_cargo(&["bindeps"])
+        .with_status(101)
+        .with_stderr_contains("[..]panicked[..]")
+        .run();
+}
+
+#[cargo_test]
+fn transitive_build_script_artifact_dep_with_target() {
+    // Regression test for #16881: a git dependency with a build script has a
+    // path artifact build-dependency that introduces a non-default target.
+    // The target is only reachable transitively, so it must still be
+    // registered before dependency collection evaluates target cfgs.
+    if cross_compile_disabled() {
+        return;
+    }
+    let target = cross_compile::alternate();
+    let fdb = git::new("fdb", |project| {
+        project
+            .file(
+                "Cargo.toml",
+                &format!(
+                    r#"
+                        [package]
+                        name = "fdb"
+                        version = "0.0.0"
+                        edition = "2015"
+                        build = "build.rs"
+
+                        [dependencies]
+                        redux_helper32 = {{ path = "redux_helper32/" }}
+
+                        [build-dependencies]
+                        redux_helper32 = {{ path = "redux_helper32/", artifact = "bin", target = "{target}" }}
+                    "#,
+                ),
+            )
+            .file("src/lib.rs", "")
+            .file(
+                "build.rs",
+                r#"fn main() {
+                    let bin = std::env::var_os("CARGO_BIN_FILE_REDUX_HELPER32").unwrap();
+                    assert!(std::path::PathBuf::from(bin).exists());
+                }"#,
+            )
+            .file(
+                "redux_helper32/Cargo.toml",
+                r#"
+                    [package]
+                    name = "redux_helper32"
+                    version = "0.0.0"
+                    edition = "2015"
+
+                    [target.'cfg(unix)'.dependencies]
+                    qux = { path = "qux/" }
+                "#,
+            )
+            .file("redux_helper32/src/lib.rs", "")
+            .file("redux_helper32/src/main.rs", "fn main() {}")
+            .file("redux_helper32/qux/Cargo.toml", &basic_manifest("qux", "0.0.0"))
+            .file("redux_helper32/qux/src/lib.rs", "")
+    });
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            &format!(
+                r#"
+                    [package]
+                    name = "foo"
+                    version = "0.0.0"
+                    edition = "2015"
+
+                    [dependencies]
+                    fdb = {{ git = '{}' }}
+                "#,
+                fdb.url()
+            ),
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check -Z bindeps")
+        .masquerade_as_nightly_cargo(&["bindeps"])
+        .with_status(101)
+        .with_stderr_contains("[..]panicked[..]")
         .run();
 }
 


### PR DESCRIPTION
This is a follow-up to two reports of Cargo panicking when an artifact dependency introduces a target that Cargo did not register.

#10647 reported the older case: a dependency has a transitive artifact dependency with an explicit non-host target. Cargo only loaded artifact targets for workspace members and direct local dependencies, so the transitive target was missing from `RustcTargetData`.

#16881 hit the same underlying bug through a different shape: a git dependency with a build script depends on a path artifact build-dependency for `i686-pc-windows-msvc`.

In both cases, the panic happens later when Cargo walks dependencies and applies target-specific cfg filtering. At that point Cargo asks `RustcTargetData` for cfg information for the artifact target, but that target was never registered.

I originally opened #17073 for #16881. That fixed the path where the reported repro failed by loading missing targets inside `PackageSet::download_accessible`. After looking at #10647 and #10405, I think that is too narrow: download traversal is only one consumer of the resolved graph.

This PR instead registers artifact dependency targets after dependency resolution, before later graph walks inspect target-specific dependencies. That makes the target data available at the point where all of those consumers expect it.

The first commit adds regression tests that reproduce the panic. The second commit applies the fix and updates the tests to the expected successful behavior.

The tests cover:

- the #10647 shape: a path dependency pulls in an artifact dependency with an explicit target
- the #16881 shape: a git dependency with a build script has a path artifact build-dependency with an explicit target

Fixes #10647.
Fixes #16881.
Refs #10405.