### PR TITLE
Use a larger placeholder future rust version in `report_rust_version_note_over_too_new_note` test

### DIFF
--- a/tests/testsuite/min_publish_age.rs
+++ b/tests/testsuite/min_publish_age.rs
@@ -480,7 +480,7 @@ fn report_rust_version_note_over_too_new_note() {
         .publish();
     // 2 days before `NOW`, and needs a newer Rust than the workspace.
     Package::new("bar", "1.1.0")
-        .rust_version("1.99.0")
+        .rust_version("1.65535.0")
         .pubtime("2006-08-06T00:00:00Z")
         .publish();
 
@@ -517,7 +517,7 @@ fn report_rust_version_note_over_too_new_note() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to latest compatible version
-[ADDING] bar v1.1.0 (requires Rust 1.99.0)
+[ADDING] bar v1.1.0 (requires Rust 1.65535.0)
 
 "#]])
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

Unblock (IINM after a submodule update that includes this patch) version bump to 1.99.0 by using a larger placeholder future rust version in `report_rust_version_note_over_too_new_note` test. See https://github.com/rust-lang/rust/pull/158740#issuecomment-4884893543.

* In the compiler, the {major, minor, patch} numbers are currently represented via `u16` in *several* places, so I elected to use `u16::MAX` here. We should be good for *a while*.

### How to test and review this PR?

Exercise normally through CI.
