### PR TITLE
Pre-allocate a few vectors

### DIFF
--- a/src/cargo/sources/registry/index/mod.rs
+++ b/src/cargo/sources/registry/index/mod.rs
@@ -633,15 +633,18 @@ impl Summaries {
     pub fn parse_cache(contents: Vec<u8>) -> CargoResult<(Summaries, InternedString)> {
         let cache = SummariesCache::parse(&contents)?;
         let index_version = cache.index_version.into();
-        let mut ret = Summaries::default();
+        let mut versions = Vec::with_capacity(cache.versions.len());
         for (version, summary) in cache.versions {
             let (start, end) = subslice_bounds(&contents, summary);
-            ret.versions.push((
+            versions.push((
                 version,
                 RefCell::new(MaybeIndexSummary::Unparsed { start, end }),
             ));
         }
-        ret.raw_data = contents;
+        let ret = Summaries {
+            raw_data: contents,
+            versions,
+        };
         return Ok((ret, index_version));
 
         // Returns the start/end offsets of `inner` with `outer`. Asserts that

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -368,7 +368,7 @@ fn to_bin_targets(
 
     validate_unique_names(&bins, TARGET_KIND_HUMAN_BIN)?;
 
-    let mut result = Vec::new();
+    let mut result = Vec::with_capacity(bins.len());
     for bin in bins {
         let path = package_root.join(&bin.path.as_ref().expect("previously normalized").0);
         let mut target = Target::bin_target(
@@ -442,7 +442,7 @@ fn to_example_targets(
 ) -> CargoResult<Vec<Target>> {
     validate_unique_names(&targets, TARGET_KIND_EXAMPLE)?;
 
-    let mut result = Vec::new();
+    let mut result = Vec::with_capacity(targets.len());
     for toml in targets {
         let path = package_root.join(&toml.path.as_ref().expect("previously normalized").0);
         let crate_types = match toml.crate_types() {
@@ -500,7 +500,7 @@ fn to_test_targets(
 ) -> CargoResult<Vec<Target>> {
     validate_unique_names(&targets, TARGET_KIND_TEST)?;
 
-    let mut result = Vec::new();
+    let mut result = Vec::with_capacity(targets.len());
     for toml in targets {
         let path = package_root.join(&toml.path.as_ref().expect("previously normalized").0);
         let mut target = Target::test_target(
@@ -568,7 +568,7 @@ fn to_bench_targets(
 ) -> CargoResult<Vec<Target>> {
     validate_unique_names(&targets, TARGET_KIND_BENCH)?;
 
-    let mut result = Vec::new();
+    let mut result = Vec::with_capacity(targets.len());
     for toml in targets {
         let path = package_root.join(&toml.path.as_ref().expect("previously normalized").0);
         let mut target = Target::bench_target(


### PR DESCRIPTION
Found this while browsing performance profiles and the source code. It's almost not noticeable (~0.5% instruction count win on bors), but at least the first two commits looked like a generally good idea. The third commit is a bit annoying with the precomputation.
