### PR TITLE
Make TOML manifest document non-optional

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -2111,7 +2111,7 @@ struct ManifestErrorContext {
     /// The path to the manifest.
     path: PathBuf,
     /// The locations of various spans within the manifest.
-    spans: Option<Arc<toml::Spanned<toml::de::DeTable<'static>>>>,
+    spans: Arc<toml::Spanned<toml::de::DeTable<'static>>>,
     /// The raw manifest contents.
     contents: Option<String>,
     /// A lookup for all the unambiguous renamings, mapping from the original package
@@ -2533,13 +2533,9 @@ impl ManifestErrorContext {
     /// baz = { path = "../bar", package = "bar" }
     /// ```
     fn find_crate_span(&self, unrenamed: &str) -> Option<Range<usize>> {
-        let Some(ref spans) = self.spans else {
-            return None;
-        };
-
         let orig_name = self.rename_table.get(unrenamed)?.as_str();
 
-        if let Some((k, v)) = get_key_value(&spans, &["dependencies", orig_name]) {
+        if let Some((k, v)) = get_key_value(&self.spans, &["dependencies", orig_name]) {
             // We make some effort to find the unrenamed text: in
             //
             // ```
@@ -2559,7 +2555,8 @@ impl ManifestErrorContext {
         // [target.x86_64-unknown-linux-gnu.dependencies] or
         // [target.'cfg(something)'.dependencies]. We filter out target tables
         // that don't match a requested target or a requested cfg.
-        if let Some(target) = spans
+        if let Some(target) = self
+            .spans
             .deref()
             .as_ref()
             .get("target")

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -63,7 +63,7 @@ impl EitherManifest {
 pub struct Manifest {
     // alternate forms of manifests:
     contents: Option<Rc<String>>,
-    document: Option<Arc<toml::Spanned<toml::de::DeTable<'static>>>>,
+    document: Arc<toml::Spanned<toml::de::DeTable<'static>>>,
     original_toml: Option<Rc<TomlManifest>>,
     normalized_toml: Rc<TomlManifest>,
     summary: Summary,
@@ -110,7 +110,7 @@ pub struct Warnings(Vec<DelayedWarning>);
 pub struct VirtualManifest {
     // alternate forms of manifests:
     contents: Option<Rc<String>>,
-    document: Option<Rc<toml::Spanned<toml::de::DeTable<'static>>>>,
+    document: Rc<toml::Spanned<toml::de::DeTable<'static>>>,
     original_toml: Option<Rc<TomlManifest>>,
     normalized_toml: Rc<TomlManifest>,
 
@@ -497,7 +497,7 @@ compact_debug! {
 impl Manifest {
     pub fn new(
         contents: Option<Rc<String>>,
-        document: Option<Arc<toml::Spanned<toml::de::DeTable<'static>>>>,
+        document: Arc<toml::Spanned<toml::de::DeTable<'static>>>,
         original_toml: Option<Rc<TomlManifest>>,
         normalized_toml: Rc<TomlManifest>,
         summary: Summary,
@@ -568,12 +568,12 @@ impl Manifest {
         Ok(format!("{}\n{}", MANIFEST_PREAMBLE, toml))
     }
     /// Collection of spans for the original TOML
-    pub fn document(&self) -> Option<&toml::Spanned<toml::de::DeTable<'static>>> {
-        self.document.as_deref()
+    pub fn document(&self) -> &toml::Spanned<toml::de::DeTable<'static>> {
+        &self.document
     }
 
     /// Collection of spans for the original TOML, returned as a cloned Arc.
-    pub fn document_rc(&self) -> Option<Arc<toml::Spanned<toml::de::DeTable<'static>>>> {
+    pub fn document_rc(&self) -> Arc<toml::Spanned<toml::de::DeTable<'static>>> {
         self.document.clone()
     }
 
@@ -751,7 +751,7 @@ impl Manifest {
 impl VirtualManifest {
     pub fn new(
         contents: Option<Rc<String>>,
-        document: Option<Rc<toml::Spanned<toml::de::DeTable<'static>>>>,
+        document: Rc<toml::Spanned<toml::de::DeTable<'static>>>,
         original_toml: Option<Rc<TomlManifest>>,
         normalized_toml: Rc<TomlManifest>,
         replace: Vec<(PackageIdSpec, Dependency)>,
@@ -779,8 +779,8 @@ impl VirtualManifest {
         self.contents.as_deref().map(|c| c.as_str())
     }
     /// Collection of spans for the original TOML
-    pub fn document(&self) -> Option<&toml::Spanned<toml::de::DeTable<'static>>> {
-        self.document.as_deref()
+    pub fn document(&self) -> &toml::Spanned<toml::de::DeTable<'static>> {
+        &self.document
     }
     /// The [`TomlManifest`] as parsed from [`VirtualManifest::document`]
     pub fn original_toml(&self) -> Option<&TomlManifest> {

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1917,7 +1917,7 @@ impl MaybePackage {
         }
     }
 
-    pub fn document(&self) -> Option<&toml::Spanned<toml::de::DeTable<'static>>> {
+    pub fn document(&self) -> &toml::Spanned<toml::de::DeTable<'static>> {
         match self {
             MaybePackage::Package(p) => p.manifest().document(),
             MaybePackage::Virtual(v) => v.document(),

--- a/src/cargo/diagnostics/mod.rs
+++ b/src/cargo/diagnostics/mod.rs
@@ -230,7 +230,7 @@ impl ManifestFor<'_> {
         }
     }
 
-    pub fn document(&self) -> Option<&toml::Spanned<toml::de::DeTable<'static>>> {
+    pub fn document(&self) -> &toml::Spanned<toml::de::DeTable<'static>> {
         match self {
             ManifestFor::Package(p) => p.manifest().document(),
             ManifestFor::Workspace { ws: _, maybe_pkg } => maybe_pkg.document(),

--- a/src/cargo/diagnostics/rules/blanket_hint_mostly_unused.rs
+++ b/src/cargo/diagnostics/rules/blanket_hint_mostly_unused.rs
@@ -122,8 +122,8 @@ pub(crate) fn lint_workspace(
         let mut report = Vec::new();
         let mut primary_group = Group::with_title(level.clone().primary_title(title));
 
+        let document = maybe_pkg.document();
         if let Some(contents) = maybe_pkg.contents()
-            && let Some(document) = maybe_pkg.document()
             && let Some(span) = get_key_value_span(document, &path)
             && let Some(table_span) = get_key_value_span(document, &path[..path.len() - 1])
         {
@@ -144,8 +144,8 @@ pub(crate) fn lint_workspace(
 
             report.push(
                 if let Some(contents) = maybe_pkg.contents()
-                    && let Some(document) = maybe_pkg.document()
-                    && let Some(table_span) = get_key_value_span(document, &path[..path.len() - 1])
+                    && let Some(table_span) =
+                        get_key_value_span(maybe_pkg.document(), &path[..path.len() - 1])
                 {
                     help_group.element(Snippet::source(contents).path(&manifest_path).patch(
                         Patch::new(

--- a/src/cargo/diagnostics/rules/im_a_teapot.rs
+++ b/src/cargo/diagnostics/rules/im_a_teapot.rs
@@ -55,10 +55,9 @@ pub(crate) fn lint_package(
 
         let mut desc = Group::with_title(level.primary_title(LINT.desc));
 
-        if let Some(document) = manifest.document()
-            && let Some(contents) = manifest.contents()
-        {
-            let span = get_key_value_span(document, &["package", "im-a-teapot"]).unwrap();
+        if let Some(contents) = manifest.contents() {
+            let span =
+                get_key_value_span(manifest.document(), &["package", "im-a-teapot"]).unwrap();
 
             desc = desc.element(
                 Snippet::source(contents)

--- a/src/cargo/diagnostics/rules/implicit_minimum_version_req.rs
+++ b/src/cargo/diagnostics/rules/implicit_minimum_version_req.rs
@@ -248,7 +248,7 @@ fn report<'a>(
     lint_level: LintLevel,
     source: LintLevelSource,
     contents: Option<&'a str>,
-    document: Option<&toml::Spanned<toml::de::DeTable<'static>>>,
+    document: &toml::Spanned<toml::de::DeTable<'static>>,
     key_path: &[&str],
     manifest_path: &str,
     suggested_req: &str,
@@ -263,9 +263,7 @@ fn report<'a>(
     let mut desc = Group::with_title(level.primary_title(LINT.desc));
     let mut help = Group::with_title(Level::HELP.secondary_title(secondary_title));
 
-    if let Some(document) = document
-        && let Some(contents) = contents
-    {
+    if let Some(contents) = contents {
         let Some(span) = span_of_version_req(document, key_path) else {
             return None;
         };

--- a/src/cargo/diagnostics/rules/missing_lints_features.rs
+++ b/src/cargo/diagnostics/rules/missing_lints_features.rs
@@ -116,14 +116,12 @@ fn report_feature_not_enabled(
         Level::ERROR.primary_title(format!("use of unstable lint `{lint_name}`")),
     );
 
-    if let Some(document) = manifest.document()
-        && let Some(contents) = manifest.contents()
-    {
+    if let Some(contents) = manifest.contents() {
         let key_path = match manifest {
             ManifestFor::Package(_) => &["lints", "cargo", lint_name][..],
             ManifestFor::Workspace { .. } => &["workspace", "lints", "cargo", lint_name][..],
         };
-        let Some(span) = get_key_value_span(document, key_path) else {
+        let Some(span) = get_key_value_span(manifest.document(), key_path) else {
             // This lint is handled by either package or workspace lint.
             return Ok(());
         };

--- a/src/cargo/diagnostics/rules/non_kebab_case_bins.rs
+++ b/src/cargo/diagnostics/rules/non_kebab_case_bins.rs
@@ -138,8 +138,7 @@ fn lint_package_inner(
                 Level::HELP
                     .secondary_title("to change the binary name to kebab case, convert `bin.name`"),
             );
-            if let Some(document) = document
-                && let Some(contents) = contents
+            if let Some(contents) = contents
                 && let Some(span) = get_key_value_span(
                     document,
                     &["bin".as_index(), i.as_index(), "name".as_index()],
@@ -174,8 +173,7 @@ fn lint_package_inner(
             // Preferring it over moving the file to avoid having to get into moving the
             // files it `mod`s
             let help_bin_table = "to change the binary name to kebab case, specify `bin.name`";
-            if let Some(document) = document
-                && let Some(contents) = contents
+            if let Some(contents) = contents
                 && let Some(span) = get_key_value_span(document, &["package", "name"])
             {
                 report.push(

--- a/src/cargo/diagnostics/rules/non_kebab_case_features.rs
+++ b/src/cargo/diagnostics/rules/non_kebab_case_features.rs
@@ -99,8 +99,7 @@ fn lint_package_inner(
         let emitted_source = LINT.emitted_source(lint_level, source);
 
         let mut primary = Group::with_title(level.primary_title(LINT.desc));
-        if let Some(document) = document
-            && let Some(contents) = contents
+        if let Some(contents) = contents
             && let Some(span) = get_key_value_span(document, &["features", original_name])
         {
             primary = primary.element(
@@ -108,8 +107,7 @@ fn lint_package_inner(
                     .path(manifest_path)
                     .annotation(AnnotationKind::Primary.span(span.key)),
             );
-        } else if let Some(document) = document
-            && let Some(contents) = contents
+        } else if let Some(contents) = contents
             && let Some(dep_span) = get_key_value_span(document, &["dependencies", original_name])
             && let Some(optional_span) =
                 get_key_value_span(document, &["dependencies", original_name, "optional"])
@@ -129,8 +127,7 @@ fn lint_package_inner(
         }
         primary = primary.element(Level::NOTE.message(emitted_source));
         let mut report = vec![primary];
-        if let Some(document) = document
-            && let Some(contents) = contents
+        if let Some(contents) = contents
             && let Some(span) = get_key_value_span(document, &["features", original_name])
         {
             let mut help = Group::with_title(Level::HELP.secondary_title(

--- a/src/cargo/diagnostics/rules/non_kebab_case_packages.rs
+++ b/src/cargo/diagnostics/rules/non_kebab_case_packages.rs
@@ -99,8 +99,7 @@ fn lint_package_inner(
     let emitted_source = LINT.emitted_source(lint_level, source);
 
     let mut primary = Group::with_title(level.primary_title(LINT.desc));
-    if let Some(document) = document
-        && let Some(contents) = contents
+    if let Some(contents) = contents
         && let Some(span) = get_key_value_span(document, &["package", "name"])
     {
         primary = primary.element(
@@ -113,8 +112,7 @@ fn lint_package_inner(
     }
     primary = primary.element(Level::NOTE.message(emitted_source));
     let mut report = vec![primary];
-    if let Some(document) = document
-        && let Some(contents) = contents
+    if let Some(contents) = contents
         && let Some(span) = get_key_value_span(document, &["package", "name"])
     {
         let mut help =

--- a/src/cargo/diagnostics/rules/non_snake_case_features.rs
+++ b/src/cargo/diagnostics/rules/non_snake_case_features.rs
@@ -99,8 +99,7 @@ fn lint_package_inner(
         let emitted_source = LINT.emitted_source(lint_level, source);
 
         let mut primary = Group::with_title(level.primary_title(LINT.desc));
-        if let Some(document) = document
-            && let Some(contents) = contents
+        if let Some(contents) = contents
             && let Some(span) = get_key_value_span(document, &["features", original_name])
         {
             primary = primary.element(
@@ -108,8 +107,7 @@ fn lint_package_inner(
                     .path(manifest_path)
                     .annotation(AnnotationKind::Primary.span(span.key)),
             );
-        } else if let Some(document) = document
-            && let Some(contents) = contents
+        } else if let Some(contents) = contents
             && let Some(dep_span) = get_key_value_span(document, &["dependencies", original_name])
             && let Some(optional_span) =
                 get_key_value_span(document, &["dependencies", original_name, "optional"])
@@ -129,8 +127,7 @@ fn lint_package_inner(
         }
         primary = primary.element(Level::NOTE.message(emitted_source));
         let mut report = vec![primary];
-        if let Some(document) = document
-            && let Some(contents) = contents
+        if let Some(contents) = contents
             && let Some(span) = get_key_value_span(document, &["features", original_name])
         {
             let mut help = Group::with_title(Level::HELP.secondary_title(

--- a/src/cargo/diagnostics/rules/non_snake_case_packages.rs
+++ b/src/cargo/diagnostics/rules/non_snake_case_packages.rs
@@ -99,8 +99,7 @@ fn lint_package_inner(
     let emitted_source = LINT.emitted_source(lint_level, source);
 
     let mut primary = Group::with_title(level.primary_title(LINT.desc));
-    if let Some(document) = document
-        && let Some(contents) = contents
+    if let Some(contents) = contents
         && let Some(span) = get_key_value_span(document, &["package", "name"])
     {
         primary = primary.element(
@@ -113,8 +112,7 @@ fn lint_package_inner(
     }
     primary = primary.element(Level::NOTE.message(emitted_source));
     let mut report = vec![primary];
-    if let Some(document) = document
-        && let Some(contents) = contents
+    if let Some(contents) = contents
         && let Some(span) = get_key_value_span(document, &["package", "name"])
     {
         let mut help =

--- a/src/cargo/diagnostics/rules/redundant_homepage.rs
+++ b/src/cargo/diagnostics/rules/redundant_homepage.rs
@@ -115,8 +115,7 @@ fn lint_package_inner(
     let emitted_source = LINT.emitted_source(lint_level, source);
 
     let mut primary = Group::with_title(level.primary_title(LINT.desc));
-    if let Some(document) = document
-        && let Some(contents) = contents
+    if let Some(contents) = contents
         && let Some(span) = get_key_value_span(document, &["package", "homepage"])
     {
         let mut snippet = Snippet::source(contents)

--- a/src/cargo/diagnostics/rules/redundant_readme.rs
+++ b/src/cargo/diagnostics/rules/redundant_readme.rs
@@ -119,8 +119,7 @@ fn lint_package_inner(
     let emitted_source = LINT.emitted_source(lint_level, source);
 
     let mut primary = Group::with_title(level.primary_title(LINT.desc));
-    if let Some(document) = document
-        && let Some(contents) = contents
+    if let Some(contents) = contents
         && let Some(span) = get_key_value_span(document, &["package", "readme"])
     {
         let span = span.key.start..span.value.end;

--- a/src/cargo/diagnostics/rules/unknown_lints.rs
+++ b/src/cargo/diagnostics/rules/unknown_lints.rs
@@ -156,10 +156,8 @@ fn lint_manifest_inner(
         let mut report = Vec::new();
         let mut group = Group::with_title(level.clone().primary_title(title));
 
-        if let Some(document) = manifest.document()
-            && let Some(contents) = manifest.contents()
-        {
-            let Some(span) = get_key_value_span(document, key_path) else {
+        if let Some(contents) = manifest.contents() {
+            let Some(span) = get_key_value_span(manifest.document(), key_path) else {
                 // This lint is handled by either package or workspace lint.
                 return Ok(());
             };

--- a/src/cargo/diagnostics/rules/unused_dependencies.rs
+++ b/src/cargo/diagnostics/rules/unused_dependencies.rs
@@ -131,8 +131,7 @@ pub(crate) fn lint_package(
         let emitted_source = LINT.emitted_source(lint_level, source);
 
         let mut primary = Group::with_title(level.primary_title(LINT.desc));
-        if let Some(document) = document
-            && let Some(contents) = contents
+        if let Some(contents) = contents
             && let Some(span) = get_key_value_span(document, &["build-dependencies", dep_name])
         {
             let span = span.key.start..span.value.end;
@@ -307,8 +306,7 @@ fn lint_package_build_results(
                 let toml_path = dependency.toml_path();
 
                 let mut primary = Group::with_title(level.primary_title(LINT.desc));
-                if let Some(document) = document
-                    && let Some(contents) = contents
+                if let Some(contents) = contents
                     && let Some(span) = get_key_value_span(document, &toml_path)
                 {
                     let span = span.key.start..span.value.end;

--- a/src/cargo/diagnostics/rules/unused_workspace_dependencies.rs
+++ b/src/cargo/diagnostics/rules/unused_workspace_dependencies.rs
@@ -132,9 +132,7 @@ pub(crate) fn lint_workspace(
         let emitted_source = LINT.emitted_source(lint_level, source);
 
         let mut primary = Group::with_title(level.primary_title(LINT.desc));
-        if let Some(document) = document
-            && let Some(contents) = contents
-        {
+        if let Some(contents) = contents {
             let mut snippet = Snippet::source(contents).path(&manifest_path);
             if let Some(span) =
                 get_key_value_span(document, &["workspace", "dependencies", unused.as_str()])

--- a/src/cargo/diagnostics/rules/unused_workspace_package_fields.rs
+++ b/src/cargo/diagnostics/rules/unused_workspace_package_fields.rs
@@ -61,7 +61,8 @@ pub(crate) fn lint_workspace(
 
     let workspace_package_fields: IndexSet<_> = maybe_pkg
         .document()
-        .and_then(|d| d.get_ref().get("workspace"))
+        .get_ref()
+        .get("workspace")
         .and_then(|w| w.get_ref().get("package"))
         .and_then(|p| p.get_ref().as_table())
         .iter()
@@ -74,7 +75,8 @@ pub(crate) fn lint_workspace(
             member
                 .manifest()
                 .document()
-                .and_then(|w| w.get_ref().get("package"))
+                .get_ref()
+                .get("package")
                 .and_then(|p| p.get_ref().as_table())
                 .iter()
                 .flat_map(|d| {
@@ -101,9 +103,7 @@ pub(crate) fn lint_workspace(
         let emitted_source = LINT.emitted_source(lint_level, source);
 
         let mut primary = Group::with_title(level.primary_title(LINT.desc));
-        if let Some(document) = document
-            && let Some(contents) = contents
-        {
+        if let Some(contents) = contents {
             let mut snippet = Snippet::source(contents).path(&manifest_path);
             if let Some(span) =
                 get_key_value_span(document, &["workspace", "package", unused.as_ref()])

--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -514,7 +514,7 @@ fn prepare_for_vendor(
     let mut errors = Default::default();
     let manifest = crate::util::toml::to_real_manifest(
         contents.map(|c| c.to_owned()),
-        document.cloned(),
+        document.clone(),
         original_toml,
         normalized_toml,
         features,

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -102,7 +102,7 @@ pub fn read_manifest(
         if normalized_toml.package().is_some() {
             to_real_manifest(
                 Some(contents),
-                Some(document),
+                document,
                 original_toml,
                 normalized_toml,
                 features,
@@ -119,7 +119,7 @@ pub fn read_manifest(
             assert!(!is_embedded);
             to_virtual_manifest(
                 Some(contents),
-                Some(document),
+                document,
                 original_toml,
                 normalized_toml,
                 features,
@@ -1271,7 +1271,7 @@ fn deprecated_ws_default_features(
 #[tracing::instrument(skip_all)]
 pub fn to_real_manifest(
     contents: Option<String>,
-    document: Option<toml::Spanned<toml::de::DeTable<'static>>>,
+    document: toml::Spanned<toml::de::DeTable<'static>>,
     original_toml: manifest::TomlManifest,
     normalized_toml: manifest::TomlManifest,
     features: Features,
@@ -1766,7 +1766,7 @@ pub fn to_real_manifest(
                 missing_dep_diagnostic(
                     missing_dep,
                     &original_toml,
-                    document.as_ref(),
+                    &document,
                     contents.as_deref(),
                     manifest_file,
                     gctx,
@@ -1829,7 +1829,7 @@ note: only a feature named `default` will be enabled by default"
     let metabuild = normalized_package.metabuild.clone().map(|sov| sov.0);
     let manifest = Manifest::new(
         contents.map(Rc::new),
-        document.map(Arc::new),
+        Arc::new(document),
         Some(Rc::new(original_toml)),
         Rc::new(normalized_toml),
         summary,
@@ -1891,7 +1891,7 @@ note: only a feature named `default` will be enabled by default"
 fn missing_dep_diagnostic(
     missing_dep: &MissingDependencyError,
     orig_toml: &TomlManifest,
-    document: Option<&toml::Spanned<toml::de::DeTable<'static>>>,
+    document: &toml::Spanned<toml::de::DeTable<'static>>,
     contents: Option<&str>,
     manifest_file: &Path,
     gctx: &GlobalContext,
@@ -1910,9 +1910,7 @@ fn missing_dep_diagnostic(
     );
     let group = Group::with_title(Level::ERROR.primary_title(&title));
     let group =
-        if let Some(contents) = contents
-            && let Some(document) = document
-        {
+        if let Some(contents) = contents {
             let feature_span =
                 get_key_value_span(&document, &["features", missing_dep.feature.as_str()]).unwrap();
 
@@ -1979,7 +1977,7 @@ fn missing_dep_diagnostic(
 
 fn to_virtual_manifest(
     contents: Option<String>,
-    document: Option<toml::Spanned<toml::de::DeTable<'static>>>,
+    document: toml::Spanned<toml::de::DeTable<'static>>,
     original_toml: manifest::TomlManifest,
     normalized_toml: manifest::TomlManifest,
     features: Features,
@@ -2019,7 +2017,7 @@ fn to_virtual_manifest(
     }
     let manifest = VirtualManifest::new(
         contents.map(Rc::new),
-        document.map(Rc::new),
+        Rc::new(document),
         Some(Rc::new(original_toml)),
         Rc::new(normalized_toml),
         replace,
@@ -2950,7 +2948,7 @@ pub fn prepare_for_publish(
     let gctx = ws.gctx();
     let manifest = to_real_manifest(
         contents.map(|c| c.to_owned()),
-        document.cloned(),
+        document.clone(),
         original_toml,
         normalized_toml,
         features,


### PR DESCRIPTION
While examining how the TOML manifest machinery works, it seemed to me that the TOML document is always present, so I made it non-optional.

I don't know if the `Option` actually had some meaning in the current codebase or not, but I figured that since I already removed it, I might as well share the PR.

r? @epage
