### PR TITLE
Reduce rustc `-L` args used in the new `build-dir` layout

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1854,6 +1854,10 @@ fn add_dep_arg<'a, 'b: 'a>(
     unit: &'a Unit,
 ) {
     for dep in build_runner.unit_deps(unit) {
+        // Don't include build script out dir in the args to reduce rustc command bloat.
+        if dep.unit.target.is_custom_build() {
+            continue;
+        }
         if map.contains_key(&dep.unit) {
             continue;
         }

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1853,12 +1853,11 @@ fn add_dep_arg<'a, 'b: 'a>(
     build_runner: &'b BuildRunner<'b, '_>,
     unit: &'a Unit,
 ) {
-    if map.contains_key(&unit) {
-        return;
-    }
-    map.insert(&unit, build_runner.files().deps_dir(&unit));
-
     for dep in build_runner.unit_deps(unit) {
+        if map.contains_key(&dep.unit) {
+            continue;
+        }
+        map.insert(&dep.unit, build_runner.files().deps_dir(&dep.unit));
         add_dep_arg(map, build_runner, &dep.unit);
     }
 }

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -6558,10 +6558,10 @@ fn should_not_include_current_build_unit_path_in_rustc_args() {
     p.cargo("-Zbuild-dir-new-layout -v build")
         .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .enable_mac_dsym()
-        // We currently pass the current build unit's out_dir as a `-L` arg to rustc
+        // Don't pass any `-L` args if there are no dependencies (including our own `out` dir)
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo [..] --out-dir [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out -L dependency=[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out --verbose`
+[RUNNING] `rustc --crate-name foo [..] --out-dir [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out --verbose`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -6540,3 +6540,30 @@ fn no_embed_metadata_invalidate() {
 "#]])
         .run();
 }
+
+#[cargo_test]
+fn should_not_include_current_build_unit_path_in_rustc_args() {
+    let p = project()
+        .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [build]
+            target-dir = "target-dir"
+            build-dir = "build-dir"
+            "#,
+        )
+        .build();
+
+    p.cargo("-Zbuild-dir-new-layout -v build")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .enable_mac_dsym()
+        // We currently pass the current build unit's out_dir as a `-L` arg to rustc
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..] --out-dir [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out -L dependency=[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out --verbose`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -6586,12 +6586,13 @@ fn should_not_include_build_script_out_dir_path_in_rustc_args() {
     p.cargo("-Zbuild-dir-new-layout -v build")
         .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .enable_mac_dsym()
-        // Currently we pass build script out dirs.
+        // Don't pass build script `out` dirs and avoid bloating the rustc command args which can
+        // lead to problems on Windows.
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]`
 [RUNNING] `[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/build_script_build`
-[RUNNING] `rustc --crate-name foo [..] --out-dir [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out -L dependency=[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out -L dependency=[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out --verbose`
+[RUNNING] `rustc --crate-name foo [..] --out-dir [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out --verbose`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -6567,3 +6567,33 @@ fn should_not_include_current_build_unit_path_in_rustc_args() {
 "#]])
         .run();
 }
+
+#[cargo_test]
+fn should_not_include_build_script_out_dir_path_in_rustc_args() {
+    let p = project()
+        .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
+        .file("build.rs", r#"fn main() { }"#)
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [build]
+            target-dir = "target-dir"
+            build-dir = "build-dir"
+            "#,
+        )
+        .build();
+
+    p.cargo("-Zbuild-dir-new-layout -v build")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .enable_mac_dsym()
+        // Currently we pass build script out dirs.
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name build_script_build [..]`
+[RUNNING] `[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `rustc --crate-name foo [..] --out-dir [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out -L dependency=[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out -L dependency=[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out --verbose`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}


### PR DESCRIPTION
### What does this PR try to resolve?

With the new `build-dir` enabled in rust-lang/rust there are have been a few reported issues due to long commands / PATH.
This PR attempts to mitigate this by doing the following:
1. Fix a bug where the current build unit's out dir would be added the rustc args even though it is never needed. (due to the first iteration in the recursive `add_dep_arg` fn).
    * This probably wont make much different for long PATHs but it should not passed.
2. Avoid passing build-script build unit's out dir which contains the build-script binary as it would very odd to link against a build script. This also has the effect of not recursively including other `[build-dependencies]` the build-script unit depended on.

I included this both in the PR as they are small and related but happy to split into dedicated PRs if desired :) 

### How to test and review this PR?

See the included tests. Best reviewed commit by commit

cc: @Kobzol 