### PR TITLE
fix(diag): Remove sometimes-invalid removal suggestions 

### DIFF
--- a/src/cargo/diagnostics/rules/redundant_homepage.rs
+++ b/src/cargo/diagnostics/rules/redundant_homepage.rs
@@ -132,6 +132,8 @@ fn lint_package_inner(
     }
     primary = primary.element(Level::NOTE.message(emitted_source));
     let mut report = vec![primary];
+    let mut help =
+        Group::with_title(Level::HELP.secondary_title("consider removing `package.homepage`"));
     if let Some(document) = document
         && let Some(contents) = contents
         && let Some(span) = get_key_value_span(document, &["package", "homepage"])
@@ -143,15 +145,13 @@ fn lint_package_inner(
         } else {
             span.key.start..span.value.end
         };
-        let mut help =
-            Group::with_title(Level::HELP.secondary_title("consider removing `package.homepage`"));
         help = help.element(
             Snippet::source(contents)
                 .path(manifest_path)
                 .patch(Patch::new(span, "")),
         );
-        report.push(help);
     }
+    report.push(help);
 
     pkg_stats.record_lint(lint_level);
     gctx.shell().print_report(&report, lint_level.force())?;

--- a/src/cargo/diagnostics/rules/redundant_homepage.rs
+++ b/src/cargo/diagnostics/rules/redundant_homepage.rs
@@ -5,7 +5,6 @@ use cargo_util_terminal::report::AnnotationKind;
 use cargo_util_terminal::report::Group;
 use cargo_util_terminal::report::Level;
 use cargo_util_terminal::report::Origin;
-use cargo_util_terminal::report::Patch;
 use cargo_util_terminal::report::Snippet;
 use tracing::instrument;
 
@@ -132,25 +131,8 @@ fn lint_package_inner(
     }
     primary = primary.element(Level::NOTE.message(emitted_source));
     let mut report = vec![primary];
-    let mut help =
+    let help =
         Group::with_title(Level::HELP.secondary_title("consider removing `package.homepage`"));
-    if let Some(document) = document
-        && let Some(contents) = contents
-        && let Some(span) = get_key_value_span(document, &["package", "homepage"])
-    {
-        let span = if let Some(workspace_span) =
-            get_key_value_span(document, &["package", "homepage", "workspace"])
-        {
-            span.key.start..workspace_span.value.end
-        } else {
-            span.key.start..span.value.end
-        };
-        help = help.element(
-            Snippet::source(contents)
-                .path(manifest_path)
-                .patch(Patch::new(span, "")),
-        );
-    }
     report.push(help);
 
     pkg_stats.record_lint(lint_level);

--- a/src/cargo/diagnostics/rules/redundant_readme.rs
+++ b/src/cargo/diagnostics/rules/redundant_readme.rs
@@ -6,7 +6,6 @@ use cargo_util_terminal::report::AnnotationKind;
 use cargo_util_terminal::report::Group;
 use cargo_util_terminal::report::Level;
 use cargo_util_terminal::report::Origin;
-use cargo_util_terminal::report::Patch;
 use cargo_util_terminal::report::Snippet;
 use tracing::instrument;
 
@@ -135,25 +134,7 @@ fn lint_package_inner(
     }
     primary = primary.element(Level::NOTE.message(emitted_source));
     let mut report = vec![primary];
-    let mut help =
-        Group::with_title(Level::HELP.secondary_title("consider removing `package.readme`"));
-    if let Some(document) = document
-        && let Some(contents) = contents
-        && let Some(span) = get_key_value_span(document, &["package", "readme"])
-    {
-        let span = if let Some(workspace_span) =
-            get_key_value_span(document, &["package", "readme", "workspace"])
-        {
-            span.key.start..workspace_span.value.end
-        } else {
-            span.key.start..span.value.end
-        };
-        help = help.element(
-            Snippet::source(contents)
-                .path(manifest_path)
-                .patch(Patch::new(span, "")),
-        );
-    }
+    let help = Group::with_title(Level::HELP.secondary_title("consider removing `package.readme`"));
     report.push(help);
 
     pkg_stats.record_lint(lint_level);

--- a/src/cargo/diagnostics/rules/redundant_readme.rs
+++ b/src/cargo/diagnostics/rules/redundant_readme.rs
@@ -135,6 +135,8 @@ fn lint_package_inner(
     }
     primary = primary.element(Level::NOTE.message(emitted_source));
     let mut report = vec![primary];
+    let mut help =
+        Group::with_title(Level::HELP.secondary_title("consider removing `package.readme`"));
     if let Some(document) = document
         && let Some(contents) = contents
         && let Some(span) = get_key_value_span(document, &["package", "readme"])
@@ -146,15 +148,13 @@ fn lint_package_inner(
         } else {
             span.key.start..span.value.end
         };
-        let mut help =
-            Group::with_title(Level::HELP.secondary_title("consider removing `package.readme`"));
         help = help.element(
             Snippet::source(contents)
                 .path(manifest_path)
                 .patch(Patch::new(span, "")),
         );
-        report.push(help);
     }
+    report.push(help);
 
     pkg_stats.record_lint(lint_level);
     gctx.shell().print_report(&report, lint_level.force())?;

--- a/src/cargo/diagnostics/rules/unused_dependencies.rs
+++ b/src/cargo/diagnostics/rules/unused_dependencies.rs
@@ -6,7 +6,6 @@ use cargo_util_terminal::report::AnnotationKind;
 use cargo_util_terminal::report::Group;
 use cargo_util_terminal::report::Level;
 use cargo_util_terminal::report::Origin;
-use cargo_util_terminal::report::Patch;
 use cargo_util_terminal::report::Snippet;
 use indexmap::IndexMap;
 use tracing::{debug, instrument, trace};
@@ -149,20 +148,9 @@ pub(crate) fn lint_package(
             primary = primary.element(Level::NOTE.message(emitted_source));
         }
         let mut report = vec![primary];
-        let mut help = Group::with_title(
+        let help = Group::with_title(
             Level::HELP.secondary_title("consider removing the unused dependency"),
         );
-        if let Some(document) = document
-            && let Some(contents) = contents
-            && let Some(span) = get_key_value_span(document, &["build-dependencies", dep_name])
-        {
-            let span = span.key.start..span.value.end;
-            help = help.element(
-                Snippet::source(contents)
-                    .path(&manifest_path)
-                    .patch(Patch::new(span, "")),
-            );
-        }
         report.push(help);
 
         pkg_stats.record_lint(lint_level);
@@ -337,20 +325,9 @@ fn lint_package_build_results(
                 }
                 lint_count += 1;
                 let mut report = vec![primary];
-                let mut help = Group::with_title(
+                let help = Group::with_title(
                     Level::HELP.secondary_title("consider removing the unused dependency"),
                 );
-                if let Some(document) = document
-                    && let Some(contents) = contents
-                    && let Some(span) = get_key_value_span(document, &toml_path)
-                {
-                    let span = span.key.start..span.value.end;
-                    help = help.element(
-                        Snippet::source(contents)
-                            .path(&manifest_path)
-                            .patch(Patch::new(span, "")),
-                    );
-                }
                 report.push(help);
                 if used_in_dev {
                     let help = Group::with_title(Level::HELP.secondary_title(

--- a/src/cargo/diagnostics/rules/unused_dependencies.rs
+++ b/src/cargo/diagnostics/rules/unused_dependencies.rs
@@ -149,7 +149,9 @@ pub(crate) fn lint_package(
             primary = primary.element(Level::NOTE.message(emitted_source));
         }
         let mut report = vec![primary];
-        let mut help = Group::with_title(Level::HELP.secondary_title("remove the dependency"));
+        let mut help = Group::with_title(
+            Level::HELP.secondary_title("consider removing the unused dependency"),
+        );
         if let Some(document) = document
             && let Some(contents) = contents
             && let Some(span) = get_key_value_span(document, &["build-dependencies", dep_name])
@@ -335,8 +337,9 @@ fn lint_package_build_results(
                 }
                 lint_count += 1;
                 let mut report = vec![primary];
-                let mut help =
-                    Group::with_title(Level::HELP.secondary_title("remove the dependency"));
+                let mut help = Group::with_title(
+                    Level::HELP.secondary_title("consider removing the unused dependency"),
+                );
                 if let Some(document) = document
                     && let Some(contents) = contents
                     && let Some(span) = get_key_value_span(document, &toml_path)

--- a/src/cargo/diagnostics/rules/unused_dependencies.rs
+++ b/src/cargo/diagnostics/rules/unused_dependencies.rs
@@ -149,19 +149,19 @@ pub(crate) fn lint_package(
             primary = primary.element(Level::NOTE.message(emitted_source));
         }
         let mut report = vec![primary];
+        let mut help = Group::with_title(Level::HELP.secondary_title("remove the dependency"));
         if let Some(document) = document
             && let Some(contents) = contents
             && let Some(span) = get_key_value_span(document, &["build-dependencies", dep_name])
         {
             let span = span.key.start..span.value.end;
-            let mut help = Group::with_title(Level::HELP.secondary_title("remove the dependency"));
             help = help.element(
                 Snippet::source(contents)
                     .path(&manifest_path)
                     .patch(Patch::new(span, "")),
             );
-            report.push(help);
         }
+        report.push(help);
 
         pkg_stats.record_lint(lint_level);
         gctx.shell().print_report(&report, lint_level.force())?;
@@ -335,20 +335,20 @@ fn lint_package_build_results(
                 }
                 lint_count += 1;
                 let mut report = vec![primary];
+                let mut help =
+                    Group::with_title(Level::HELP.secondary_title("remove the dependency"));
                 if let Some(document) = document
                     && let Some(contents) = contents
                     && let Some(span) = get_key_value_span(document, &toml_path)
                 {
                     let span = span.key.start..span.value.end;
-                    let mut help =
-                        Group::with_title(Level::HELP.secondary_title("remove the dependency"));
                     help = help.element(
                         Snippet::source(contents)
                             .path(&manifest_path)
                             .patch(Patch::new(span, "")),
                     );
-                    report.push(help);
                 }
+                report.push(help);
                 if used_in_dev {
                     let help = Group::with_title(Level::HELP.secondary_title(
                         "to still use for development builds, move to `dev-dependencies`",

--- a/src/cargo/diagnostics/rules/unused_workspace_dependencies.rs
+++ b/src/cargo/diagnostics/rules/unused_workspace_dependencies.rs
@@ -151,7 +151,7 @@ pub(crate) fn lint_workspace(
         }
         let mut report = vec![primary];
         let mut help = Group::with_title(
-            Level::HELP.secondary_title("consider removing the unused dependency"),
+            Level::HELP.secondary_title("consider removing the unused workspace dependency"),
         );
         if let Some(document) = document
             && let Some(contents) = contents

--- a/src/cargo/diagnostics/rules/unused_workspace_dependencies.rs
+++ b/src/cargo/diagnostics/rules/unused_workspace_dependencies.rs
@@ -150,12 +150,12 @@ pub(crate) fn lint_workspace(
             primary = primary.element(Level::NOTE.message(emitted_source));
         }
         let mut report = vec![primary];
+        let mut help = Group::with_title(
+            Level::HELP.secondary_title("consider removing the unused dependency"),
+        );
         if let Some(document) = document
             && let Some(contents) = contents
         {
-            let mut help = Group::with_title(
-                Level::HELP.secondary_title("consider removing the unused dependency"),
-            );
             let mut snippet = Snippet::source(contents).path(&manifest_path);
             if let Some(span) =
                 get_key_value_span(document, &["workspace", "dependencies", unused.as_str()])
@@ -163,8 +163,8 @@ pub(crate) fn lint_workspace(
                 snippet = snippet.patch(Patch::new(span.key.start..span.value.end, ""));
             }
             help = help.element(snippet);
-            report.push(help);
         }
+        report.push(help);
 
         pkg_stats.record_lint(lint_level);
         gctx.shell().print_report(&report, lint_level.force())?;

--- a/src/cargo/diagnostics/rules/unused_workspace_dependencies.rs
+++ b/src/cargo/diagnostics/rules/unused_workspace_dependencies.rs
@@ -5,7 +5,6 @@ use cargo_util_terminal::report::AnnotationKind;
 use cargo_util_terminal::report::Group;
 use cargo_util_terminal::report::Level;
 use cargo_util_terminal::report::Origin;
-use cargo_util_terminal::report::Patch;
 use cargo_util_terminal::report::Snippet;
 use indexmap::IndexSet;
 use tracing::instrument;
@@ -150,20 +149,9 @@ pub(crate) fn lint_workspace(
             primary = primary.element(Level::NOTE.message(emitted_source));
         }
         let mut report = vec![primary];
-        let mut help = Group::with_title(
+        let help = Group::with_title(
             Level::HELP.secondary_title("consider removing the unused workspace dependency"),
         );
-        if let Some(document) = document
-            && let Some(contents) = contents
-        {
-            let mut snippet = Snippet::source(contents).path(&manifest_path);
-            if let Some(span) =
-                get_key_value_span(document, &["workspace", "dependencies", unused.as_str()])
-            {
-                snippet = snippet.patch(Patch::new(span.key.start..span.value.end, ""));
-            }
-            help = help.element(snippet);
-        }
         report.push(help);
 
         pkg_stats.record_lint(lint_level);

--- a/src/cargo/diagnostics/rules/unused_workspace_package_fields.rs
+++ b/src/cargo/diagnostics/rules/unused_workspace_package_fields.rs
@@ -119,12 +119,11 @@ pub(crate) fn lint_workspace(
             primary = primary.element(Level::NOTE.message(emitted_source));
         }
         let mut report = vec![primary];
+        let mut help =
+            Group::with_title(Level::HELP.secondary_title("consider removing the unused field"));
         if let Some(document) = document
             && let Some(contents) = contents
         {
-            let mut help = Group::with_title(
-                Level::HELP.secondary_title("consider removing the unused field"),
-            );
             let mut snippet = Snippet::source(contents).path(&manifest_path);
             if let Some(span) =
                 get_key_value_span(document, &["workspace", "package", unused.as_ref()])
@@ -132,8 +131,8 @@ pub(crate) fn lint_workspace(
                 snippet = snippet.patch(Patch::new(span.key.start..span.value.end, ""));
             }
             help = help.element(snippet);
-            report.push(help);
         }
+        report.push(help);
 
         pkg_stats.record_lint(lint_level);
         gctx.shell().print_report(&report, lint_level.force())?;

--- a/src/cargo/diagnostics/rules/unused_workspace_package_fields.rs
+++ b/src/cargo/diagnostics/rules/unused_workspace_package_fields.rs
@@ -4,7 +4,6 @@ use cargo_util_terminal::report::AnnotationKind;
 use cargo_util_terminal::report::Group;
 use cargo_util_terminal::report::Level;
 use cargo_util_terminal::report::Origin;
-use cargo_util_terminal::report::Patch;
 use cargo_util_terminal::report::Snippet;
 use indexmap::IndexSet;
 use tracing::instrument;
@@ -119,19 +118,8 @@ pub(crate) fn lint_workspace(
             primary = primary.element(Level::NOTE.message(emitted_source));
         }
         let mut report = vec![primary];
-        let mut help =
+        let help =
             Group::with_title(Level::HELP.secondary_title("consider removing the unused field"));
-        if let Some(document) = document
-            && let Some(contents) = contents
-        {
-            let mut snippet = Snippet::source(contents).path(&manifest_path);
-            if let Some(span) =
-                get_key_value_span(document, &["workspace", "package", unused.as_ref()])
-            {
-                snippet = snippet.patch(Patch::new(span.key.start..span.value.end, ""));
-            }
-            help = help.element(snippet);
-        }
         report.push(help);
 
         pkg_stats.record_lint(lint_level);

--- a/tests/testsuite/lints/mod.rs
+++ b/tests/testsuite/lints/mod.rs
@@ -484,9 +484,6 @@ fn explicit_lint_level_overrides_default() {
   |
   = [NOTE] `cargo::redundant_homepage` is set to `deny` in `[lints]`
 [HELP] consider removing `package.homepage`
-  |
-8 -             homepage = "https://github.com/rust-lang/cargo/"
-  |
 [ERROR] could not parse `foo` (manifest) due to 1 previous error
 
 "#]])

--- a/tests/testsuite/lints/redundant_homepage.rs
+++ b/tests/testsuite/lints/redundant_homepage.rs
@@ -37,9 +37,6 @@ redundant_homepage = "warn"
   |
   = [NOTE] `cargo::redundant_homepage` is set to `warn` in `[lints]`
 [HELP] consider removing `package.homepage`
-  |
-7 - homepage = "https://github.com/rust-lang/cargo/"
-  |
 [WARNING] `cargo` (manifest) generated 1 warning
 
 "#]])
@@ -81,9 +78,6 @@ redundant_homepage = "warn"
   |
   = [NOTE] `cargo::redundant_homepage` is set to `warn` in `[lints]`
 [HELP] consider removing `package.homepage`
-  |
-7 - homepage = "https://docs.rs/cargo/latest/cargo/"
-  |
 [WARNING] `cargo` (manifest) generated 1 warning
 
 "#]])
@@ -129,9 +123,6 @@ redundant_homepage = "warn"
    |
    = [NOTE] `cargo::redundant_homepage` is set to `warn` in `[lints]`
 [HELP] consider removing `package.homepage`
-   |
-11 - homepage.workspace = true
-   |
 [WARNING] `cargo` (manifest) generated 1 warning
 
 "#]])

--- a/tests/testsuite/lints/redundant_readme.rs
+++ b/tests/testsuite/lints/redundant_readme.rs
@@ -35,9 +35,6 @@ redundant_readme = "warn"
   |
   = [NOTE] `cargo::redundant_readme` is set to `warn` in `[lints]`
 [HELP] consider removing `package.readme`
-  |
-7 - readme = "README.md"
-  |
 [WARNING] `foo` (manifest) generated 1 warning
 
 "#]])

--- a/tests/testsuite/lints/unused_dependencies.rs
+++ b/tests/testsuite/lints/unused_dependencies.rs
@@ -51,9 +51,6 @@ fn unused_dep_normal() {
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] consider removing the unused dependency
-  |
-9 -             unused = "0.1.0"
-  |
 [WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -113,9 +110,6 @@ fn unused_dep_build() {
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] consider removing the unused dependency
-  |
-9 -             unused = "0.1.0"
-  |
 [WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -163,9 +157,6 @@ fn unused_dep_build_no_build_rs() {
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] consider removing the unused dependency
-  |
-9 -             unused = "0.1.0"
-  |
 [WARNING] `foo` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
@@ -250,9 +241,6 @@ fn unused_dep_lib_bins() {
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] consider removing the unused dependency
-  |
-9 -             unused = "0.1.0"
-  |
 [WARNING] `foo` (manifest) generated 1 warning
 
 "#]]
@@ -343,9 +331,6 @@ fn unused_dep_build_with_used_dep_normal() {
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] consider removing the unused dependency
-  |
-9 -             unused_build = "0.1.0"
-  |
 [WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -408,9 +393,6 @@ fn unused_dep_normal_but_implicit_used_dep_dev() {
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] consider removing the unused dependency
-  |
-9 -             used_dev = "0.1.0"
-  |
 [WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -429,9 +411,6 @@ fn unused_dep_normal_but_implicit_used_dep_dev() {
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] consider removing the unused dependency
-  |
-9 -             used_dev = "0.1.0"
-  |
 [HELP] to still use for development builds, move to `dev-dependencies`
 [WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -498,9 +477,6 @@ fn unused_dep_normal_but_explicit_used_dep_dev() {
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] consider removing the unused dependency
-  |
-9 -             used_once = "0.1.0"
-  |
 [WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -632,9 +608,6 @@ fn optional_dependency() {
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] consider removing the unused dependency
-  |
-9 -             unused = { version = "0.1.0", optional = true }
-  |
 [WARNING] `foo` (manifest) generated 1 warning
 
 "#]]
@@ -697,9 +670,6 @@ fn unused_dep_renamed() {
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] consider removing the unused dependency
-  |
-9 -             baz = { package = "bar", version = "0.1.0" }
-  |
 [WARNING] `foo` (manifest) generated 1 warning
 
 "#]]
@@ -755,9 +725,6 @@ fn warning_replay() {
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] consider removing the unused dependency
-  |
-9 -             unused = "0.1.0"
-  |
 [WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -775,9 +742,6 @@ fn warning_replay() {
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] consider removing the unused dependency
-  |
-9 -             unused = "0.1.0"
-  |
 [WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -842,9 +806,6 @@ fn unused_dep_target() {
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] consider removing the unused dependency
-  |
-9 -             unused = "0.1.0"
-  |
 [WARNING] `foo` (manifest) generated 1 warning
 
 "#]]
@@ -1134,7 +1095,6 @@ fn package_selection() {
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] consider removing the unused dependency
   |
-9 -             unused_bar = "0.1.0"
   |
 [WARNING] unused dependency
   --> foo/Cargo.toml:11:13
@@ -1145,30 +1105,17 @@ fn package_selection() {
    = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] consider removing the unused dependency
    |
-11 -             bar.path = "../bar"
-11 +             .path = "../bar"
    |
 [WARNING] unused dependency
   --> foo/Cargo.toml:12:13
-   |
 12 |             external.path = "../external"
    |             ^^^^^^^^
-   |
 [HELP] consider removing the unused dependency
-   |
-12 -             external.path = "../external"
-12 +             .path = "../external"
-   |
 [WARNING] unused dependency
  --> foo/Cargo.toml:9:13
-  |
 9 |             unused_foo = "0.1.0"
   |             ^^^^^^^^^^^^^^^^^^^^
-  |
 [HELP] consider removing the unused dependency
-  |
-9 -             unused_foo = "0.1.0"
-  |
 [WARNING] `bar` (manifest) generated 1 warning
 [WARNING] `foo` (manifest) generated 3 warnings
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1191,20 +1138,12 @@ fn package_selection() {
    = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] consider removing the unused dependency
    |
-11 -             bar.path = "../bar"
-11 +             .path = "../bar"
    |
 [WARNING] unused dependency
   --> foo/Cargo.toml:12:13
-   |
 12 |             external.path = "../external"
    |             ^^^^^^^^
-   |
 [HELP] consider removing the unused dependency
-   |
-12 -             external.path = "../external"
-12 +             .path = "../external"
-   |
 [WARNING] unused dependency
  --> foo/Cargo.toml:9:13
   |
@@ -1212,9 +1151,6 @@ fn package_selection() {
   |             ^^^^^^^^^^^^^^^^^^^^
   |
 [HELP] consider removing the unused dependency
-  |
-9 -             unused_foo = "0.1.0"
-  |
 [WARNING] `foo` (manifest) generated 3 warnings
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1235,9 +1171,6 @@ fn package_selection() {
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] consider removing the unused dependency
-  |
-9 -             unused_bar = "0.1.0"
-  |
 [WARNING] `bar` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1432,9 +1365,6 @@ fn allow_rustflags() {
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] consider removing the unused dependency
-  |
-9 -             unused = "0.1.0"
-  |
 [WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1490,9 +1420,6 @@ fn allow_attribute() {
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] consider removing the unused dependency
-  |
-9 -             unused = "0.1.0"
-  |
 [WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1547,9 +1474,6 @@ fn deny_in_manifest() {
   |
   = [NOTE] `cargo::unused_dependencies` is set to `deny` in `[lints]`
 [HELP] consider removing the unused dependency
-  |
-9 -             unused = "0.1.0"
-  |
 [ERROR] could not finalize `foo` (manifest) due to 1 previous error
 
 "#]])
@@ -1604,9 +1528,6 @@ fn deny_rustflags() {
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] consider removing the unused dependency
-  |
-9 -             unused = "0.1.0"
-  |
 [WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1662,9 +1583,6 @@ fn deny_attribute() {
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] consider removing the unused dependency
-  |
-9 -             unused = "0.1.0"
-  |
 [WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1720,9 +1638,6 @@ fn forbid_rustflags() {
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] consider removing the unused dependency
-  |
-9 -             unused = "0.1.0"
-  |
 [WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1778,9 +1693,6 @@ fn forbid_attribute() {
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] consider removing the unused dependency
-  |
-9 -             unused = "0.1.0"
-  |
 [WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/lints/unused_dependencies.rs
+++ b/tests/testsuite/lints/unused_dependencies.rs
@@ -50,7 +50,7 @@ fn unused_dep_normal() {
   |             ^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
-[HELP] remove the dependency
+[HELP] consider removing the unused dependency
   |
 9 -             unused = "0.1.0"
   |
@@ -112,7 +112,7 @@ fn unused_dep_build() {
   |             ^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
-[HELP] remove the dependency
+[HELP] consider removing the unused dependency
   |
 9 -             unused = "0.1.0"
   |
@@ -162,7 +162,7 @@ fn unused_dep_build_no_build_rs() {
   |             ^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
-[HELP] remove the dependency
+[HELP] consider removing the unused dependency
   |
 9 -             unused = "0.1.0"
   |
@@ -249,7 +249,7 @@ fn unused_dep_lib_bins() {
   |             ^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
-[HELP] remove the dependency
+[HELP] consider removing the unused dependency
   |
 9 -             unused = "0.1.0"
   |
@@ -342,7 +342,7 @@ fn unused_dep_build_with_used_dep_normal() {
   |             ^^^^^^^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
-[HELP] remove the dependency
+[HELP] consider removing the unused dependency
   |
 9 -             unused_build = "0.1.0"
   |
@@ -407,7 +407,7 @@ fn unused_dep_normal_but_implicit_used_dep_dev() {
   |             ^^^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
-[HELP] remove the dependency
+[HELP] consider removing the unused dependency
   |
 9 -             used_dev = "0.1.0"
   |
@@ -428,7 +428,7 @@ fn unused_dep_normal_but_implicit_used_dep_dev() {
   |             ^^^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
-[HELP] remove the dependency
+[HELP] consider removing the unused dependency
   |
 9 -             used_dev = "0.1.0"
   |
@@ -497,7 +497,7 @@ fn unused_dep_normal_but_explicit_used_dep_dev() {
   |             ^^^^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
-[HELP] remove the dependency
+[HELP] consider removing the unused dependency
   |
 9 -             used_once = "0.1.0"
   |
@@ -631,7 +631,7 @@ fn optional_dependency() {
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
-[HELP] remove the dependency
+[HELP] consider removing the unused dependency
   |
 9 -             unused = { version = "0.1.0", optional = true }
   |
@@ -696,7 +696,7 @@ fn unused_dep_renamed() {
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
-[HELP] remove the dependency
+[HELP] consider removing the unused dependency
   |
 9 -             baz = { package = "bar", version = "0.1.0" }
   |
@@ -754,7 +754,7 @@ fn warning_replay() {
   |             ^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
-[HELP] remove the dependency
+[HELP] consider removing the unused dependency
   |
 9 -             unused = "0.1.0"
   |
@@ -774,7 +774,7 @@ fn warning_replay() {
   |             ^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
-[HELP] remove the dependency
+[HELP] consider removing the unused dependency
   |
 9 -             unused = "0.1.0"
   |
@@ -841,7 +841,7 @@ fn unused_dep_target() {
   |             ^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
-[HELP] remove the dependency
+[HELP] consider removing the unused dependency
   |
 9 -             unused = "0.1.0"
   |
@@ -1132,7 +1132,7 @@ fn package_selection() {
   |             ^^^^^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
-[HELP] remove the dependency
+[HELP] consider removing the unused dependency
   |
 9 -             unused_bar = "0.1.0"
   |
@@ -1143,7 +1143,7 @@ fn package_selection() {
    |             ^^^
    |
    = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
-[HELP] remove the dependency
+[HELP] consider removing the unused dependency
    |
 11 -             bar.path = "../bar"
 11 +             .path = "../bar"
@@ -1154,7 +1154,7 @@ fn package_selection() {
 12 |             external.path = "../external"
    |             ^^^^^^^^
    |
-[HELP] remove the dependency
+[HELP] consider removing the unused dependency
    |
 12 -             external.path = "../external"
 12 +             .path = "../external"
@@ -1165,7 +1165,7 @@ fn package_selection() {
 9 |             unused_foo = "0.1.0"
   |             ^^^^^^^^^^^^^^^^^^^^
   |
-[HELP] remove the dependency
+[HELP] consider removing the unused dependency
   |
 9 -             unused_foo = "0.1.0"
   |
@@ -1189,7 +1189,7 @@ fn package_selection() {
    |             ^^^
    |
    = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
-[HELP] remove the dependency
+[HELP] consider removing the unused dependency
    |
 11 -             bar.path = "../bar"
 11 +             .path = "../bar"
@@ -1200,7 +1200,7 @@ fn package_selection() {
 12 |             external.path = "../external"
    |             ^^^^^^^^
    |
-[HELP] remove the dependency
+[HELP] consider removing the unused dependency
    |
 12 -             external.path = "../external"
 12 +             .path = "../external"
@@ -1211,7 +1211,7 @@ fn package_selection() {
 9 |             unused_foo = "0.1.0"
   |             ^^^^^^^^^^^^^^^^^^^^
   |
-[HELP] remove the dependency
+[HELP] consider removing the unused dependency
   |
 9 -             unused_foo = "0.1.0"
   |
@@ -1234,7 +1234,7 @@ fn package_selection() {
   |             ^^^^^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
-[HELP] remove the dependency
+[HELP] consider removing the unused dependency
   |
 9 -             unused_bar = "0.1.0"
   |
@@ -1431,7 +1431,7 @@ fn allow_rustflags() {
   |             ^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
-[HELP] remove the dependency
+[HELP] consider removing the unused dependency
   |
 9 -             unused = "0.1.0"
   |
@@ -1489,7 +1489,7 @@ fn allow_attribute() {
   |             ^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
-[HELP] remove the dependency
+[HELP] consider removing the unused dependency
   |
 9 -             unused = "0.1.0"
   |
@@ -1546,7 +1546,7 @@ fn deny_in_manifest() {
   |             ^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::unused_dependencies` is set to `deny` in `[lints]`
-[HELP] remove the dependency
+[HELP] consider removing the unused dependency
   |
 9 -             unused = "0.1.0"
   |
@@ -1603,7 +1603,7 @@ fn deny_rustflags() {
   |             ^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
-[HELP] remove the dependency
+[HELP] consider removing the unused dependency
   |
 9 -             unused = "0.1.0"
   |
@@ -1661,7 +1661,7 @@ fn deny_attribute() {
   |             ^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
-[HELP] remove the dependency
+[HELP] consider removing the unused dependency
   |
 9 -             unused = "0.1.0"
   |
@@ -1719,7 +1719,7 @@ fn forbid_rustflags() {
   |             ^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
-[HELP] remove the dependency
+[HELP] consider removing the unused dependency
   |
 9 -             unused = "0.1.0"
   |
@@ -1777,7 +1777,7 @@ fn forbid_attribute() {
   |             ^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
-[HELP] remove the dependency
+[HELP] consider removing the unused dependency
   |
 9 -             unused = "0.1.0"
   |

--- a/tests/testsuite/lints/unused_workspace_dependencies.rs
+++ b/tests/testsuite/lints/unused_workspace_dependencies.rs
@@ -87,9 +87,6 @@ workspace = true
    |
    = [NOTE] `cargo::unused_workspace_dependencies` is set to `warn` in `[lints]`
 [HELP] consider removing the unused workspace dependency
-   |
-12 - not-inherited = "1"
-   |
 [WARNING] unused workspace dependency
   --> Cargo.toml:11:1
    |
@@ -97,9 +94,6 @@ workspace = true
    | ^^^^^^
    |
 [HELP] consider removing the unused workspace dependency
-   |
-11 - unused = "1"
-   |
 [WARNING] workspace (manifest) generated 2 warnings
 [UPDATING] `dummy-registry` index
 [LOCKING] 6 packages to latest compatible versions

--- a/tests/testsuite/lints/unused_workspace_dependencies.rs
+++ b/tests/testsuite/lints/unused_workspace_dependencies.rs
@@ -86,7 +86,7 @@ workspace = true
    | ^^^^^^^^^^^^^
    |
    = [NOTE] `cargo::unused_workspace_dependencies` is set to `warn` in `[lints]`
-[HELP] consider removing the unused dependency
+[HELP] consider removing the unused workspace dependency
    |
 12 - not-inherited = "1"
    |
@@ -96,7 +96,7 @@ workspace = true
 11 | unused = "1"
    | ^^^^^^
    |
-[HELP] consider removing the unused dependency
+[HELP] consider removing the unused workspace dependency
    |
 11 - unused = "1"
    |

--- a/tests/testsuite/lints/unused_workspace_package_fields.rs
+++ b/tests/testsuite/lints/unused_workspace_package_fields.rs
@@ -59,9 +59,6 @@ workspace = true
   |
   = [NOTE] `cargo::unused_workspace_package_fields` is set to `warn` in `[lints]`
 [HELP] consider removing the unused field
-  |
-8 - rust-version = "1.0"
-  |
 [WARNING] unused field in `workspace.package`
  --> Cargo.toml:9:1
   |
@@ -69,9 +66,6 @@ workspace = true
   | ^^^^^^^
   |
 [HELP] consider removing the unused field
-  |
-9 - unknown = "foo"
-  |
 [WARNING] workspace (manifest) generated 2 warnings
 [WARNING] Cargo.toml: unused manifest key: workspace.package.unknown
 [WARNING] `foo` (manifest) generated 1 warning

--- a/tests/testsuite/warning_override.rs
+++ b/tests/testsuite/warning_override.rs
@@ -268,9 +268,6 @@ fn lint_parse_pass() {
   |
   = [NOTE] `cargo::redundant_homepage` is set to `warn` in `[lints]`
 [HELP] consider removing `package.homepage`
-  |
-8 -             homepage = "https://github.com/rust-lang/cargo/"
-  |
 [WARNING] `foo` (manifest) generated 1 warning
 
 "#]])
@@ -288,9 +285,6 @@ fn lint_parse_pass() {
   |
   = [NOTE] `cargo::redundant_homepage` is set to `warn` in `[lints]`
 [HELP] consider removing `package.homepage`
-  |
-8 -             homepage = "https://github.com/rust-lang/cargo/"
-  |
 [WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -330,9 +324,6 @@ fn lint_parse_pass() {
   |
   = [NOTE] `cargo::redundant_homepage` is set to `warn` in `[lints]`
 [HELP] consider removing `package.homepage`
-  |
-8 -             homepage = "https://github.com/rust-lang/cargo/"
-  |
 [WARNING] `foo` (manifest) generated 1 warning
 [ERROR] warnings are denied by `build.warnings` configuration
 
@@ -354,9 +345,6 @@ fn lint_parse_pass() {
   |
   = [NOTE] `cargo::redundant_homepage` is set to `warn` in `[lints]`
 [HELP] consider removing `package.homepage`
-  |
-8 -             homepage = "https://github.com/rust-lang/cargo/"
-  |
 [WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [ERROR] warnings are denied by `build.warnings` configuration
@@ -413,9 +401,6 @@ fn lint_build_result_pass() {
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] consider removing the unused dependency
-  |
-9 -             unused = "0.1.0"
-  |
 [WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -446,9 +431,6 @@ fn lint_build_result_pass() {
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
 [HELP] consider removing the unused dependency
-  |
-9 -             unused = "0.1.0"
-  |
 [WARNING] `foo` (manifest) generated 1 warning
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [ERROR] warnings are denied by `build.warnings` configuration

--- a/tests/testsuite/warning_override.rs
+++ b/tests/testsuite/warning_override.rs
@@ -412,7 +412,7 @@ fn lint_build_result_pass() {
   |             ^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
-[HELP] remove the dependency
+[HELP] consider removing the unused dependency
   |
 9 -             unused = "0.1.0"
   |
@@ -445,7 +445,7 @@ fn lint_build_result_pass() {
   |             ^^^^^^^^^^^^^^^^
   |
   = [NOTE] `cargo::unused_dependencies` is set to `warn` in `[lints]`
-[HELP] remove the dependency
+[HELP] consider removing the unused dependency
   |
 9 -             unused = "0.1.0"
   |


### PR DESCRIPTION
### What does this PR try to resolve?

Depending on where a removal shows up (like a basic key-value pair), it
can be valid.
However, it won't be if
- the key is for a standard table
- the key is used with dotted keys
- there is a comma after the value

For now, we'll remove this.
I'll open an issue for adding these back in.
One idea is we re-parse using `toml_parse`, detect our case, and
directly edit the token stream to find the removal span.

Fixes #16982

### How to test and review this PR?

