### PR TITLE
docs(report): add missing entry for `cargo report future-incompatibilities`

### DIFF
--- a/src/doc/src/commands/report-commands.md
+++ b/src/doc/src/commands/report-commands.md
@@ -1,3 +1,4 @@
 # Report Commands
 
 * [cargo report](cargo-report.md)
+* [cargo report future-incompatibilities](cargo-report-future-incompatibilities.md)


### PR DESCRIPTION
### What does this PR try to resolve?

An entry for `cargo report future-incompatibilities` was missing on the "Report Commands" page.
See also https://github.com/rust-lang/cargo/pull/16430#discussion_r3545361302
