### PR TITLE
Fixed `Compilation::deps_output` only taking the last dep

### DIFF
--- a/src/cargo/core/compiler/build_runner/mod.rs
+++ b/src/cargo/core/compiler/build_runner/mod.rs
@@ -485,12 +485,18 @@ impl<'a, 'gctx> BuildRunner<'a, 'gctx> {
                 for (unit, _) in self.bcx.unit_graph.iter() {
                     let dep_dir = self.files().deps_dir(unit);
                     paths::create_dir_all(&dep_dir)?;
-                    self.compilation.deps_output.insert(kind, dep_dir);
+                    self.compilation
+                        .deps_output
+                        .entry(kind)
+                        .or_default()
+                        .insert(dep_dir);
                 }
             } else {
                 self.compilation
                     .deps_output
-                    .insert(kind, layout.build_dir().legacy_deps().to_path_buf());
+                    .entry(kind)
+                    .or_default()
+                    .insert(layout.build_dir().legacy_deps().to_path_buf());
             }
         }
         Ok(())

--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -95,9 +95,9 @@ pub struct Compilation<'gctx> {
     /// Root output directory (for the local package's artifacts)
     pub root_output: HashMap<CompileKind, PathBuf>,
 
-    /// Output directory for rust dependencies.
+    /// Output directories for rust dependencies.
     /// May be for the host or for a specific target.
-    pub deps_output: HashMap<CompileKind, PathBuf>,
+    pub deps_output: HashMap<CompileKind, BTreeSet<PathBuf>>,
 
     /// The path to libstd for each target
     sysroot_target_libdir: HashMap<CompileKind, PathBuf>,
@@ -375,7 +375,7 @@ impl<'gctx> Compilation<'gctx> {
                     &self.root_output[&CompileKind::Host],
                 ));
             }
-            search_path.push(self.deps_output[&CompileKind::Host].clone());
+            search_path.extend(self.deps_output[&CompileKind::Host].clone());
         } else {
             if let Some(path) = self.root_output.get(&kind) {
                 search_path.extend(super::filter_dynamic_search_path(
@@ -384,7 +384,7 @@ impl<'gctx> Compilation<'gctx> {
                 ));
                 search_path.push(path.clone());
             }
-            search_path.push(self.deps_output[&kind].clone());
+            search_path.extend(self.deps_output[&kind].clone());
             // For build-std, we don't want to accidentally pull in any shared
             // libs from the sysroot that ships with rustc. This may not be
             // required (at least I cannot craft a situation where it

--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -1397,7 +1397,6 @@ fn dylib_deps_output_overwrite() {
         .masquerade_as_nightly_cargo(&["build-dir-new-layout"])
         .env("__CARGO_DEFAULT_LIB_METADATA", "1")
         .enable_mac_dsym()
-        .with_status(127)
         .with_stderr_data(
             str![[r#"
 [LOCKING] 2 packages to latest compatible versions
@@ -1407,12 +1406,6 @@ fn dylib_deps_output_overwrite() {
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] unittests src/main.rs (build-dir/debug/build/main/[HASH]/out/[..])
 [RUNNING] tests/use_both_dylibs.rs (build-dir/debug/build/main/[HASH]/out/[..])
-[..]: error while loading shared libraries: [..]
-
-Caused by:
-[..]
-  process didn't exit successfully: `[ROOT]/foo/build-dir/debug/build/main/[HASH]/out/use_both_dylibs-[HASH]` ([EXIT_STATUS]: 127)
-[NOTE] test exited abnormally; to see the full output pass --no-capture to the harness.
 
 "#]]
             .unordered(),

--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -1311,6 +1311,140 @@ CARGO_BIN_FILE_BAR_bar=[ROOT]/foo/build-dir/debug/build/bar/[HASH]/artifact/bin/
 "#]]);
 }
 
+/// Verify multiple dylibs are properly added to the search path.
+/// Regression test for https://github.com/rust-lang/rust/issues/158526
+#[cargo_test]
+fn dylib_deps_output_overwrite() {
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [build]
+            target-dir = "target-dir"
+            build-dir = "build-dir"
+            rustflags = ["-C", "prefer-dynamic"]
+            "#,
+        )
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "main"
+                version = "0.0.0"
+                edition = "2021"
+                authors = []
+                resolver = "2"
+
+                [dependencies]
+                bar = { path = "bar" }
+                baz = { path = "baz" }
+            "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+                use bar::bar_value;
+                use baz::baz_value;
+
+                fn main() {
+                    println!("sum = {}", bar_value() + baz_value());
+                }
+            "#,
+        )
+        .file(
+            "tests/use_both_dylibs.rs",
+            r#"
+                use bar::bar_value;
+                use baz::baz_value;
+
+                #[test]
+                fn uses_both_dylibs() {
+                    assert_eq!(bar_value() + baz_value(), 300);
+                }
+            "#,
+        )
+        .file(
+            "bar/Cargo.toml",
+            r#"
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                edition = "2021"
+                authors = []
+
+                [lib]
+                crate-type = ["dylib"]
+            "#,
+        )
+        .file("bar/src/lib.rs", r#"pub fn bar_value() -> i32 { 100 }"#)
+        .file(
+            "baz/Cargo.toml",
+            r#"
+                [package]
+                name = "baz"
+                version = "0.1.0"
+                edition = "2021"
+                authors = []
+
+                [lib]
+                crate-type = ["dylib"]
+            "#,
+        )
+        .file("baz/src/lib.rs", r#"pub fn baz_value() -> i32 { 200 }"#)
+        .build();
+
+    p.cargo("test -Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["build-dir-new-layout"])
+        .env("__CARGO_DEFAULT_LIB_METADATA", "1")
+        .enable_mac_dsym()
+        .with_status(127)
+        .with_stderr_data(
+            str![[r#"
+[LOCKING] 2 packages to latest compatible versions
+[COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
+[COMPILING] baz v0.1.0 ([ROOT]/foo/baz)
+[COMPILING] main v0.0.0 ([ROOT]/foo)
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[RUNNING] unittests src/main.rs (build-dir/debug/build/main/[HASH]/out/[..])
+[RUNNING] tests/use_both_dylibs.rs (build-dir/debug/build/main/[HASH]/out/[..])
+[..]: error while loading shared libraries: [..]
+
+Caused by:
+[..]
+  process didn't exit successfully: `[ROOT]/foo/build-dir/debug/build/main/[HASH]/out/use_both_dylibs-[HASH]` ([EXIT_STATUS]: 127)
+[NOTE] test exited abnormally; to see the full output pass --no-capture to the harness.
+
+"#]]
+            .unordered(),
+        )
+        .run();
+
+    // Check that the dylibs are uplifted
+    assert_exists_patterns_with_base_dir(
+        &p.root().join("target-dir/debug"),
+        &[
+            &format!("{DLL_PREFIX}bar{DLL_SUFFIX}"),
+            &format!("{DLL_PREFIX}baz{DLL_SUFFIX}"),
+        ],
+    );
+
+    // Check the correctly-named (hashed) dylibs exist in per-unit out/ dirs.
+    assert_exists_pattern(
+        &p.root()
+            .join(format!(
+                "build-dir/debug/build/bar/*/out/{DLL_PREFIX}bar-*{DLL_SUFFIX}"
+            ))
+            .to_string_lossy(),
+    );
+    assert_exists_pattern(
+        &p.root()
+            .join(format!(
+                "build-dir/debug/build/baz/*/out/{DLL_PREFIX}baz-*{DLL_SUFFIX}"
+            ))
+            .to_string_lossy(),
+    );
+}
+
 /// __CARGO_DEFAULT_LIB_METADATA is internal but used by rustc bootstrap and Miri
 /// Regression test for https://github.com/rust-lang/cargo/issues/16854
 #[cargo_test]

--- a/tests/testsuite/build_dir_legacy.rs
+++ b/tests/testsuite/build_dir_legacy.rs
@@ -1220,6 +1220,121 @@ CARGO_BIN_FILE_BAR_bar=[ROOT]/foo/build-dir/debug/deps/artifact/bar-[HASH]/bin/b
 "#]]);
 }
 
+/// Verify multiple dylibs are properly added to the search path.
+/// Regression test for https://github.com/rust-lang/rust/issues/158526
+#[cargo_test]
+fn dylib_deps_output() {
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [build]
+            target-dir = "target-dir"
+            build-dir = "build-dir"
+            rustflags = ["-C", "prefer-dynamic"]
+            "#,
+        )
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                edition = "2021"
+                resolver = "2"
+
+                [dependencies]
+                bar = { path = "bar" }
+                baz = { path = "baz" }
+            "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+                use bar::bar_value;
+                use baz::baz_value;
+
+                fn main() {
+                    println!("sum = {}", bar_value() + baz_value());
+                }
+            "#,
+        )
+        .file(
+            "tests/use_both_dylibs.rs",
+            r#"
+                use bar::bar_value;
+                use baz::baz_value;
+
+                #[test]
+                fn uses_both_dylibs() {
+                    assert_eq!(bar_value() + baz_value(), 300);
+                }
+            "#,
+        )
+        .file(
+            "bar/Cargo.toml",
+            r#"
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                edition = "2021"
+                authors = []
+
+                [lib]
+                crate-type = ["dylib"]
+            "#,
+        )
+        .file("bar/src/lib.rs", r#"pub fn bar_value() -> i32 { 100 }"#)
+        .file(
+            "baz/Cargo.toml",
+            r#"
+                [package]
+                name = "baz"
+                version = "0.1.0"
+                edition = "2021"
+                authors = []
+
+                [lib]
+                crate-type = ["dylib"]
+            "#,
+        )
+        .file("baz/src/lib.rs", r#"pub fn baz_value() -> i32 { 200 }"#)
+        .build();
+
+    p.cargo("test")
+        .env("__CARGO_DEFAULT_LIB_METADATA", "repro")
+        .enable_mac_dsym()
+        .with_stderr_data(
+            str![[r#"
+[LOCKING] 2 packages to latest compatible versions
+[COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
+[COMPILING] baz v0.1.0 ([ROOT]/foo/baz)
+[COMPILING] foo v0.0.0 ([ROOT]/foo)
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[RUNNING] unittests src/main.rs (build-dir/debug/deps/[..])
+[RUNNING] tests/use_both_dylibs.rs (build-dir/debug/deps/[..])
+
+"#]]
+            .unordered(),
+        )
+        .run();
+
+    assert_exists_pattern(
+        &p.root()
+            .join(format!(
+                "build-dir/debug/deps/{DLL_PREFIX}bar-*{DLL_SUFFIX}",
+            ))
+            .to_string_lossy(),
+    );
+    assert_exists_pattern(
+        &p.root()
+            .join(format!(
+                "build-dir/debug/deps/{DLL_PREFIX}baz-*{DLL_SUFFIX}",
+            ))
+            .to_string_lossy(),
+    );
+}
+
 fn parse_workspace_manifest_path_hash(hash_dir: &PathBuf) -> PathBuf {
     // Since the hash will change between test runs simply find the first directories and assume
     // that is the hash dir. The format is a 2 char directory followed by the remaining hash in the


### PR DESCRIPTION
### What does this PR try to resolve?

This PR fixes a bug in the compilation logic that causes the `compilation.dep_output` being overwritten instead of appending the directories. (`HashMap::insert` called in a loop, causing only the last element to be added)

This is normally not reachable for most uses as dylibs are uplifted, so the uplifted dylibs usually land on the search path masking the bug. I believe its only a problem when `__CARGO_DEFAULT_LIB_METADATA=1` is set as the metadata hash causing the bin or test to fail to find the dylib if there are more than one.

Reported in https://github.com/rust-lang/rust/issues/158526

I guess this will further put pressure on the Windows `PATH`, it seems necessary for correctness. :-(

### How to test and review this PR?

The change is fairly straight forward, just make the hashmap value a set so it could hold multiple paths.
I added a regression test that verifies `cargo test` runs for a crate with multiple dylibs.

cc: @yuzibo @HNO3Miracle (would appreciate if you would be able check if this change fixes your issue reported in https://github.com/rust-lang/rust/issues/158526)