### PR TITLE
Use a set when checking visited workspace members

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1,4 +1,4 @@
-use crate::util::data_structures::{HashMap, HashSet};
+use crate::util::data_structures::{HashMap, HashSet, IndexSet};
 use std::cell::RefCell;
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, BTreeSet};
@@ -78,7 +78,11 @@ pub struct Workspace<'gctx> {
     /// List of members in this workspace with a listing of all their manifest
     /// paths. The packages themselves can be looked up through the `packages`
     /// set above.
-    members: Vec<PathBuf>,
+    ///
+    /// Note: this uses a set because we query it using `contains`, which is
+    /// faster with a set, partly because running `PartialEq` on a bunch of paths
+    /// isn't very fast.
+    members: IndexSet<PathBuf>,
     /// Set of ids of workspace members
     member_ids: HashSet<PackageId>,
 
@@ -253,7 +257,7 @@ impl<'gctx> Workspace<'gctx> {
             root_manifest: None,
             target_dir: None,
             build_dir: None,
-            members: Vec::new(),
+            members: IndexSet::default(),
             member_ids: HashSet::default(),
             default_members: Vec::new(),
             is_ephemeral: false,
@@ -300,7 +304,7 @@ impl<'gctx> Workspace<'gctx> {
             ws.gctx.target_dir()?
         };
         ws.build_dir = ws.target_dir.clone();
-        ws.members.push(ws.current_manifest.clone());
+        ws.members.insert(ws.current_manifest.clone());
         ws.member_ids.insert(id);
         ws.default_members.push(ws.current_manifest.clone());
         ws.set_resolve_behavior()?;
@@ -861,7 +865,7 @@ impl<'gctx> Workspace<'gctx> {
     fn find_members(&mut self) -> CargoResult<()> {
         let Some(workspace_config) = self.load_workspace_config()? else {
             debug!("find_members - only me as a member");
-            self.members.push(self.current_manifest.clone());
+            self.members.insert(self.current_manifest.clone());
             self.default_members.push(self.current_manifest.clone());
             if let Ok(pkg) = self.current() {
                 let id = pkg.package_id();
@@ -929,7 +933,7 @@ impl<'gctx> Workspace<'gctx> {
                 self.default_members.push(manifest_path)
             }
         } else if self.is_virtual() {
-            self.default_members = self.members.clone()
+            self.default_members = self.members.iter().cloned().collect();
         } else {
             self.default_members.push(self.current_manifest.clone())
         }
@@ -969,7 +973,7 @@ impl<'gctx> Workspace<'gctx> {
         }
 
         debug!("find_path_deps - {}", manifest_path.display());
-        self.members.push(manifest_path.clone());
+        self.members.insert(manifest_path.clone());
 
         let candidates = {
             let pkg = match *self.packages.load(&manifest_path)? {


### PR DESCRIPTION
While profiling Cargo, I started gathering a set of micro-optimizations on the side that help for stress tests, e.g. Zed. Most of those did not seem worth landing on their own, but this one provided non-trivial improvements, while being a reasonably simple change, so I thought I'd post it as a PR to see what you think.

When finding workspace members, the `self.members.contains` check can be quite hot. Not necessarily because of traversing through a `Vec`, because that itself is quite fast, but `Eq` for `PathBuf` is not necessarily so fast. The same result can be gained by switching the workspace `members` field to a set, but that would have 

On Zed, this was a ~1.5% wall-time and ~4% icount improvement, on bors it was also a ~1.5% wall-time win.

```
Benchmark 1 (4 runs): /projects/personal/rust/cargo/cargo-baseline check
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          1.53s  ± 4.42ms    1.52s  … 1.53s           0 ( 0%)        0%
  peak_rss            269MB ±  275KB     268MB …  269MB          1 (25%)        0%
  cpu_cycles         3.03G  ± 11.2M     3.02G  … 3.05G           0 ( 0%)        0%
  instructions       6.25G  ±  729K     6.25G  … 6.26G           0 ( 0%)        0%
  cache_references    201M  ±  756K      200M  …  202M           0 ( 0%)        0%
  cache_misses       58.1M  ±  328K     57.7M  … 58.5M           0 ( 0%)        0%
  branch_misses      19.6M  ±  115K     19.5M  … 19.7M           0 ( 0%)        0%

Benchmark 2 (4 runs): ./cargo-perf check
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          1.50s  ± 4.12ms    1.50s  … 1.51s           0 ( 0%)        ⚡-  1.8% ±  0.5%
  peak_rss            269MB ±  258KB     269MB …  269MB          0 ( 0%)          +  0.1% ±  0.2%
  cpu_cycles         2.96G  ± 13.2M     2.95G  … 2.98G           0 ( 0%)        ⚡-  2.4% ±  0.7%
  instructions       6.00G  ±  847K     6.00G  … 6.00G           0 ( 0%)        ⚡-  4.1% ±  0.0%
  cache_references    199M  ±  740K      198M  …  200M           0 ( 0%)          -  0.8% ±  0.6%
  cache_misses       57.3M  ±  317K     56.9M  … 57.6M           0 ( 0%)          -  1.5% ±  1.0%
  branch_misses      19.3M  ±  187K     19.2M  … 19.6M           0 ( 0%)          -  1.2% ±  1.4%
```

I think that it shouldn't be behavior altering, but I'll defer to CI and tests.