### PR TITLE
Enable cargo:libsecret on all Unix platforms except macOS and mobile

### DIFF
--- a/credential/cargo-credential-libsecret/README.md
+++ b/credential/cargo-credential-libsecret/README.md
@@ -5,9 +5,9 @@ See the [credential-provider] documentation for how to use this.
 
 This credential provider is built-in to cargo as `cargo:libsecret`.
 
-It is available on Unix-like platforms such as Linux and the BSDs — except
-macOS, which uses its OS-specific keyring via the `cargo:macos-keychain`
-provider instead, and mobile platforms, where libsecret does not exist.
+It is available on Unix-like platforms such as Linux and the BSDs.
+Apple and mobile platforms either use their OS-specific keyring,
+or libsecret doesn't exist there.
 
 > This crate is maintained by the Cargo team, primarily for use by Cargo
 > and not intended for external use (except as a transitive dependency). This

--- a/credential/cargo-credential-libsecret/README.md
+++ b/credential/cargo-credential-libsecret/README.md
@@ -5,6 +5,10 @@ See the [credential-provider] documentation for how to use this.
 
 This credential provider is built-in to cargo as `cargo:libsecret`.
 
+It is available on Unix-like platforms such as Linux and the BSDs — except
+macOS, which uses its OS-specific keyring via the `cargo:macos-keychain`
+provider instead, and mobile platforms, where libsecret does not exist.
+
 > This crate is maintained by the Cargo team, primarily for use by Cargo
 > and not intended for external use (except as a transitive dependency). This
 > crate may make major changes to its APIs or be deprecated without warning.

--- a/credential/cargo-credential-libsecret/src/lib.rs
+++ b/credential/cargo-credential-libsecret/src/lib.rs
@@ -2,7 +2,17 @@
 //! > and not intended for external use (except as a transitive dependency). This
 //! > crate may make major changes to its APIs or be deprecated without warning.
 
-#[cfg(target_os = "linux")]
+#[cfg(all(
+    unix,
+    not(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "visionos",
+        target_os = "android"
+    ))
+))]
 mod linux {
     //! Implementation of the libsecret credential helper.
 
@@ -259,7 +269,27 @@ mod linux {
     }
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(all(
+    unix,
+    not(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "visionos",
+        target_os = "android"
+    ))
+)))]
 pub use cargo_credential::UnsupportedCredential as LibSecretCredential;
-#[cfg(target_os = "linux")]
+#[cfg(all(
+    unix,
+    not(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "visionos",
+        target_os = "android"
+    ))
+))]
 pub use linux::LibSecretCredential;

--- a/doc/book/src/reference/registry-authentication.md
+++ b/doc/book/src/reference/registry-authentication.md
@@ -55,12 +55,10 @@ The Keychain Access app can be used to view stored tokens.
 ### `cargo:libsecret`
 Uses [libsecret](https://wiki.gnome.org/Projects/Libsecret) to store tokens.
 
-This provider is available on Unix-like platforms, including Linux and the
-BSDs — except macOS, which uses its OS-specific keyring via
-[`cargo:macos-keychain`](#cargomacos-keychain), and mobile platforms (iOS,
-Android, and similar), where libsecret does not exist. The `libsecret` library
-is loaded at runtime, so it only needs to be installed when this provider is
-used.
+It is available on Unix-like platforms such as Linux and the BSDs.
+Apple and mobile platforms either use their OS-specific keyring,
+or libsecret doesn't exist there. The `libsecret` library is loaded at
+runtime, so it only needs to be installed when this provider is used.
 
 Any password manager with libsecret support can be used to view stored tokens.
 The following are a few examples (non-exhaustive):

--- a/doc/book/src/reference/registry-authentication.md
+++ b/doc/book/src/reference/registry-authentication.md
@@ -55,6 +55,13 @@ The Keychain Access app can be used to view stored tokens.
 ### `cargo:libsecret`
 Uses [libsecret](https://wiki.gnome.org/Projects/Libsecret) to store tokens.
 
+This provider is available on Unix-like platforms, including Linux and the
+BSDs — except macOS, which uses its OS-specific keyring via
+[`cargo:macos-keychain`](#cargomacos-keychain), and mobile platforms (iOS,
+Android, and similar), where libsecret does not exist. The `libsecret` library
+is loaded at runtime, so it only needs to be installed when this provider is
+used.
+
 Any password manager with libsecret support can be used to view stored tokens.
 The following are a few examples (non-exhaustive):
 

--- a/src/util/auth/mod.rs
+++ b/src/util/auth/mod.rs
@@ -480,7 +480,17 @@ static BUILT_IN_PROVIDERS: &[&'static str] = &[
 
 /// Retrieves a cached instance of `LibSecretCredential`.
 /// Must be cached to avoid repeated load/unload cycles, which are not supported by `glib`.
-#[cfg(target_os = "linux")]
+#[cfg(all(
+    unix,
+    not(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "visionos",
+        target_os = "android"
+    ))
+))]
 fn get_credential_libsecret()
 -> CargoResult<&'static cargo_credential_libsecret::LibSecretCredential> {
     static CARGO_CREDENTIAL_LIBSECRET: std::sync::OnceLock<
@@ -535,7 +545,17 @@ fn credential_action(
             "cargo:wincred" => Box::new(cargo_credential_wincred::WindowsCredential {}),
             #[cfg(target_os = "macos")]
             "cargo:macos-keychain" => Box::new(cargo_credential_macos_keychain::MacKeychain {}),
-            #[cfg(target_os = "linux")]
+            #[cfg(all(
+                unix,
+                not(any(
+                    target_os = "macos",
+                    target_os = "ios",
+                    target_os = "tvos",
+                    target_os = "watchos",
+                    target_os = "visionos",
+                    target_os = "android"
+                ))
+            ))]
             "cargo:libsecret" => Box::new(get_credential_libsecret()?),
             name if BUILT_IN_PROVIDERS.contains(&name) => {
                 Box::new(cargo_credential::UnsupportedCredential {})


### PR DESCRIPTION
### What does this PR try to resolve?

The `cargo:libsecret` built-in credential provider is currently gated on `target_os = "linux"`, with every other platform receiving an `UnsupportedCredential` stub. That gate is an artificial restriction rather than a technical one: libsecret and Secret Service implementations (gnome-keyring, KWallet) are packaged on FreeBSD, OpenBSD, and NetBSD, the provider loads `libsecret-1.so.0` dynamically at runtime via `libloading` (which supports these platforms), and no code inside the provider is Linux-specific. As a result, BSD users have no built-in secure token storage option at all.

This PR widens the cfg gate at all five sites (three in `cargo-credential-libsecret`, two in `src/cargo/util/auth/mod.rs`) to:

```rust
all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos", target_os = "android")))
```

macOS keeps its OS-specific `cargo:macos-keychain` provider, and the mobile Unix targets are excluded since libsecret does not exist there. Platform availability is now documented in `registry-authentication.md` and the crate README.

This is pre-work for the in-progress **RFC 3981: Store registry tokens in the OS credential store by default** (rust-lang/rfcs#3981). That RFC proposes flipping secure token storage from opt-in to the default and calls out the BSD gap in Cargo's built-in providers as an adoption blocker; this change closes that gap independently of the RFC's outcome. Since `cargo:libsecret` is never in the default provider list, nothing changes for users who haven't explicitly configured it.

### How to test and review this PR?

The diff is a mechanical cfg widening plus docs — the Linux behavior is unchanged (the new predicate is true exactly where the old one was, plus the newly enabled targets).

Tested on a FreeBSD 15.1-RELEASE amd64 VM with `libsecret` and `gnome-keyring` over a D-Bus session bus, using a small harness that drives the `Credential` trait implementation directly:

- `LibSecretCredential::new()` loads `libsecret-1.so.0` via dlopen
- `Login` stores the token in the Secret Service
- `Get` retrieves a matching token
- `Logout` removes it, and a subsequent `Get` correctly returns `Error::NotFound`

On Linux (x86_64-unknown-linux-gnu): `cargo check -p cargo`, `cargo check -p cargo-credential-libsecret`, and `cargo fmt --check` pass.

One reviewer question worth settling: on the newly enabled platforms (as on Linux today), a libsecret load failure in `get_credential_libsecret()` propagates out of `credential_action` rather than falling through to the next provider in a configured list, unlike the `UrlNotSupported` the stub used to return at `perform()` time. This is pre-existing chain semantics extended to more platforms — happy to adjust if fall-through on construction failure is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)