### PR TITLE
Do not pass lint rustflags when `--cap-lints=allow` is set

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1148,19 +1148,38 @@ fn append_crate_version_flag(unit: &Unit, rustdoc: &mut ProcessBuilder) {
         .arg(unit.pkg.version().to_string());
 }
 
+enum CapLints {
+    Allow,
+    Warn,
+}
+
+fn compute_cap_lints(bcx: &BuildContext<'_, '_>, unit: &Unit) -> Option<CapLints> {
+    // If this is an upstream dep we don't want warnings from, turn off all
+    // lints.
+    if !unit.show_warnings(bcx.gctx) {
+        Some(CapLints::Allow)
+    // If this is an upstream dep but we *do* want warnings, make sure that they
+    // don't fail compilation.
+    } else if !unit.is_local() {
+        Some(CapLints::Warn)
+    } else {
+        None
+    }
+}
+
 /// Adds [`--cap-lints`] to the command to execute.
 ///
 /// [`--cap-lints`]: https://doc.rust-lang.org/nightly/rustc/lints/levels.html#capping-lints
 fn add_cap_lints(bcx: &BuildContext<'_, '_>, unit: &Unit, cmd: &mut ProcessBuilder) {
-    // If this is an upstream dep we don't want warnings from, turn off all
-    // lints.
-    if !unit.show_warnings(bcx.gctx) {
-        cmd.arg("--cap-lints").arg("allow");
-
-    // If this is an upstream dep but we *do* want warnings, make sure that they
-    // don't fail compilation.
-    } else if !unit.is_local() {
-        cmd.arg("--cap-lints").arg("warn");
+    if let Some(cap_lints) = compute_cap_lints(bcx, unit) {
+        match cap_lints {
+            CapLints::Allow => {
+                cmd.arg("--cap-lints").arg("allow");
+            }
+            CapLints::Warn => {
+                cmd.arg("--cap-lints").arg("warn");
+            }
+        }
     }
 }
 
@@ -1364,7 +1383,14 @@ fn build_base_args(
         trim_paths_args(cmd, build_runner, unit, &trim_paths)?;
     }
 
-    cmd.args(unit.pkg.manifest().lint_rustflags());
+    match compute_cap_lints(bcx, unit) {
+        None | Some(CapLints::Warn) => {
+            cmd.args(unit.pkg.manifest().lint_rustflags());
+        }
+        // If we pass --cap-lints=allow, there is no point in making the CLI larger by including
+        // potentially a lot of --warn lint flags.
+        Some(CapLints::Allow) => {}
+    }
     cmd.args(&profile_rustflags);
 
     // `-C overflow-checks` is implied by the setting of `-C debug-assertions`,


### PR DESCRIPTION
### What does this PR try to resolve?

This PR attempts to reduce the size of the command-line arguments for dependencies that use lints in their `Cargo.toml` manifest. As discussed on [Zulip](https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/Not.20passing.20allow.2Fwarn.20lints.20when.20compiling.20dependencies/with/607970717), when we pass `--cap-lints allow`, it shouldn't matter if we also pass any lint level flags, because they will be capped anyway. For some dependencies, it can be quite a lot of CLI arguments, e.g. for `env_logger`, just the lint flags are ~2.2k characters, so more around 2 KiB of data passed on the CLI that should be useless.

Note that there are some optimizations within `rustc` that skip running lints that are allowed (and do not have to run always, and don't have future breakage warnings). However, that optimization takes `--cap-lints allow` into account, so this PR shouldn't change this optimization heuristic.

### How to test and review this PR?

I haven't found any tests that would mention `--cap-lints`, so I wasn't sure how to test this. Maybe we could add some test-only environment variable that would allow treating specific test crates as being "upstream deps", so that cap lints would trigger for then?