### PR TITLE
Rename `-Zno-embed-metadata` to `-Zembed-metadata=no`

### DIFF
--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -625,7 +625,7 @@ impl TargetInfo {
             }
         }
         if !result.is_empty() {
-            if gctx.cli_unstable().no_embed_metadata
+            if !gctx.should_embed_metadata()
                 && crate_types
                     .iter()
                     .any(|ct| ct.benefits_from_no_embed_metadata())

--- a/src/cargo/core/compiler/fingerprint/mod.rs
+++ b/src/cargo/core/compiler/fingerprint/mod.rs
@@ -384,6 +384,7 @@ use std::fs;
 use std::fs::File;
 use std::hash::{self, Hash, Hasher};
 use std::io::{self};
+use std::ops::Not;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
@@ -1659,13 +1660,13 @@ fn calculate_normal(
         && build_runner.unit_deps(unit).iter().any(|dep| !dep.public)
         && super::is_public_dependency_enabled(build_runner, unit))
     .hash(&mut config);
-    // -Zno-embed-metadata changes how all units are compiled, and it also changes how we tell
+    // -Zembed-metadata changes how all units are compiled, and it also changes how we tell
     // rustc to link to deps using `--extern`. If it changes, we should rebuild everything.
     build_runner
         .bcx
         .gctx
-        .cli_unstable()
-        .no_embed_metadata
+        .should_embed_metadata()
+        .not()
         .hash(&mut config);
 
     let compile_kind = unit.kind.fingerprint_hash();

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1304,7 +1304,7 @@ fn build_base_args(
 
     if unit.mode.is_check() {
         cmd.arg("--emit=dep-info,metadata");
-    } else if build_runner.bcx.gctx.cli_unstable().no_embed_metadata {
+    } else if !build_runner.bcx.gctx.should_embed_metadata() {
         // Nightly rustc supports the -Zembed-metadata=no flag, which tells it to avoid including
         // full metadata in rlib/dylib artifacts, to save space on disk. In this case, metadata
         // will only be stored in .rmeta files.
@@ -1947,7 +1947,7 @@ pub fn extern_args(
     let mut result = Vec::new();
     let deps = build_runner.unit_deps(unit);
 
-    let no_embed_metadata = build_runner.bcx.gctx.cli_unstable().no_embed_metadata;
+    let no_embed_metadata = !build_runner.bcx.gctx.should_embed_metadata();
     let public_dependency_enabled = is_public_dependency_enabled(build_runner, unit);
 
     // Closure to add one dependency to `result`.

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -408,6 +408,18 @@ enum Status {
     Removed,
 }
 
+/// Config for the `-Zembed-metadata` option.
+#[derive(Debug, Default, Deserialize)]
+pub enum EmbedMetadata {
+    /// Embed metadata in .rlib files, the original rustc behavior.
+    Embed,
+    /// Do not embed metadata in .rlib files.
+    DoNotEmbed,
+    /// The `-Zembed-metadata` flag wasn't set.
+    #[default]
+    Unset,
+}
+
 /// A listing of stable and unstable new syntax in Cargo.toml.
 ///
 /// This generates definitions and impls for [`Features`] and [`Feature`]
@@ -843,7 +855,8 @@ macro_rules! unstable_cli_options {
                     location.line()
                 );
                 let mut expected = vec![$(stringify!($element)),*];
-                expected[2..].sort();
+                // Skip permanently unstable fields
+                expected[3..].sort();
                 let expected = format!("{:#?}", expected);
                 let actual = format!("{:#?}", vec![$(stringify!($element)),*]);
                 snapbox::assert_data_eq!(actual, expected);
@@ -855,6 +868,7 @@ macro_rules! unstable_cli_options {
 unstable_cli_options!(
     // Permanently unstable features:
     allow_features: Option<AllowFeatures> = ("Allow *only* the listed unstable features"),
+    embed_metadata: EmbedMetadata = ("Avoid embedding metadata in library artifacts"),
     print_im_a_teapot: bool,
 
     // All other unstable features.
@@ -893,7 +907,6 @@ unstable_cli_options!(
     msrv_policy: bool = ("Enable rust-version aware policy within cargo"),
     mtime_on_use: bool = ("Configure Cargo to update the mtime of used files"),
     next_lockfile_bump: bool,
-    no_embed_metadata: bool = ("Avoid embedding metadata in library artifacts"),
     no_index_update: bool = ("Do not update the registry index even if the cache is outdated"),
     panic_abort_tests: bool = ("Enable support to run tests with -Cpanic=abort"),
     panic_immediate_abort: bool = ("Enable setting `panic = \"immediate-abort\"` in profiles"),
@@ -1294,6 +1307,15 @@ impl CliUnstable {
             }
         }
 
+        fn parse_embed_metadata(key: &str, value: Option<&str>) -> CargoResult<EmbedMetadata> {
+            match value {
+                None => Ok(EmbedMetadata::Unset),
+                Some("yes") => Ok(EmbedMetadata::Embed),
+                Some("no") => Ok(EmbedMetadata::DoNotEmbed),
+                Some(s) => bail!("flag -Z{key} expected `no` or `yes`, found: `{s}`"),
+            }
+        }
+
         /// Parse a comma-separated list
         fn parse_list(value: Option<&str>) -> Vec<String> {
             match value {
@@ -1345,6 +1367,7 @@ impl CliUnstable {
             // Permanently unstable features
             // Sorted alphabetically:
             "allow-features" => self.allow_features = Some(parse_list(v).into_iter().collect()),
+            "embed-metadata" => self.embed_metadata = parse_embed_metadata(k, v)?,
             "print-im-a-teapot" => self.print_im_a_teapot = parse_bool(k, v)?,
 
             // Stabilized features
@@ -1446,7 +1469,6 @@ impl CliUnstable {
             "msrv-policy" => self.msrv_policy = parse_empty(k, v)?,
             // can also be set in .cargo/config or with and ENV
             "mtime-on-use" => self.mtime_on_use = parse_empty(k, v)?,
-            "no-embed-metadata" => self.no_embed_metadata = parse_empty(k, v)?,
             "no-index-update" => self.no_index_update = parse_empty(k, v)?,
             "panic-abort-tests" => self.panic_abort_tests = parse_empty(k, v)?,
             "public-dependency" => self.public_dependency = parse_empty(k, v)?,

--- a/src/cargo/util/context/mod.rs
+++ b/src/cargo/util/context/mod.rs
@@ -134,9 +134,9 @@ mod environment;
 use environment::Env;
 
 mod schema;
-pub use schema::*;
-
 use super::auth::RegistryConfig;
+use crate::core::features::EmbedMetadata;
+pub use schema::*;
 
 /// Helper macro for creating typed access methods.
 macro_rules! get_value_typed {
@@ -1259,6 +1259,14 @@ impl GlobalContext {
 
     pub fn extra_verbose(&self) -> bool {
         self.extra_verbose
+    }
+
+    pub fn should_embed_metadata(&self) -> bool {
+        match self.cli_unstable().embed_metadata {
+            EmbedMetadata::Embed => true,
+            EmbedMetadata::DoNotEmbed => false,
+            EmbedMetadata::Unset => true,
+        }
     }
 
     pub fn network_allowed(&self) -> bool {

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -94,7 +94,7 @@ Each new feature described below should explain how to use it.
     * [checksum-freshness](#checksum-freshness) --- When passed, the decision as to whether a crate needs to be rebuilt is made using file checksums instead of the file mtime.
     * [panic-abort-tests](#panic-abort-tests) --- Allows running tests with the "abort" panic strategy.
     * [host-config](#host-config) --- Allows setting `[target]`-like configuration settings for host build targets.
-    * [no-embed-metadata](#no-embed-metadata) --- Passes `-Zembed-metadata=no` to the compiler, which avoid embedding metadata into rlib and dylib artifacts, to save disk space.
+    * [embed-metadata](#embed-metadata) --- If set to `no`, cargo will pass `-Zembed-metadata=no` to the compiler, which avoid embedding metadata into rlib and dylib artifacts, to save disk space.
     * [target-applies-to-host](#target-applies-to-host) --- Alters whether certain flags will be passed to host build targets.
     * [gc](#gc) --- Global cache garbage collection.
     * [open-namespaces](#open-namespaces) --- Allow multiple packages to participate in the same API namespace
@@ -1865,7 +1865,7 @@ The `-Z rustdoc-depinfo` flag leverages rustdoc's dep-info files to determine
 whether documentations are required to re-generate. This can be combined with
 `-Z checksum-freshness` to detect checksum changes rather than file mtime.
 
-## no-embed-metadata
+## embed-metadata
 * Original Pull Request: [#15378](https://github.com/rust-lang/cargo/pull/15378)
 * Tracking Issue: [#15495](https://github.com/rust-lang/cargo/issues/15495)
 
@@ -1874,13 +1874,14 @@ Since Cargo also passes `--emit=metadata` to these intermediate artifacts to ena
 compilation, this means that a lot of metadata ends up being duplicated on disk, which wastes
 disk space in the target directory.
 
-This feature tells Cargo to pass the `-Zembed-metadata=no` flag to the compiler, which instructs
-it not to embed metadata within rlib and dylib artifacts. In this case, the metadata will only
+If you pass `-Zembed-metadata=no` to Cago, it will then pass the `-Zembed-metadata=no` flag to the compiler, which instructs it not to embed metadata within rlib and dylib artifacts. In this case, the metadata will only
 be stored in `.rmeta` files.
 
 ```console
-cargo +nightly -Zno-embed-metadata build
+cargo +nightly -Zembed-metadata=no build
 ```
+
+> Note that this flag is planned to be removed in the future, as the `no` behavior should become the default.
 
 ## `unstable-editions`
 

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -6404,8 +6404,8 @@ fn renamed_uplifted_artifact_remains_unmodified_after_rebuild() {
     assert!(not_the_same, "renamed uplifted artifact must be unmodified");
 }
 
-#[cargo_test(nightly, reason = "-Zno-embed-metadata is nightly only")]
-fn no_embed_metadata() {
+#[cargo_test(nightly, reason = "-Zembed-metadata is nightly only")]
+fn embed_metadata_no() {
     let p = project()
         .file(
             "Cargo.toml",
@@ -6432,8 +6432,8 @@ fn no_embed_metadata() {
         )
         .build();
 
-    p.cargo("build -Z no-embed-metadata")
-        .masquerade_as_nightly_cargo(&["-Z no-embed-metadata"])
+    p.cargo("build -Z embed-metadata=no")
+        .masquerade_as_nightly_cargo(&["-Z embed-metadata"])
         .arg("-v")
         .with_stderr_contains("[RUNNING] `[..]-Z embed-metadata=no[..]`")
         .with_stderr_contains(
@@ -6444,8 +6444,8 @@ fn no_embed_metadata() {
 
 // Make sure that cargo passes --extern=<dep>.rmeta even if <dep>
 // is compiled as a dylib.
-#[cargo_test(nightly, reason = "-Zno-embed-metadata is nightly only")]
-fn no_embed_metadata_dylib_dep() {
+#[cargo_test(nightly, reason = "-Zembed-metadata is nightly only")]
+fn embed_metadata_no_dylib_dep() {
     let p = project()
         .file(
             "Cargo.toml",
@@ -6482,8 +6482,8 @@ fn no_embed_metadata_dylib_dep() {
         )
         .build();
 
-    p.cargo("build -Z no-embed-metadata")
-        .masquerade_as_nightly_cargo(&["-Z no-embed-metadata"])
+    p.cargo("build -Z embed-metadata=no")
+        .masquerade_as_nightly_cargo(&["-Z embed-metadata"])
         .arg("-v")
         .with_stderr_contains("[RUNNING] `[..]-Z embed-metadata=no[..]`")
         .with_stderr_contains(
@@ -6492,9 +6492,9 @@ fn no_embed_metadata_dylib_dep() {
         .run();
 }
 
-#[cargo_test(nightly, reason = "-Zno-embed-metadata is nightly only")]
-fn no_embed_metadata_invalidate() {
-    // Invalidate all deps when -Zno-embed-metadata is toggled
+#[cargo_test(nightly, reason = "-Zembed-metadata is nightly only")]
+fn embed_metadata_no_invalidate() {
+    // Invalidate all deps when -Zembed-metadata is toggled
     let p = project()
         .file(
             "Cargo.toml",
@@ -6521,8 +6521,8 @@ fn no_embed_metadata_invalidate() {
         )
         .build();
 
-    p.cargo("build -Z no-embed-metadata")
-        .masquerade_as_nightly_cargo(&["-Z no-embed-metadata"])
+    p.cargo("build -Z embed-metadata=no")
+        .masquerade_as_nightly_cargo(&["-Z embed-metadata"])
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
@@ -6532,7 +6532,7 @@ fn no_embed_metadata_invalidate() {
 "#]])
         .run();
     p.cargo("build")
-        .masquerade_as_nightly_cargo(&["-Z no-embed-metadata"])
+        .masquerade_as_nightly_cargo(&["-Z embed-metadata"])
         .with_stderr_data(str![[r#"
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.5.0 ([ROOT]/foo)

--- a/tests/testsuite/cargo/z_help/stdout.term.svg
+++ b/tests/testsuite/cargo/z_help/stdout.term.svg
@@ -22,61 +22,61 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan>    -Z allow-features              Allow *only* the listed unstable features</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>    -Z any-build-script-metadata   Allow any build script to specify env vars via cargo::metadata=key=value</tspan>
+    <tspan x="10px" y="82px"><tspan>    -Z embed-metadata              Avoid embedding metadata in library artifacts</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>    -Z asymmetric-token            Allows authenticating with asymmetric tokens</tspan>
+    <tspan x="10px" y="100px"><tspan>    -Z any-build-script-metadata   Allow any build script to specify env vars via cargo::metadata=key=value</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>    -Z avoid-dev-deps              Avoid installing dev-dependencies if possible</tspan>
+    <tspan x="10px" y="118px"><tspan>    -Z asymmetric-token            Allows authenticating with asymmetric tokens</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>    -Z binary-dep-depinfo          Track changes to dependency artifacts</tspan>
+    <tspan x="10px" y="136px"><tspan>    -Z avoid-dev-deps              Avoid installing dev-dependencies if possible</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>    -Z bindeps                     Allow Cargo packages to depend on bin, cdylib, and staticlib crates, and use the artifacts built by those crates</tspan>
+    <tspan x="10px" y="154px"><tspan>    -Z binary-dep-depinfo          Track changes to dependency artifacts</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>    -Z build-analysis              Record and persist build metrics across runs, with commands to query past builds.</tspan>
+    <tspan x="10px" y="172px"><tspan>    -Z bindeps                     Allow Cargo packages to depend on bin, cdylib, and staticlib crates, and use the artifacts built by those crates</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>    -Z build-dir-new-layout        Use the new build-dir filesystem layout</tspan>
+    <tspan x="10px" y="190px"><tspan>    -Z build-analysis              Record and persist build metrics across runs, with commands to query past builds.</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>    -Z build-std                   Enable Cargo to compile the standard library itself as part of a crate graph compilation</tspan>
+    <tspan x="10px" y="208px"><tspan>    -Z build-dir-new-layout        Use the new build-dir filesystem layout</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>    -Z build-std-features          Configure features enabled for the standard library itself when building the standard library</tspan>
+    <tspan x="10px" y="226px"><tspan>    -Z build-std                   Enable Cargo to compile the standard library itself as part of a crate graph compilation</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>    -Z cargo-lints                 Enable the `[lints.cargo]` table</tspan>
+    <tspan x="10px" y="244px"><tspan>    -Z build-std-features          Configure features enabled for the standard library itself when building the standard library</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>    -Z checksum-freshness          Use a checksum to determine if output is fresh rather than filesystem mtime</tspan>
+    <tspan x="10px" y="262px"><tspan>    -Z cargo-lints                 Enable the `[lints.cargo]` table</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>    -Z codegen-backend             Enable the `codegen-backend` option in profiles in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="280px"><tspan>    -Z checksum-freshness          Use a checksum to determine if output is fresh rather than filesystem mtime</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>    -Z direct-minimal-versions     Resolve minimal dependency versions instead of maximum (direct dependencies only)</tspan>
+    <tspan x="10px" y="298px"><tspan>    -Z codegen-backend             Enable the `codegen-backend` option in profiles in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>    -Z dual-proc-macros            Build proc-macros for both the host and the target</tspan>
+    <tspan x="10px" y="316px"><tspan>    -Z direct-minimal-versions     Resolve minimal dependency versions instead of maximum (direct dependencies only)</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>    -Z feature-unification         Enable new feature unification modes in workspaces</tspan>
+    <tspan x="10px" y="334px"><tspan>    -Z dual-proc-macros            Build proc-macros for both the host and the target</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>    -Z fine-grain-locking          Use fine grain locking instead of locking the entire build cache</tspan>
+    <tspan x="10px" y="352px"><tspan>    -Z feature-unification         Enable new feature unification modes in workspaces</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>    -Z fix-edition                 Permanently unstable edition migration helper</tspan>
+    <tspan x="10px" y="370px"><tspan>    -Z fine-grain-locking          Use fine grain locking instead of locking the entire build cache</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>    -Z gc                          Track cache usage and "garbage collect" unused files</tspan>
+    <tspan x="10px" y="388px"><tspan>    -Z fix-edition                 Permanently unstable edition migration helper</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>    -Z git                         Enable support for shallow git fetch operations</tspan>
+    <tspan x="10px" y="406px"><tspan>    -Z gc                          Track cache usage and "garbage collect" unused files</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>    -Z gitoxide                    Use gitoxide for the given git interactions, or all of them if no argument is given</tspan>
+    <tspan x="10px" y="424px"><tspan>    -Z git                         Enable support for shallow git fetch operations</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>    -Z hint-msrv                   Enable passing `package.rust-version` to rustc for lints</tspan>
+    <tspan x="10px" y="442px"><tspan>    -Z gitoxide                    Use gitoxide for the given git interactions, or all of them if no argument is given</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>    -Z host-config                 Enable the `[host]` section in the .cargo/config.toml file</tspan>
+    <tspan x="10px" y="460px"><tspan>    -Z hint-msrv                   Enable passing `package.rust-version` to rustc for lints</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>    -Z json-target-spec            Enable `.json` target spec files</tspan>
+    <tspan x="10px" y="478px"><tspan>    -Z host-config                 Enable the `[host]` section in the .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>    -Z min-publish-age             Enable the `min-publish-age` configuration for dependency version age filtering</tspan>
+    <tspan x="10px" y="496px"><tspan>    -Z json-target-spec            Enable `.json` target spec files</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>    -Z minimal-versions            Resolve minimal dependency versions instead of maximum</tspan>
+    <tspan x="10px" y="514px"><tspan>    -Z min-publish-age             Enable the `min-publish-age` configuration for dependency version age filtering</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>    -Z msrv-policy                 Enable rust-version aware policy within cargo</tspan>
+    <tspan x="10px" y="532px"><tspan>    -Z minimal-versions            Resolve minimal dependency versions instead of maximum</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>    -Z mtime-on-use                Configure Cargo to update the mtime of used files</tspan>
+    <tspan x="10px" y="550px"><tspan>    -Z msrv-policy                 Enable rust-version aware policy within cargo</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>    -Z no-embed-metadata           Avoid embedding metadata in library artifacts</tspan>
+    <tspan x="10px" y="568px"><tspan>    -Z mtime-on-use                Configure Cargo to update the mtime of used files</tspan>
 </tspan>
     <tspan x="10px" y="586px"><tspan>    -Z no-index-update             Do not update the registry index even if the cache is outdated</tspan>
 </tspan>


### PR DESCRIPTION
### What does this PR try to resolve?

This PR renames the unstable `-Zno-embed-metadata` flag to `-Zembed-metadata=no`, as proposed in https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/Usage.20of.20-Zno-embed-metadata/with/607232149. So that in the future it can be controlled both via `no` and `yes`, to allow opt-in/opt-out.

~~To enable the flag by default, I want to detect whether we both have nightly Cargo *and* nightly rustc. I'm not sure what's the best way to do that, but I tried to access `Rustc` through the `BuildContext` and determine if it is `nightly` or `dev` based on the output of `rustc -vV`.~~ We decided to postpone this to a follow-up PR.

### How to test and review this PR?

`cargo test --test testsuite -- build` will run a few tests that leverage `-Zembed-metadata`.