### PR TITLE
Avoid cloning parsed TOML manifest in `ManifestErrorContext`

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -61,7 +61,7 @@ use std::ffi::{OsStr, OsString};
 use std::fmt::Display;
 use std::fs::{self, File};
 use std::io::{BufRead, BufWriter, Write};
-use std::ops::Range;
+use std::ops::{Deref, Range};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock};
 
@@ -2111,7 +2111,7 @@ struct ManifestErrorContext {
     /// The path to the manifest.
     path: PathBuf,
     /// The locations of various spans within the manifest.
-    spans: Option<toml::Spanned<toml::de::DeTable<'static>>>,
+    spans: Option<Arc<toml::Spanned<toml::de::DeTable<'static>>>>,
     /// The raw manifest contents.
     contents: Option<String>,
     /// A lookup for all the unambiguous renamings, mapping from the original package
@@ -2491,7 +2491,7 @@ impl ManifestErrorContext {
         let bcx = build_runner.bcx;
         ManifestErrorContext {
             path: unit.pkg.manifest_path().to_owned(),
-            spans: unit.pkg.manifest().document().cloned(),
+            spans: unit.pkg.manifest().document_rc(),
             contents: unit.pkg.manifest().contents().map(String::from),
             requested_kinds: bcx.target_data.requested_kinds().to_owned(),
             host_name: bcx.rustc().host,
@@ -2560,6 +2560,7 @@ impl ManifestErrorContext {
         // [target.'cfg(something)'.dependencies]. We filter out target tables
         // that don't match a requested target or a requested cfg.
         if let Some(target) = spans
+            .deref()
             .as_ref()
             .get("target")
             .and_then(|t| t.as_ref().as_table())

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -63,7 +63,7 @@ impl EitherManifest {
 pub struct Manifest {
     // alternate forms of manifests:
     contents: Option<Rc<String>>,
-    document: Option<Rc<toml::Spanned<toml::de::DeTable<'static>>>>,
+    document: Option<Arc<toml::Spanned<toml::de::DeTable<'static>>>>,
     original_toml: Option<Rc<TomlManifest>>,
     normalized_toml: Rc<TomlManifest>,
     summary: Summary,
@@ -497,7 +497,7 @@ compact_debug! {
 impl Manifest {
     pub fn new(
         contents: Option<Rc<String>>,
-        document: Option<Rc<toml::Spanned<toml::de::DeTable<'static>>>>,
+        document: Option<Arc<toml::Spanned<toml::de::DeTable<'static>>>>,
         original_toml: Option<Rc<TomlManifest>>,
         normalized_toml: Rc<TomlManifest>,
         summary: Summary,
@@ -571,6 +571,12 @@ impl Manifest {
     pub fn document(&self) -> Option<&toml::Spanned<toml::de::DeTable<'static>>> {
         self.document.as_deref()
     }
+
+    /// Collection of spans for the original TOML, returned as a cloned Arc.
+    pub fn document_rc(&self) -> Option<Arc<toml::Spanned<toml::de::DeTable<'static>>>> {
+        self.document.clone()
+    }
+
     /// The [`TomlManifest`] as parsed from [`Manifest::document`]
     pub fn original_toml(&self) -> Option<&TomlManifest> {
         self.original_toml.as_deref()

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -6,6 +6,7 @@ use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::str::{self, FromStr};
+use std::sync::Arc;
 
 use crate::AlreadyPrintedError;
 use crate::core::summary::MissingDependencyError;
@@ -1828,7 +1829,7 @@ note: only a feature named `default` will be enabled by default"
     let metabuild = normalized_package.metabuild.clone().map(|sov| sov.0);
     let manifest = Manifest::new(
         contents.map(Rc::new),
-        document.map(Rc::new),
+        document.map(Arc::new),
         Some(Rc::new(original_toml)),
         Rc::new(normalized_toml),
         summary,


### PR DESCRIPTION
### What does this PR try to resolve?

I was profiling the build performance of `bors`, and noticed that running Cargo on a no-op build takes >300ms, which seemed like a lot. I found a few places that could be micro-optimized, this one is the one that produced the largest performance win with the fewest code changes.

I noticed that `ManifestErrorContext` is being unconditionally created for each compiled unit (whether fresh or not), even though in the vast majority of cases, there are no manifest errors to be enriched. The error context clones a bunch of things. While taking a look at memory profiles using Valgrind's dhat, I noticed that a lot of time and memory allocations were spent on cloning the TOML document, which happened inside the error context.

This PR changes the representation of the TOML manifest from `Rc` to `Arc`, so that it can be directly used in `ManifestErrorContext` without cloning the whole thing.

This produced a ~6% wall-time win on the Cargo invocation on `bors`:

```
Benchmark 1: /projects/personal/rust/cargo/target/release/cargo test --no-run
Time (mean ± σ):     317.8 ms ±   1.0 ms    [User: 204.1 ms, System: 117.6 ms]
Range (min … max):   316.5 ms … 319.7 ms    10 runs

Benchmark 2: ./cargo-baseline test --no-run
Time (mean ± σ):     336.4 ms ±   1.3 ms    [User: 218.7 ms, System: 121.4 ms]
Range (min … max):   334.8 ms … 339.5 ms    10 runs

Summary
/projects/personal/rust/cargo/target/release/cargo test --no-run ran
1.06 ± 0.01 times faster than ./cargo-baseline test --no-run
```

I compiled Cargo with `lto = "thin"` to emulate the configuration we use in the Cargo that is distributed through Rustup.

### How to test and review this PR?

I suppose try to run and benchmark Cargo on a project with hundreds of deps before and after this change :)