### PR TITLE
chore: upgrade to libssh2-sys@0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3059,9 +3059,9 @@ dependencies = [
 
 [[package]]
 name = "libssh2-sys"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+checksum = "c04141a07bb0c0bc461cb657808764de571702a59bc5c726c400ac9a7625e3ab"
 dependencies = [
  "cc",
  "libc",
@@ -4749,7 +4749,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",


### PR DESCRIPTION
### What does this PR try to resolve?

Basically rust-lang/cargo#17140 but with official libssh2-sys release.

See

* https://blog.rust-lang.org/2026/06/30/Rust-1.96.1/
* https://rust-lang.zulipchat.com/#narrow/channel/241545-t-release/topic/libssh2.20backport.20for.20cargo.20release/with/607458944