### PR TITLE
Revert "feat: Stablize build-dir layout v2"

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -814,7 +814,7 @@ macro_rules! unstable_cli_options {
         /// Cargo, like `rustc`, accepts a suite of `-Z` flags which are intended for
         /// gating unstable functionality to Cargo. These flags are only available on
         /// the nightly channel of Cargo.
-        #[derive(Debug, Deserialize)]
+        #[derive(Default, Debug, Deserialize)]
         #[serde(default, rename_all = "kebab-case")]
         pub struct CliUnstable {
             $(
@@ -848,70 +848,6 @@ macro_rules! unstable_cli_options {
                 let actual = format!("{:#?}", vec![$(stringify!($element)),*]);
                 snapbox::assert_data_eq!(actual, expected);
             }
-        }
-    }
-}
-
-// TODO: Move this back to derive(Default) once `build_dir_new_layout` is stabilized and the old
-// layout has been removed.
-impl Default for CliUnstable {
-    fn default() -> Self {
-        Self {
-            build_dir_new_layout: !is_new_build_dir_layout_opt_out(),
-
-            allow_features: Default::default(),
-            print_im_a_teapot: Default::default(),
-            advanced_env: Default::default(),
-            any_build_script_metadata: Default::default(),
-            asymmetric_token: Default::default(),
-            avoid_dev_deps: Default::default(),
-            binary_dep_depinfo: Default::default(),
-            bindeps: Default::default(),
-            build_analysis: Default::default(),
-            build_std: Default::default(),
-            build_std_features: Default::default(),
-            cargo_lints: Default::default(),
-            checksum_freshness: Default::default(),
-            codegen_backend: Default::default(),
-            direct_minimal_versions: Default::default(),
-            dual_proc_macros: Default::default(),
-            feature_unification: Default::default(),
-            features: Default::default(),
-            fine_grain_locking: Default::default(),
-            fix_edition: Default::default(),
-            gc: Default::default(),
-            git: Default::default(),
-            gitoxide: Default::default(),
-            hint_msrv: Default::default(),
-            host_config: Default::default(),
-            json_target_spec: Default::default(),
-            min_publish_age: Default::default(),
-            minimal_versions: Default::default(),
-            msrv_policy: Default::default(),
-            mtime_on_use: Default::default(),
-            next_lockfile_bump: Default::default(),
-            no_embed_metadata: Default::default(),
-            no_index_update: Default::default(),
-            panic_abort_tests: Default::default(),
-            panic_immediate_abort: Default::default(),
-            profile_hint_mostly_unused: Default::default(),
-            profile_rustflags: Default::default(),
-            public_dependency: Default::default(),
-            publish_timeout: Default::default(),
-            root_dir: Default::default(),
-            rustc_unicode: Default::default(),
-            rustdoc_depinfo: Default::default(),
-            rustdoc_map: Default::default(),
-            rustdoc_mergeable_info: Default::default(),
-            rustdoc_scrape_examples: Default::default(),
-            sbom: Default::default(),
-            script: Default::default(),
-            section_timings: Default::default(),
-            separate_nightlies: Default::default(),
-            skip_rustdoc_fingerprint: Default::default(),
-            target_applies_to_host: Default::default(),
-            trim_paths: Default::default(),
-            unstable_options: Default::default(),
         }
     }
 }
@@ -1068,8 +1004,6 @@ const STABILIZED_CONFIG_INCLUDE: &str = "The `include` config key is now always 
 const STABILIZED_LOCKFILE_PATH: &str = "The `lockfile-path` config key is now always available";
 
 const STABILIZED_WARNINGS: &str = "The `build.warnings` config key is now always available";
-
-const STABILIZED_BUILD_DIR_NEW_LAYOUT: &str = "build.build-dir-new-layout is now always enabled.";
 
 fn deserialize_comma_separated_list<'de, D>(
     deserializer: D,
@@ -1467,7 +1401,6 @@ impl CliUnstable {
             "config-include" => stabilized_warn(k, "1.93", STABILIZED_CONFIG_INCLUDE),
             "lockfile-path" => stabilized_warn(k, "1.97", STABILIZED_LOCKFILE_PATH),
             "warnings" => stabilized_warn(k, "1.97", STABILIZED_WARNINGS),
-            "build-dir-new-layout" => stabilized_warn(k, "1.99", STABILIZED_BUILD_DIR_NEW_LAYOUT),
 
             // Unstable features
             // Sorted alphabetically:
@@ -1478,6 +1411,7 @@ impl CliUnstable {
             "binary-dep-depinfo" => self.binary_dep_depinfo = parse_empty(k, v)?,
             "bindeps" => self.bindeps = parse_empty(k, v)?,
             "build-analysis" => self.build_analysis = parse_empty(k, v)?,
+            "build-dir-new-layout" => self.build_dir_new_layout = parse_empty(k, v)?,
             "build-std" => self.build_std = Some(parse_list(v)),
             "build-std-features" => self.build_std_features = Some(parse_list(v)),
             "cargo-lints" => self.cargo_lints = parse_empty(k, v)?,

--- a/src/doc/src/reference/build-cache.md
+++ b/src/doc/src/reference/build-cache.md
@@ -70,10 +70,9 @@ change. Some of these directories are:
 
 Directory | Description
 ----------|------------
+<code style="white-space: nowrap">\<build-dir>/debug/deps/</code> | Dependencies and other artifacts.
 <code style="white-space: nowrap">\<build-dir>/debug/incremental/</code> | `rustc` [incremental output], a cache used to speed up subsequent builds.
-<code style="white-space: nowrap">\<build-dir>/debug/build/</code> | Build step results including compilation artifacts and [build script] output.
-
-> **Note**: The build-dir layout was changed in Cargo 1.99.0, thus prior versions use a different layout. (see [#15010](https://github.com/rust-lang/cargo/issues/15010))
+<code style="white-space: nowrap">\<build-dir>/debug/build/</code> | Output from [build scripts].
 
 ## Dep-info files
 
@@ -108,7 +107,7 @@ configuration][config]. Refer to sccache documentation for more details.
 [`cargo doc`]: ../commands/cargo-doc.md
 [`cargo package`]: ../commands/cargo-package.md
 [`cargo publish`]: ../commands/cargo-publish.md
-[build script]: ../reference/build-scripts.md
+[build scripts]: ../reference/build-scripts.md
 [config]: ../reference/config.md
 [def-workspace]:  ../appendix/glossary.md#workspace  '"workspace" (glossary entry)'
 [target]: ../appendix/glossary.md#target '"target" (glossary entry)'

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -83,6 +83,7 @@ Each new feature described below should explain how to use it.
     * [min-publish-age](#min-publish-age) --- Filters out dependency versions published more recently than a configured minimum age.
 * Output behavior
     * [artifact-dir](#artifact-dir) --- Adds a directory where artifacts are copied to.
+    * [build-dir-new-layout](#build-dir-new-layout) --- Enables the new build-dir filesystem layout
     * [Different binary name](#different-binary-name) --- Assign a name to the built binary that is separate from the crate name.
     * [root-dir](#root-dir) --- Controls the root directory relative to which paths are printed
 * Compile behavior
@@ -1963,6 +1964,14 @@ The following commands are available under `-Zbuild-analysis`:
 - `cargo report rebuilds` --- Reports why crates were rebuilt,
   helping diagnose unexpected recompilations.
 
+## build-dir-new-layout
+
+* Tracking Issue: [#15010](https://github.com/rust-lang/cargo/issues/15010)
+
+Enables the new build-dir filesystem layout.
+This layout change unblocks work towards caching and locking improvements.
+
+
 ## compile-time-deps
 
 This permanently-unstable flag to only build proc-macros and build scripts (and their required dependencies),
@@ -2428,7 +2437,3 @@ Support for `resolver.lockfile-path` config field has been stabilized in Rust 1.
 ## warnings
 
 The `build.warnings` config field has been stabilized in Rust 1.97.
-
-## build-dir-new-layout
-
-The new build-dir filesystem layout was stabilized in the 1.99.0 release.

--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -168,9 +168,9 @@ fn basic() {
 [COMPILING] [..]
 ...
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/[HOST_TARGET]/debug/build/foo/[HASH]/out/foo-[HASH])
-[RUNNING] unittests src/main.rs (target/[HOST_TARGET]/debug/build/foo/[HASH]/out/foo-[HASH])
-[RUNNING] tests/smoke.rs (target/[HOST_TARGET]/debug/build/foo/[HASH]/out/smoke-[HASH])
+[RUNNING] unittests src/lib.rs (target/[HOST_TARGET]/debug/deps/foo-[HASH])
+[RUNNING] unittests src/main.rs (target/[HOST_TARGET]/debug/deps/foo-[HASH])
+[RUNNING] tests/smoke.rs (target/[HOST_TARGET]/debug/deps/smoke-[HASH])
 [DOCTEST] foo
 
 "#]])
@@ -180,9 +180,9 @@ fn basic() {
     let deps_dir = Path::new("target")
         .join(rustc_host())
         .join("debug")
-        .join("build");
-    assert!(p.glob(deps_dir.join("**/*.rlib")).count() > 0);
-    assert_eq!(p.glob(deps_dir.join("**/*.dylib")).count(), 0);
+        .join("deps");
+    assert!(p.glob(deps_dir.join("*.rlib")).count() > 0);
+    assert_eq!(p.glob(deps_dir.join("*.dylib")).count(), 0);
 }
 
 #[cargo_test(build_std_real)]
@@ -432,7 +432,7 @@ fn test_proc_macro() {
 ...
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH])
 
 "#]])
         .run();

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -620,12 +620,12 @@ fn build_script_with_bin_artifacts() {
         assert_e2e().eq(
             &build_script_output,
             str![[r#"
-[ROOT]/foo/target/debug/build/bar/[HASH]/artifact/bin/baz[EXE]
-[ROOT]/foo/target/debug/build/bar/[HASH]/artifact/staticlib/bar-[HASH].lib
-[ROOT]/foo/target/debug/build/bar/[HASH]/artifact/cdylib/bar.dll
-[ROOT]/foo/target/debug/build/bar/[HASH]/artifact/bin
-[ROOT]/foo/target/debug/build/bar/[HASH]/artifact/bin/bar[EXE]
-[ROOT]/foo/target/debug/build/bar/[HASH]/artifact/bin/bar[EXE]
+[ROOT]/foo/target/debug/deps/artifact/bar-[HASH]/bin/baz[EXE]
+[ROOT]/foo/target/debug/deps/artifact/bar-[HASH]/staticlib/bar-[HASH].lib
+[ROOT]/foo/target/debug/deps/artifact/bar-[HASH]/cdylib/bar.dll
+[ROOT]/foo/target/debug/deps/artifact/bar-[HASH]/bin
+[ROOT]/foo/target/debug/deps/artifact/bar-[HASH]/bin/bar[EXE]
+[ROOT]/foo/target/debug/deps/artifact/bar-[HASH]/bin/bar[EXE]
 
 "#]],
         );
@@ -633,12 +633,12 @@ fn build_script_with_bin_artifacts() {
         assert_e2e().eq(
             &build_script_output,
             str![[r#"
-[ROOT]/foo/target/debug/build/bar/[HASH]/artifact/bin/baz[EXE]
-[ROOT]/foo/target/debug/build/bar/[HASH]/artifact/staticlib/libbar-[HASH].a
-[ROOT]/foo/target/debug/build/bar/[HASH]/artifact/cdylib/[..]bar.[..]
-[ROOT]/foo/target/debug/build/bar/[HASH]/artifact/bin
-[ROOT]/foo/target/debug/build/bar/[HASH]/artifact/bin/bar[EXE]
-[ROOT]/foo/target/debug/build/bar/[HASH]/artifact/bin/bar[EXE]
+[ROOT]/foo/target/debug/deps/artifact/bar-[HASH]/bin/baz-[HASH][EXE]
+[ROOT]/foo/target/debug/deps/artifact/bar-[HASH]/staticlib/libbar-[HASH].a
+[ROOT]/foo/target/debug/deps/artifact/bar-[HASH]/cdylib/[..]bar.[..]
+[ROOT]/foo/target/debug/deps/artifact/bar-[HASH]/bin
+[ROOT]/foo/target/debug/deps/artifact/bar-[HASH]/bin/bar-[HASH][EXE]
+[ROOT]/foo/target/debug/deps/artifact/bar-[HASH]/bin/bar-[HASH][EXE]
 
 "#]],
         );
@@ -810,8 +810,8 @@ fn build_script_with_selected_dashed_bin_artifact_and_lib_true() {
         assert_e2e().eq(
             &build_script_output,
             str![[r#"
-[ROOT]/foo/target/debug/build/bar-baz/[HASH]/artifact/bin
-[ROOT]/foo/target/debug/build/bar-baz/[HASH]/artifact/bin/baz_suffix[EXE]
+[ROOT]/foo/target/debug/deps/artifact/bar-baz-[HASH]/bin
+[ROOT]/foo/target/debug/deps/artifact/bar-baz-[HASH]/bin/baz_suffix[EXE]
 
 "#]],
         );
@@ -819,8 +819,8 @@ fn build_script_with_selected_dashed_bin_artifact_and_lib_true() {
         assert_e2e().eq(
             &build_script_output,
             str![[r#"
-[ROOT]/foo/target/debug/build/bar-baz/[HASH]/artifact/bin
-[ROOT]/foo/target/debug/build/bar-baz/[HASH]/artifact/bin/baz_suffix[EXE]
+[ROOT]/foo/target/debug/deps/artifact/bar-baz-[HASH]/bin
+[ROOT]/foo/target/debug/deps/artifact/bar-baz-[HASH]/bin/baz_suffix-[HASH][EXE]
 
 "#]],
         );
@@ -830,7 +830,7 @@ fn build_script_with_selected_dashed_bin_artifact_and_lib_true() {
         !p.bin("bar").is_file(),
         "artifacts are located in their own directory, exclusively, and won't be lifted up"
     );
-    assert_artifact_executable_output(&p, "debug", "bar-baz", "baz_suffix");
+    assert_artifact_executable_output(&p, "debug", "bar", "baz_suffix");
 }
 
 #[cargo_test]
@@ -900,7 +900,7 @@ fn lib_with_selected_dashed_bin_artifact_and_lib_true() {
         !p.bin("bar").is_file(),
         "artifacts are located in their own directory, exclusively, and won't be lifted up"
     );
-    assert_artifact_executable_output(&p, "debug", "bar-baz", "baz_suffix");
+    assert_artifact_executable_output(&p, "debug", "bar", "baz_suffix");
 }
 
 #[cargo_test]
@@ -943,7 +943,7 @@ fn allow_artifact_and_no_artifact_dep_to_same_package_within_different_dep_categ
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -1292,7 +1292,7 @@ fn cross_doctests_works_with_artifacts() {
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/[HOST_TARGET]/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/[HOST_TARGET]/debug/deps/foo-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -1316,7 +1316,7 @@ fn cross_doctests_works_with_artifacts() {
 [RUNNING] `rustc --crate-name foo [..]
 [RUNNING] `rustc --crate-name foo [..]
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/[ALT_TARGET]/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/[ALT_TARGET]/debug/deps/foo-[HASH][EXE]`
 [DOCTEST] foo
 [RUNNING] `rustdoc [..]--test src/lib.rs --test-run-directory [ROOT]/foo --target [ALT_TARGET] [..]
 
@@ -1422,7 +1422,7 @@ fn profile_override_basic() {
 [RUNNING] `rustc --crate-name bar --edition=2015 bar/src/lib.rs [..] -C opt-level=1 [..]`
 [RUNNING] `rustc --crate-name bar --edition=2015 bar/src/lib.rs [..] -C opt-level=3 [..]`
 [RUNNING] `rustc --crate-name foo [..] -C opt-level=3 [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [FINISHED] `dev` profile [optimized + debuginfo] target(s) in [ELAPSED]s
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 
@@ -2207,8 +2207,8 @@ fn env_vars_and_build_products_for_various_build_targets() {
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
-[RUNNING] tests/main.rs (target/debug/build/foo/[HASH]/out/main-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] tests/main.rs (target/debug/deps/main-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -2416,11 +2416,7 @@ fn doc_lib_true() {
 
     // Verify that it emits rmeta for the bin and lib dependency.
     assert_eq!(p.glob("target/debug/artifact/*.rlib").count(), 0);
-    assert_eq!(
-        p.glob("target/debug/build/bar/*/out/libbar-*.rmeta")
-            .count(),
-        2
-    );
+    assert_eq!(p.glob("target/debug/deps/libbar-*.rmeta").count(), 2);
 
     p.cargo("doc -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
@@ -2512,7 +2508,7 @@ fn assert_artifact_executable_output(
     if cfg!(target_env = "msvc") {
         assert_eq!(
             p.glob(format!(
-                "target/{}/build/{}/*/artifact/bin/{}{}",
+                "target/{}/deps/artifact/{}-*/bin/{}{}",
                 target_name,
                 dep_name,
                 bin_name,
@@ -2525,7 +2521,7 @@ fn assert_artifact_executable_output(
     } else {
         assert_eq!(
             p.glob(format!(
-                "target/{}/build/{}/*/artifact/bin/{}{}",
+                "target/{}/deps/artifact/{}-*/bin/{}-*{}",
                 target_name,
                 dep_name,
                 bin_name,
@@ -2542,7 +2538,7 @@ fn assert_artifact_executable_output(
 
 fn build_script_output_string(p: &Project, package_name: &str) -> String {
     let paths = p
-        .glob(format!("target/debug/build/{}/*/run/stdout", package_name))
+        .glob(format!("target/debug/build/{}-*/output", package_name))
         .collect::<Result<Vec<_>, _>>()
         .unwrap();
     assert_eq!(paths.len(), 1);
@@ -2826,7 +2822,7 @@ fn with_assumed_host_target_and_optional_build_dep() {
 [COMPILING] d1 v0.0.1 ([ROOT]/foo/d1)
 [RUNNING] `rustc --crate-name build_script_build --edition=2021 [..]--crate-type bin[..]
 [RUNNING] `rustc --crate-name d1 --edition=2021 [..]--crate-type bin[..]
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name foo --edition=2021 [..]--cfg[..]d1[..]
 [FINISHED] `dev` profile [..]
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -3642,7 +3638,7 @@ fn artifact_dep_target_does_not_propagate_to_deps_of_build_script() {
 [COMPILING] artifact v0.0.1 ([ROOT]/foo/artifact)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/main.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/deps/foo-[HASH][EXE])
 
 "#]])
         .masquerade_as_nightly_cargo(&["bindeps"])
@@ -3734,7 +3730,7 @@ fn artifact_dep_target_does_not_propagate_to_proc_macro() {
 [COMPILING] artifact v0.0.1 ([ROOT]/foo/artifact)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/main.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/deps/foo-[HASH][EXE])
 
 "#]])
         .masquerade_as_nightly_cargo(&["bindeps"])

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -44,7 +44,7 @@ hello
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] unittests src/main.rs (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/release/deps/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -94,8 +94,8 @@ fn bench_bench_implicit() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
-[RUNNING] [..] (target/release/build/foo/[HASH]/out/mybench-[HASH][EXE])
+[RUNNING] [..] (target/release/deps/foo-[HASH][EXE])
+[RUNNING] [..] (target/release/deps/mybench-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -151,7 +151,7 @@ fn bench_bin_implicit() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] [..] (target/release/deps/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -191,7 +191,7 @@ fn bench_tarname() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/release/build/foo/[HASH]/out/bin2-[HASH][EXE])
+[RUNNING] [..] (target/release/deps/bin2-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -240,8 +240,8 @@ fn bench_multiple_targets() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] benches/bin1.rs (target/release/build/foo/[HASH]/out/bin1-[HASH][EXE])
-[RUNNING] benches/bin2.rs (target/release/build/foo/[HASH]/out/bin2-[HASH][EXE])
+[RUNNING] benches/bin1.rs (target/release/deps/bin1-[HASH][EXE])
+[RUNNING] benches/bin2.rs (target/release/deps/bin2-[HASH][EXE])
 
 "#]])
         .run();
@@ -268,7 +268,7 @@ fn cargo_bench_verbose() {
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `rustc [..] src/main.rs [..]`
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[..]target/release/build/foo/[HASH]/out/foo-[HASH][EXE] hello --bench`
+[RUNNING] `[..]target/release/deps/foo-[HASH][EXE] hello --bench`
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -385,7 +385,7 @@ hello
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] [..] (target/release/deps/foo-[HASH][EXE])
 [ERROR] bench failed, to rerun pass `--bin foo`
 
 "#]])
@@ -450,8 +450,8 @@ fn bench_with_lib_dep() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
-[RUNNING] [..] (target/release/build/foo/[HASH]/out/baz-[HASH][EXE])
+[RUNNING] [..] (target/release/deps/foo-[HASH][EXE])
+[RUNNING] [..] (target/release/deps/baz-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -526,7 +526,7 @@ fn bench_with_deep_lib_dep() {
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [COMPILING] bar v0.0.1 ([ROOT]/bar)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/release/build/bar/[HASH]/out/bar-[HASH][EXE])
+[RUNNING] [..] (target/release/deps/bar-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -588,8 +588,8 @@ fn external_bench_explicit() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
-[RUNNING] [..] (target/release/build/foo/[HASH]/out/bench-[HASH][EXE])
+[RUNNING] [..] (target/release/deps/foo-[HASH][EXE])
+[RUNNING] [..] (target/release/deps/bench-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -644,8 +644,8 @@ fn external_bench_implicit() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
-[RUNNING] [..] (target/release/build/foo/[HASH]/out/external-[HASH][EXE])
+[RUNNING] [..] (target/release/deps/foo-[HASH][EXE])
+[RUNNING] [..] (target/release/deps/external-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -733,7 +733,7 @@ https://github.com/rust-lang/cargo/issues/5330
 [WARNING] `foo` (manifest) generated 1 warning
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] [..] (target/release/deps/foo-[HASH][EXE])
 
 "#]])
         .run();
@@ -771,7 +771,7 @@ fn pass_through_command_line() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] [..] (target/release/deps/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -788,7 +788,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured; 1 filtered out; fini
     p.cargo("bench foo")
         .with_stderr_data(str![[r#"
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] [..] (target/release/deps/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -874,8 +874,8 @@ fn lib_bin_same_name() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
-[RUNNING] [..] (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] [..] (target/release/deps/foo-[HASH][EXE])
+[RUNNING] [..] (target/release/deps/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -933,8 +933,8 @@ fn lib_with_standard_name() {
         .with_stderr_data(str![[r#"
 [COMPILING] syntax v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/release/build/syntax/[HASH]/out/syntax-[HASH][EXE])
-[RUNNING] [..] (target/release/build/syntax/[HASH]/out/bench-[HASH][EXE])
+[RUNNING] [..] (target/release/deps/syntax-[HASH][EXE])
+[RUNNING] [..] (target/release/deps/bench-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -995,7 +995,7 @@ fn lib_with_standard_name2() {
         .with_stderr_data(str![[r#"
 [COMPILING] syntax v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/release/build/syntax/[HASH]/out/syntax-[HASH][EXE])
+[RUNNING] [..] (target/release/deps/syntax-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1082,8 +1082,8 @@ fn bench_dylib() {
 [RUNNING] [..] -C opt-level=3 [..]
 [RUNNING] [..] -C opt-level=3 [..]
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[..]target/release/build/foo/[HASH]/out/foo-[HASH][EXE] --bench`
-[RUNNING] `[..]target/release/build/foo/[HASH]/out/bench-[HASH][EXE] --bench`
+[RUNNING] `[..]target/release/deps/foo-[HASH][EXE] --bench`
+[RUNNING] `[..]target/release/deps/bench-[HASH][EXE] --bench`
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1109,8 +1109,8 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured; 0 filtered out; fini
 [FRESH] bar v0.0.1 ([ROOT]/foo/bar)
 [FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[..]target/release/build/foo/[HASH]/out/foo-[HASH][EXE] --bench`
-[RUNNING] `[..]target/release/build/foo/[HASH]/out/bench-[HASH][EXE] --bench`
+[RUNNING] `[..]target/release/deps/foo-[HASH][EXE] --bench`
+[RUNNING] `[..]target/release/deps/bench-[HASH][EXE] --bench`
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1162,7 +1162,7 @@ fn bench_twice_with_build_cmd() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] [..] (target/release/deps/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1179,7 +1179,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured; 0 filtered out; fini
     p.cargo("bench")
         .with_stderr_data(str![[r#"
 [FINISHED] `bench` profile [optimized] target(s) in [..]
-[RUNNING] [..] (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] [..] (target/release/deps/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1269,8 +1269,8 @@ fn bench_with_examples() {
 [RUNNING] `rustc [..]`
 [RUNNING] `rustc [..]`
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE] --bench`
-[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/testb1-[HASH][EXE] --bench`
+[RUNNING] `[ROOT]/foo/target/release/deps/foo-[HASH][EXE] --bench`
+[RUNNING] `[ROOT]/foo/target/release/deps/testb1-[HASH][EXE] --bench`
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1321,7 +1321,7 @@ fn test_a_bench() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/debug/build/foo/[HASH]/out/b-[HASH][EXE])
+[RUNNING] [..] (target/debug/deps/b-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1359,8 +1359,8 @@ fn test_bench_no_run() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[EXECUTABLE] benches src/lib.rs (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
-[EXECUTABLE] benches/bbaz.rs (target/release/build/foo/[HASH]/out/bbaz-[HASH][EXE])
+[EXECUTABLE] benches src/lib.rs (target/release/deps/foo-[HASH][EXE])
+[EXECUTABLE] benches/bbaz.rs (target/release/deps/bbaz-[HASH][EXE])
 
 "#]])
         .run();
@@ -1439,9 +1439,9 @@ fn test_bench_no_fail_fast() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] unittests src/main.rs (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/release/deps/foo-[HASH][EXE])
 [ERROR] bench failed, to rerun pass `--bin foo`
-[RUNNING] benches/b1.rs (target/release/build/foo/[HASH]/out/b1-[HASH][EXE])
+[RUNNING] benches/b1.rs (target/release/deps/b1-[HASH][EXE])
 [ERROR] bench failed, to rerun pass `--bench b1`
 [ERROR] 2 targets failed:
     `--bin foo`
@@ -1546,8 +1546,8 @@ fn test_bench_multiple_packages() {
 
     p.cargo("bench -p bar -p baz")
         .with_stderr_data(str![[r#"
-[RUNNING] [..] (target/release/build/foo/[HASH]/out/bbaz-[HASH][EXE])
-[RUNNING] [..] (target/release/build/foo/[HASH]/out/bbar-[HASH][EXE])
+[RUNNING] [..] (target/release/deps/bbaz-[HASH][EXE])
+[RUNNING] [..] (target/release/deps/bbar-[HASH][EXE])
 
 "#]])
         .with_stderr_data(
@@ -1556,10 +1556,10 @@ fn test_bench_multiple_packages() {
 [COMPILING] bar v0.1.0 ([ROOT]/bar)
 [COMPILING] baz v0.1.0 ([ROOT]/baz)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/release/build/bar/[HASH]/out/bar-[HASH][EXE])
-[RUNNING] benches/bbar.rs (target/release/build/bar/[HASH]/out/bbar-[HASH][EXE])
-[RUNNING] unittests src/lib.rs (target/release/build/baz/[HASH]/out/baz-[HASH][EXE])
-[RUNNING] benches/bbaz.rs (target/release/build/baz/[HASH]/out/bbaz-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/release/deps/bar-[HASH][EXE])
+[RUNNING] benches/bbar.rs (target/release/deps/bbar-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/release/deps/baz-[HASH][EXE])
+[RUNNING] benches/bbaz.rs (target/release/deps/bbaz-[HASH][EXE])
 
 "#]]
             .unordered(),
@@ -1618,10 +1618,10 @@ fn bench_all_workspace() {
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/release/build/bar/[HASH]/out/bar-[HASH][EXE])
-[RUNNING] benches/bar.rs (target/release/build/bar/[HASH]/out/bar-[HASH][EXE])
-[RUNNING] unittests src/main.rs (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
-[RUNNING] benches/foo.rs (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/release/deps/bar-[HASH][EXE])
+[RUNNING] benches/bar.rs (target/release/deps/bar-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/release/deps/foo-[HASH][EXE])
+[RUNNING] benches/foo.rs (target/release/deps/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1809,10 +1809,10 @@ fn bench_all_virtual_manifest() {
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [COMPILING] baz v0.1.0 ([ROOT]/foo/baz)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/release/build/bar/[HASH]/out/bar-[HASH][EXE])
-[RUNNING] benches/bar.rs (target/release/build/bar/[HASH]/out/bar-[HASH][EXE])
-[RUNNING] unittests src/lib.rs (target/release/build/baz/[HASH]/out/baz-[HASH][EXE])
-[RUNNING] benches/baz.rs (target/release/build/baz/[HASH]/out/baz-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/release/deps/bar-[HASH][EXE])
+[RUNNING] benches/bar.rs (target/release/deps/bar-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/release/deps/baz-[HASH][EXE])
+[RUNNING] benches/baz.rs (target/release/deps/baz-[HASH][EXE])
 
 "#]]
             .unordered(),
@@ -1890,8 +1890,8 @@ fn bench_virtual_manifest_glob() {
         .with_stderr_data(str![[r#"
 [COMPILING] baz v0.1.0 ([ROOT]/foo/baz)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/release/build/baz/[HASH]/out/baz-[HASH][EXE])
-[RUNNING] benches/baz.rs (target/release/build/baz/[HASH]/out/baz-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/release/deps/baz-[HASH][EXE])
+[RUNNING] benches/baz.rs (target/release/deps/baz-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1949,8 +1949,8 @@ please set bench.path in Cargo.toml
 [WARNING] `foo` (manifest) generated 1 warning
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
-[RUNNING] src/bench.rs (target/release/build/foo/[HASH]/out/bench-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/release/deps/foo-[HASH][EXE])
+[RUNNING] src/bench.rs (target/release/deps/bench-[HASH][EXE])
 
 "#]])
         .run();
@@ -2000,10 +2000,10 @@ fn bench_virtual_manifest_all_implied() {
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [COMPILING] baz v0.1.0 ([ROOT]/foo/baz)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/release/build/bar/[HASH]/out/bar-[HASH][EXE])
-[RUNNING] benches/bar.rs (target/release/build/bar/[HASH]/out/bar-[HASH][EXE])
-[RUNNING] unittests src/lib.rs (target/release/build/baz/[HASH]/out/baz-[HASH][EXE])
-[RUNNING] benches/baz.rs (target/release/build/baz/[HASH]/out/baz-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/release/deps/bar-[HASH][EXE])
+[RUNNING] benches/bar.rs (target/release/deps/bar-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/release/deps/baz-[HASH][EXE])
+[RUNNING] benches/baz.rs (target/release/deps/baz-[HASH][EXE])
 
 "#]]
             .unordered(),
@@ -2124,7 +2124,7 @@ fn cargo_bench_print_env_verbose() {
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..]CARGO_MANIFEST_DIR=[ROOT]/foo[..] rustc[..]`
 [FINISHED] `bench` profile [optimized] target(s) in [..]
-[RUNNING] `[..]CARGO_MANIFEST_DIR=[ROOT]/foo[..] [ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE] --bench`
+[RUNNING] `[..]CARGO_MANIFEST_DIR=[ROOT]/foo[..] [ROOT]/foo/target/release/deps/foo-[HASH][EXE] --bench`
 
 "#]])
         .run();

--- a/tests/testsuite/binary_name.rs
+++ b/tests/testsuite/binary_name.rs
@@ -195,7 +195,7 @@ fn binary_name2() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/main.rs (target/debug/build/foo/[HASH]/out/foo-[..][EXE])
+[RUNNING] unittests src/main.rs (target/debug/deps/foo-[..][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -127,7 +127,7 @@ fn cargo_compile_incremental() {
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `rustc [..] -C incremental=[ROOT]/foo/target/debug/incremental[..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
 
 "#]])
         .run();
@@ -1571,7 +1571,7 @@ fn cargo_default_env_metadata_env_var() {
         .with_stderr_data(format!(
             "\
 ...
-[RUNNING] `rustc --crate-name foo [..]--extern bar=[ROOT]/foo/target/debug/build/bar/[HASH]/out/{dll_prefix}bar{dll_suffix}[..]`
+[RUNNING] `rustc --crate-name foo [..]--extern bar=[ROOT]/foo/target/debug/deps/{dll_prefix}bar{dll_suffix}[..]`
 ...
 "))
         .run();
@@ -1584,7 +1584,7 @@ fn cargo_default_env_metadata_env_var() {
         .with_stderr_data(format!(
             "\
 ...
-[RUNNING] `rustc --crate-name foo [..]--extern bar=[ROOT]/foo/target/debug/build/bar/[HASH]/out/{dll_prefix}bar-[..]{dll_suffix}[..]`
+[RUNNING] `rustc --crate-name foo [..]--extern bar=[ROOT]/foo/target/debug/deps/{dll_prefix}bar-[..]{dll_suffix}[..]`
 ...
 "))
         .run();
@@ -1689,9 +1689,6 @@ fn crate_env_vars() {
 
                     let exe: PathBuf = env::current_exe().unwrap().into();
                     let mut expected: PathBuf = exe.parent().unwrap()
-                        .parent().unwrap()
-                        .parent().unwrap()
-                        .parent().unwrap()
                         .parent().unwrap()
                         .parent().unwrap()
                         .into();
@@ -3603,7 +3600,7 @@ fn compiler_json_error_format() {
     "env": [],
     "linked_libs": [],
     "linked_paths": [],
-    "out_dir": "[ROOT]/foo/target/debug/build/foo/[HASH]/out",
+    "out_dir": "[ROOT]/foo/target/debug/build/foo-[HASH]/out",
     "package_id": "path+[ROOTURL]/foo#0.5.0",
     "reason": "build-script-executed"
   },
@@ -4739,18 +4736,7 @@ fn cdylib_not_lifted() {
 
     for file in files {
         println!("checking: {}", file);
-        assert_eq!(
-            glob::glob(
-                p.root()
-                    .join("target/debug/build/foo/*/out")
-                    .join(&file)
-                    .to_str()
-                    .unwrap()
-            )
-            .into_iter()
-            .count(),
-            1
-        );
+        assert!(p.root().join("target/debug/deps").join(&file).is_file());
     }
 }
 
@@ -4828,12 +4814,11 @@ fn no_dep_info_collision_when_cdylib_and_bin_coexist() {
         )
         .run();
 
-    let build_dir = p.target_debug_dir().join("build");
-    let dep_info_count = build_dir
+    let deps_dir = p.target_debug_dir().join("deps");
+    assert!(deps_dir.join("foo.d").exists());
+    let dep_info_count = deps_dir
         .read_dir()
         .unwrap()
-        .flat_map(|build_unit| build_unit.unwrap().path().read_dir().unwrap())
-        .flat_map(|hash_dir| hash_dir.unwrap().path().join("out").read_dir().unwrap())
         .filter(|e| {
             let filename = e.as_ref().unwrap().file_name();
             let filename = filename.to_str().unwrap();
@@ -4887,7 +4872,7 @@ fn deterministic_cfg_flags() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [RUNNING] `rustc [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..] --cfg[..]default[..]--cfg[..]f_a[..]--cfg[..]f_b[..] --cfg[..]f_c[..]--cfg[..]f_d[..] --cfg cfg_a --cfg cfg_b --cfg cfg_c --cfg cfg_d --cfg cfg_e`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -5905,7 +5890,7 @@ fn build_lib_only() {
     p.cargo("build --lib -v")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..] -L dependency=[ROOT]/foo/target/debug/build/foo/[HASH]/out[..]`
+[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..] -L dependency=[ROOT]/foo/target/debug/deps[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -6451,7 +6436,7 @@ fn no_embed_metadata() {
         .arg("-v")
         .with_stderr_contains("[RUNNING] `[..]-Z embed-metadata=no[..]`")
         .with_stderr_contains(
-            "[RUNNING] `[..]--extern bar=[ROOT]/foo/target/debug/build/bar/[HASH]/out/libbar-[HASH].rmeta[..]`",
+            "[RUNNING] `[..]--extern bar=[ROOT]/foo/target/debug/deps/libbar-[HASH].rmeta[..]`",
         )
         .run();
 }
@@ -6501,7 +6486,7 @@ fn no_embed_metadata_dylib_dep() {
         .arg("-v")
         .with_stderr_contains("[RUNNING] `[..]-Z embed-metadata=no[..]`")
         .with_stderr_contains(
-            "[RUNNING] `[..]--extern bar=[ROOT]/foo/target/debug/build/bar/[HASH]/out/libbar.rmeta[..]`",
+            "[RUNNING] `[..]--extern bar=[ROOT]/foo/target/debug/deps/libbar.rmeta[..]`",
         )
         .run();
 }

--- a/tests/testsuite/build_analysis.rs
+++ b/tests/testsuite/build_analysis.rs
@@ -439,7 +439,7 @@ fn log_rebuild_reason_file_changed() {
     "cause": {
       "dirty_reason": "fs-status-outdated",
       "fs_status": "stale-item",
-      "reference": "[ROOT]/foo/target/debug/build/foo/[HASH]/fingerprint/dep-lib-foo",
+      "reference": "[ROOT]/foo/target/debug/.fingerprint/foo-[HASH]/dep-lib-foo",
       "reference_mtime": "{...}",
       "stale": "[ROOT]/foo/src/lib.rs",
       "stale_item": "changed-file",

--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -33,7 +33,10 @@ fn binary_with_debug() {
         )
         .build();
 
-    p.cargo("build").enable_mac_dsym().run();
+    p.cargo("-Zbuild-dir-new-layout build")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .enable_mac_dsym()
+        .run();
 
     assert_not_exists(&p.root().join("target"));
 
@@ -76,7 +79,10 @@ fn binary_with_release() {
         )
         .build();
 
-    p.cargo("build --release").enable_mac_dsym().run();
+    p.cargo("-Zbuild-dir-new-layout build --release")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .enable_mac_dsym()
+        .run();
 
     assert_exists_patterns_with_base_dir(
         &p.root(),
@@ -178,7 +184,10 @@ fn libs() {
             )
             .build();
 
-        p.cargo("build").enable_mac_dsym().run();
+        p.cargo("-Zbuild-dir-new-layout build")
+            .masquerade_as_nightly_cargo(&["new build-dir layout"])
+            .enable_mac_dsym()
+            .run();
 
         // Verify lib artifacts were copied into the artifact dir
         assert_exists_patterns_with_base_dir(&p.root().join("target-dir/debug"), &expected_files);
@@ -191,7 +200,10 @@ fn should_default_to_target() {
         .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
         .build();
 
-    p.cargo("build").enable_mac_dsym().run();
+    p.cargo("-Zbuild-dir-new-layout build")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .enable_mac_dsym()
+        .run();
 
     p.root().join("target").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target/.rustc_info.json
@@ -217,7 +229,8 @@ fn should_respect_env_var() {
         .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
         .build();
 
-    p.cargo("build")
+    p.cargo("-Zbuild-dir-new-layout build")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .env("CARGO_BUILD_BUILD_DIR", "build-dir")
         .enable_mac_dsym()
         .run();
@@ -232,61 +245,6 @@ fn should_respect_env_var() {
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
-
-"#]]);
-}
-
-#[cargo_test]
-fn build_script_should_output_to_build_dir() {
-    let p = project()
-        .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
-        .file(
-            "build.rs",
-            r#"
-            fn main() {
-                std::fs::write(
-                    format!("{}/foo.txt", std::env::var("OUT_DIR").unwrap()),
-                    "Hello, world!",
-                )
-                .unwrap();
-            }
-            "#,
-        )
-        .file(
-            ".cargo/config.toml",
-            r#"
-            [build]
-            target-dir = "target-dir"
-            build-dir = "build-dir"
-            "#,
-        )
-        .build();
-
-    p.cargo("build").enable_mac_dsym().run();
-
-    p.root().join("build-dir").assert_build_dir_layout(str![[r#"
-[ROOT]/foo/build-dir/CACHEDIR.TAG
-[ROOT]/foo/build-dir/debug/.cargo-build-lock
-[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo.txt
-[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/build_script_build.d
-[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/build_script_build[EXE]
-[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
-[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
-[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
-[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
-[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo
-[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
-[ROOT]/foo/build-dir/.rustc_info.json
-[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/run-build-script-build-script-build
-[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/run-build-script-build-script-build.json
-[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
-[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-build-script-build-script-build
-[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/build-script-build-script-build
-[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/build-script-build-script-build.json
-[ROOT]/foo/build-dir/debug/build/foo/[HASH]/run/invoked.timestamp
-[ROOT]/foo/build-dir/debug/build/foo/[HASH]/run/stdout
-[ROOT]/foo/build-dir/debug/build/foo/[HASH]/run/root-output
-[ROOT]/foo/build-dir/debug/build/foo/[HASH]/run/stderr
 
 "#]]);
 }
@@ -318,7 +276,10 @@ fn cargo_tmpdir_should_output_to_build_dir() {
         )
         .build();
 
-    p.cargo("test").enable_mac_dsym().run();
+    p.cargo("-Zbuild-dir-new-layout test")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .enable_mac_dsym()
+        .run();
 
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/CACHEDIR.TAG
@@ -372,7 +333,10 @@ fn examples_should_output_to_build_dir_and_uplift_to_target_dir() {
         )
         .build();
 
-    p.cargo("build --examples").enable_mac_dsym().run();
+    p.cargo("-Zbuild-dir-new-layout build --examples")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .enable_mac_dsym()
+        .run();
 
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/.rustc_info.json
@@ -416,7 +380,10 @@ fn benches_should_output_to_build_dir() {
         )
         .build();
 
-    p.cargo("build --bench=foo").enable_mac_dsym().run();
+    p.cargo("-Zbuild-dir-new-layout build --bench=foo")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .enable_mac_dsym()
+        .run();
 
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/CACHEDIR.TAG
@@ -462,7 +429,10 @@ fn cargo_doc_should_output_to_target_dir() {
         )
         .build();
 
-    p.cargo("doc").enable_mac_dsym().run();
+    p.cargo("-Zbuild-dir-new-layout doc")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .enable_mac_dsym()
+        .run();
 
     let docs_dir = p.root().join("target-dir/doc");
 
@@ -562,7 +532,10 @@ fn cargo_package_should_build_in_build_dir_and_output_to_target_dir() {
         )
         .build();
 
-    p.cargo("package").enable_mac_dsym().run();
+    p.cargo("-Zbuild-dir-new-layout package")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .enable_mac_dsym()
+        .run();
 
     let package_artifact_dir = p.root().join("target-dir/package");
     assert_exists(&package_artifact_dir);
@@ -616,7 +589,8 @@ fn cargo_publish_should_only_touch_build_dir() {
         )
         .build();
 
-    p.cargo("publish")
+    p.cargo("-Zbuild-dir-new-layout publish")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .replace_crates_io(registry.index_url())
         .enable_mac_dsym()
         .run();
@@ -644,7 +618,10 @@ fn cargo_clean_should_clean_the_target_dir_and_build_dir() {
         )
         .build();
 
-    p.cargo("build").enable_mac_dsym().run();
+    p.cargo("-Zbuild-dir-new-layout build")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .enable_mac_dsym()
+        .run();
 
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/.rustc_info.json
@@ -670,7 +647,10 @@ fn cargo_clean_should_clean_the_target_dir_and_build_dir() {
 
 "#]]);
 
-    p.cargo("clean").enable_mac_dsym().run();
+    p.cargo("-Zbuild-dir-new-layout clean")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .enable_mac_dsym()
+        .run();
 
     assert_not_exists(&p.root().join("build-dir"));
     assert_not_exists(&p.root().join("target-dir"));
@@ -708,7 +688,10 @@ fn cargo_clean_should_remove_correct_files() {
         )
         .build();
 
-    p.cargo("build").enable_mac_dsym().run();
+    p.cargo("-Zbuild-dir-new-layout build")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .enable_mac_dsym()
+        .run();
 
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/.rustc_info.json
@@ -730,7 +713,10 @@ fn cargo_clean_should_remove_correct_files() {
 
 "#]]);
 
-    p.cargo("clean -p bar").enable_mac_dsym().run();
+    p.cargo("-Zbuild-dir-new-layout clean -p bar")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .enable_mac_dsym()
+        .run();
 
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/.rustc_info.json
@@ -760,7 +746,10 @@ fn timings_report_should_output_to_target_dir() {
         )
         .build();
 
-    p.cargo("build --timings").enable_mac_dsym().run();
+    p.cargo("-Zbuild-dir-new-layout build --timings")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .enable_mac_dsym()
+        .run();
 
     assert_exists(&p.root().join("target-dir/cargo-timings/cargo-timing.html"));
 }
@@ -782,7 +771,8 @@ fn future_incompat_should_output_to_build_dir() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("-Zbuild-dir-new-layout build")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .arg("--future-incompat-report")
         .env("RUSTFLAGS", "-Zfuture-incompat-test")
         .run();
@@ -804,7 +794,8 @@ fn template_should_error_for_invalid_variables() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("-Zbuild-dir-new-layout build")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .enable_mac_dsym()
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -829,7 +820,8 @@ fn template_should_suggest_nearest_variable() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("-Zbuild-dir-new-layout build")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] unexpected variable `workspace-ro` in build.build-dir path `{workspace-ro}/build-dir`
@@ -854,7 +846,10 @@ fn template_workspace_root() {
         )
         .build();
 
-    p.cargo("build").enable_mac_dsym().run();
+    p.cargo("-Zbuild-dir-new-layout build")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .enable_mac_dsym()
+        .run();
 
     // Verify the binary was uplifted to the target-dir
     assert_exists(&p.root().join(&format!("target-dir/debug/foo{EXE_SUFFIX}")));
@@ -897,7 +892,10 @@ fn template_cargo_cache_home() {
         )
         .build();
 
-    p.cargo("build").enable_mac_dsym().run();
+    p.cargo("-Zbuild-dir-new-layout build")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .enable_mac_dsym()
+        .run();
 
     // Verify the binary was uplifted to the target-dir
     assert_exists(&p.root().join(&format!("target-dir/debug/foo{EXE_SUFFIX}")));
@@ -952,7 +950,10 @@ fn template_workspace_path_hash() {
         )
         .build();
 
-    p.cargo("build").enable_mac_dsym().run();
+    p.cargo("-Zbuild-dir-new-layout build")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .enable_mac_dsym()
+        .run();
 
     let foo_dir = p.root().join("foo");
     assert_exists(&foo_dir);
@@ -1020,7 +1021,10 @@ fn template_workspace_path_hash_should_handle_symlink() {
         .build();
 
     // Build from the non-symlinked directory
-    p.cargo("check").enable_mac_dsym().run();
+    p.cargo("-Zbuild-dir-new-layout check")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .enable_mac_dsym()
+        .run();
 
     // Parse and verify the hash dir created from the non-symlinked dir
     let foo_dir = p.root().join("foo");
@@ -1056,7 +1060,11 @@ fn template_workspace_path_hash_should_handle_symlink() {
     foo_dir.rm_rf();
 
     // Run cargo from the symlinked dir
-    p.cargo("check").enable_mac_dsym().cwd(&symlinked_dir).run();
+    p.cargo("-Zbuild-dir-new-layout check")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .enable_mac_dsym()
+        .cwd(&symlinked_dir)
+        .run();
 
     // Parse and verify the hash created from the symlinked dir
     assert_exists(&foo_dir);
@@ -1098,7 +1106,7 @@ fn template_should_handle_reject_unmatched_brackets() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("-Zbuild-dir-new-layout build")
         .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -1177,8 +1185,8 @@ fn artifact_deps() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("run -Z bindeps")
-        .masquerade_as_nightly_cargo(&["bindeps"])
+    p.cargo("run -Zbuild-dir-new-layout -Z bindeps")
+        .masquerade_as_nightly_cargo(&["bindeps", "build-dir-new-layout"])
         .enable_mac_dsym()
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to latest compatible version
@@ -1308,7 +1316,8 @@ fn dylib_deps_output_overwrite() {
         .file("baz/src/lib.rs", r#"pub fn baz_value() -> i32 { 200 }"#)
         .build();
 
-    p.cargo("test")
+    p.cargo("test -Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["build-dir-new-layout"])
         .env("__CARGO_DEFAULT_LIB_METADATA", "1")
         .enable_mac_dsym()
         .with_stderr_data(
@@ -1369,7 +1378,7 @@ fn should_work_with_cargo_default_lib_metadata() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("-Zbuild-dir-new-layout build")
         .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .env("__CARGO_DEFAULT_LIB_METADATA", "true")
         .enable_mac_dsym()
@@ -1421,8 +1430,9 @@ fn new_layout_opt_out_nightly() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("-Zbuild-dir-new-layout build")
         .env("__CARGO_TEMPORARY_BUILD_DIR_NEW_LAYOUT_OPT_OUT", "1")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .enable_mac_dsym()
         .run();
 

--- a/tests/testsuite/build_dir_fine_grain_locking.rs
+++ b/tests/testsuite/build_dir_fine_grain_locking.rs
@@ -32,8 +32,8 @@ fn binary_with_debug() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build")
-        .masquerade_as_nightly_cargo(&["fine grain locking"])
+    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .enable_mac_dsym()
         .run();
 
@@ -79,8 +79,8 @@ fn binary_with_release() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build --release")
-        .masquerade_as_nightly_cargo(&["fine grain locking"])
+    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build --release")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .enable_mac_dsym()
         .run();
 
@@ -185,8 +185,8 @@ fn libs() {
             )
             .build();
 
-        p.cargo("-Zfine-grain-locking build")
-            .masquerade_as_nightly_cargo(&["fine grain locking"])
+        p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build")
+            .masquerade_as_nightly_cargo(&["new build-dir layout"])
             .enable_mac_dsym()
             .run();
 
@@ -201,8 +201,8 @@ fn should_default_to_target() {
         .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
         .build();
 
-    p.cargo("-Zfine-grain-locking build")
-        .masquerade_as_nightly_cargo(&["fine grain locking"])
+    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .enable_mac_dsym()
         .run();
 
@@ -231,8 +231,8 @@ fn should_respect_env_var() {
         .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
         .build();
 
-    p.cargo("-Zfine-grain-locking build")
-        .masquerade_as_nightly_cargo(&["fine grain locking"])
+    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .env("CARGO_BUILD_BUILD_DIR", "build-dir")
         .enable_mac_dsym()
         .run();
@@ -278,8 +278,8 @@ fn build_script_should_output_to_build_dir() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build")
-        .masquerade_as_nightly_cargo(&["fine grain locking"])
+    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .enable_mac_dsym()
         .run();
 
@@ -340,8 +340,8 @@ fn cargo_tmpdir_should_output_to_build_dir() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking test")
-        .masquerade_as_nightly_cargo(&["fine grain locking"])
+    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking test")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .enable_mac_dsym()
         .run();
 
@@ -400,8 +400,8 @@ fn examples_should_output_to_build_dir_and_uplift_to_target_dir() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build --examples")
-        .masquerade_as_nightly_cargo(&["fine grain locking"])
+    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build --examples")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .enable_mac_dsym()
         .run();
 
@@ -448,8 +448,8 @@ fn benches_should_output_to_build_dir() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build --bench=foo")
-        .masquerade_as_nightly_cargo(&["fine grain locking"])
+    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build --bench=foo")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .enable_mac_dsym()
         .run();
 
@@ -499,8 +499,8 @@ fn cargo_doc_should_output_to_target_dir() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking doc")
-        .masquerade_as_nightly_cargo(&["fine grain locking"])
+    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking doc")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .enable_mac_dsym()
         .run();
 
@@ -524,8 +524,8 @@ fn cargo_rustdoc_json_should_output_to_target_dir() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking -Zunstable-options rustdoc --output-format json")
-        .masquerade_as_nightly_cargo(&["fine grain locking", "rustdoc-output-format"])
+    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking -Zunstable-options rustdoc --output-format json")
+        .masquerade_as_nightly_cargo(&["new build-dir layout", "rustdoc-output-format"])
         .enable_mac_dsym()
         .run();
 
@@ -564,8 +564,8 @@ fn cargo_package_should_build_in_build_dir_and_output_to_target_dir() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking package")
-        .masquerade_as_nightly_cargo(&["fine grain locking"])
+    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking package")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .enable_mac_dsym()
         .run();
 
@@ -622,8 +622,8 @@ fn cargo_publish_should_only_touch_build_dir() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking publish")
-        .masquerade_as_nightly_cargo(&["fine grain locking"])
+    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking publish")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .replace_crates_io(registry.index_url())
         .enable_mac_dsym()
         .run();
@@ -651,8 +651,8 @@ fn cargo_clean_should_clean_the_target_dir_and_build_dir() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build")
-        .masquerade_as_nightly_cargo(&["fine grain locking"])
+    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .enable_mac_dsym()
         .run();
 
@@ -681,8 +681,8 @@ fn cargo_clean_should_clean_the_target_dir_and_build_dir() {
 
 "#]]);
 
-    p.cargo("-Zfine-grain-locking clean")
-        .masquerade_as_nightly_cargo(&["fine grain locking"])
+    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking clean")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .enable_mac_dsym()
         .run();
 
@@ -722,8 +722,8 @@ fn cargo_clean_should_remove_correct_files() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build")
-        .masquerade_as_nightly_cargo(&["fine grain locking"])
+    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .enable_mac_dsym()
         .run();
 
@@ -749,8 +749,8 @@ fn cargo_clean_should_remove_correct_files() {
 
 "#]]);
 
-    p.cargo("-Zfine-grain-locking clean -p bar")
-        .masquerade_as_nightly_cargo(&["fine grain locking"])
+    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking clean -p bar")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .enable_mac_dsym()
         .run();
 
@@ -783,8 +783,8 @@ fn timings_report_should_output_to_target_dir() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build --timings")
-        .masquerade_as_nightly_cargo(&["fine grain locking"])
+    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build --timings")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .enable_mac_dsym()
         .run();
 
@@ -808,8 +808,8 @@ fn future_incompat_should_output_to_build_dir() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build")
-        .masquerade_as_nightly_cargo(&["fine grain locking"])
+    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .arg("--future-incompat-report")
         .env("RUSTFLAGS", "-Zfuture-incompat-test")
         .run();
@@ -831,8 +831,8 @@ fn template_should_error_for_invalid_variables() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build")
-        .masquerade_as_nightly_cargo(&["fine grain locking"])
+    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .enable_mac_dsym()
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -857,8 +857,8 @@ fn template_should_suggest_nearest_variable() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build")
-        .masquerade_as_nightly_cargo(&["fine grain locking"])
+    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] unexpected variable `workspace-ro` in build.build-dir path `{workspace-ro}/build-dir`
@@ -883,8 +883,8 @@ fn template_workspace_root() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build")
-        .masquerade_as_nightly_cargo(&["fine grain locking"])
+    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .enable_mac_dsym()
         .run();
 
@@ -930,8 +930,8 @@ fn template_cargo_cache_home() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build")
-        .masquerade_as_nightly_cargo(&["fine grain locking"])
+    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .enable_mac_dsym()
         .run();
 
@@ -989,8 +989,8 @@ fn template_workspace_path_hash() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build")
-        .masquerade_as_nightly_cargo(&["fine grain locking"])
+    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .enable_mac_dsym()
         .run();
 
@@ -1061,8 +1061,8 @@ fn template_workspace_path_hash_should_handle_symlink() {
         .build();
 
     // Build from the non-symlinked directory
-    p.cargo("-Zfine-grain-locking check")
-        .masquerade_as_nightly_cargo(&["fine grain locking"])
+    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking check")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .enable_mac_dsym()
         .run();
 
@@ -1102,8 +1102,8 @@ fn template_workspace_path_hash_should_handle_symlink() {
     foo_dir.rm_rf();
 
     // Run cargo from the symlinked dir
-    p.cargo("-Zfine-grain-locking check")
-        .masquerade_as_nightly_cargo(&["fine grain locking"])
+    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking check")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .enable_mac_dsym()
         .cwd(&symlinked_dir)
         .run();
@@ -1150,8 +1150,8 @@ fn template_should_handle_reject_unmatched_brackets() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build")
-        .masquerade_as_nightly_cargo(&["fine grain locking"])
+    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] unexpected opening bracket `{` in build.build-dir path `foo/{bar`
@@ -1229,7 +1229,7 @@ fn artifact_deps() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("run -Z bindeps")
+    p.cargo("run -Zbuild-dir-new-layout -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps", "build-dir-new-layout"])
         .enable_mac_dsym()
         .with_stderr_data(str![[r#"
@@ -1294,9 +1294,9 @@ fn new_layout_opt_out() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build")
+    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build")
         .env("__CARGO_TEMPORARY_BUILD_DIR_NEW_LAYOUT_OPT_OUT", "1")
-        .masquerade_as_nightly_cargo(&["fine grain locking"])
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .enable_mac_dsym()
         .run();
 

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -3,8 +3,6 @@
 use std::env;
 use std::fs;
 use std::io;
-use std::path::Path;
-use std::path::PathBuf;
 use std::thread;
 
 use crate::prelude::*;
@@ -44,11 +42,11 @@ fn custom_build_script_failed() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [ERROR] failed to run custom build command for `foo v0.5.0 ([ROOT]/foo)`
 
 Caused by:
-  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build` ([EXIT_STATUS]: 101)
+  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build` ([EXIT_STATUS]: 101)
 
 "#]])
         .run();
@@ -82,12 +80,12 @@ fn custom_build_script_failed_backtraces_message() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [ERROR] failed to run custom build command for `foo v0.5.0 ([ROOT]/foo)`
 [NOTE] To improve backtraces for build dependencies, set the CARGO_PROFILE_DEV_BUILD_OVERRIDE_DEBUG=true environment variable to enable debug information generation.
 
 Caused by:
-  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build` ([EXIT_STATUS]: 101)
+  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build` ([EXIT_STATUS]: 101)
 
 "#]])
         .run();
@@ -97,12 +95,12 @@ Caused by:
         .with_status(101)
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [ERROR] failed to run custom build command for `foo v0.5.0 ([ROOT]/foo)`
 [NOTE] To improve backtraces for build dependencies, set the CARGO_PROFILE_DEV_BUILD_OVERRIDE_DEBUG=true environment variable to enable debug information generation.
 
 Caused by:
-  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build` ([EXIT_STATUS]: 101)
+  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build` ([EXIT_STATUS]: 101)
 
 "#]])
         .run();
@@ -136,11 +134,11 @@ fn custom_build_script_failed_backtraces_message_with_debuginfo() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [ERROR] failed to run custom build command for `foo v0.5.0 ([ROOT]/foo)`
 
 Caused by:
-  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build` ([EXIT_STATUS]: 101)
+  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build` ([EXIT_STATUS]: 101)
 
 "#]])
         .run();
@@ -829,7 +827,7 @@ fn host_runner_wraps_build_script() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc [..]build.rs [..]`
-[RUNNING] `[..]/rustc-echo-wrapper[EXE] [ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[..]/rustc-echo-wrapper[EXE] [ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc [..]--crate-name foo [..]`
 [FINISHED] [..]
 
@@ -866,7 +864,7 @@ fn host_runner_does_not_apply_to_target() {
 [ERROR] failed to run custom build command for `foo v0.0.1 ([ROOT]/foo)`
 
 Caused by:
-  could not execute process `nonexistent-runner [ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build` (never executed)
+  could not execute process `nonexistent-runner [ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build` (never executed)
 
 Caused by:
   [NOT_FOUND]
@@ -904,7 +902,7 @@ fn host_runner_arch_takes_precedence() {
 [ERROR] failed to run custom build command for `foo v0.0.1 ([ROOT]/foo)`
 
 Caused by:
-  could not execute process `nonexistent-arch-runner [ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build` (never executed)
+  could not execute process `nonexistent-arch-runner [ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build` (never executed)
 
 Caused by:
   [NOT_FOUND]
@@ -956,7 +954,7 @@ fn host_runner_with_args() {
 [ERROR] failed to run custom build command for `foo v0.0.1 ([ROOT]/foo)`
 
 Caused by:
-  could not execute process `nonexistent-runner --flag arg1 [ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build` (never executed)
+  could not execute process `nonexistent-runner --flag arg1 [ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build` (never executed)
 
 Caused by:
   [NOT_FOUND]
@@ -1123,10 +1121,10 @@ fn custom_build_script_rustc_flags() {
 [LOCKING] 1 package to latest compatible version
 [COMPILING] foo v0.5.0 ([ROOT]/foo/foo)
 [RUNNING] `rustc --crate-name build_script_build --edition=2015 foo/build.rs [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
-[RUNNING] `rustc --crate-name foo --edition=2015 foo/src/lib.rs [..] --verbose -L [ROOT]/foo/dummy-path1 -L [ROOT]/foo/dummy-path2 -l nonexistinglib`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `rustc --crate-name foo --edition=2015 foo/src/lib.rs [..]-L dependency=[ROOT]/foo/target/debug/deps --verbose -L [ROOT]/foo/dummy-path1 -L [ROOT]/foo/dummy-path2 -l nonexistinglib`
 [COMPILING] bar v0.5.0 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name bar --edition=2015 src/main.rs [..] --extern foo=[ROOT]/foo/target/debug/build/foo/[HASH]/out/libfoo-[HASH].rlib --verbose -L [ROOT]/foo/dummy-path1 -L [ROOT]/foo/dummy-path2`
+[RUNNING] `rustc --crate-name bar --edition=2015 src/main.rs [..]-L dependency=[ROOT]/foo/target/debug/deps --extern foo=[ROOT]/foo/target/debug/deps/libfoo-[HASH].rlib --verbose -L [ROOT]/foo/dummy-path1 -L [ROOT]/foo/dummy-path2`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]]).run();
@@ -1182,10 +1180,10 @@ fn custom_build_script_rustc_flags_no_space() {
 [LOCKING] 1 package to latest compatible version
 [COMPILING] foo v0.5.0 ([ROOT]/foo/foo)
 [RUNNING] `rustc --crate-name build_script_build --edition=2015 foo/build.rs [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
-[RUNNING] `rustc --crate-name foo --edition=2015 foo/src/lib.rs [..] --verbose -L [ROOT]/foo/dummy-path1 -L [ROOT]/foo/dummy-path2 -l nonexistinglib`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `rustc --crate-name foo --edition=2015 foo/src/lib.rs [..]-L dependency=[ROOT]/foo/target/debug/deps --verbose -L [ROOT]/foo/dummy-path1 -L [ROOT]/foo/dummy-path2 -l nonexistinglib`
 [COMPILING] bar v0.5.0 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name bar --edition=2015 src/main.rs [..] --extern foo=[ROOT]/foo/target/debug/build/foo/[HASH]/out/libfoo-[HASH].rlib --verbose -L [ROOT]/foo/dummy-path1 -L [ROOT]/foo/dummy-path2`
+[RUNNING] `rustc --crate-name bar --edition=2015 src/main.rs [..]-L dependency=[ROOT]/foo/target/debug/deps --extern foo=[ROOT]/foo/target/debug/deps/libfoo-[HASH].rlib --verbose -L [ROOT]/foo/dummy-path1 -L [ROOT]/foo/dummy-path2`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]]).run();
@@ -1473,7 +1471,7 @@ fn overrides_and_links() {
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]`
 [RUNNING] `rustc --crate-name a [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..] -L foo -L bar`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2032,7 +2030,7 @@ fn only_rerun_build_script() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.5.0 ([ROOT]/foo): the precalculated components changed
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2141,11 +2139,11 @@ fn testing_and_such() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.5.0 ([ROOT]/foo): the precalculated components changed
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
 [DOCTEST] foo
 [RUNNING] `rustdoc [..]--test [..]`
 
@@ -2376,8 +2374,8 @@ fn build_deps_simple() {
 [COMPILING] a v0.5.0 ([ROOT]/foo/a)
 [RUNNING] `rustc --crate-name a [..]`
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name build_script_build [..] build.rs [..] --extern a=[ROOT]/foo/target/debug/build/a/[HASH]/out/liba-[HASH].rlib[..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `rustc --crate-name build_script_build [..] build.rs [..] --extern a=[ROOT]/foo/target/debug/deps/liba-[HASH].rlib[..]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2489,13 +2487,13 @@ fn build_cmd_with_a_build_cmd() {
 [COMPILING] b v0.5.0 ([ROOT]/foo/b)
 [RUNNING] `rustc --crate-name b [..]`
 [COMPILING] a v0.5.0 ([ROOT]/foo/a)
-[RUNNING] `rustc --crate-name build_script_build [..] a/build.rs [..] --extern b=[ROOT]/foo/target/debug/build/b/[HASH]/out/libb-[HASH].rlib[..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/a/[HASH]/out/build_script_build`
-[RUNNING] `rustc --crate-name a [..]a/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/build/a/[HASH]/out [..]`
+[RUNNING] `rustc --crate-name build_script_build [..] a/build.rs [..] --extern b=[ROOT]/foo/target/debug/deps/libb-[HASH].rlib[..]`
+[RUNNING] `[ROOT]/foo/target/debug/build/a-[HASH]/build-script-build`
+[RUNNING] `rustc --crate-name a [..]a/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/deps -L dependency=[ROOT]/foo/target/debug/deps[..]`
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin --emit=[..]link[..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out [..] --extern a=[ROOT]/foo/target/debug/build/a/[HASH]/out/liba-[HASH].rlib[..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
-[RUNNING] `rustc --crate-name foo [..]src/lib.rs [..]--crate-type lib --emit=[..]-C debuginfo=2 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out [..]`
+[RUNNING] `rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin --emit=[..]link[..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/build/foo-[HASH] -L dependency=[ROOT]/foo/target/debug/deps --extern a=[ROOT]/foo/target/debug/deps/liba-[HASH].rlib[..]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `rustc --crate-name foo [..]src/lib.rs [..]--crate-type lib --emit=[..]-C debuginfo=2 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/deps -L dependency=[ROOT]/foo/target/debug/deps[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]]).run();
@@ -2551,7 +2549,7 @@ fn out_dir_is_preserved() {
 [DIRTY] foo v0.5.0 ([ROOT]/foo): the file `build.rs` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2573,7 +2571,7 @@ fn out_dir_is_preserved() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.5.0 ([ROOT]/foo): the precalculated components changed
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2611,7 +2609,7 @@ fn output_separate_lines() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..] -L foo -l static=foo`
 [ERROR] could not find native static library `foo`, perhaps an -L flag is missing?
 ...
@@ -2652,7 +2650,7 @@ fn output_separate_lines_new() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..] -L foo -L bar -l static=foo -l bar`
 [ERROR] could not find native static library `foo`, perhaps an -L flag is missing?
 ...
@@ -3234,13 +3232,13 @@ fn cfg_test() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..] --cfg foo[..]`
 [RUNNING] `rustc --crate-name foo [..] --cfg foo[..]`
 [RUNNING] `rustc --crate-name test [..] --cfg foo[..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/test-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/deps/test-[HASH][EXE]`
 [DOCTEST] foo
 [RUNNING] `rustdoc [..]--cfg foo[..]`
 
@@ -3374,8 +3372,8 @@ fn cfg_override_test() {
 [RUNNING] `rustc --crate-name foo[..]`
 [RUNNING] `rustc --crate-name test[..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/test-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/deps/test-[HASH][EXE]`
 [DOCTEST] foo
 [RUNNING] `rustdoc [..] --cfg foo[..]`
 
@@ -3526,13 +3524,13 @@ fn env_test() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build[..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name foo[..]`
 [RUNNING] `rustc --crate-name foo[..]`
 [RUNNING] `rustc --crate-name test[..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/test-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/deps/test-[HASH][EXE]`
 [DOCTEST] foo
 [RUNNING] `rustdoc --edition=2015 --crate-type lib --color auto --crate-name foo[..]`
 
@@ -3648,7 +3646,7 @@ fn flags_go_into_tests() {
 [LOCKING] 2 packages to latest compatible versions
 [COMPILING] a v0.5.0 ([ROOT]/foo/a)
 [RUNNING] `rustc [..] a/build.rs [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/a/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/a-[HASH]/build-script-build`
 [RUNNING] `rustc [..] a/src/lib.rs [..] -L [ROOT]/foo/link-dir`
 [COMPILING] b v0.5.0 ([ROOT]/foo/b)
 [RUNNING] `rustc [..] b/src/lib.rs [..] -L [ROOT]/foo/link-dir`
@@ -3656,7 +3654,7 @@ fn flags_go_into_tests() {
 [RUNNING] `rustc [..] src/lib.rs [..] -L [ROOT]/foo/link-dir`
 [RUNNING] `rustc [..] tests/foo.rs [..] -L [ROOT]/foo/link-dir`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -3675,7 +3673,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
 [COMPILING] b v0.5.0 ([ROOT]/foo/b)
 [RUNNING] `rustc --crate-name b [..] -L [ROOT]/foo/link-dir`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/build/b/[HASH]/out/b-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/deps/b-[HASH][EXE]`
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -3762,7 +3760,7 @@ fn diamond_passes_args_only_once() {
 [LOCKING] 3 packages to latest compatible versions
 [COMPILING] c v0.5.0 ([ROOT]/foo/c)
 [RUNNING] `rustc --crate-name build_script_build [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/c/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/c-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name c [..] -L native=test`
 [COMPILING] b v0.5.0 ([ROOT]/foo/b)
 [RUNNING] `rustc --crate-name b [..] -L native=test`
@@ -3808,7 +3806,7 @@ fn adding_an_override_invalidates() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..] -L native=foo`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -4186,7 +4184,7 @@ fn rebuild_only_on_explicit_paths() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.5.0 ([ROOT]/foo): the file `foo` is missing
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc [..] src/lib.rs [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -4204,7 +4202,7 @@ fn rebuild_only_on_explicit_paths() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.5.0 ([ROOT]/foo): the file `foo` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc [..] src/lib.rs [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -4240,7 +4238,7 @@ fn rebuild_only_on_explicit_paths() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.5.0 ([ROOT]/foo): the file `foo` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc [..] src/lib.rs [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -4254,7 +4252,7 @@ fn rebuild_only_on_explicit_paths() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.5.0 ([ROOT]/foo): the file `bar` is missing
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc [..] src/lib.rs [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -4682,7 +4680,7 @@ fn warnings_emitted_when_build_script_panics() {
 [ERROR] failed to run custom build command for `foo v0.5.0 ([ROOT]/foo)`
 
 Caused by:
-  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build` ([EXIT_STATUS]: 101)
+  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build` ([EXIT_STATUS]: 101)
   --- stdout
   cargo::warning=foo
   cargo::warning=bar
@@ -4752,7 +4750,7 @@ fn warnings_emitted_when_dependency_panics() {
 [ERROR] failed to run custom build command for `published v0.1.0`
 
 Caused by:
-  process didn't exit successfully: `[ROOT]/foo/target/debug/build/published/[HASH]/out/build_script_build` ([EXIT_STATUS]: 101)
+  process didn't exit successfully: `[ROOT]/foo/target/debug/build/published-[HASH]/build-script-build` ([EXIT_STATUS]: 101)
   --- stdout
   cargo::warning=foo
   cargo::warning=bar
@@ -4879,7 +4877,7 @@ fn warnings_hidden_for_upstream() {
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [COMPILING] bar v0.1.0
 [RUNNING] `rustc --crate-name build_script_build [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/bar/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/bar-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name bar [..]`
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo [..]`
@@ -4940,7 +4938,7 @@ fn warnings_printed_on_vv() {
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [COMPILING] bar v0.1.0
 [RUNNING] `[..] rustc --crate-name build_script_build [..]`
-[RUNNING] `[..] [ROOT]/foo/target/debug/build/bar/[HASH]/out/build_script_build`
+[RUNNING] `[..] [ROOT]/foo/target/debug/build/bar-[HASH]/build-script-build`
 [WARNING] bar@0.1.0: foo
 [WARNING] bar@0.1.0: bar
 [RUNNING] `[..] rustc --crate-name bar [..]`
@@ -4988,7 +4986,7 @@ fn output_shows_on_vv() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `[..] rustc --crate-name build_script_build [..]`
-[RUNNING] `[..] [ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[..] [ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [foo 0.5.0] stderr
 [RUNNING] `[..] rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -5550,20 +5548,17 @@ fn _rename_with_link_search_path(cross: bool, expected: impl IntoData) {
     // the `p` project. On macOS, the `libfoo.dylib` artifact references the
     // original path in `p` so we want to make sure that it can't find it (hence
     // the deletion).
-    let file = format!("{}foo{}", env::consts::DLL_PREFIX, env::consts::DLL_SUFFIX);
-    let src = if cross {
-        find_file(
-            &p.root()
-                .join("target")
-                .join(cross_compile::alternate())
-                .join("debug"),
-            &file,
-        )
-        .unwrap()
+    let root = if cross {
+        p.root()
+            .join("target")
+            .join(cross_compile::alternate())
+            .join("debug")
+            .join("deps")
     } else {
-        find_file(&p.root().join("target").join("debug"), &file).unwrap()
+        p.root().join("target").join("debug").join("deps")
     };
-    let root = src.parent().unwrap();
+    let file = format!("{}foo{}", env::consts::DLL_PREFIX, env::consts::DLL_SUFFIX);
+    let src = root.join(&file);
 
     let dst = p2.root().join(&file);
 
@@ -5609,14 +5604,6 @@ fn _rename_with_link_search_path(cross: bool, expected: impl IntoData) {
         .cwd(&new)
         .with_stderr_data(expected)
         .run();
-}
-
-fn find_file(root: &Path, file_name: &str) -> Option<PathBuf> {
-    walkdir::WalkDir::new(root)
-        .into_iter()
-        .filter_map(|e| e.ok())
-        .find(|e| e.file_name() == file_name)
-        .map(|f| f.into_path())
 }
 
 #[cargo_test]
@@ -5872,7 +5859,7 @@ fn links_interrupted_can_restart() {
         .env("SOMEVAR", "1")
         .with_stderr_data(str![[r#"
 ...
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 ...
 "#]])
         .run();
@@ -5955,7 +5942,7 @@ fn rerun_if_directory() {
     dirty(str![[r#"
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build[..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -5965,7 +5952,7 @@ fn rerun_if_directory() {
     dirty(str![[r#"
 [DIRTY] foo v0.1.0 ([ROOT]/foo): the file `somedir` is missing
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -5980,7 +5967,7 @@ fn rerun_if_directory() {
     dirty(str![[r#"
 [DIRTY] foo v0.1.0 ([ROOT]/foo): the file `somedir` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -5997,7 +5984,7 @@ fn rerun_if_directory() {
     dirty(str![[r#"
 [DIRTY] foo v0.1.0 ([ROOT]/foo): the file `somedir` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -6013,7 +6000,7 @@ fn rerun_if_directory() {
     dirty(str![[r#"
 [DIRTY] foo v0.1.0 ([ROOT]/foo): the file `somedir` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -6030,7 +6017,7 @@ fn rerun_if_directory() {
     dirty(str![[r#"
 [DIRTY] foo v0.1.0 ([ROOT]/foo): the file `somedir` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -6046,7 +6033,7 @@ fn rerun_if_directory() {
     dirty(str![[r#"
 [DIRTY] foo v0.1.0 ([ROOT]/foo): the file `somedir` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -6122,7 +6109,7 @@ fn rerun_if_published_directory() {
         .with_stderr_data(str![[r#"
 [COMPILING] mylib-sys v1.0.1
 [RUNNING] `rustc --crate-name build_script_build [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/mylib-sys/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/mylib-sys-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name mylib_sys [..]`
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo [..]`
@@ -6821,7 +6808,7 @@ fn linker_search_path_preference() {
 
     p.cargo("build -v").with_stderr_data(str![[r#"
 ...
-[RUNNING] `rustc --crate-name foo [..] -L [ROOT]/foo/target/debug/build/foo/[HASH]/out/libs2 -L [ROOT]/foo/target/debug/build/foo/[HASH]/out/libs1 -L [ROOT]/foo/target/debug/build/a/[HASH]/out/libsA.2 -L [ROOT]/foo/target/debug/build/a/[HASH]/out/libsA.1 -L [ROOT]/foo/target/debug/build/b/[HASH]/out/libsB.1 -L [ROOT]/foo/target/debug/build/b/[HASH]/out/libsB.2 -L /usr/lib -L /lib -L /usr/lib3 -L /lib3 -L /usr/lib2 -L /lib2`
+[RUNNING] `rustc --crate-name foo [..] -L [ROOT]/foo/target/debug/build/foo-[HASH]/out/libs2 -L [ROOT]/foo/target/debug/build/foo-[HASH]/out/libs1 -L [ROOT]/foo/target/debug/build/a-[HASH]/out/libsA.2 -L [ROOT]/foo/target/debug/build/a-[HASH]/out/libsA.1 -L [ROOT]/foo/target/debug/build/b-[HASH]/out/libsB.1 -L [ROOT]/foo/target/debug/build/b-[HASH]/out/libsB.2 -L /usr/lib -L /lib -L /usr/lib3 -L /lib3 -L /usr/lib2 -L /lib2`
 ...
 "#]]).run();
 }
@@ -6847,7 +6834,7 @@ fn target_runner_does_not_apply_to_build_script_with_host_config() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 
@@ -6876,7 +6863,7 @@ fn target_linker_does_not_apply_to_build_script_with_host_config() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 

--- a/tests/testsuite/build_script_env.rs
+++ b/tests/testsuite/build_script_env.rs
@@ -223,7 +223,7 @@ fn build_script_env_verbose() {
         .with_stderr_data(
             "\
 ...
-[RUNNING] `[..]CARGO=[..]build_script_build`
+[RUNNING] `[..]CARGO=[..]build-script-build`
 ...",
         )
         .run();

--- a/tests/testsuite/build_script_extra_link_arg.rs
+++ b/tests/testsuite/build_script_extra_link_arg.rs
@@ -219,7 +219,7 @@ fn cdylib_link_arg_transitive() {
 ...
 [COMPILING] bar v1.0.0 ([ROOT]/foo/bar)
 [RUNNING] `rustc --crate-name build_script_build --edition=2015 bar/build.rs [..]
-[RUNNING] `[ROOT]/foo/target/debug/build/bar/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/bar-[HASH]/build-script-build`
 [WARNING] bar@1.0.0: cargo::rustc-link-arg-cdylib was specified in the build script of bar v1.0.0 \
 ([ROOT]/foo/bar), but that package does not contain a cdylib target
 
@@ -279,7 +279,7 @@ fn link_arg_transitive_not_allowed() {
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [COMPILING] bar v1.0.0
 [RUNNING] `rustc --crate-name build_script_build [..]
-[RUNNING] `[ROOT]/foo/target/debug/build/bar/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/bar-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name bar [..]
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]
@@ -437,7 +437,7 @@ fn cdylib_both_forms() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..]--crate-type cdylib [..]-C link-arg=--bogus-flag-one -C link-arg=--bogus-flag-two[..]
 ...
 "#]])

--- a/tests/testsuite/build_scripts_multiple.rs
+++ b/tests/testsuite/build_scripts_multiple.rs
@@ -441,7 +441,7 @@ fn custom_build_script_first_index_script_failed() {
 [ERROR] failed to run custom build command for `foo v0.1.0 ([ROOT]/foo)`
 
 Caused by:
-  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build1` ([EXIT_STATUS]: 101)
+  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build1` ([EXIT_STATUS]: 101)
 ...
 "#]])
         .run();
@@ -479,7 +479,7 @@ fn custom_build_script_second_index_script_failed() {
 [ERROR] failed to run custom build command for `foo v0.1.0 ([ROOT]/foo)`
 
 Caused by:
-  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build2` ([EXIT_STATUS]: 101)
+  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build2` ([EXIT_STATUS]: 101)
 ...
 "#]])
         .run();
@@ -741,7 +741,7 @@ fn bar() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.1.0 ([ROOT]/foo): the [..]
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build1`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build1`
 [RUNNING] `rustc --crate-name foo --edition=2024 src/main.rs [..] --crate-type bin [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -756,8 +756,8 @@ fn bar() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.1.0 ([ROOT]/foo): the [..]
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build[..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build[..]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build[..]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build[..]`
 [RUNNING] `rustc --crate-name foo --edition=2024 src/main.rs [..] --crate-type bin [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/cache_messages.rs
+++ b/tests/testsuite/cache_messages.rs
@@ -143,7 +143,7 @@ fn clears_cache_after_fix() {
 "#]])
         .run();
     let cpath = p
-        .glob("target/debug/build/foo/*/fingerprint/output-*")
+        .glob("target/debug/.fingerprint/foo-*/output-*")
         .next()
         .unwrap()
         .unwrap();
@@ -164,8 +164,7 @@ fn clears_cache_after_fix() {
 "#]])
         .run();
     assert_eq!(
-        p.glob("target/debug/build/foo/*/fingerprint/output-*")
-            .count(),
+        p.glob("target/debug/.fingerprint/foo-*/output-*").count(),
         0
     );
 
@@ -197,8 +196,7 @@ fn rustdoc() {
     assert!(rustdoc_stderr.contains("missing"));
     assert!(rustdoc_stderr.contains("\x1b["));
     assert_eq!(
-        p.glob("target/debug/build/foo/*/fingerprint/output-*")
-            .count(),
+        p.glob("target/debug/.fingerprint/foo-*/output-*").count(),
         1
     );
 
@@ -304,13 +302,11 @@ fn doesnt_create_extra_files() {
     p.cargo("check").run();
 
     assert_eq!(
-        p.glob("target/debug/build/foo/*/fingerprint/output-*")
-            .count(),
+        p.glob("target/debug/.fingerprint/foo-*/output-*").count(),
         0
     );
     assert_eq!(
-        p.glob("target/debug/build/foo/*/fingerprint/dep-*/output-*")
-            .count(),
+        p.glob("target/debug/.fingerprint/dep-*/output-*").count(),
         0
     );
     if is_coarse_mtime() {
@@ -319,8 +315,7 @@ fn doesnt_create_extra_files() {
     p.change_file("src/lib.rs", "fn unused() {}");
     p.cargo("check").run();
     assert_eq!(
-        p.glob("target/debug/build/foo/*/fingerprint/output-*")
-            .count(),
+        p.glob("target/debug/.fingerprint/foo-*/output-*").count(),
         1
     );
 }

--- a/tests/testsuite/cargo_alias_config.rs
+++ b/tests/testsuite/cargo_alias_config.rs
@@ -156,7 +156,7 @@ fn builtin_alias_shadowing_external_subcommand() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/main.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/deps/foo-[HASH][EXE])
 
 "#]])
         .run();

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -773,33 +773,21 @@ fn check_artifacts() {
     assert!(!p.root().join("target/debug/libfoo.rmeta").is_file());
     assert!(!p.root().join("target/debug/libfoo.rlib").is_file());
     assert!(!p.root().join("target/debug").join(exe("foo")).is_file());
-    assert_eq!(
-        p.glob("target/debug/build/foo/*/out/libfoo-*.rmeta")
-            .count(),
-        2
-    );
+    assert_eq!(p.glob("target/debug/deps/libfoo-*.rmeta").count(), 2);
 
     p.root().join("target").rm_rf();
     p.cargo("check --lib").run();
     assert!(!p.root().join("target/debug/libfoo.rmeta").is_file());
     assert!(!p.root().join("target/debug/libfoo.rlib").is_file());
     assert!(!p.root().join("target/debug").join(exe("foo")).is_file());
-    assert_eq!(
-        p.glob("target/debug/build/foo/*/out/libfoo-*.rmeta")
-            .count(),
-        1
-    );
+    assert_eq!(p.glob("target/debug/deps/libfoo-*.rmeta").count(), 1);
 
     p.root().join("target").rm_rf();
     p.cargo("check --bin foo").run();
     assert!(!p.root().join("target/debug/libfoo.rmeta").is_file());
     assert!(!p.root().join("target/debug/libfoo.rlib").is_file());
     assert!(!p.root().join("target/debug").join(exe("foo")).is_file());
-    assert_eq!(
-        p.glob("target/debug/build/foo/*/out/libfoo-*.rmeta")
-            .count(),
-        2
-    );
+    assert_eq!(p.glob("target/debug/deps/libfoo-*.rmeta").count(), 2);
 
     p.root().join("target").rm_rf();
     p.cargo("check --test t1").run();
@@ -807,15 +795,8 @@ fn check_artifacts() {
     assert!(!p.root().join("target/debug/libfoo.rlib").is_file());
     assert!(!p.root().join("target/debug").join(exe("foo")).is_file());
     assert_eq!(p.glob("target/debug/t1-*").count(), 0);
-    assert_eq!(
-        p.glob("target/debug/build/foo/*/out/libfoo-*.rmeta")
-            .count(),
-        1
-    );
-    assert_eq!(
-        p.glob("target/debug/build/foo/*/out/libt1-*.rmeta").count(),
-        1
-    );
+    assert_eq!(p.glob("target/debug/deps/libfoo-*.rmeta").count(), 1);
+    assert_eq!(p.glob("target/debug/deps/libt1-*.rmeta").count(), 1);
 
     p.root().join("target").rm_rf();
     p.cargo("check --example ex1").run();
@@ -827,16 +808,8 @@ fn check_artifacts() {
             .join(exe("ex1"))
             .is_file()
     );
-    assert_eq!(
-        p.glob("target/debug/build/foo/*/out/libfoo-*.rmeta")
-            .count(),
-        1
-    );
-    assert_eq!(
-        p.glob("target/debug/build/foo/*/out/libex1-*.rmeta")
-            .count(),
-        1
-    );
+    assert_eq!(p.glob("target/debug/deps/libfoo-*.rmeta").count(), 1);
+    assert_eq!(p.glob("target/debug/examples/libex1-*.rmeta").count(), 1);
 
     p.root().join("target").rm_rf();
     p.cargo("check --bench b1").run();
@@ -844,15 +817,8 @@ fn check_artifacts() {
     assert!(!p.root().join("target/debug/libfoo.rlib").is_file());
     assert!(!p.root().join("target/debug").join(exe("foo")).is_file());
     assert_eq!(p.glob("target/debug/b1-*").count(), 0);
-    assert_eq!(
-        p.glob("target/debug/build/foo/*/out/libfoo-*.rmeta")
-            .count(),
-        1
-    );
-    assert_eq!(
-        p.glob("target/debug/build/foo/*/out/libb1-*.rmeta").count(),
-        1
-    );
+    assert_eq!(p.glob("target/debug/deps/libfoo-*.rmeta").count(), 1);
+    assert_eq!(p.glob("target/debug/deps/libb1-*.rmeta").count(), 1);
 }
 
 #[cargo_test]

--- a/tests/testsuite/check_cfg.rs
+++ b/tests/testsuite/check_cfg.rs
@@ -397,7 +397,7 @@ fn build_script_doc() {
             "\
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc [..] build.rs [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
 {running_rustdoc}
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -18,10 +18,16 @@ fn cargo_clean_simple() {
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-    p.cargo("build").run();
+    p.cargo("build")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
     assert!(p.build_dir().is_dir());
 
-    p.cargo("clean").run();
+    p.cargo("clean")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
     assert!(!p.build_dir().is_dir());
 }
 
@@ -33,7 +39,10 @@ fn different_dir() {
         .file("src/bar/a.rs", "")
         .build();
 
-    p.cargo("build").run();
+    p.cargo("build")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
     assert!(p.build_dir().is_dir());
 
     p.cargo("clean")
@@ -42,6 +51,8 @@ fn different_dir() {
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
 "#]])
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
     assert!(!p.build_dir().is_dir());
 }
@@ -74,7 +85,10 @@ fn clean_multiple_packages() {
         .file("d2/src/main.rs", "fn main() { println!(\"d2\"); }")
         .build();
 
-    p.cargo("build -p d1 -p d2 -p foo").run();
+    p.cargo("build -p d1 -p d2 -p foo")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
 
     let d1_path = &p
         .build_dir()
@@ -95,6 +109,8 @@ fn clean_multiple_packages() {
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
 "#]])
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
     assert!(p.bin("foo").is_file());
     assert!(!d1_path.is_file());
@@ -116,11 +132,16 @@ fn clean_multiple_packages_in_glob_char_path() {
     let file_glob = "foo/*/out/foo.pdb";
 
     // Assert that build artifacts are produced
-    p.cargo("build").run();
+    p.cargo("build")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
     assert_ne!(get_build_artifacts(foo_path, file_glob).len(), 0);
 
     // Assert that build artifacts are destroyed
     p.cargo("clean -p foo")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .with_stderr_data(str![[r#"
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
@@ -165,7 +186,10 @@ fn clean_p_only_cleans_specified_package() {
 
     let units_path = &p.build_dir().join("debug").join("build");
 
-    p.cargo("build -p foo -p foo_core -p foo-base").run();
+    p.cargo("build -p foo -p foo_core -p foo-base")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
 
     let mut fingerprint_names = get_fingerprints_without_hashes(units_path);
 
@@ -182,7 +206,10 @@ fn clean_p_only_cleans_specified_package() {
         .count();
     assert_ne!(num_foo_base_artifacts, 0);
 
-    p.cargo("clean -p foo").run();
+    p.cargo("clean -p foo")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
 
     fingerprint_names = get_fingerprints_without_hashes(units_path);
 
@@ -237,28 +264,48 @@ fn clean_release() {
         .file("a/src/lib.rs", "")
         .build();
 
-    p.cargo("build --release").run();
+    p.cargo("build --release")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
 
-    p.cargo("clean -p foo").run();
+    p.cargo("clean -p foo")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
     p.cargo("build --release")
         .with_stderr_data(str![[r#"
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 
 "#]])
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
 
-    p.cargo("clean -p foo --release").run();
+    p.cargo("clean -p foo --release")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
     p.cargo("build --release")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 
 "#]])
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
 
-    p.cargo("build").run();
+    p.cargo("build")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
 
-    p.cargo("clean").arg("--release").run();
+    p.cargo("clean")
+        .arg("--release")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
     assert!(p.build_dir().is_dir());
     assert!(p.build_dir().join("debug").is_dir());
     assert!(!p.build_dir().join("release").is_dir());
@@ -285,7 +332,10 @@ fn clean_doc() {
         .file("a/src/lib.rs", "")
         .build();
 
-    p.cargo("doc").run();
+    p.cargo("doc")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
 
     let doc_path = &p.build_dir().join("doc");
 
@@ -296,6 +346,8 @@ fn clean_doc() {
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
 "#]])
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
 
     assert!(!doc_path.is_dir());
@@ -336,8 +388,15 @@ fn build_script() {
         .file("a/src/lib.rs", "")
         .build();
 
-    p.cargo("build").env("FIRST", "1").run();
-    p.cargo("clean -p foo").run();
+    p.cargo("build")
+        .env("FIRST", "1")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
+    p.cargo("clean -p foo")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
     p.cargo("build -v")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -347,6 +406,8 @@ fn build_script() {
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
 }
 
@@ -378,14 +439,22 @@ fn clean_git() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build").run();
+    p.cargo("build")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
     p.cargo("clean -p dep")
         .with_stderr_data(str![[r#"
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
 "#]])
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
-    p.cargo("build").run();
+    p.cargo("build")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
 }
 
 #[cargo_test]
@@ -409,14 +478,22 @@ fn registry() {
 
     Package::new("bar", "0.1.0").publish();
 
-    p.cargo("build").run();
+    p.cargo("build")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
     p.cargo("clean -p bar")
         .with_stderr_data(str![[r#"
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
 "#]])
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
-    p.cargo("build").run();
+    p.cargo("build")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
 }
 
 #[cargo_test]
@@ -439,15 +516,23 @@ fn clean_verbose() {
 
     Package::new("bar", "0.1.0").publish();
 
-    p.cargo("build").run();
+    p.cargo("build")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
     p.cargo("clean -p bar --verbose")
         .with_stderr_data(str![[r#"
 [REMOVING] [ROOT]/foo/target/debug/build/bar
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
 "#]])
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
-    p.cargo("build").run();
+    p.cargo("build")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
 }
 
 #[cargo_test]
@@ -465,7 +550,10 @@ fn clean_remove_rlib_rmeta() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build").run();
+    p.cargo("build")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
     assert!(p.target_debug_dir().join("libfoo.rlib").exists());
     let rmeta = p
         .glob("target/debug/build/*/*/out/*.rmeta")
@@ -473,7 +561,10 @@ fn clean_remove_rlib_rmeta() {
         .unwrap()
         .unwrap();
     assert!(rmeta.exists());
-    p.cargo("clean -p foo").run();
+    p.cargo("clean -p foo")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
     assert!(!p.target_debug_dir().join("libfoo.rlib").exists());
     assert!(!rmeta.exists());
 }
@@ -503,8 +594,14 @@ fn package_cleans_all_the_things() {
             )
             .file("src/lib.rs", "")
             .build();
-        p.cargo("build").run();
-        p.cargo("clean -p foo-bar").run();
+        p.cargo("build")
+            .arg("-Zbuild-dir-new-layout")
+            .masquerade_as_nightly_cargo(&["new build-dir layout"])
+            .run();
+        p.cargo("clean -p foo-bar")
+            .arg("-Zbuild-dir-new-layout")
+            .masquerade_as_nightly_cargo(&["new build-dir layout"])
+            .run();
         assert_all_clean(&p.build_dir());
     }
     let p = project()
@@ -547,21 +644,36 @@ fn package_cleans_all_the_things() {
 
     p.cargo("build --all-targets")
         .env("CARGO_INCREMENTAL", "1")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
     p.cargo("test --all-targets")
         .env("CARGO_INCREMENTAL", "1")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
     p.cargo("check --all-targets")
         .env("CARGO_INCREMENTAL", "1")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
-    p.cargo("clean -p foo-bar").run();
+    p.cargo("clean -p foo-bar")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
     assert_all_clean(&p.build_dir());
 
     // Try some targets.
     p.cargo("build --all-targets --target")
         .arg(rustc_host())
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
-    p.cargo("clean -p foo-bar --target").arg(rustc_host()).run();
+    p.cargo("clean -p foo-bar --target")
+        .arg(rustc_host())
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
     assert_all_clean(&p.build_dir());
 }
 
@@ -627,7 +739,10 @@ fn clean_spec_version() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build").run();
+    p.cargo("build")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
 
     // Check suggestion for bad pkgid.
     p.cargo("clean -p baz")
@@ -638,6 +753,8 @@ fn clean_spec_version() {
 [HELP] a package with a similar name exists: `bar`
 
 "#]])
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
 
     p.cargo("clean -p bar:0.1.0")
@@ -646,6 +763,8 @@ fn clean_spec_version() {
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
 "#]])
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
     let mut walker = walkdir::WalkDir::new(p.build_dir())
         .into_iter()
@@ -682,7 +801,10 @@ fn clean_spec_partial_version() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build").run();
+    p.cargo("build")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
 
     // Check suggestion for bad pkgid.
     p.cargo("clean -p baz")
@@ -693,6 +815,8 @@ fn clean_spec_partial_version() {
 [HELP] a package with a similar name exists: `bar`
 
 "#]])
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
 
     p.cargo("clean -p bar:0.1")
@@ -701,6 +825,8 @@ fn clean_spec_partial_version() {
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
 "#]])
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
     let mut walker = walkdir::WalkDir::new(p.build_dir())
         .into_iter()
@@ -737,7 +863,10 @@ fn clean_spec_partial_version_ambiguous() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build").run();
+    p.cargo("build")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
 
     // Check suggestion for bad pkgid.
     p.cargo("clean -p baz")
@@ -748,6 +877,8 @@ fn clean_spec_partial_version_ambiguous() {
 [HELP] a package with a similar name exists: `bar`
 
 "#]])
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
 
     p.cargo("clean -p bar:0")
@@ -756,6 +887,8 @@ fn clean_spec_partial_version_ambiguous() {
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
 "#]])
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
     let mut walker = walkdir::WalkDir::new(p.build_dir())
         .into_iter()
@@ -796,7 +929,10 @@ fn clean_spec_reserved() {
         .file("tests/build.rs", "")
         .build();
 
-    p.cargo("build --all-targets").run();
+    p.cargo("build --all-targets")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
     assert!(p.target_debug_dir().join("build").is_dir());
     let build_test = p
         .glob("target/debug/build/*/*/out/build-*")
@@ -807,7 +943,10 @@ fn clean_spec_reserved() {
     // Tests are never "uplifted".
     assert!(p.glob("target/debug/build-*").next().is_none());
 
-    p.cargo("clean -p foo").run();
+    p.cargo("clean -p foo")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
     // Should not delete this.
     assert!(p.target_debug_dir().join("build").is_dir());
 
@@ -822,6 +961,8 @@ fn clean_spec_reserved() {
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
 }
 
@@ -853,8 +994,13 @@ fn clean_dry_run() {
 [WARNING] no files deleted due to --dry-run
 
 "#]])
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
-    p.cargo("check").run();
+    p.cargo("check")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
     let before = p.build_dir().ls_r();
     p.cargo("clean --dry-run")
         .with_stderr_data(str![[r#"
@@ -862,6 +1008,8 @@ fn clean_dry_run() {
 [WARNING] no files deleted due to --dry-run
 
 "#]])
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
     // Verify it didn't delete anything.
     let after = p.build_dir().ls_r();
@@ -879,6 +1027,8 @@ fn clean_dry_run() {
 [WARNING] no files deleted due to --dry-run
 
 "#]])
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
 }
 
@@ -892,6 +1042,8 @@ fn doc_with_package_selection() {
 [ERROR] --doc cannot be used with -p
 
 "#]])
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
 }
 
@@ -904,10 +1056,15 @@ fn quiet_does_not_show_summary() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("check").run();
+    p.cargo("check")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
     p.cargo("clean --quiet --dry-run")
         .with_stdout_data("")
         .with_stderr_data("")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
     // Verify exact same command without -q would actually display something.
     p.cargo("clean --dry-run")
@@ -917,6 +1074,8 @@ fn quiet_does_not_show_summary() {
 [WARNING] no files deleted due to --dry-run
 
 "#]])
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
 }
 
@@ -931,6 +1090,8 @@ fn explicit_target_dir_tag_not_present() {
         .build();
 
     p.cargo("clean --target-dir bar")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [ERROR] cannot clean `[ROOT]/foo/bar`: missing or invalid `CACHEDIR.TAG` file
@@ -951,6 +1112,8 @@ fn explicit_target_dir_tag_invalid_signature() {
         .build();
 
     p.cargo("clean --target-dir bar")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [ERROR] cannot clean `[ROOT]/foo/bar`: invalid signature in `CACHEDIR.TAG` file
@@ -975,6 +1138,8 @@ fn explicit_target_dir_tag_symlink() {
         .build();
 
     p.cargo("clean --target-dir bar")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [ERROR] cannot clean `[ROOT]/foo/bar`: expect `CACHEDIR.TAG` to be a regular file, got a symlink
@@ -997,7 +1162,10 @@ fn explicit_target_dir_tag_valid() {
         )
         .build();
 
-    p.cargo("clean --target-dir bar").run();
+    p.cargo("clean --target-dir bar")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
 }
 
 #[cargo_test]
@@ -1011,6 +1179,8 @@ fn env_target_dir_tag_not_present() {
         .build();
 
     p.cargo("clean")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .env("CARGO_TARGET_DIR", "bar")
         .with_stderr_data(str![[r#"
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
@@ -1028,6 +1198,8 @@ fn env_target_dir_tag_invalid_signature() {
         .build();
 
     p.cargo("clean")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .env("CARGO_TARGET_DIR", "bar")
         .with_stderr_data(str![[r#"
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
@@ -1049,6 +1221,8 @@ fn env_target_dir_tag_symlink() {
         .build();
 
     p.cargo("clean")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .env("CARGO_TARGET_DIR", "bar")
         .with_stderr_data(str![[r#"
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
@@ -1068,7 +1242,11 @@ fn env_target_dir_tag_valid() {
         )
         .build();
 
-    p.cargo("clean").env("CARGO_TARGET_DIR", "bar").run();
+    p.cargo("clean")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .env("CARGO_TARGET_DIR", "bar")
+        .run();
 }
 
 #[cargo_test]
@@ -1087,6 +1265,8 @@ fn config_target_dir_tag_not_present() {
         .build();
 
     p.cargo("clean")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .with_stderr_data(str![[r#"
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
@@ -1108,6 +1288,8 @@ fn config_target_dir_tag_invalid_signature() {
         .build();
 
     p.cargo("clean")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .with_stderr_data(str![[r#"
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
@@ -1133,6 +1315,8 @@ fn config_target_dir_tag_symlink() {
         .build();
 
     p.cargo("clean")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .with_stderr_data(str![[r#"
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
@@ -1156,7 +1340,10 @@ fn config_target_dir_tag_valid() {
         )
         .build();
 
-    p.cargo("clean").run();
+    p.cargo("clean")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
 }
 
 #[cargo_test]
@@ -1168,6 +1355,8 @@ fn explicit_target_dir_not_exists() {
 
     // should not error if target_dir does not exist
     p.cargo("clean --target-dir bar")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .with_stderr_data(str![[r#"
 [REMOVED] 0 files
 

--- a/tests/testsuite/collisions.rs
+++ b/tests/testsuite/collisions.rs
@@ -55,7 +55,7 @@ fn collision_dylib() {
     p.cargo("build -j=1")
         .with_stderr_data(&format!("\
 ...
-[WARNING] output filename collision at [ROOT]/foo/target/debug/{}a{}
+[WARNING] output filename collision at [ROOT]/foo/target/debug/deps/{}a{}
   |
   = [NOTE] the lib target `a` in package `b v1.0.0 ([ROOT]/foo/b)` has the same output filename as the lib target `a` in package `a v1.0.0 ([ROOT]/foo/a)`
   = [NOTE] this may become a hard error in the future; see <https://github.com/rust-lang/cargo/issues/6313>

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -494,7 +494,7 @@ fn linker() {
 please set bin.path in Cargo.toml
 [WARNING] `foo` (manifest) generated 1 warning
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo --edition=2015 src/foo.rs [..]--crate-type bin --emit=[..]link[..]-C debuginfo=2 [..] -C metadata=[..] --out-dir [ROOT]/foo/target/[ALT_TARGET]/debug/build/foo/[HASH]/out --target [ALT_TARGET] -C linker=my-linker-tool -L dependency=[ROOT]/foo/target/[ALT_TARGET]/debug/build/foo/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/foo/[HASH]/out[..]`
+[RUNNING] `rustc --crate-name foo --edition=2015 src/foo.rs [..]--crate-type bin --emit=[..]link[..]-C debuginfo=2 [..] -C metadata=[..] --out-dir [ROOT]/foo/target/[ALT_TARGET]/debug/deps --target [ALT_TARGET] -C linker=my-linker-tool -L dependency=[ROOT]/foo/target/[ALT_TARGET]/debug/deps -L dependency=[ROOT]/foo/target/debug/deps[..]`
 [ERROR] linker `my-linker-tool` not found
 ...
 "#]])
@@ -560,8 +560,8 @@ fn cross_tests() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/[ALT_TARGET]/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
-[RUNNING] unittests src/bin/bar.rs (target/[ALT_TARGET]/debug/build/foo/[HASH]/out/bar-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/[ALT_TARGET]/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/bin/bar.rs (target/[ALT_TARGET]/debug/deps/bar-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -644,9 +644,8 @@ fn cross_with_a_build_script() {
                         let mut path = PathBuf::from(env::var_os("OUT_DIR").unwrap());
                         assert_eq!(path.file_name().unwrap().to_str().unwrap(), "out");
                         path.pop();
-                        assert_eq!(path.file_name().unwrap().to_str().unwrap().len(), 16);
-                        path.pop();
-                        assert_eq!(path.file_name().unwrap().to_str().unwrap(), "foo");
+                        assert!(path.file_name().unwrap().to_str().unwrap()
+                                    .starts_with("foo-"));
                         path.pop();
                         assert_eq!(path.file_name().unwrap().to_str().unwrap(), "build");
                         path.pop();
@@ -667,8 +666,8 @@ fn cross_with_a_build_script() {
         .arg(&target)
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustc [..] build.rs [..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out [..]
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `rustc [..] build.rs [..] --out-dir [ROOT]/foo/target/debug/build/foo-[HASH] [..]
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc [..] src/main.rs [..] --target [ALT_TARGET] [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -770,17 +769,17 @@ fn build_script_needed_for_host_and_target() {
         .with_stderr_data(str![[r#"
 [LOCKING] 2 packages to latest compatible versions
 [COMPILING] d1 v0.0.0 ([ROOT]/foo/d1)
-[RUNNING] `rustc [..] d1/build.rs [..] --out-dir [ROOT]/foo/target/debug/build/d1/[HASH]/out [..]
-[RUNNING] `[ROOT]/foo/target/debug/build/d1/[HASH]/out/build_script_build`
-[RUNNING] `[ROOT]/foo/target/debug/build/d1/[HASH]/out/build_script_build`
-[RUNNING] `rustc [..] d1/src/lib.rs [..] --out-dir [ROOT]/foo/target/debug/build/d1/[HASH]/out [..]
-[RUNNING] `rustc [..] d1/src/lib.rs [..] --out-dir [ROOT]/foo/target/[ALT_TARGET]/debug/build/d1/[HASH]/out [..]
+[RUNNING] `rustc [..] d1/build.rs [..] --out-dir [ROOT]/foo/target/debug/build/d1-[HASH] [..]
+[RUNNING] `[ROOT]/foo/target/debug/build/d1-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/d1-[HASH]/build-script-build`
+[RUNNING] `rustc [..] d1/src/lib.rs [..] --out-dir [ROOT]/foo/target/debug/deps [..]
+[RUNNING] `rustc [..] d1/src/lib.rs [..] --out-dir [ROOT]/foo/target/[ALT_TARGET]/debug/deps [..]
 [COMPILING] d2 v0.0.0 ([ROOT]/foo/d2)
-[RUNNING] `rustc [..] d2/src/lib.rs [..] --out-dir [ROOT]/foo/target/debug/build/d2/[HASH]/out [..]-L [ROOT]/foo/link-[HOST_TARGET]`
+[RUNNING] `rustc [..] d2/src/lib.rs [..] --out-dir [ROOT]/foo/target/debug/deps [..]-L [ROOT]/foo/link-[HOST_TARGET]`
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustc [..] build.rs [..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out [..]-L [ROOT]/foo/link-[HOST_TARGET]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
-[RUNNING] `rustc [..] src/main.rs [..] --out-dir [ROOT]/foo/target/[ALT_TARGET]/debug/build/foo/[HASH]/out --target [ALT_TARGET] [..]-L [ROOT]/foo/link-[ALT_TARGET]`
+[RUNNING] `rustc [..] build.rs [..] --out-dir [ROOT]/foo/target/debug/build/foo-[HASH] [..]-L [ROOT]/foo/link-[HOST_TARGET]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `rustc [..] src/main.rs [..] --out-dir [ROOT]/foo/target/[ALT_TARGET]/debug/deps --target [ALT_TARGET] [..]-L [ROOT]/foo/link-[ALT_TARGET]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]].unordered())
@@ -874,7 +873,7 @@ fn build_script_only_host() {
 
                 fn main() {
                     assert!(env::var("OUT_DIR").unwrap().replace("\\", "/")
-                                               .contains("target/debug/build/d1/"),
+                                               .contains("target/debug/build/d1-"),
                             "bad: {:?}", env::var("OUT_DIR"));
                 }
             "#,
@@ -951,7 +950,7 @@ fn build_script_with_platform_specific_dependencies() {
 [RUNNING] `rustc [..] d1/src/lib.rs [..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc [..] build.rs [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc [..] src/lib.rs [..] --target [ALT_TARGET] [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1199,8 +1198,8 @@ fn cross_test_dylib() {
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/[ALT_TARGET]/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
-[RUNNING] tests/test.rs (target/[ALT_TARGET]/debug/build/foo/[HASH]/out/test-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/[ALT_TARGET]/debug/deps/foo-[HASH][EXE])
+[RUNNING] tests/test.rs (target/[ALT_TARGET]/debug/deps/test-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1257,7 +1256,7 @@ fn doctest_xcompile_linker() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..] --out-dir [ROOT]/foo/target/[ALT_TARGET]/debug/build/foo/[HASH]/out --target [ALT_TARGET] [..]
+[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..] --out-dir [ROOT]/foo/target/[ALT_TARGET]/debug/deps --target [ALT_TARGET] [..]
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [DOCTEST] foo
 [RUNNING] `rustdoc [..] src/lib.rs [..]

--- a/tests/testsuite/dep_info.rs
+++ b/tests/testsuite/dep_info.rs
@@ -266,41 +266,32 @@ fn relative_depinfo_paths_ws() {
 
     assert_deps_contains(
         &p,
-        "target/debug/build/pm/*/fingerprint/dep-lib-pm",
-        &[
-            (0, "src/lib.rs"),
-            (1, "debug/build/pmdep/*/out/libpmdep-*.rlib"),
-        ],
+        "target/debug/.fingerprint/pm-*/dep-lib-pm",
+        &[(0, "src/lib.rs"), (1, "debug/deps/libpmdep-*.rlib")],
     );
 
     assert_deps_contains(
         &p,
-        &format!("target/{}/debug/build/foo/*/fingerprint/dep-bin-foo", host),
+        &format!("target/{}/debug/.fingerprint/foo-*/dep-bin-foo", host),
         &[
             (0, "src/main.rs"),
             (
                 1,
                 &format!(
-                    "debug/build/pm/*/out/{}pm-*.{}",
+                    "debug/deps/{}pm-*.{}",
                     paths::get_lib_prefix("proc-macro"),
                     paths::get_lib_extension("proc-macro")
                 ),
             ),
-            (1, &format!("{}/debug/build/bar/*/out/libbar-*.rlib", host)),
-            (
-                1,
-                &format!("{}/debug/build/regdep/*/out/libregdep-*.rlib", host),
-            ),
+            (1, &format!("{}/debug/deps/libbar-*.rlib", host)),
+            (1, &format!("{}/debug/deps/libregdep-*.rlib", host)),
         ],
     );
 
     assert_deps_contains(
         &p,
-        "target/debug/build/foo/*/fingerprint/dep-build-script-build-script-build",
-        &[
-            (0, "build.rs"),
-            (1, "debug/build/bdep/*/out/libbdep-*.rlib"),
-        ],
+        "target/debug/.fingerprint/foo-*/dep-build-script-build-script-build",
+        &[(0, "build.rs"), (1, "debug/deps/libbdep-*.rlib")],
     );
 
     // Make sure it stays fresh.
@@ -405,38 +396,32 @@ fn relative_depinfo_paths_no_ws() {
 
     assert_deps_contains(
         &p,
-        "target/debug/build/pm/*/fingerprint/dep-lib-pm",
-        &[
-            (0, "src/lib.rs"),
-            (1, "debug/build/pmdep/*/out/libpmdep-*.rlib"),
-        ],
+        "target/debug/.fingerprint/pm-*/dep-lib-pm",
+        &[(0, "src/lib.rs"), (1, "debug/deps/libpmdep-*.rlib")],
     );
 
     assert_deps_contains(
         &p,
-        "target/debug/build/foo/*/fingerprint/dep-bin-foo",
+        "target/debug/.fingerprint/foo-*/dep-bin-foo",
         &[
             (0, "src/main.rs"),
             (
                 1,
                 &format!(
-                    "debug/build/pm/*/out/{}pm-*.{}",
+                    "debug/deps/{}pm-*.{}",
                     paths::get_lib_prefix("proc-macro"),
                     paths::get_lib_extension("proc-macro")
                 ),
             ),
-            (1, "debug/build/bar/*/out/libbar-*.rlib"),
-            (1, "debug/build/regdep/*/out/libregdep-*.rlib"),
+            (1, "debug/deps/libbar-*.rlib"),
+            (1, "debug/deps/libregdep-*.rlib"),
         ],
     );
 
     assert_deps_contains(
         &p,
-        "target/debug/build/foo/*/fingerprint/dep-build-script-build-script-build",
-        &[
-            (0, "build.rs"),
-            (1, "debug/build/bdep/*/out/libbdep-*.rlib"),
-        ],
+        "target/debug/.fingerprint/foo-*/dep-build-script-build-script-build",
+        &[(0, "build.rs"), (1, "debug/deps/libbdep-*.rlib")],
     );
 
     // Make sure it stays fresh.
@@ -475,7 +460,7 @@ fn reg_dep_source_not_tracked() {
 
     assert_deps(
         &p,
-        "target/debug/build/regdep/*/fingerprint/dep-lib-regdep",
+        "target/debug/.fingerprint/regdep-*/dep-lib-regdep",
         |info_path, entries| {
             for (kind, path) in entries {
                 if *kind == 1 {
@@ -523,11 +508,8 @@ fn canonical_path() {
 
     assert_deps_contains(
         &p,
-        "target/debug/build/foo/*/fingerprint/dep-lib-foo",
-        &[
-            (0, "src/lib.rs"),
-            (1, "debug/build/regdep/*/out/libregdep-*.rmeta"),
-        ],
+        "target/debug/.fingerprint/foo-*/dep-lib-foo",
+        &[(0, "src/lib.rs"), (1, "debug/deps/libregdep-*.rmeta")],
     );
 }
 

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -137,11 +137,7 @@ fn doc_deps() {
 
     // Verify that it only emits rmeta for the dependency.
     assert_eq!(p.glob("target/debug/**/*.rlib").count(), 0);
-    assert_eq!(
-        p.glob("target/debug/build/bar/*/out/libbar-*.rmeta")
-            .count(),
-        1
-    );
+    assert_eq!(p.glob("target/debug/deps/libbar-*.rmeta").count(), 1);
 
     // Make sure it doesn't recompile.
     p.cargo("doc")
@@ -1918,7 +1914,7 @@ fn doc_json_artifacts() {
     "executable": null,
     "features": [],
     "filenames": [
-      "[ROOT]/foo/target/debug/build/foo/[HASH]/out/libfoo-[HASH].rmeta"
+      "[ROOT]/foo/target/debug/deps/libfoo-[HASH].rmeta"
     ],
     "fresh": false,
     "manifest_path": "[ROOT]/foo/Cargo.toml",
@@ -3253,13 +3249,13 @@ fn mergeable_info_with_deps() {
 [LOCKING] 1 package to latest compatible version
 [DOCUMENTING] dep v0.0.0 ([ROOT]/foo/dep)
 [CHECKING] dep v0.0.0 ([ROOT]/foo/dep)
-[RUNNING] `rustdoc [..]--crate-name dep [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name dep [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/out [..]`
 [RUNNING] `rustc --crate-name dep [..]`
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out[..]`
+[RUNNING] `rustdoc [..]--crate-name foo [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 2 docs for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/out --include-parts-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/out --include-parts-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 
@@ -3269,16 +3265,16 @@ fn mergeable_info_with_deps() {
 
     assert!(p.root().join("target/doc/foo/index.html").is_file());
     assert!(p.root().join("target/doc/dep/index.html").is_file());
-    assert_eq!(p.glob("target/debug/build/foo/*/out/foo.json").count(), 1);
-    assert_eq!(p.glob("target/debug/build/dep/*/out/dep.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/foo-*/out/foo.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/dep-*/out/dep.json").count(), 1);
 
     assert_e2e().eq(
         fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/dep/[HASH]/out/dep.json",
-    "debug/build/foo/[HASH]/out/foo.json"
+    "debug/build/dep-[HASH]/out/dep.json",
+    "debug/build/foo-[HASH]/out/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3314,10 +3310,10 @@ fn mergeable_info_no_deps() {
 [CHECKING] dep v0.0.0 ([ROOT]/foo/dep)
 [RUNNING] `rustc --crate-name dep --edition=2015 [..]`
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name foo [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 
@@ -3327,15 +3323,15 @@ fn mergeable_info_no_deps() {
 
     assert!(p.root().join("target/doc/foo/index.html").is_file());
     assert!(!p.root().join("target/doc/dep/index.html").is_file());
-    assert_eq!(p.glob("target/debug/build/foo/*/out/foo.json").count(), 1);
-    assert_eq!(p.glob("target/debug/build/dep/*/out/dep.json").count(), 0);
+    assert_eq!(p.glob("target/debug/build/foo-*/out/foo.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/dep-*/out/dep.json").count(), 0);
 
     assert_e2e().eq(
         fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/foo/[HASH]/out/foo.json"
+    "debug/build/foo-[HASH]/out/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3380,14 +3376,14 @@ fn mergeable_info_workspace() {
 [DOCUMENTING] dep v0.0.0 ([ROOT]/foo/dep)
 [CHECKING] dep v0.0.0 ([ROOT]/foo/dep)
 [DOCUMENTING] bar v0.0.0 ([ROOT]/foo/bar)
-[RUNNING] `rustdoc [..]--crate-name dep [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/out [..]`
-[RUNNING] `rustdoc [..]--crate-name bar [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/bar/[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name dep [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name bar [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/bar-[HASH]/out [..]`
 [RUNNING] `rustc --crate-name dep [..]`
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name foo [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 3 docs for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/bar/[HASH]/out --include-parts-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/out --include-parts-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/bar-[HASH]/out --include-parts-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/out --include-parts-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/bar/index.html
 [GENERATED] [ROOT]/foo/target/doc/dep/index.html
@@ -3400,18 +3396,18 @@ fn mergeable_info_workspace() {
     assert!(p.root().join("target/doc/foo/index.html").is_file());
     assert!(p.root().join("target/doc/bar/index.html").is_file());
     assert!(p.root().join("target/doc/dep/index.html").is_file());
-    assert_eq!(p.glob("target/debug/build/foo/*/out/foo.json").count(), 1);
-    assert_eq!(p.glob("target/debug/build/bar/*/out/bar.json").count(), 1);
-    assert_eq!(p.glob("target/debug/build/dep/*/out/dep.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/foo-*/out/foo.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/bar-*/out/bar.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/dep-*/out/dep.json").count(), 1);
 
     assert_e2e().eq(
         fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/bar/[HASH]/out/bar.json",
-    "debug/build/dep/[HASH]/out/dep.json",
-    "debug/build/foo/[HASH]/out/foo.json"
+    "debug/build/bar-[HASH]/out/bar.json",
+    "debug/build/dep-[HASH]/out/dep.json",
+    "debug/build/foo-[HASH]/out/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3447,13 +3443,13 @@ fn mergeable_info_multi_targets() {
         .with_stderr_data(
             str![[r#"
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo src/lib.rs --target [HOST_TARGET] [..]--merge=none --parts-out-dir=[ROOT]/foo/target/[HOST_TARGET]/debug/build/foo/[HASH]/out [..]`
-[RUNNING] `rustdoc [..]--crate-name foo src/lib.rs --target [ALT_TARGET] [..]--merge=none --parts-out-dir=[ROOT]/foo/target/[ALT_TARGET]/debug/build/foo/[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name foo src/lib.rs --target [HOST_TARGET] [..]--merge=none --parts-out-dir=[ROOT]/foo/target/[HOST_TARGET]/debug/build/foo-[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name foo src/lib.rs --target [ALT_TARGET] [..]--merge=none --parts-out-dir=[ROOT]/foo/target/[ALT_TARGET]/debug/build/foo-[HASH]/out [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for [ALT_TARGET]
-[RUNNING] `rustdoc -o [ROOT]/foo/target/[ALT_TARGET]/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/[ALT_TARGET]/debug/build/foo/[HASH]/out`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/[ALT_TARGET]/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/[ALT_TARGET]/debug/build/foo-[HASH]/out`
 [MERGING] 1 doc for [HOST_TARGET]
-[RUNNING] `rustdoc -o [ROOT]/foo/target/[HOST_TARGET]/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/[HOST_TARGET]/debug/build/foo/[HASH]/out`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/[HOST_TARGET]/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/[HOST_TARGET]/debug/build/foo-[HASH]/out`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/[HOST_TARGET]/doc/foo/index.html
 [GENERATED] [ROOT]/foo/target/[ALT_TARGET]/doc/foo/index.html
@@ -3468,9 +3464,9 @@ fn mergeable_info_multi_targets() {
     assert!(p.root().join(path).is_file());
     let path = format!("target/{target}/doc/foo/index.html");
     assert!(p.root().join(path).is_file());
-    let path = format!("target/{host}/debug/build/foo/*/out/foo.json");
+    let path = format!("target/{host}/debug/build/foo-*/out/foo.json");
     assert_eq!(p.glob(path).count(), 1);
-    let path = format!("target/{target}/debug/build/foo/*/out/foo.json");
+    let path = format!("target/{target}/debug/build/foo-*/out/foo.json");
     assert_eq!(p.glob(path).count(), 1);
 
     assert_e2e().eq(
@@ -3478,7 +3474,7 @@ fn mergeable_info_multi_targets() {
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/foo/[HASH]/out/foo.json"
+    "debug/build/foo-[HASH]/out/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3491,7 +3487,7 @@ fn mergeable_info_multi_targets() {
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/foo/[HASH]/out/foo.json"
+    "debug/build/foo-[HASH]/out/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3519,10 +3515,10 @@ fn mergeable_info_rebuild_detection() {
         .with_stderr_data(
             str![[r#"
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name foo [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 
@@ -3531,14 +3527,14 @@ fn mergeable_info_rebuild_detection() {
         .run();
 
     assert!(p.root().join("target/doc/foo/index.html").is_file());
-    assert_eq!(p.glob("target/debug/build/foo/*/out/foo.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/foo-*/out/foo.json").count(), 1);
 
     assert_e2e().eq(
         fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/foo/[HASH]/out/foo.json"
+    "debug/build/foo-[HASH]/out/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3565,7 +3561,7 @@ fn mergeable_info_rebuild_detection() {
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/foo/[HASH]/out/foo.json"
+    "debug/build/foo-[HASH]/out/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3583,10 +3579,10 @@ fn mergeable_info_rebuild_detection() {
             str![[r#"
 [DIRTY] foo v0.0.0 ([ROOT]/foo): the precalculated components changed
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name foo [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 
@@ -3626,7 +3622,7 @@ fn mergeable_info_rebuild_detection() {
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/foo/[HASH]/out/foo.json"
+    "debug/build/foo-[HASH]/out/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3657,10 +3653,10 @@ fn mergeable_info_rebuild_with_depinfo() {
         .with_stderr_data(
             str![[r#"
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--emit=html-non-static-files,dep-info=[..] --merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name foo [..]--emit=html-non-static-files,dep-info=[..] --merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 
@@ -3669,14 +3665,14 @@ fn mergeable_info_rebuild_with_depinfo() {
         .run();
 
     assert!(p.root().join("target/doc/foo/index.html").is_file());
-    assert_eq!(p.glob("target/debug/build/foo/*/out/foo.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/foo-*/out/foo.json").count(), 1);
 
     assert_e2e().eq(
         fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/foo/[HASH]/out/foo.json"
+    "debug/build/foo-[HASH]/out/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3703,7 +3699,7 @@ fn mergeable_info_rebuild_with_depinfo() {
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/foo/[HASH]/out/foo.json"
+    "debug/build/foo-[HASH]/out/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3721,10 +3717,10 @@ fn mergeable_info_rebuild_with_depinfo() {
             str![[r#"
 [DIRTY] foo v0.0.0 ([ROOT]/foo): the file `src/lib.rs` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--emit=html-non-static-files,dep-info=[..] --merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name foo [..]--emit=html-non-static-files,dep-info=[..] --merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 
@@ -3764,7 +3760,7 @@ fn mergeable_info_rebuild_with_depinfo() {
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/foo/[HASH]/out/foo.json"
+    "debug/build/foo-[HASH]/out/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3809,10 +3805,10 @@ fn mergeable_info_additive() {
 [CHECKING] dep v0.0.0 ([ROOT]/foo/dep)
 [RUNNING] `rustc --crate-name dep [..]`
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name foo [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 
@@ -3823,16 +3819,16 @@ fn mergeable_info_additive() {
     assert!(p.root().join("target/doc/foo/index.html").is_file());
     assert!(!p.root().join("target/doc/bar/index.html").is_file());
     assert!(!p.root().join("target/doc/dep/index.html").is_file());
-    assert_eq!(p.glob("target/debug/build/foo/*/out/foo.json").count(), 1);
-    assert_eq!(p.glob("target/debug/build/bar/*/out/bar.json").count(), 0);
-    assert_eq!(p.glob("target/debug/build/dep/*/out/dep.json").count(), 0);
+    assert_eq!(p.glob("target/debug/build/foo-*/out/foo.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/bar-*/out/bar.json").count(), 0);
+    assert_eq!(p.glob("target/debug/build/dep-*/out/dep.json").count(), 0);
 
     assert_e2e().eq(
         fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/foo/[HASH]/out/foo.json"
+    "debug/build/foo-[HASH]/out/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3845,10 +3841,10 @@ fn mergeable_info_additive() {
         .with_stderr_data(
             str![[r#"
 [DOCUMENTING] dep v0.0.0 ([ROOT]/foo/dep)
-[RUNNING] `rustdoc [..]--crate-name dep [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name dep [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/out [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 2 docs for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/out --include-parts-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/out --include-parts-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/dep/index.html
 
@@ -3859,17 +3855,17 @@ fn mergeable_info_additive() {
     assert!(p.root().join("target/doc/foo/index.html").is_file());
     assert!(!p.root().join("target/doc/bar/index.html").is_file());
     assert!(p.root().join("target/doc/dep/index.html").is_file());
-    assert_eq!(p.glob("target/debug/build/foo/*/out/foo.json").count(), 1);
-    assert_eq!(p.glob("target/debug/build/bar/*/out/bar.json").count(), 0);
-    assert_eq!(p.glob("target/debug/build/dep/*/out/dep.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/foo-*/out/foo.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/bar-*/out/bar.json").count(), 0);
+    assert_eq!(p.glob("target/debug/build/dep-*/out/dep.json").count(), 1);
 
     assert_e2e().eq(
         fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/dep/[HASH]/out/dep.json",
-    "debug/build/foo/[HASH]/out/foo.json"
+    "debug/build/dep-[HASH]/out/dep.json",
+    "debug/build/foo-[HASH]/out/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3882,10 +3878,10 @@ fn mergeable_info_additive() {
         .with_stderr_data(
             str![[r#"
 [DOCUMENTING] bar v0.0.0 ([ROOT]/foo/bar)
-[RUNNING] `rustdoc [..]--crate-name bar [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/bar/[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name bar [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/bar-[HASH]/out [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 3 docs for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/bar/[HASH]/out --include-parts-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/out --include-parts-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/bar-[HASH]/out --include-parts-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/out --include-parts-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/bar/index.html
 
@@ -3896,18 +3892,18 @@ fn mergeable_info_additive() {
     assert!(p.root().join("target/doc/foo/index.html").is_file());
     assert!(p.root().join("target/doc/bar/index.html").is_file());
     assert!(p.root().join("target/doc/dep/index.html").is_file());
-    assert_eq!(p.glob("target/debug/build/foo/*/out/foo.json").count(), 1);
-    assert_eq!(p.glob("target/debug/build/bar/*/out/bar.json").count(), 1);
-    assert_eq!(p.glob("target/debug/build/dep/*/out/dep.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/foo-*/out/foo.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/bar-*/out/bar.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/dep-*/out/dep.json").count(), 1);
 
     assert_e2e().eq(
         fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/bar/[HASH]/out/bar.json",
-    "debug/build/dep/[HASH]/out/dep.json",
-    "debug/build/foo/[HASH]/out/foo.json"
+    "debug/build/bar-[HASH]/out/bar.json",
+    "debug/build/dep-[HASH]/out/dep.json",
+    "debug/build/foo-[HASH]/out/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3958,10 +3954,10 @@ fn mergeable_info_dep_collision() {
 [DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)
 [DOWNLOADED] dep v0.2.0 (registry `dummy-registry`)
 [DOCUMENTING] dep v0.1.0
-[RUNNING] `rustdoc [..]--crate-name dep [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/out [..]--crate-version 0.1.0`
+[RUNNING] `rustdoc [..]--crate-name dep [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/out [..]--crate-version 0.1.0`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/out`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/out`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/dep/index.html
 
@@ -3970,7 +3966,7 @@ fn mergeable_info_dep_collision() {
         .run();
 
     assert!(p.root().join("target/doc/dep/index.html").is_file());
-    assert_eq!(p.glob("target/debug/build/dep/*/out/dep.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/dep-*/out/dep.json").count(), 1);
 
     // See `fn dep010()`
     assert!(p.build_dir().join("doc/dep/fn.dep010.html").exists());
@@ -3983,7 +3979,7 @@ fn mergeable_info_dep_collision() {
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/dep/[HASH]/out/dep.json"
+    "debug/build/dep-[HASH]/out/dep.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3997,10 +3993,10 @@ fn mergeable_info_dep_collision() {
         .with_stderr_data(
             str![[r#"
 [DOCUMENTING] dep v0.2.0
-[RUNNING] `rustdoc [..]--crate-name dep [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/out [..]--crate-version 0.2.0`
+[RUNNING] `rustdoc [..]--crate-name dep [..]--merge=none --parts-out-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/out [..]--crate-version 0.2.0`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/out`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --merge=finalize --include-parts-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/out`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/dep/index.html
 
@@ -4010,7 +4006,7 @@ fn mergeable_info_dep_collision() {
 
     assert!(p.root().join("target/doc/dep/index.html").is_file());
     // We'll have two dep.json
-    assert_eq!(p.glob("target/debug/build/dep/*/out/dep.json").count(), 2);
+    assert_eq!(p.glob("target/debug/build/dep-*/out/dep.json").count(), 2);
 
     // ...but only the selected dep@0.2.0 would be merged
     assert!(!p.build_dir().join("doc/dep/fn.dep010.html").exists());
@@ -4023,7 +4019,7 @@ fn mergeable_info_dep_collision() {
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/dep/[HASH]/out/dep.json"
+    "debug/build/dep-[HASH]/out/dep.json"
   ],
   "rustc_vv": "{...}"
 }

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -674,15 +674,28 @@ fn no_feature_doesnt_build() {
         .run();
     p.process(&p.bin("foo")).with_stdout_data("").run();
 
-    p.cargo("build --features bar -v")
-        .with_stderr_data(str![[r#"
+    let expected = if cfg!(target_os = "windows") && cfg!(target_env = "msvc") {
+        str![[r#"
+[COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
+[RUNNING] `rustc --crate-name bar [..]`
+[DIRTY] foo v0.0.1 ([ROOT]/foo): the list of features changed
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]]
+    } else {
+        str![[r#"
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `rustc --crate-name bar [..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
-"#]])
+"#]]
+    };
+    p.cargo("build --features bar -v")
+        .with_stderr_data(expected)
         .run();
     p.process(&p.bin("foo"))
         .with_stdout_data(str![[r#"
@@ -743,13 +756,24 @@ bar
 "#]])
         .run();
 
-    p.cargo("build --no-default-features -v")
-        .with_stderr_data(str![[r#"
+    let expected = if cfg!(target_os = "windows") && cfg!(target_env = "msvc") {
+        str![[r#"
+[DIRTY] foo v0.0.1 ([ROOT]/foo): the list of features changed
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
-"#]])
+"#]]
+    } else {
+        str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]]
+    };
+    p.cargo("build --no-default-features -v")
+        .with_stderr_data(expected)
         .run();
     p.process(&p.bin("foo")).with_stdout_data("").run();
 }

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -2292,7 +2292,7 @@ fn minimal_download() {
 [COMPILING] dev_dep_pm v1.0.0
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[EXECUTABLE] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
 
 "#]]
             .unordered(),

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -280,7 +280,7 @@ fn changing_profiles_caches_targets() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -298,7 +298,7 @@ fn changing_profiles_caches_targets() {
     p.cargo("test foo")
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
 
 "#]])
         .run();
@@ -545,13 +545,26 @@ feature on
         .run();
 
     /* Targets should be cached from the first build */
-    p.cargo("build -v")
-        .with_stderr_data(str![[r#"
+
+    let mut e = p.cargo("build -v");
+
+    // MSVC does not include hash in binary filename, so it gets recompiled.
+    if cfg!(target_env = "msvc") {
+        e.with_stderr_data(str![[r#"
+[DIRTY] foo v0.0.1 ([ROOT]/foo): the list of features changed
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]]);
+    } else {
+        e.with_stderr_data(str![[r#"
 [FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
-"#]])
-        .run();
+"#]]);
+    }
+    e.run();
     p.rename_run("foo", "off2")
         .with_stdout_data(str![[r#"
 feature off
@@ -559,13 +572,23 @@ feature off
 "#]])
         .run();
 
-    p.cargo("build --features foo -v")
-        .with_stderr_data(str![[r#"
+    let mut e = p.cargo("build --features foo -v");
+    if cfg!(target_env = "msvc") {
+        e.with_stderr_data(str![[r#"
+[DIRTY] foo v0.0.1 ([ROOT]/foo): the list of features changed
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]]);
+    } else {
+        e.with_stderr_data(str![[r#"
 [FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
-"#]])
-        .run();
+"#]]);
+    }
+    e.run();
     p.rename_run("foo", "on2")
         .with_stdout_data(str![[r#"
 feature on
@@ -594,7 +617,7 @@ fn rebuild_tests_if_lib_changes() {
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo_test [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo_test-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/deps/foo_test-[HASH][EXE]`
 
 "#]])
         .run();
@@ -659,8 +682,8 @@ fn no_rebuild_transitive_target_deps() {
 [COMPILING] b v0.0.1 ([ROOT]/foo/b)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
-[EXECUTABLE] tests/foo.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[EXECUTABLE] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[EXECUTABLE] tests/foo.rs (target/debug/deps/foo-[HASH][EXE])
 
 "#]])
         .run();
@@ -1244,7 +1267,7 @@ fn reuse_workspace_lib() {
 [COMPILING] baz v0.1.1 ([ROOT]/foo/baz)
 [RUNNING] `rustc --crate-name baz [..]
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] `[ROOT]/foo/target/debug/build/baz/[HASH]/out/baz-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/deps/baz-[HASH][EXE]`
 
 "#]])
         .run();
@@ -1435,23 +1458,21 @@ fn fingerprint_cleaner(mut dir: PathBuf, timestamp: filetime::FileTime) {
     // if all the files in the fingerprint's folder are older then a time stamp without
     // effecting any builds that happened since that time stamp.
     let mut cleaned = false;
-    dir.push("build");
-    let outdated = |f: io::Result<fs::DirEntry>| {
-        filetime::FileTime::from_last_modification_time(&f.unwrap().metadata().unwrap())
-            <= timestamp
-    };
-    for build_unit in fs::read_dir(&dir).unwrap() {
-        let build_unit = build_unit.unwrap();
-        for hash_dir in fs::read_dir(&build_unit.path()).unwrap() {
-            let hash_dir = hash_dir.unwrap();
-            let fingerprint = hash_dir.path().join("fingerprint");
-            if fs::read_dir(fingerprint).unwrap().all(outdated) {
-                fs::remove_dir_all(hash_dir.path()).unwrap();
-                println!("remove: {:?}", hash_dir.path());
-                // a real cleaner would remove the big files in deps and build as well
-                // but fingerprint is sufficient for our tests
-                cleaned = true;
-            }
+    dir.push(".fingerprint");
+    for fingerprint in fs::read_dir(&dir).unwrap() {
+        let fingerprint = fingerprint.unwrap();
+
+        let outdated = |f: io::Result<fs::DirEntry>| {
+            filetime::FileTime::from_last_modification_time(&f.unwrap().metadata().unwrap())
+                <= timestamp
+        };
+        if fs::read_dir(fingerprint.path()).unwrap().all(outdated) {
+            fs::remove_dir_all(fingerprint.path()).unwrap();
+            println!("remove: {:?}", fingerprint.path());
+            // a real cleaner would remove the big files in deps and build as well
+            // but fingerprint is sufficient for our tests
+            cleaned = true;
+        } else {
         }
     }
     assert!(
@@ -1564,10 +1585,10 @@ fn reuse_panic_build_dep_test() {
 [RUNNING] `rustc --crate-name bar [..]
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..] src/lib.rs [..]--test[..]
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
 
 "#]])
         .run();
@@ -2079,7 +2100,7 @@ fn simulated_docker_deps_stay_cached() {
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FRESH] regdep_rerun [..]
 [FRESH] regdep_old_style [..]
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2250,10 +2271,7 @@ fn edition_change_invalidates() {
 
 "#]])
         .run();
-    assert_eq!(
-        p.glob("target/debug/build/foo/*/out/libfoo-*.rlib").count(),
-        1
-    );
+    assert_eq!(p.glob("target/debug/deps/libfoo-*.rlib").count(), 1);
 }
 
 #[cargo_test]
@@ -2421,7 +2439,7 @@ fn rerun_if_changes() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.0.1 ([ROOT]/foo): the env variable FOO changed
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2441,7 +2459,7 @@ fn rerun_if_changes() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.0.1 ([ROOT]/foo): the env variable BAR changed
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2461,7 +2479,7 @@ fn rerun_if_changes() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.0.1 ([ROOT]/foo): the env variable FOO changed
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2766,7 +2784,7 @@ fn linking_interrupted() {
 [RUNNING] `rustc --crate-name foo [..]
 [RUNNING] `rustc --crate-name t1 [..]
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/t1-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/deps/t1-[HASH][EXE]`
 
 "#]])
         .run();
@@ -3202,7 +3220,7 @@ fn incremental_build_script_execution_got_new_mtime_and_cargo_check() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.0.1 ([ROOT]/foo): the file `touch-me` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/freshness_checksum.rs
+++ b/tests/testsuite/freshness_checksum.rs
@@ -181,14 +181,11 @@ fn binary_depinfo_correctly_encoded() {
 
     assert_deps_contains(
         &p,
-        &format!("target/{}/debug/build/foo/*/fingerprint/dep-bin-foo", host),
+        &format!("target/{}/debug/.fingerprint/foo-*/dep-bin-foo", host),
         &[
             (0, "src/main.rs"),
-            (1, &format!("{}/debug/build/bar/*/out/libbar-*.rlib", host)),
-            (
-                1,
-                &format!("{}/debug/build/regdep/*/out/libregdep-*.rlib", host),
-            ),
+            (1, &format!("{}/debug/deps/libbar-*.rlib", host)),
+            (1, &format!("{}/debug/deps/libregdep-*.rlib", host)),
         ],
     );
 
@@ -435,7 +432,7 @@ fn changing_profiles_caches_targets() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -455,7 +452,7 @@ fn changing_profiles_caches_targets() {
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
 
 "#]])
         .run();
@@ -710,14 +707,27 @@ feature on
         .run();
 
     /* Targets should be cached from the first build */
-    p.cargo("build -Zchecksum-freshness -v")
-        .masquerade_as_nightly_cargo(&["checksum-freshness"])
-        .with_stderr_data(str![[r#"
+
+    let mut e = p.cargo("build -Zchecksum-freshness -v");
+    e.masquerade_as_nightly_cargo(&["checksum-freshness"]);
+
+    // MSVC does not include hash in binary filename, so it gets recompiled.
+    if cfg!(target_env = "msvc") {
+        e.with_stderr_data(str![[r#"
+[DIRTY] foo v0.0.1 ([ROOT]/foo): the list of features changed
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]]);
+    } else {
+        e.with_stderr_data(str![[r#"
 [FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
-"#]])
-        .run();
+"#]]);
+    }
+    e.run();
     p.rename_run("foo", "off2")
         .with_stdout_data(str![[r#"
 feature off
@@ -725,14 +735,24 @@ feature off
 "#]])
         .run();
 
-    p.cargo("build -Zchecksum-freshness --features foo -v")
-        .masquerade_as_nightly_cargo(&["checksum-freshness"])
-        .with_stderr_data(str![[r#"
+    let mut e = p.cargo("build -Zchecksum-freshness --features foo -v");
+    e.masquerade_as_nightly_cargo(&["checksum-freshness"]);
+    if cfg!(target_env = "msvc") {
+        e.with_stderr_data(str![[r#"
+[DIRTY] foo v0.0.1 ([ROOT]/foo): the list of features changed
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]]);
+    } else {
+        e.with_stderr_data(str![[r#"
 [FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
-"#]])
-        .run();
+"#]]);
+    }
+    e.run();
     p.rename_run("foo", "on2")
         .with_stdout_data(str![[r#"
 feature on
@@ -767,7 +787,7 @@ fn rebuild_tests_if_lib_changes() {
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo_test [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo_test-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/deps/foo_test-[HASH][EXE]`
 
 "#]])
         .run();
@@ -835,8 +855,8 @@ fn no_rebuild_transitive_target_deps() {
 [COMPILING] b v0.0.1 ([ROOT]/foo/b)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
-[EXECUTABLE] tests/foo.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[EXECUTABLE] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[EXECUTABLE] tests/foo.rs (target/debug/deps/foo-[HASH][EXE])
 
 "#]])
         .run();
@@ -1414,7 +1434,7 @@ fn reuse_workspace_lib() {
 [COMPILING] baz v0.1.1 ([ROOT]/foo/baz)
 [RUNNING] `rustc --crate-name baz [..]
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] `[ROOT]/foo/target/debug/build/baz/[HASH]/out/baz-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/deps/baz-[HASH][EXE]`
 
 "#]])
         .run();
@@ -1592,10 +1612,10 @@ fn reuse_panic_build_dep_test() {
 [RUNNING] `rustc --crate-name bar [..]
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..] src/lib.rs [..]--test[..]
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
 
 "#]])
         .run();
@@ -2027,10 +2047,7 @@ fn edition_change_invalidates() {
 
 "#]])
         .run();
-    assert_eq!(
-        p.glob("target/debug/build/foo/*/out/libfoo-*.rlib").count(),
-        1
-    );
+    assert_eq!(p.glob("target/debug/deps/libfoo-*.rlib").count(), 1);
 }
 
 #[cargo_test(nightly, reason = "requires -Zchecksum-hash-algorithm")]
@@ -2208,7 +2225,7 @@ fn rerun_if_changes() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.0.1 ([ROOT]/foo): the env variable FOO changed
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2230,7 +2247,7 @@ fn rerun_if_changes() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.0.1 ([ROOT]/foo): the env variable BAR changed
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2252,7 +2269,7 @@ fn rerun_if_changes() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.0.1 ([ROOT]/foo): the env variable FOO changed
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2573,7 +2590,7 @@ fn linking_interrupted() {
 [RUNNING] `rustc --crate-name foo [..]
 [RUNNING] `rustc --crate-name t1 [..]
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/t1-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/deps/t1-[HASH][EXE]`
 
 "#]])
         .run();
@@ -2980,7 +2997,7 @@ fn incremental_build_script_execution_got_new_mtime_and_cargo_check() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.0.1 ([ROOT]/foo): the file `touch-me` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -1709,7 +1709,7 @@ fn dev_deps_with_testing() {
 [COMPILING] bar v0.5.0 ([ROOTURL]/bar#[..])
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/main.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/deps/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -2794,7 +2794,7 @@ fn include_overrides_gitignore() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.5.0 ([ROOT]/foo): the precalculated components changed
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/glob_targets.rs
+++ b/tests/testsuite/glob_targets.rs
@@ -217,7 +217,7 @@ fn test_example() {
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name example1 [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/example1-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/examples/example1-[HASH][EXE]`
 
 "#]])
         .run();
@@ -231,7 +231,7 @@ fn test_bin() {
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name bin1 [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/bin1-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/deps/bin1-[HASH][EXE]`
 
 "#]])
         .run();
@@ -249,7 +249,7 @@ fn test_bench() {
 [RUNNING] `rustc --crate-name bench1 [..]`
 [RUNNING] `rustc --crate-name bin1 [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/bench1-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/deps/bench1-[HASH][EXE]`
 
 "#]]
             .unordered(),
@@ -269,7 +269,7 @@ fn test_test() {
 [RUNNING] `rustc --crate-name foo [..]`
 [RUNNING] `rustc --crate-name bin2 [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/test1-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/deps/test1-[HASH][EXE]`
 
 "#]]
             .unordered(),
@@ -285,7 +285,7 @@ fn bench_example() {
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name example1 [..]`
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/example1-[HASH][EXE] --bench`
+[RUNNING] `[ROOT]/foo/target/release/examples/example1-[HASH][EXE] --bench`
 
 "#]])
         .run();
@@ -299,7 +299,7 @@ fn bench_bin() {
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name bin1 [..]`
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/bin1-[HASH][EXE] --bench`
+[RUNNING] `[ROOT]/foo/target/release/deps/bin1-[HASH][EXE] --bench`
 
 "#]])
         .run();
@@ -317,7 +317,7 @@ fn bench_bench() {
 [RUNNING] `rustc --crate-name foo [..]`
 [RUNNING] `rustc --crate-name bench1 [..]`
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/bench1-[HASH][EXE] --bench`
+[RUNNING] `[ROOT]/foo/target/release/deps/bench1-[HASH][EXE] --bench`
 
 "#]]
             .unordered(),
@@ -337,7 +337,7 @@ fn bench_test() {
 [RUNNING] `rustc --crate-name test1 [..]`
 [RUNNING] `rustc --crate-name bin1 [..]`
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/test1-[HASH][EXE] --bench`
+[RUNNING] `[ROOT]/foo/target/release/deps/test1-[HASH][EXE] --bench`
 
 "#]]
             .unordered(),

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -2617,7 +2617,7 @@ To reuse those artifacts with a future compilation, set the environment variable
     let end = stderr.find('.').unwrap() - 1;
     let path = Path::new(&stderr[..end]);
     assert!(path.exists());
-    assert!(path.join("release/build/foo").exists());
+    assert!(path.join("release/deps").exists());
 }
 
 #[cargo_test]

--- a/tests/testsuite/jobserver.rs
+++ b/tests/testsuite/jobserver.rs
@@ -220,7 +220,7 @@ this is a runner
         .arg("-j2")
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/cargo-jobserver-check/[HASH]/out/cargo_jobserver_check-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/cargo_jobserver_check-[HASH][EXE])
 this is a runner
 
 "#]])
@@ -264,7 +264,7 @@ this is a runner
         .with_status(101)
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/cargo-jobserver-check/[HASH]/out/cargo_jobserver_check-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/cargo_jobserver_check-[HASH][EXE])
 this is a runner
 ...
 

--- a/tests/testsuite/lints/unused_dependencies.rs
+++ b/tests/testsuite/lints/unused_dependencies.rs
@@ -933,8 +933,8 @@ fn unused_dev_deps() {
 [COMPILING] doctest_used v0.1.0
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
-[EXECUTABLE] tests/hello.rs (target/debug/build/foo/[HASH]/out/hello-[HASH][EXE])
+[EXECUTABLE] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[EXECUTABLE] tests/hello.rs (target/debug/deps/hello-[HASH][EXE])
 
 "#]]
             .unordered(),
@@ -947,10 +947,10 @@ fn unused_dev_deps() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
-[EXECUTABLE] tests/hello.rs (target/debug/build/foo/[HASH]/out/hello-[HASH][EXE])
-[EXECUTABLE] benches/hello.rs (target/debug/build/foo/[HASH]/out/hello-[HASH][EXE])
-[EXECUTABLE] unittests examples/hello.rs (target/debug/build/foo/[HASH]/out/hello-[HASH][EXE])
+[EXECUTABLE] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[EXECUTABLE] tests/hello.rs (target/debug/deps/hello-[HASH][EXE])
+[EXECUTABLE] benches/hello.rs (target/debug/deps/hello-[HASH][EXE])
+[EXECUTABLE] unittests examples/hello.rs (target/debug/examples/hello-[HASH][EXE])
 
 "#]])
         .run();
@@ -961,8 +961,8 @@ fn unused_dev_deps() {
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
-[RUNNING] tests/hello.rs (target/debug/build/foo/[HASH]/out/hello-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] tests/hello.rs (target/debug/deps/hello-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])

--- a/tests/testsuite/lto.rs
+++ b/tests/testsuite/lto.rs
@@ -80,7 +80,7 @@ fn shared_deps() {
 [RUNNING] `rustc --crate-name bar [..]-C embed-bitcode=no [..]`
 [COMPILING] test v0.0.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]`
-[RUNNING] `[ROOT]/foo/target/release/build/test/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/release/build/test-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name test [..]-C lto [..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 
@@ -123,7 +123,7 @@ fn build_dep_not_ltod() {
 [RUNNING] `rustc --crate-name bar [..]-C embed-bitcode=no [..]`
 [COMPILING] test v0.0.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]`
-[RUNNING] `[ROOT]/foo/target/release/build/test/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/release/build/test-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name test [..]-C lto [..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 
@@ -375,9 +375,9 @@ fn test_all() {
 [RUNNING] `rustc --crate-name foo [..]-C lto [..]--test [..]`
 [RUNNING] `rustc --crate-name foo [..]--crate-type bin [..]-C lto [..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE]`
-[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/a-[HASH][EXE]`
-[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/b-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/deps/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/deps/a-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/deps/b-[HASH][EXE]`
 
 "#]]
             .unordered(),
@@ -415,9 +415,9 @@ fn test_all_and_bench() {
 [RUNNING] `rustc --crate-name foo [..]-C lto [..]--test [..]`
 [RUNNING] `rustc --crate-name foo [..]--crate-type bin [..]-C lto [..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE]`
-[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/a-[HASH][EXE]`
-[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/b-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/deps/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/deps/a-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/deps/b-[HASH][EXE]`
 
 "#]]
             .unordered(),
@@ -587,8 +587,8 @@ fn cdylib_and_rlib() {
 [RUNNING] `rustc --crate-name foo [..]-C lto [..]--test [..]`
 [RUNNING] `rustc --crate-name a [..]-C lto [..]--test [..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE]`
-[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/a-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/deps/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/deps/a-[HASH][EXE]`
 
 "#]]
             .unordered(),
@@ -614,8 +614,8 @@ fn cdylib_and_rlib() {
 [RUNNING] `rustc --crate-name bar [..]-C lto [..]--test [..]`
 [RUNNING] `rustc --crate-name b [..]-C lto [..]--test [..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/release/build/bar/[HASH]/out/bar-[HASH][EXE]`
-[RUNNING] `[ROOT]/foo/target/release/build/bar/[HASH]/out/b-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/deps/bar-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/deps/b-[HASH][EXE]`
 [DOCTEST] bar
 [RUNNING] `rustdoc --edition=2015 --crate-type cdylib --crate-type rlib --color auto --crate-name bar --test [..]-C lto [..]
 
@@ -654,8 +654,8 @@ fn dylib() {
 [RUNNING] `rustc --crate-name foo [..]-C lto [..]--test [..]`
 [RUNNING] `rustc --crate-name a [..]-C lto [..]--test [..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE]`
-[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/a-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/deps/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/deps/a-[HASH][EXE]`
 
 "#]]
             .unordered(),
@@ -672,6 +672,7 @@ fn dylib() {
 [COMPILING] registry-shared v0.0.1
 [FRESH] registry v0.0.1
 [RUNNING] `rustc --crate-name registry_shared [..]-C embed-bitcode=no [..]`
+[DIRTY] bar v0.0.0 ([ROOT]/foo/bar): info of dependency `registry-shared` changed
 [COMPILING] bar v0.0.0 ([ROOT]/foo/bar)
 [RUNNING] `rustc --crate-name bar [..]--crate-type dylib [..]-C embed-bitcode=no [..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
@@ -691,13 +692,14 @@ fn dylib() {
 [FRESH] registry-shared v0.0.1
 [COMPILING] registry v0.0.1
 [RUNNING] `rustc --crate-name registry [..]`
+[DIRTY] bar v0.0.0 ([ROOT]/foo/bar): info of dependency `registry` changed
 [COMPILING] bar v0.0.0 ([ROOT]/foo/bar)
 [RUNNING] `rustc --crate-name bar [..]--crate-type dylib [..]-C embed-bitcode=no [..]`
 [RUNNING] `rustc --crate-name bar [..]-C lto [..]--test [..]`
 [RUNNING] `rustc --crate-name b [..]-C lto [..]--test [..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/release/build/bar/[HASH]/out/bar-[HASH][EXE]`
-[RUNNING] `[ROOT]/foo/target/release/build/bar/[HASH]/out/b-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/deps/bar-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/deps/b-[HASH][EXE]`
 
 "#]]
             .unordered(),
@@ -756,7 +758,7 @@ fn test_profile() {
 [RUNNING] `rustc --crate-name foo [..]--crate-type lib --emit=dep-info,metadata,link -C linker-plugin-lto [..]`
 [RUNNING] `rustc --crate-name foo [..]--emit=dep-info,link -C lto=thin [..]--test [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
 [DOCTEST] foo
 [RUNNING] `rustdoc [..]
 
@@ -914,7 +916,7 @@ fn fresh_swapping_commands() {
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]-C lto [..]--test [..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/deps/foo-[HASH][EXE]`
 [DOCTEST] foo
 [RUNNING] `rustdoc [..]-C lto [..]`
 
@@ -936,7 +938,7 @@ fn fresh_swapping_commands() {
 [FRESH] bar v1.0.0
 [FRESH] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[EXECUTABLE] `[ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/release/deps/foo-[HASH][EXE]`
 
 "#]])
         .run();

--- a/tests/testsuite/messages.rs
+++ b/tests/testsuite/messages.rs
@@ -73,7 +73,7 @@ fn deduplicate_messages_basic() {
 [WARNING] `foo` (lib) generated 1 warning[..]
 [WARNING] `foo` (lib test) generated 1 warning (1 duplicate)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[EXECUTABLE] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
 ",
         rustc_message
     );
@@ -122,7 +122,7 @@ fn deduplicate_messages_mismatched_warnings() {
 {}\
 [WARNING] `foo` (lib test) generated 2 warnings (1 duplicate)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[EXECUTABLE] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
 ",
         lib_output, lib_test_output
     );

--- a/tests/testsuite/metabuild.rs
+++ b/tests/testsuite/metabuild.rs
@@ -649,7 +649,7 @@ fn metabuild_json_artifact() {
     "env": [],
     "linked_libs": [],
     "linked_paths": [],
-    "out_dir": "[ROOT]/foo/target/debug/build/foo/[HASH]/out",
+    "out_dir": "[ROOT]/foo/target/debug/build/foo-[HASH]/out",
     "package_id": "path+[ROOTURL]/foo#0.0.1",
     "reason": "build-script-executed"
   },

--- a/tests/testsuite/multitarget.rs
+++ b/tests/testsuite/multitarget.rs
@@ -75,8 +75,8 @@ fn simple_test() {
         .arg(&t2)
         .with_stderr_data(
             str![[r#"
-[RUNNING] unittests src/lib.rs (target/[ALT_TARGET]/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
-[RUNNING] unittests src/lib.rs (target/[HOST_TARGET]/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/[ALT_TARGET]/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/[HOST_TARGET]/debug/deps/foo-[HASH][EXE])
 ...
 
 "#]]

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -211,7 +211,7 @@ fn cargo_compile_with_root_dev_deps_with_testing() {
 [COMPILING] bar v0.5.0 ([ROOT]/bar)
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/main.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/deps/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1465,7 +1465,7 @@ fn dev_deps_no_rebuild_lib() {
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"

--- a/tests/testsuite/proc_macro.rs
+++ b/tests/testsuite/proc_macro.rs
@@ -562,7 +562,7 @@ fn proc_macro_built_once() {
 [RUNNING] `rustc --crate-name b [..]`
 [COMPILING] a v0.1.0 ([ROOT]/foo/a)
 [RUNNING] `rustc --crate-name build_script_build [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/a/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/a-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name a [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -262,7 +262,7 @@ fn profile_config_all_options() {
         .env_remove("CARGO_INCREMENTAL")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo [..] -C opt-level=1 -C panic=abort -C lto[..]-C codegen-units=2 -C debuginfo=2 [..]-C debug-assertions=on -C overflow-checks=off [..]-C rpath --out-dir [ROOT]/foo/target/release/build/foo/[HASH]/out -C incremental=[ROOT]/foo/target/release/incremental[..]`
+[RUNNING] `rustc --crate-name foo [..] -C opt-level=1 -C panic=abort -C lto[..]-C codegen-units=2 -C debuginfo=2 [..]-C debug-assertions=on -C overflow-checks=off [..]-C rpath --out-dir [ROOT]/foo/target/release/deps -C incremental=[ROOT]/foo/target/release/incremental[..]`
 [FINISHED] `release` profile [optimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -517,7 +517,7 @@ fn test_with_dev_profile() {
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `test` profile [unoptimized] target(s) in [ELAPSED]s
-[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
 
 "#]])
         .with_stdout_does_not_contain("[..] -C debuginfo=0[..]")

--- a/tests/testsuite/profile_overrides.rs
+++ b/tests/testsuite/profile_overrides.rs
@@ -235,8 +235,8 @@ fn profile_override_hierarchy() {
 [RUNNING] `rustc --crate-name build_script_build --edition=2015 m1/build.rs [..] --crate-type bin --emit=[..]link[..]-C codegen-units=4 [..]`
 [COMPILING] m2 v0.0.1 ([ROOT]/foo/m2)
 [RUNNING] `rustc --crate-name build_script_build --edition=2015 m2/build.rs [..] --crate-type bin --emit=[..]link[..]-C codegen-units=2 [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/m1/[HASH]/out/build_script_build`
-[RUNNING] `[ROOT]/foo/target/debug/build/m2/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/m1-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/m2-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name m2 --edition=2015 m2/src/lib.rs [..] --crate-type lib --emit=[..]link[..]-C codegen-units=2 [..]`
 [COMPILING] m1 v0.0.1 ([ROOT]/foo/m1)
 [RUNNING] `rustc --crate-name m1 --edition=2015 m1/src/lib.rs [..] --crate-type lib --emit=[..]link[..]-C codegen-units=1 [..]`

--- a/tests/testsuite/profile_targets.rs
+++ b/tests/testsuite/profile_targets.rs
@@ -97,7 +97,7 @@ fn profile_selection_build() {
 [RUNNING] `[..] rustc --crate-name bdep --edition=2015 bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..] rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 [..]
-[RUNNING] `[..][ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[..][ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/main.rs [..]--crate-type bin --emit=[..]link -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]
@@ -135,7 +135,7 @@ fn profile_selection_build_release() {
 [RUNNING] `[..] rustc --crate-name bdep --edition=2015 bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=6 [..]
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..] rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=6 [..]
-[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[..][ROOT]/foo/target/release/build/foo-[HASH]/build-script-build`
 [foo 0.0.1] foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3 -C panic=abort[..]-C codegen-units=2 [..]
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/main.rs [..]--crate-type bin --emit=[..]link -C opt-level=3 -C panic=abort[..]-C codegen-units=2 [..]
@@ -201,7 +201,7 @@ fn profile_selection_build_all_targets() {
 [RUNNING] `[..] rustc --crate-name bdep --edition=2015 bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..] rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 [..]`
-[RUNNING] `[..][ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[..][ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]`
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--emit=[..]link[..]-C codegen-units=1 -C debuginfo=2 [..]--test [..]`
@@ -274,7 +274,7 @@ fn profile_selection_build_all_targets_release() {
 [RUNNING] `[..] rustc --crate-name bdep --edition=2015 bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=6 [..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..] rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=6 [..]`
-[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[..][ROOT]/foo/target/release/build/foo-[HASH]/build-script-build`
 [foo 0.0.1] foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3 -C panic=abort[..]-C codegen-units=2 [..]`
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--emit=[..]link -C opt-level=3[..]-C codegen-units=2 --test [..]`
@@ -337,7 +337,7 @@ fn profile_selection_test() {
 [RUNNING] `[..] rustc --crate-name bdep --edition=2015 bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..] rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 [..]`
-[RUNNING] `[..][ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[..][ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort[..]-C codegen-units=3 -C debuginfo=2 [..]`
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=3 -C debuginfo=2 [..]`
@@ -347,9 +347,9 @@ fn profile_selection_test() {
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/main.rs [..]--emit=[..]link[..]-C codegen-units=3 -C debuginfo=2 [..]--test [..]`
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/main.rs [..]--crate-type bin --emit=[..]link -C panic=abort[..]-C codegen-units=3 -C debuginfo=2 [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[..][ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
-[RUNNING] `[..][ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
-[RUNNING] `[..][ROOT]/foo/target/debug/build/foo/[HASH]/out/test1-[HASH][EXE]`
+[RUNNING] `[..][ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[RUNNING] `[..][ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[RUNNING] `[..][ROOT]/foo/target/debug/deps/test1-[HASH][EXE]`
 [DOCTEST] foo
 [RUNNING] `[..] rustdoc [..]--test [..]
 
@@ -362,9 +362,9 @@ fn profile_selection_test() {
 [FRESH] bar v0.0.1 ([ROOT]/foo/bar)
 [FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[..][ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
-[RUNNING] `[..][ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
-[RUNNING] `[..][ROOT]/foo/target/debug/build/foo/[HASH]/out/test1-[HASH][EXE]`
+[RUNNING] `[..][ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[RUNNING] `[..][ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[RUNNING] `[..][ROOT]/foo/target/debug/deps/test1-[HASH][EXE]`
 [DOCTEST] foo
 [RUNNING] `[..] rustdoc [..]--test [..]
 
@@ -410,7 +410,7 @@ fn profile_selection_test_release() {
 [RUNNING] `[..] rustc --crate-name bdep --edition=2015 bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=6 [..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..] rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=6 [..]`
-[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[..][ROOT]/foo/target/release/build/foo-[HASH]/build-script-build`
 [foo 0.0.1] foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3 -C panic=abort[..]-C codegen-units=2 [..]`
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3[..]-C codegen-units=2 [..]`
@@ -420,9 +420,9 @@ fn profile_selection_test_release() {
 [RUNNING] `[..] rustc --crate-name ex1 --edition=2015 examples/ex1.rs [..]--crate-type bin --emit=[..]link -C opt-level=3[..]-C codegen-units=2 [..]`
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/main.rs [..]--crate-type bin --emit=[..]link -C opt-level=3 -C panic=abort[..]-C codegen-units=2 [..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE]`
-[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE]`
-[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/test1-[HASH][EXE]`
+[RUNNING] `[..][ROOT]/foo/target/release/deps/foo-[HASH][EXE]`
+[RUNNING] `[..][ROOT]/foo/target/release/deps/foo-[HASH][EXE]`
+[RUNNING] `[..][ROOT]/foo/target/release/deps/test1-[HASH][EXE]`
 [DOCTEST] foo
 [RUNNING] `[..] rustdoc [..]--test [..]`
 
@@ -435,9 +435,9 @@ fn profile_selection_test_release() {
 [FRESH] bar v0.0.1 ([ROOT]/foo/bar)
 [FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE]`
-[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE]`
-[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/test1-[HASH][EXE]`
+[RUNNING] `[..][ROOT]/foo/target/release/deps/foo-[HASH][EXE]`
+[RUNNING] `[..][ROOT]/foo/target/release/deps/foo-[HASH][EXE]`
+[RUNNING] `[..][ROOT]/foo/target/release/deps/test1-[HASH][EXE]`
 [DOCTEST] foo
 [RUNNING] `[..] rustdoc [..]--test [..]
 
@@ -482,7 +482,7 @@ fn profile_selection_bench() {
 [RUNNING] `[..] rustc --crate-name bdep --edition=2015 bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=6 [..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..] rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=6 [..]`
-[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[..][ROOT]/foo/target/release/build/foo-[HASH]/build-script-build`
 [foo 0.0.1] foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3 -C panic=abort[..]-C codegen-units=4 [..]`
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3[..]-C codegen-units=4 [..]`
@@ -491,9 +491,9 @@ fn profile_selection_bench() {
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/main.rs [..]--emit=[..]link -C opt-level=3[..]-C codegen-units=4 --test [..]`
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/main.rs [..]--crate-type bin --emit=[..]link -C opt-level=3 -C panic=abort[..]-C codegen-units=4 [..]`
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE] --bench`
-[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE] --bench`
-[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/bench1-[HASH][EXE] --bench`
+[RUNNING] `[..][ROOT]/foo/target/release/deps/foo-[HASH][EXE] --bench`
+[RUNNING] `[..][ROOT]/foo/target/release/deps/foo-[HASH][EXE] --bench`
+[RUNNING] `[..][ROOT]/foo/target/release/deps/bench1-[HASH][EXE] --bench`
 
 "#]].unordered())
         .run();
@@ -504,9 +504,9 @@ fn profile_selection_bench() {
 [FRESH] bar v0.0.1 ([ROOT]/foo/bar)
 [FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE] --bench`
-[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE] --bench`
-[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/bench1-[HASH][EXE] --bench`
+[RUNNING] `[..][ROOT]/foo/target/release/deps/foo-[HASH][EXE] --bench`
+[RUNNING] `[..][ROOT]/foo/target/release/deps/foo-[HASH][EXE] --bench`
+[RUNNING] `[..][ROOT]/foo/target/release/deps/bench1-[HASH][EXE] --bench`
 
 "#]]
             .unordered(),
@@ -553,7 +553,7 @@ fn profile_selection_check_all_targets() {
 [RUNNING] `[..] rustc --crate-name bdep --edition=2015 bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..] rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 [..]`
-[RUNNING] `[..][ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[..][ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]metadata -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]`
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]metadata[..]-C codegen-units=1 -C debuginfo=2 [..]`
@@ -604,7 +604,7 @@ fn profile_selection_check_all_targets_release() {
 [RUNNING] `[..] rustc --crate-name bdep --edition=2015 bdep/src/lib.rs [..]--crate-type lib --emit=[..]link [..]-C codegen-units=6 [..]
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..] rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=6 [..]
-[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[..][ROOT]/foo/target/release/build/foo-[HASH]/build-script-build`
 [foo 0.0.1] foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]metadata -C opt-level=3 -C panic=abort[..]-C codegen-units=2 [..]
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]metadata -C opt-level=3[..]-C codegen-units=2 [..]
@@ -668,7 +668,7 @@ fn profile_selection_check_all_targets_test() {
 [RUNNING] `[..] rustc --crate-name bdep --edition=2015 bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..] rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 [..]`
-[RUNNING] `[..][ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[..][ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]metadata[..]-C codegen-units=3 -C debuginfo=2 [..]`
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--emit=[..]metadata[..]-C codegen-units=3 -C debuginfo=2 [..]--test [..]`
@@ -721,7 +721,7 @@ fn profile_selection_doc() {
 [RUNNING] `[..] rustc --crate-name bdep --edition=2015 bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..] rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 [..]`
-[RUNNING] `[..][ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `[..][ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..] rustdoc [..]--crate-name foo src/lib.rs [..]

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -297,7 +297,7 @@ fn registry_dependency_with_build_script_codegen() {
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         // Macros should be sanitized
         .with_stdout_data(str![[r#"
-/cargo/build-dir/debug/build/bar/[HASH]/out/bindings.rs
+/cargo/build-dir/debug/build/bar-[HASH]/out/bindings.rs
 
 "#]]) // Omit the hash of Source URL
         .with_stderr_data(str![[r#"
@@ -307,7 +307,7 @@ fn registry_dependency_with_build_script_codegen() {
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [COMPILING] bar v0.0.1
 [RUNNING] `rustc --crate-name build_script_build [..]--remap-path-scope=object --remap-path-prefix=[ROOT]/home/.cargo/registry/src= --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/bar/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/bar-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name bar [..]--remap-path-scope=object --remap-path-prefix=[ROOT]/home/.cargo/registry/src= --remap-path-prefix=[ROOT]/foo/target=/cargo/build-dir --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo [..]--remap-path-scope=object --remap-path-prefix=[ROOT]/foo=. --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`

--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -29,7 +29,7 @@ fn profile_overrides() {
         .build();
     p.cargo("build -v").with_stderr_data(str![[r#"
 [COMPILING] test v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name test --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..] -C opt-level=1[..] -C debug-assertions=on[..] -C metadata=[..] -C rpath --out-dir [ROOT]/foo/target/debug/build/test/[HASH]/out [..] -L dependency=[ROOT]/foo/target/debug/build/test/[HASH]/out[..]`
+[RUNNING] `rustc --crate-name test --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..] -C opt-level=1[..] -C debug-assertions=on[..] -C metadata=[..] -C rpath --out-dir [ROOT]/foo/target/debug/deps [..] -L dependency=[ROOT]/foo/target/debug/deps[..]`
 [FINISHED] `dev` profile [optimized] target(s) in [ELAPSED]s
 
 "#]]).run();
@@ -56,7 +56,7 @@ fn opt_level_override_0() {
         .build();
     p.cargo("build -v").with_stderr_data(str![[r#"
 [COMPILING] test v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name test --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=2 [..] -C metadata=[..] --out-dir [ROOT]/foo/target/debug/build/test/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/test/[HASH]/out[..]`
+[RUNNING] `rustc --crate-name test --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=2 [..] -C metadata=[..] --out-dir [ROOT]/foo/target/debug/deps -L dependency=[ROOT]/foo/target/debug/deps[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]]).run();
@@ -82,7 +82,7 @@ fn debug_override_1() {
         .build();
     p.cargo("build -v").with_stderr_data(str![[r#"
 [COMPILING] test v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name test --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=1 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/build/test/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/test/[HASH]/out[..]`
+[RUNNING] `rustc --crate-name test --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=1 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/deps -L dependency=[ROOT]/foo/target/debug/deps[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]]).run();
@@ -120,7 +120,7 @@ fn check_opt_level_override(profile_level: &str, rustc_level: &str) {
         -C debug-assertions=on[..] \
         -C metadata=[..] \
         --out-dir [..] \
-        -L dependency=[ROOT]/foo/target/debug/build/test/[HASH]/out[..]`
+        -L dependency=[ROOT]/foo/target/debug/deps[..]`
 [FINISHED] `dev` profile [..]+ debuginfo] target(s) in [ELAPSED]s
 ",
             level = rustc_level
@@ -196,8 +196,8 @@ fn top_level_overrides_deps() {
         -C opt-level=1[..]\
         -C debuginfo=2 [..]\
         -C metadata=[..] \
-        --out-dir [ROOT]/foo/target/release/build/foo/[HASH]/out \
-        -L dependency=[ROOT]/foo/target/release/build/foo/[HASH]/out[..]`
+        --out-dir [ROOT]/foo/target/release/deps \
+        -L dependency=[ROOT]/foo/target/release/deps[..]`
 [COMPILING] test v0.0.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name test --edition=2015 src/lib.rs [..]--crate-type lib \
         --emit=[..]link \
@@ -205,11 +205,10 @@ fn top_level_overrides_deps() {
         -C debuginfo=2 [..]\
         -C metadata=[..] \
         --out-dir [..] \
-        -L dependency=[ROOT]/foo/target/release/build/foo/[HASH]/out \
-        -L dependency=[ROOT]/foo/target/release/build/test/[HASH]/out \
-        --extern foo=[ROOT]/foo/target/release/build/foo/[HASH]/out/\
+        -L dependency=[ROOT]/foo/target/release/deps \
+        --extern foo=[ROOT]/foo/target/release/deps/\
                      {prefix}foo[..]{suffix} \
-        --extern foo=[ROOT]/foo/target/release/build/foo/[HASH]/out/libfoo.rlib[..]`
+        --extern foo=[ROOT]/foo/target/release/deps/libfoo.rlib[..]`
 [FINISHED] `release` profile [optimized + debuginfo] target(s) in [ELAPSED]s
 ",
             prefix = env::consts::DLL_PREFIX,
@@ -431,9 +430,9 @@ fn panic_unwind_does_not_build_twice() {
 [RUNNING] `rustc --crate-name foo --edition=2015 src/main.rs [..] --test [..]`
 [RUNNING] `rustc --crate-name t1 --edition=2015 tests/t1.rs [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
-[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
-[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/t1-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/deps/t1-[HASH][EXE]`
 
 "#]]
             .unordered(),

--- a/tests/testsuite/rename_deps.rs
+++ b/tests/testsuite/rename_deps.rs
@@ -282,7 +282,7 @@ fn can_run_doc_tests() {
     foo.cargo("test -v").with_stderr_data(str![[r#"
 ...
 [DOCTEST] foo
-[RUNNING] `rustdoc [..]--test src/lib.rs [..] --extern bar=[ROOT]/foo/target/debug/build/bar/[HASH]/out/libbar-[HASH].rlib --extern baz=[ROOT]/foo/target/debug/build/bar/[HASH]/out/libbar-[HASH].rlib [..]`
+[RUNNING] `rustdoc [..]--test src/lib.rs [..] --extern bar=[ROOT]/foo/target/debug/deps/libbar-[HASH].rlib --extern baz=[ROOT]/foo/target/debug/deps/libbar-[HASH].rlib [..]`
 
 "#]]).run();
 }

--- a/tests/testsuite/required_features.rs
+++ b/tests/testsuite/required_features.rs
@@ -295,7 +295,7 @@ fn test_default_features() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] tests/foo.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] tests/foo.rs (target/debug/deps/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -320,7 +320,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
     p.cargo("test --test=foo")
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] tests/foo.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] tests/foo.rs (target/debug/deps/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -371,7 +371,7 @@ fn test_arg_features() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] tests/foo.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] tests/foo.rs (target/debug/deps/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -421,7 +421,7 @@ fn test_multiple_required_features() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] tests/foo_2.rs (target/debug/build/foo/[HASH]/out/foo_2-[HASH][EXE])
+[RUNNING] tests/foo_2.rs (target/debug/deps/foo_2-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -439,8 +439,8 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] tests/foo_1.rs (target/debug/build/foo/[HASH]/out/foo_1-[HASH][EXE])
-[RUNNING] tests/foo_2.rs (target/debug/build/foo/[HASH]/out/foo_2-[HASH][EXE])
+[RUNNING] tests/foo_1.rs (target/debug/deps/foo_1-[HASH][EXE])
+[RUNNING] tests/foo_2.rs (target/debug/deps/foo_2-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -507,7 +507,7 @@ fn bench_default_features() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] benches/foo.rs (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] benches/foo.rs (target/release/deps/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -532,7 +532,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured; 0 filtered out; fini
     p.cargo("bench --bench=foo")
         .with_stderr_data(str![[r#"
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] benches/foo.rs (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] benches/foo.rs (target/release/deps/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -593,7 +593,7 @@ fn bench_arg_features() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] benches/foo.rs (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] benches/foo.rs (target/release/deps/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -663,7 +663,7 @@ fn bench_multiple_required_features() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] benches/foo_2.rs (target/release/build/foo/[HASH]/out/foo_2-[HASH][EXE])
+[RUNNING] benches/foo_2.rs (target/release/deps/foo_2-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -681,8 +681,8 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured; 0 filtered out; fini
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] benches/foo_1.rs (target/release/build/foo/[HASH]/out/foo_1-[HASH][EXE])
-[RUNNING] benches/foo_2.rs (target/release/build/foo/[HASH]/out/foo_2-[HASH][EXE])
+[RUNNING] benches/foo_1.rs (target/release/deps/foo_1-[HASH][EXE])
+[RUNNING] benches/foo_2.rs (target/release/deps/foo_2-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1036,7 +1036,7 @@ fn dep_feature_in_toml() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] tests/foo.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] tests/foo.rs (target/debug/deps/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1057,7 +1057,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] benches/foo.rs (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] benches/foo.rs (target/release/deps/foo-[HASH][EXE])
 
 "#]])
             .with_stdout_data(str![[r#"
@@ -1203,7 +1203,7 @@ Consider enabling them by passing, e.g., `--features="bar/a"`
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] tests/foo.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] tests/foo.rs (target/debug/deps/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1232,7 +1232,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] benches/foo.rs (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] benches/foo.rs (target/release/deps/foo-[HASH][EXE])
 
 "#]])
             .with_stdout_data(str![[r#"
@@ -1297,7 +1297,7 @@ fn test_skips_compiling_bin_with_missing_required_features() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] tests/foo.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] tests/foo.rs (target/debug/deps/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1324,7 +1324,7 @@ error[E0463]: can't find crate for `bar`
             .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] benches/foo.rs (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] benches/foo.rs (target/release/deps/foo-[HASH][EXE])
 
 "#]])
             .with_stdout_data(str![[r#"

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -1105,9 +1105,9 @@ fn example_with_release_flag() {
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to latest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
-[RUNNING] `rustc --crate-name bar --edition=2015 bar/src/bar.rs [..]--crate-type lib --emit=[..]link -C opt-level=3[..] -C metadata=[..] --out-dir [ROOT]/foo/target/release/build/bar/[HASH]/out -C strip=debuginfo -L dependency=[ROOT]/foo/target/release/build/bar/[HASH]/out[..]`
+[RUNNING] `rustc --crate-name bar --edition=2015 bar/src/bar.rs [..]--crate-type lib --emit=[..]link -C opt-level=3[..] -C metadata=[..] --out-dir [ROOT]/foo/target/release/deps -C strip=debuginfo -L dependency=[ROOT]/foo/target/release/deps[..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name a --edition=2015 examples/a.rs [..]--crate-type bin --emit=[..]link -C opt-level=3[..] -C metadata=[..] --out-dir [ROOT]/foo/target/release/build/foo/[HASH]/out -C strip=debuginfo -L dependency=[ROOT]/foo/target/release/build/bar/[HASH]/out -L dependency=[ROOT]/foo/target/release/build/foo/[HASH]/out --extern bar=[ROOT]/foo/target/release/build/bar/[HASH]/out/libbar-[HASH].rlib[..]`
+[RUNNING] `rustc --crate-name a --edition=2015 examples/a.rs [..]--crate-type bin --emit=[..]link -C opt-level=3[..] -C metadata=[..] --out-dir [ROOT]/foo/target/release/examples -C strip=debuginfo -L dependency=[ROOT]/foo/target/release/deps --extern bar=[ROOT]/foo/target/release/deps/libbar-[HASH].rlib[..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 [RUNNING] `target/release/examples/a[EXE]`
 
@@ -1122,9 +1122,9 @@ fast2
     p.cargo("run -v --example a")
         .with_stderr_data(str![[r#"
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
-[RUNNING] `rustc --crate-name bar --edition=2015 bar/src/bar.rs [..]--crate-type lib --emit=[..]link [..]-C debuginfo=2 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/build/bar/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/bar/[HASH]/out[..]`
+[RUNNING] `rustc --crate-name bar --edition=2015 bar/src/bar.rs [..]--crate-type lib --emit=[..]link [..]-C debuginfo=2 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/deps -L dependency=[ROOT]/foo/target/debug/deps[..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name a --edition=2015 examples/a.rs [..]--crate-type bin --emit=[..]link [..]-C debuginfo=2 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/bar/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/foo/[HASH]/out --extern bar=[ROOT]/foo/target/debug/build/bar/[HASH]/out/libbar-[HASH].rlib[..]`
+[RUNNING] `rustc --crate-name a --edition=2015 examples/a.rs [..]--crate-type bin --emit=[..]link [..]-C debuginfo=2 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/examples -L dependency=[ROOT]/foo/target/debug/deps --extern bar=[ROOT]/foo/target/debug/deps/libbar-[HASH].rlib[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `target/debug/examples/a[EXE]`
 

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -17,7 +17,7 @@ fn build_lib_for_foo() {
 
     p.cargo("rustc --lib -v").with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=2 [..]-C metadata=[..] [..]--out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/foo/[HASH]/out[..]`
+[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=2 [..]-C metadata=[..] [..]--out-dir [ROOT]/foo/target/debug/deps -L dependency=[ROOT]/foo/target/debug/deps[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]]).run();
@@ -33,7 +33,7 @@ fn lib() {
     p.cargo("rustc --lib -v -- -C debug-assertions=off")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=2 [..]-C metadata=[..] [..]--out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/foo/[HASH]/out[..]-C debug-assertions=off[..]`
+[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=2 [..]-C metadata=[..] [..]--out-dir [ROOT]/foo/target/debug/deps -L dependency=[ROOT]/foo/target/debug/deps[..]-C debug-assertions=off[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -50,8 +50,8 @@ fn build_main_and_allow_unstable_options() {
     p.cargo("rustc -v --bin foo -- -C debug-assertions")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=2 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/foo/[HASH]/out[..]`
-[RUNNING] `rustc --crate-name foo --edition=2015 src/main.rs [..]--crate-type bin --emit=[..]link[..]-C debuginfo=2 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/foo/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/foo/[HASH]/out --extern foo=[ROOT]/foo/target/debug/build/foo/[HASH]/out/libfoo-[HASH].rlib[..]-C debug-assertions[..]`
+[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=2 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/deps -L dependency=[ROOT]/foo/target/debug/deps[..]`
+[RUNNING] `rustc --crate-name foo --edition=2015 src/main.rs [..]--crate-type bin --emit=[..]link[..]-C debuginfo=2 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/deps -L dependency=[ROOT]/foo/target/debug/deps --extern foo=[ROOT]/foo/target/debug/deps/libfoo-[HASH].rlib[..]-C debug-assertions[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])

--- a/tests/testsuite/rustdoc.rs
+++ b/tests/testsuite/rustdoc.rs
@@ -15,7 +15,7 @@ fn rustdoc_simple() {
     p.cargo("rustdoc -v")
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustdoc [..] --crate-name foo src/lib.rs -o [ROOT]/foo/target/doc [..] -L dependency=[ROOT]/foo/target/debug/build/foo/[HASH]/out [..]`
+[RUNNING] `rustdoc [..] --crate-name foo src/lib.rs -o [ROOT]/foo/target/doc [..] -L dependency=[ROOT]/foo/target/debug/deps [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 
@@ -43,6 +43,23 @@ fn rustdoc_simple_json() {
     let p = project().file("src/lib.rs", "").build();
 
     p.cargo("rustdoc -Z unstable-options --output-format json -v")
+        .masquerade_as_nightly_cargo(&["rustdoc-output-format"])
+        .with_stderr_data(str![[r#"
+[DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustdoc [..] --crate-name foo [..]-o [ROOT]/foo/target/debug/build/foo-[HASH]/out [..] --output-format=json[..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[GENERATED] [ROOT]/foo/target/doc/foo.json
+
+"#]])
+        .run();
+    assert!(p.root().join("target/doc/foo.json").is_file());
+}
+
+#[cargo_test(nightly, reason = "--output-format is unstable")]
+fn rustdoc_json_with_new_layout() {
+    let p = project().file("src/lib.rs", "").build();
+
+    p.cargo("rustdoc -Z unstable-options -Z build-dir-new-layout  --output-format json -v")
         .masquerade_as_nightly_cargo(&["rustdoc-output-format"])
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
@@ -110,7 +127,7 @@ fn rustdoc_args() {
     p.cargo("rustdoc -v -- --cfg=foo")
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustdoc [..] --crate-name foo src/lib.rs -o [ROOT]/foo/target/doc [..]-C metadata=[..] -L dependency=[ROOT]/foo/target/debug/build/foo/[HASH]/out [..]--cfg=foo[..]`
+[RUNNING] `rustdoc [..] --crate-name foo src/lib.rs -o [ROOT]/foo/target/doc [..]-C metadata=[..] -L dependency=[ROOT]/foo/target/debug/deps [..]--cfg=foo[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 
@@ -163,7 +180,7 @@ fn rustdoc_foo_with_bar_dependency() {
 [CHECKING] bar v0.0.1 ([ROOT]/bar)
 [RUNNING] `rustc [..] [ROOT]/bar/src/lib.rs [..]`
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustdoc [..] --crate-name foo src/lib.rs -o [ROOT]/foo/target/doc [..]-C metadata=[..] -L dependency=[ROOT]/foo/target/debug/build/foo/[HASH]/out --extern [..]--cfg=foo[..]`
+[RUNNING] `rustdoc [..] --crate-name foo src/lib.rs -o [ROOT]/foo/target/doc [..]-C metadata=[..] -L dependency=[ROOT]/foo/target/debug/deps --extern [..]--cfg=foo[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 
@@ -199,7 +216,7 @@ fn rustdoc_only_bar_dependency() {
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to latest compatible version
 [DOCUMENTING] bar v0.0.1 ([ROOT]/bar)
-[RUNNING] `rustdoc [..] --crate-name bar [ROOT]/bar/src/lib.rs -o [ROOT]/foo/target/doc [..]-C metadata=[..] -L dependency=[ROOT]/foo/target/debug/build/bar/[HASH]/out [..]--cfg=foo[..]`
+[RUNNING] `rustdoc [..] --crate-name bar [ROOT]/bar/src/lib.rs -o [ROOT]/foo/target/doc [..]-C metadata=[..] -L dependency=[ROOT]/foo/target/debug/deps [..]--cfg=foo[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/bar/index.html
 
@@ -217,7 +234,7 @@ fn rustdoc_same_name_documents_lib() {
     p.cargo("rustdoc -v -- --cfg=foo")
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustdoc [..] --crate-name foo src/lib.rs -o [ROOT]/foo/target/doc [..]-C metadata=[..] -L dependency=[ROOT]/foo/target/debug/build/foo/[HASH]/out [..]--cfg=foo[..]`
+[RUNNING] `rustdoc [..] --crate-name foo src/lib.rs -o [ROOT]/foo/target/doc [..]-C metadata=[..] -L dependency=[ROOT]/foo/target/debug/deps [..]--cfg=foo[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 
@@ -294,7 +311,7 @@ fn rustdoc_target() {
         .arg(cross_compile::alternate())
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo src/lib.rs [..]--target [ALT_TARGET] -o [ROOT]/foo/target/[ALT_TARGET]/doc [..] -L dependency=[ROOT]/foo/target/[ALT_TARGET]/debug/build/foo/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/foo/[HASH]/out[..]`
+[RUNNING] `rustdoc [..]--crate-name foo src/lib.rs [..]--target [ALT_TARGET] -o [ROOT]/foo/target/[ALT_TARGET]/doc [..] -L dependency=[ROOT]/foo/target/[ALT_TARGET]/debug/deps -L dependency=[ROOT]/foo/target/debug/deps[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/[..]/doc/foo/index.html
 

--- a/tests/testsuite/rustflags.rs
+++ b/tests/testsuite/rustflags.rs
@@ -1197,9 +1197,9 @@ fn cfg_rustflags_normal_source() {
 [RUNNING] `rustc [..] --cfg bar[..]`
 [RUNNING] `rustc [..] --cfg bar[..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
-[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/a-[HASH][EXE]`
-[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/c-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/deps/a-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/deps/c-[HASH][EXE]`
 
 "#]])
         .run();
@@ -1211,8 +1211,8 @@ fn cfg_rustflags_normal_source() {
 [RUNNING] `rustc [..] --cfg bar[..]`
 [RUNNING] `rustc [..] --cfg bar[..]`
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[EXECUTABLE] `[ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE]`
-[EXECUTABLE] `[ROOT]/foo/target/release/build/foo/[HASH]/out/a-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/release/deps/foo-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/release/deps/a-[HASH][EXE]`
 
 "#]])
         .run();
@@ -1279,9 +1279,9 @@ fn cfg_rustflags_precedence() {
 [RUNNING] `rustc [..] --cfg bar[..]`
 [RUNNING] `rustc [..] --cfg bar[..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
-[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/a-[HASH][EXE]`
-[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/c-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/deps/a-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/deps/c-[HASH][EXE]`
 
 "#]])
         .run();
@@ -1293,8 +1293,8 @@ fn cfg_rustflags_precedence() {
 [RUNNING] `rustc [..] --cfg bar[..]`
 [RUNNING] `rustc [..] --cfg bar[..]`
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[EXECUTABLE] `[ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE]`
-[EXECUTABLE] `[ROOT]/foo/target/release/build/foo/[HASH]/out/a-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/release/deps/foo-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/release/deps/a-[HASH][EXE]`
 
 "#]])
         .run();
@@ -1783,7 +1783,7 @@ fn host_config_shared_build_dep() {
 [RUNNING] `rustc --crate-name cc [..]--cfg from_target[..]`
 [COMPILING] bootstrap v0.0.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]--cfg from_host[..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/bootstrap/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/bootstrap-[HASH]/build-script-build`
 [RUNNING] `rustc --crate-name bootstrap[..]--cfg from_target[..]`
 [FINISHED] `dev` profile [unoptimized] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/script/cargo.rs
+++ b/tests/testsuite/script/cargo.rs
@@ -1770,7 +1770,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
 [HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 [COMPILING] script v0.0.0 ([ROOT]/foo/script.rs)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests script.rs ([ROOT]/home/.cargo/build/[HASH]/debug/build/script/[HASH]/out/script-[HASH][EXE])
+[RUNNING] unittests script.rs ([ROOT]/home/.cargo/build/[HASH]/debug/deps/script-[HASH][EXE])
 
 "#]])
         .run();

--- a/tests/testsuite/standard_lib.rs
+++ b/tests/testsuite/standard_lib.rs
@@ -420,7 +420,7 @@ fn build_std_with_no_arg_for_core_only_target() {
 [COMPILING] core v0.1.0 ([..]/library/core)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..] rustc --crate-name build_script_build [..]/compiler_builtins/build.rs [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/compiler_builtins/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/compiler_builtins-[HASH]/build-script-build`
 [RUNNING] `[..] rustc --crate-name compiler_builtins [..]--target aarch64-unknown-none[..]`
 [RUNNING] `[..] rustc --crate-name core [..]--target aarch64-unknown-none[..]`
 [RUNNING] `[..] rustc --crate-name foo [..]--target aarch64-unknown-none[..]`
@@ -459,8 +459,8 @@ fn build_std_with_no_arg_for_core_only_target() {
 [COMPILING] registry-dep-using-alloc v1.0.0
 [COMPILING] std v0.1.0 ([..]/library/std)
 [RUNNING] `[..] rustc --crate-name build_script_build [..]/compiler_builtins/build.rs [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/compiler_builtins/[HASH]/out/build_script_build`
-[RUNNING] `[ROOT]/foo/target/debug/build/compiler_builtins/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/compiler_builtins-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/compiler_builtins-[HASH]/build-script-build`
 [RUNNING] `[..]rustc --crate-name compiler_builtins [..]--target aarch64-unknown-none[..]`
 [RUNNING] `[..]rustc --crate-name core [..]--target aarch64-unknown-none[..]`
 [RUNNING] `[..]rustc --crate-name foo [..]--target aarch64-unknown-none[..]`

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -49,7 +49,7 @@ hello
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/main.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/deps/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -109,8 +109,8 @@ fn cargo_test_release() {
 [RUNNING] `rustc [..]-C opt-level=3 [..]`
 [RUNNING] `rustc [..]-C opt-level=3 [..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE]`
-[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/test-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/deps/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/deps/test-[HASH][EXE]`
 [DOCTEST] foo
 [RUNNING] `rustdoc [..]--test src/lib.rs[..]`
 
@@ -329,7 +329,7 @@ fn cargo_test_verbose() {
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `rustc [..] src/main.rs [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE] hello`
+[RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE] hello`
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -417,7 +417,7 @@ hello
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/main.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/deps/foo-[HASH][EXE])
 [ERROR] test failed, to rerun pass `--bin foo`
 
 "#]])
@@ -451,8 +451,8 @@ hello
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/main.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
-[RUNNING] tests/footest.rs (target/debug/build/foo/[HASH]/out/footest-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] tests/footest.rs (target/debug/deps/footest-[HASH][EXE])
 [ERROR] test failed, to rerun pass `--test footest`
 
 "#]])
@@ -488,7 +488,7 @@ fn cargo_test_failing_test_in_lib() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
 [ERROR] test failed, to rerun pass `--lib`
 
 "#]])
@@ -553,8 +553,8 @@ fn test_with_lib_dep() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
-[RUNNING] unittests src/main.rs (target/debug/build/foo/[HASH]/out/baz-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/deps/baz-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -615,7 +615,7 @@ fn test_with_deep_lib_dep() {
 [COMPILING] bar v0.0.1 ([ROOT]/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -671,8 +671,8 @@ fn external_test_explicit() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
-[RUNNING] src/test.rs (target/debug/build/foo/[HASH]/out/test-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] src/test.rs (target/debug/deps/test-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -738,8 +738,8 @@ fn external_test_implicit() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
-[RUNNING] tests/external.rs (target/debug/build/foo/[HASH]/out/external-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] tests/external.rs (target/debug/deps/external-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -803,7 +803,7 @@ fn pass_through_escaped() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -818,7 +818,7 @@ test test_bar ... ok
     p.cargo("test -- foo")
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -833,7 +833,7 @@ test test_foo ... ok
     p.cargo("test -- foo bar")
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -884,7 +884,7 @@ fn pass_through_testname() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -898,7 +898,7 @@ test test_bar ... ok
     p.cargo("test foo")
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -912,7 +912,7 @@ test test_foo ... ok
     p.cargo("test foo -- bar")
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(
@@ -984,8 +984,8 @@ fn lib_bin_same_name() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
-[RUNNING] unittests src/main.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/deps/foo-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -1032,8 +1032,8 @@ fn lib_with_standard_name() {
         .with_stderr_data(str![[r#"
 [COMPILING] syntax v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/syntax/[HASH]/out/syntax-[HASH][EXE])
-[RUNNING] tests/test.rs (target/debug/build/syntax/[HASH]/out/test-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/syntax-[HASH][EXE])
+[RUNNING] tests/test.rs (target/debug/deps/test-[HASH][EXE])
 [DOCTEST] syntax
 
 "#]])
@@ -1085,7 +1085,7 @@ fn lib_with_standard_name2() {
         .with_stderr_data(str![[r#"
 [COMPILING] syntax v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/main.rs (target/debug/build/syntax/[HASH]/out/syntax-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/deps/syntax-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1131,7 +1131,7 @@ fn lib_without_name() {
         .with_stderr_data(str![[r#"
 [COMPILING] syntax v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/main.rs (target/debug/build/syntax/[HASH]/out/syntax-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/deps/syntax-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1460,8 +1460,8 @@ fn test_dylib() {
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
-[RUNNING] tests/test.rs (target/debug/build/foo/[HASH]/out/test-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] tests/test.rs (target/debug/deps/test-[HASH][EXE])
 
 "#]])
         .with_stdout_data(
@@ -1478,8 +1478,8 @@ test foo ... ok
     p.cargo("test")
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
-[RUNNING] tests/test.rs (target/debug/build/foo/[HASH]/out/test-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] tests/test.rs (target/debug/deps/test-[HASH][EXE])
 
 "#]])
         .with_stdout_data(
@@ -1515,7 +1515,7 @@ fn test_twice_with_build_cmd() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -1532,7 +1532,7 @@ running 0 tests
     p.cargo("test")
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -1555,7 +1555,7 @@ fn test_then_build() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -1587,7 +1587,7 @@ fn test_no_run() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[EXECUTABLE] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
 
 "#]])
         .run();
@@ -1637,7 +1637,7 @@ fn test_run_specific_bin_target() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/bin2.rs (target/debug/build/foo/[HASH]/out/bin2-[HASH][EXE])
+[RUNNING] unittests src/bin2.rs (target/debug/deps/bin2-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1683,7 +1683,7 @@ fn test_run_implicit_bin_target() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/mybin.rs (target/debug/build/foo/[HASH]/out/mybin-[HASH][EXE])
+[RUNNING] unittests src/mybin.rs (target/debug/deps/mybin-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1707,7 +1707,7 @@ fn test_run_specific_test_target() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] tests/b.rs (target/debug/build/foo/[HASH]/out/b-[HASH][EXE])
+[RUNNING] tests/b.rs (target/debug/deps/b-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1752,8 +1752,8 @@ fn test_run_implicit_test_target() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/mybin.rs (target/debug/build/foo/[HASH]/out/mybin-[HASH][EXE])
-[RUNNING] tests/mytest.rs (target/debug/build/foo/[HASH]/out/mytest-[HASH][EXE])
+[RUNNING] unittests src/mybin.rs (target/debug/deps/mybin-[HASH][EXE])
+[RUNNING] tests/mytest.rs (target/debug/deps/mytest-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1798,8 +1798,8 @@ fn test_run_implicit_bench_target() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/mybin.rs (target/debug/build/foo/[HASH]/out/mybin-[HASH][EXE])
-[RUNNING] benches/mybench.rs (target/debug/build/foo/[HASH]/out/mybench-[HASH][EXE])
+[RUNNING] unittests src/mybin.rs (target/debug/deps/mybin-[HASH][EXE])
+[RUNNING] benches/mybench.rs (target/debug/deps/mybench-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1863,21 +1863,21 @@ fn test_run_implicit_example_target() {
         .with_stderr_does_not_contain("[RUNNING] [..]myexm1-[..]")
         // profile.test panic settings shouldn't be applied even to myexm1
         .with_stderr_line_without(&["[RUNNING] `rustc --crate-name myexm1"], &["panic=abort"])
-        .with_stderr_contains("[RUNNING] [..]target/debug/build/foo/[HASH]/out/myexm2-[..]")
+        .with_stderr_contains("[RUNNING] [..]target/debug/examples/myexm2-[..]")
         .run();
 
     // Only tests myexm2.
     prj.cargo("test --tests")
         .with_stderr_does_not_contain("[RUNNING] [..]myexm1-[..]")
-        .with_stderr_contains("[RUNNING] [..]target/debug/build/foo/[HASH]/out/myexm2-[..]")
+        .with_stderr_contains("[RUNNING] [..]target/debug/examples/myexm2-[..]")
         .run();
 
     // Tests all examples.
     prj.cargo("test --examples")
         .with_stderr_data(str![[r#"
 ...
-[RUNNING] unittests examples/myexm1.rs (target/debug/build/foo/[HASH]/out/myexm1-[HASH][EXE])
-[RUNNING] unittests examples/myexm2.rs (target/debug/build/foo/[HASH]/out/myexm2-[HASH][EXE])
+[RUNNING] unittests examples/myexm1.rs (target/debug/examples/myexm1-[HASH][EXE])
+[RUNNING] unittests examples/myexm2.rs (target/debug/examples/myexm2-[HASH][EXE])
 ...
 "#]])
         .run();
@@ -1886,7 +1886,7 @@ fn test_run_implicit_example_target() {
     prj.cargo("test --example myexm1")
         .with_stderr_data(str![[r#"
 ...
-[RUNNING] unittests examples/myexm1.rs (target/debug/build/foo/[HASH]/out/myexm1-[HASH][EXE])
+[RUNNING] unittests examples/myexm1.rs (target/debug/examples/myexm1-[HASH][EXE])
 ...
 "#]])
         .run();
@@ -1895,8 +1895,8 @@ fn test_run_implicit_example_target() {
     prj.cargo("test --all-targets")
         .with_stderr_data(str![[r#"
 ...
-[RUNNING] unittests examples/myexm1.rs (target/debug/build/foo/[HASH]/out/myexm1-[HASH][EXE])
-[RUNNING] unittests examples/myexm2.rs (target/debug/build/foo/[HASH]/out/myexm2-[HASH][EXE])
+[RUNNING] unittests examples/myexm1.rs (target/debug/examples/myexm1-[HASH][EXE])
+[RUNNING] unittests examples/myexm2.rs (target/debug/examples/myexm2-[HASH][EXE])
 ...
 "#]])
         .run();
@@ -1964,14 +1964,14 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
 [RUNNING] `rustc --crate-name mybin --edition=2015 src/bin/mybin.rs [..] --crate-type bin [..]`
 [RUNNING] `rustc --crate-name mytest --edition=2015 tests/mytest.rs [..] --test [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE] test_in_`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/mytest-[HASH][EXE] test_in_`
+[RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE] test_in_`
+[RUNNING] `[ROOT]/foo/target/debug/deps/mytest-[HASH][EXE] test_in_`
 
 "#]]
             .unordered(),
         )
         .with_stderr_does_not_contain("[RUNNING][..]rustc[..]myexm1[..]")
-        .with_stderr_does_not_contain("[RUNNING][..]build/foo/[HASH]/out/mybin-[..] test_in_")
+        .with_stderr_does_not_contain("[RUNNING][..]deps/mybin-[..] test_in_")
         .run();
 }
 
@@ -2005,7 +2005,7 @@ fn test_no_harness() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] foo.rs (target/debug/build/foo/[HASH]/out/bar-[HASH][EXE])
+[RUNNING] foo.rs (target/debug/deps/bar-[HASH][EXE])
 
 "#]])
         .run();
@@ -2080,8 +2080,8 @@ fn selective_testing() {
 [LOCKING] 2 packages to latest compatible versions
 [COMPILING] d1 v0.0.1 ([ROOT]/foo/d1)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/d1/[HASH]/out/d1-[HASH][EXE])
-[RUNNING] unittests src/main.rs (target/debug/build/d1/[HASH]/out/d1-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/d1-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/deps/d1-[HASH][EXE])
 
 "#]])
         .with_stdout_data(
@@ -2099,8 +2099,8 @@ running 0 tests
         .with_stderr_data(str![[r#"
 [COMPILING] d2 v0.0.1 ([ROOT]/foo/d2)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/d2/[HASH]/out/d2-[HASH][EXE])
-[RUNNING] unittests src/main.rs (target/debug/build/d2/[HASH]/out/d2-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/d2-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/deps/d2-[HASH][EXE])
 
 "#]])
         .with_stdout_data(
@@ -2118,7 +2118,7 @@ running 0 tests
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -2310,7 +2310,7 @@ fn selective_testing_with_docs() {
 [LOCKING] 1 package to latest compatible version
 [COMPILING] d1 v0.0.1 ([ROOT]/foo/d1)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests d1.rs (target/debug/build/d1/[HASH]/out/d1-[HASH][EXE])
+[RUNNING] unittests d1.rs (target/debug/deps/d1-[HASH][EXE])
 [DOCTEST] d1
 
 "#]])
@@ -2338,7 +2338,7 @@ fn example_bin_same_name() {
 [RUNNING] `rustc [..]`
 [RUNNING] `rustc [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
 
 "#]])
         .run();
@@ -2497,7 +2497,7 @@ fn doctest_feature() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -2651,7 +2651,7 @@ fn filter_no_doc_tests() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] tests/foo.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] tests/foo.rs (target/debug/deps/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -2795,7 +2795,7 @@ fn cyclic_dev_dep_doc_test() {
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -2899,10 +2899,10 @@ fn no_fail_fast() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
-[RUNNING] tests/test_add_one.rs (target/debug/build/foo/[HASH]/out/test_add_one-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] tests/test_add_one.rs (target/debug/deps/test_add_one-[HASH][EXE])
 [ERROR] test failed, to rerun pass `--test test_add_one`
-[RUNNING] tests/test_sub_one.rs (target/debug/build/foo/[HASH]/out/test_sub_one-[HASH][EXE])
+[RUNNING] tests/test_sub_one.rs (target/debug/deps/test_sub_one-[HASH][EXE])
 [DOCTEST] foo
 [ERROR] 1 target failed:
     `--test test_add_one`
@@ -2977,8 +2977,8 @@ fn test_multiple_packages() {
     p.cargo("test -p d1 -p d2")
         .with_stderr_data(str![[r#"
 ...
-[RUNNING] unittests src/lib.rs (target/debug/build/d1/[HASH]/out/d1-[HASH][EXE])
-[RUNNING] unittests src/lib.rs (target/debug/build/d2/[HASH]/out/d2-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/d1-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/d2-[HASH][EXE])
 ...
 "#]])
         .with_stdout_data(
@@ -3012,9 +3012,9 @@ fn bin_does_not_rebuild_tests() {
 [RUNNING] `rustc [..] src/main.rs [..]`
 [RUNNING] `rustc [..] src/main.rs [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
-[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
-[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
 
 "#]])
         .run();
@@ -3075,7 +3075,7 @@ fn selective_test_optional_dep() {
 [RUNNING] `rustc [..] a/src/lib.rs [..]`
 [RUNNING] `rustc [..] a/src/lib.rs [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] `[ROOT]/foo/target/debug/build/a/[HASH]/out/a-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/deps/a-[HASH][EXE]`
 
 "#]])
         .run();
@@ -3230,7 +3230,7 @@ hello!
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
 
 "#]])
         .run();
@@ -4315,8 +4315,8 @@ fn test_hint_workspace_virtual() {
 [COMPILING] a v0.1.0 ([ROOT]/foo/a)
 [COMPILING] b v0.1.0 ([ROOT]/foo/b)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/a/[HASH]/out/a-[HASH][EXE])
-[RUNNING] unittests src/lib.rs (target/debug/build/b/[HASH]/out/b-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/a-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/b-[HASH][EXE])
 [ERROR] test failed, to rerun pass `-p b --lib`
 
 "#]]
@@ -4328,7 +4328,7 @@ fn test_hint_workspace_virtual() {
         .cwd("b")
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs ([ROOT]/foo/target/debug/build/b/[HASH]/out/b-[HASH][EXE])
+[RUNNING] unittests src/lib.rs ([ROOT]/foo/target/debug/deps/b-[HASH][EXE])
 [ERROR] test failed, to rerun pass `--lib`
 
 "#]])
@@ -4337,13 +4337,13 @@ fn test_hint_workspace_virtual() {
     p.cargo("test --no-fail-fast")
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/a/[HASH]/out/a-[HASH][EXE])
-[RUNNING] unittests src/lib.rs (target/debug/build/b/[HASH]/out/b-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/a-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/b-[HASH][EXE])
 [ERROR] test failed, to rerun pass `-p b --lib`
-[RUNNING] unittests src/lib.rs (target/debug/build/c/[HASH]/out/c-[HASH][EXE])
-[RUNNING] unittests src/main.rs (target/debug/build/c/[HASH]/out/c-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/c-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/deps/c-[HASH][EXE])
 [ERROR] test failed, to rerun pass `-p c --bin c`
-[RUNNING] tests/t1.rs (target/debug/build/c/[HASH]/out/t1-[HASH][EXE])
+[RUNNING] tests/t1.rs (target/debug/deps/t1-[HASH][EXE])
 [ERROR] test failed, to rerun pass `-p c --test t1`
 [DOCTEST] a
 [DOCTEST] b
@@ -4363,12 +4363,12 @@ fn test_hint_workspace_virtual() {
         .with_stderr_data(str![[r#"
 [COMPILING] c v0.1.0 ([ROOT]/foo/c)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/c/[HASH]/out/c-[HASH][EXE])
-[RUNNING] unittests src/main.rs (target/debug/build/c/[HASH]/out/c-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/c-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/deps/c-[HASH][EXE])
 [ERROR] test failed, to rerun pass `-p c --bin c`
-[RUNNING] benches/b1.rs (target/debug/build/c/[HASH]/out/b1-[HASH][EXE])
+[RUNNING] benches/b1.rs (target/debug/deps/b1-[HASH][EXE])
 [ERROR] test failed, to rerun pass `-p c --bench b1`
-[RUNNING] unittests examples/ex1.rs (target/debug/build/c/[HASH]/out/ex1-[HASH][EXE])
+[RUNNING] unittests examples/ex1.rs (target/debug/examples/ex1-[HASH][EXE])
 [ERROR] test failed, to rerun pass `-p c --example ex1`
 [ERROR] 3 targets failed:
     `-p c --bin c`
@@ -4443,7 +4443,7 @@ fn json_artifact_includes_test_flag() {
             str![[r#"
 [
   {
-    "executable": "[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]",
+    "executable": "[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]",
     "features": [],
     "filenames": "{...}",
     "fresh": false,
@@ -4490,7 +4490,7 @@ fn json_artifact_includes_executable_for_library_tests() {
             str![[r#"
 [
   {
-    "executable": "[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]",
+    "executable": "[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]",
     "features": [],
     "filenames": "{...}",
     "fresh": false,
@@ -4580,7 +4580,7 @@ fn json_artifact_includes_executable_for_integration_tests() {
             str![[r#"
 [
   {
-    "executable": "[ROOT]/foo/target/debug/build/foo/[HASH]/out/integration_test-[HASH][EXE]",
+    "executable": "[ROOT]/foo/target/debug/deps/integration_test-[HASH][EXE]",
     "features": [],
     "filenames": "{...}",
     "fresh": false,
@@ -4676,7 +4676,7 @@ fn doctest_skip_staticlib() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
 
 "#]])
         .run();
@@ -4704,7 +4704,7 @@ pub fn foo() -> u8 { 1 }
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -4728,7 +4728,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
     p.cargo("test --lib")
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -4805,7 +4805,7 @@ fn test_all_targets_lib() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
 
 "#]])
         .run();
@@ -5476,11 +5476,11 @@ fn execution_error() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] tests/t1.rs (target/debug/build/foo/[HASH]/out/t1-[HASH][EXE])
+[RUNNING] tests/t1.rs (target/debug/deps/t1-[HASH][EXE])
 [ERROR] test failed, to rerun pass `--test t1`
 
 Caused by:
-  could not execute process `does_not_exist [ROOT]/foo/target/debug/build/foo/[HASH]/out/t1-[HASH][EXE]` (never executed)
+  could not execute process `does_not_exist [ROOT]/foo/target/debug/deps/t1-[HASH][EXE]` (never executed)
 
 Caused by:
   [NOT_FOUND]
@@ -5514,7 +5514,7 @@ fn nonzero_exit_status() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] tests/t1.rs (target/debug/build/foo/[HASH]/out/t1-[HASH][EXE])
+[RUNNING] tests/t1.rs (target/debug/deps/t1-[HASH][EXE])
 [ERROR] test failed, to rerun pass `--test t1`
 
 "#]])
@@ -5530,11 +5530,11 @@ this is a normal error
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] tests/t2.rs (target/debug/build/foo/[HASH]/out/t2-[HASH][EXE])
+[RUNNING] tests/t2.rs (target/debug/deps/t2-[HASH][EXE])
 [ERROR] test failed, to rerun pass `--test t2`
 
 Caused by:
-  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo/[HASH]/out/t2-[HASH][EXE]` ([EXIT_STATUS]: 4)
+  process didn't exit successfully: `[ROOT]/foo/target/debug/deps/t2-[HASH][EXE]` ([EXIT_STATUS]: 4)
 [NOTE] test exited abnormally; to see the full output pass --no-capture to the harness.
 
 "#]])
@@ -5544,11 +5544,11 @@ Caused by:
     p.cargo("test --test t2 -- --no-capture")
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] tests/t2.rs (target/debug/build/foo/[HASH]/out/t2-[HASH][EXE])
+[RUNNING] tests/t2.rs (target/debug/deps/t2-[HASH][EXE])
 [ERROR] test failed, to rerun pass `--test t2`
 
 Caused by:
-  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo/[HASH]/out/t2-[HASH][EXE] --no-capture` ([EXIT_STATUS]: 4)
+  process didn't exit successfully: `[ROOT]/foo/target/debug/deps/t2-[HASH][EXE] --no-capture` ([EXIT_STATUS]: 4)
 
 "#]])
         .with_status(4)
@@ -5558,13 +5558,13 @@ Caused by:
     p.cargo("test --no-fail-fast")
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] tests/t1.rs (target/debug/build/foo/[HASH]/out/t1-[HASH][EXE])
+[RUNNING] tests/t1.rs (target/debug/deps/t1-[HASH][EXE])
 [ERROR] test failed, to rerun pass `--test t1`
-[RUNNING] tests/t2.rs (target/debug/build/foo/[HASH]/out/t2-[HASH][EXE])
+[RUNNING] tests/t2.rs (target/debug/deps/t2-[HASH][EXE])
 [ERROR] test failed, to rerun pass `--test t2`
 
 Caused by:
-  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo/[HASH]/out/t2-[HASH][EXE]` ([EXIT_STATUS]: 4)
+  process didn't exit successfully: `[ROOT]/foo/target/debug/deps/t2-[HASH][EXE]` ([EXIT_STATUS]: 4)
 [NOTE] test exited abnormally; to see the full output pass --no-capture to the harness.
 [ERROR] 2 targets failed:
     `--test t1`
@@ -5582,7 +5582,7 @@ Caused by:
 [..]thread [..]panicked [..] tests/t1.rs[..]
 [NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 Caused by:
-  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo/[HASH]/out/t2-[HASH][EXE] --no-capture` ([EXIT_STATUS]: 4)
+  process didn't exit successfully: `[ROOT]/foo/target/debug/deps/t2-[HASH][EXE] --no-capture` ([EXIT_STATUS]: 4)
 ...
 "#]].unordered())
         .with_status(101)
@@ -5601,7 +5601,7 @@ fn cargo_test_print_env_verbose() {
 [RUNNING] `[..]CARGO_MANIFEST_DIR=[ROOT]/foo[..] rustc --crate-name foo[..]`
 [RUNNING] `[..]CARGO_MANIFEST_DIR=[ROOT]/foo[..] rustc --crate-name foo[..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[..]CARGO_MANIFEST_DIR=[ROOT]/foo[..] [ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[RUNNING] `[..]CARGO_MANIFEST_DIR=[ROOT]/foo[..] [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
 [DOCTEST] foo
 [RUNNING] `[..]CARGO_MANIFEST_DIR=[ROOT]/foo[..] rustdoc --edition=2015 --crate-type lib --color auto --crate-name foo[..]`
 

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -230,7 +230,7 @@ fn custom_runner() {
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `nonexistent-runner -r [ROOT]/foo/target/debug/build/foo/[HASH]/out/test-[HASH][EXE] --param`
+[RUNNING] `nonexistent-runner -r [ROOT]/foo/target/debug/deps/test-[HASH][EXE] --param`
 ...
 "#]])
         .run();
@@ -242,7 +242,7 @@ fn custom_runner() {
 [RUNNING] `rustc [..]`
 [RUNNING] `rustc [..]`
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `nonexistent-runner -r [ROOT]/foo/target/release/build/foo/[HASH]/out/bench-[HASH][EXE] --param --bench`
+[RUNNING] `nonexistent-runner -r [ROOT]/foo/target/release/deps/bench-[HASH][EXE] --param --bench`
 ...
 "#]])
         .run();


### PR DESCRIPTION

### What does this PR try to resolve?

This PR reverts the final stabilization commit (668039de97e189dbe3ca0a9b1085089c394cd636) in https://github.com/rust-lang/cargo/pull/16807.

At today's Cargo meeting, we discussed the recent bug reports (notably #17183) from the new `build-dir` landing on nightly. 
We felt it would be safer to revert so that are not on a shot clock to fix the issues.


### How to test and review this PR?

no response

r? @epage 
