### PR TITLE
fix: dont apply host-config gating to stable behavior

### DIFF
--- a/src/cargo/core/compiler/build_context/mod.rs
+++ b/src/cargo/core/compiler/build_context/mod.rs
@@ -21,7 +21,6 @@ pub use self::target_info::FileFlavor;
 pub use self::target_info::FileType;
 pub use self::target_info::RustcTargetData;
 pub use self::target_info::TargetInfo;
-pub(crate) use self::target_info::host_artifact_uses_only_host_config;
 
 /// The build context, containing complete information needed for a build task
 /// before it gets started.

--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -909,7 +909,7 @@ fn rustflags_from_build(gctx: &GlobalContext, flag: Flags) -> CargoResult<Option
 }
 
 /// Whether a host artifact must take its configuration solely from `[host]` and ignore `[target]`.
-pub(crate) fn host_artifact_uses_only_host_config(
+fn host_artifact_uses_only_host_config(
     gctx: &GlobalContext,
     requested_kinds: &[CompileKind],
     kind: CompileKind,

--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -14,7 +14,6 @@ use crate::core::compiler::BuildContext;
 use crate::core::compiler::CompileTarget;
 use crate::core::compiler::RustdocFingerprint;
 use crate::core::compiler::apply_env_config;
-use crate::core::compiler::build_context::host_artifact_uses_only_host_config;
 use crate::core::compiler::{CompileKind, Unit, UnitHash};
 use crate::util::{CargoResult, GlobalContext};
 
@@ -509,8 +508,10 @@ fn target_runner(
         return Ok(Some((path, runner.val.args.clone())));
     }
 
-    // Host artifacts should not pick up a runner from `[target.'cfg(...)']`.
-    if host_artifact_uses_only_host_config(bcx.gctx, &bcx.build_config.requested_kinds, kind)? {
+    // With `target-applies-to-host = true`,
+    // host artifacts must fall through to pick up from [target]
+    // since this is the stable behavior
+    if kind.is_host() && !bcx.gctx.target_applies_to_host()? {
         return Ok(None);
     }
 
@@ -555,8 +556,10 @@ fn target_linker(bcx: &BuildContext<'_, '_>, kind: CompileKind) -> CargoResult<O
         return Ok(Some(path));
     }
 
-    // Host artifacts should not pick up a linker from `[target.'cfg(...)']`.
-    if host_artifact_uses_only_host_config(bcx.gctx, &bcx.build_config.requested_kinds, kind)? {
+    // With `target-applies-to-host = true`,
+    // host artifacts must fall through to pick up from [target]
+    // since this is the stable behavior
+    if kind.is_host() && !bcx.gctx.target_applies_to_host()? {
         return Ok(None);
     }
 

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -1172,13 +1172,12 @@ fn target_cfg_linker_build_script_with_target() {
 
     p.cargo("build -v --target")
         .arg(&target)
+        .with_status(101)
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name build_script_build [..]--crate-type bin [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
-[RUNNING] `rustc --crate-name foo [..]-C linker=[..]/path/to/cfg/linker [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-
+[RUNNING] `rustc --crate-name build_script_build [..]--crate-type bin [..]-C linker=[..]/path/to/cfg/linker [..]`
+[ERROR] linker `[..]/path/to/cfg/linker` not found
+...
 "#]])
         .run();
 }

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -1039,6 +1039,98 @@ fn target_runner_does_not_apply_to_build_script() {
 }
 
 #[cargo_test]
+fn target_runner_build_script_with_target() {
+    let target = rustc_host();
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            &format!(
+                r#"
+                [target.{target}]
+                runner = "nonexistent-runner"
+                [target.'cfg(all())']
+                runner = "nonexistent-cfg-runner"
+                "#,
+            ),
+        )
+        .file("build.rs", "fn main() {}")
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check -v --target")
+        .arg(&target)
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name build_script_build [..]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `rustc --crate-name foo [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn target_cfg_runner_build_script_with_host_config_and_target() {
+    let target = rustc_host();
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [target.'cfg(all())']
+            runner = "nonexistent-cfg-runner"
+            "#,
+        )
+        .file("build.rs", "fn main() {}")
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check -v -Ztarget-applies-to-host -Zhost-config --target")
+        .arg(&target)
+        .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name build_script_build [..]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `rustc --crate-name foo [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn host_runner_build_script_without_target() {
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [host]
+            runner = "nonexistent-host-runner"
+            "#,
+        )
+        .file("build.rs", "fn main() {}")
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check -Ztarget-applies-to-host -Zhost-config")
+        .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[ERROR] failed to run custom build command for `foo v0.0.1 ([ROOT]/foo)`
+
+Caused by:
+  could not execute process `nonexistent-host-runner [ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build` (never executed)
+
+Caused by:
+  [NOT_FOUND]
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn custom_build_script_wrong_rustc_flags() {
     let p = project()
         .file(

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -1131,6 +1131,117 @@ Caused by:
 }
 
 #[cargo_test]
+fn target_cfg_linker_build_script() {
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [target.'cfg(all())']
+            linker = "/path/to/cfg/linker"
+            "#,
+        )
+        .file("build.rs", "fn main() {}")
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("build -v")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name build_script_build [..]--crate-type bin [..]-C linker=[..]/path/to/cfg/linker [..]`
+[ERROR] linker `[..]/path/to/cfg/linker` not found
+...
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn target_cfg_linker_build_script_with_target() {
+    let target = rustc_host();
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [target.'cfg(all())']
+            linker = "/path/to/cfg/linker"
+            "#,
+        )
+        .file("build.rs", "fn main() {}")
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("build -v --target")
+        .arg(&target)
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name build_script_build [..]--crate-type bin [..]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `rustc --crate-name foo [..]-C linker=[..]/path/to/cfg/linker [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn target_linker_build_script_with_target() {
+    let target = rustc_host();
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            &format!(
+                r#"
+                [target.{target}]
+                linker = "/path/to/target/linker"
+                "#,
+            ),
+        )
+        .file("build.rs", "fn main() {}")
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("build -v --target")
+        .arg(&target)
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name build_script_build [..]--crate-type bin [..]-C linker=[..]/path/to/target/linker [..]`
+[ERROR] linker `[..]/path/to/target/linker` not found
+...
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn target_cfg_linker_build_script_with_host_config_and_target() {
+    let target = rustc_host();
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [target.'cfg(all())']
+            linker = "/path/to/cfg/linker"
+            "#,
+        )
+        .file("build.rs", "fn main() {}")
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("build -v -Ztarget-applies-to-host -Zhost-config --target")
+        .arg(&target)
+        .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name build_script_build [..]--crate-type bin [..]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `rustc --crate-name foo [..]-C linker=[..]/path/to/cfg/linker [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn custom_build_script_wrong_rustc_flags() {
     let p = project()
         .file(

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -549,15 +549,18 @@ fn custom_runner_cfg_proc_macro_test_with_target() {
 
     p.cargo("test --lib -v --target")
         .arg(&target)
+        .with_status(101)
         .with_stderr_data(str![[r#"
 ...
-[RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[RUNNING] `nonexistent-runner -r [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[ERROR] test failed, to rerun pass `--lib`
 
-"#]])
-        .with_stdout_data(str![[r#"
-...
-running 1 test
-...
+Caused by:
+  could not execute process `nonexistent-runner -r [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]` (never executed)
+
+Caused by:
+  [NOT_FOUND]
+
 "#]])
         .run();
 }
@@ -793,11 +796,12 @@ fn target_cfg_linker_proc_macro_with_target() {
 
     p.cargo("build -v --target")
         .arg(&target)
+        .with_status(101)
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo [..]--crate-type proc-macro [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-
+[RUNNING] `rustc --crate-name foo [..]--crate-type proc-macro [..]-C linker=[..]/path/to/cfg/linker [..]`
+[ERROR] linker `[..]/path/to/cfg/linker` not found
+...
 "#]])
         .run();
 }
@@ -918,16 +922,11 @@ fn target_cfg_linker_proc_macro_test_with_target() {
 
     p.cargo("test --lib -v --target")
         .arg(&target)
+        .with_status(101)
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo [..]--test [..]`
-[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
-
-"#]])
-        .with_stdout_data(str![[r#"
-...
-running 1 test
+[RUNNING] `rustc --crate-name foo [..]--test [..]-C linker=[..]/path/to/cfg/linker [..]`
+[ERROR] linker `[..]/path/to/cfg/linker` not found
 ...
 "#]])
         .run();

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -1,7 +1,9 @@
 //! Tests for configuration values that point to programs.
 
 use crate::prelude::*;
-use cargo_test_support::{basic_lib_manifest, project, rustc_host, rustc_host_env, str};
+use crate::utils::cross_compile::disabled as cross_compile_disabled;
+use cargo_test_support::cross_compile::alternate as cross_compile_alternate;
+use cargo_test_support::{Project, basic_lib_manifest, project, rustc_host, rustc_host_env, str};
 
 #[cargo_test]
 fn pathless_tools() {
@@ -443,6 +445,341 @@ Caused by:
 }
 
 #[cargo_test]
+fn custom_runner_proc_macro_test() {
+    let target = rustc_host();
+    let p = proc_macro_package();
+    p.change_file(
+        ".cargo/config.toml",
+        &format!(
+            r#"
+            [target.{target}]
+            runner = "nonexistent-runner -r"
+        "#,
+        ),
+    );
+
+    p.cargo("test --lib -v")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+...
+[RUNNING] `nonexistent-runner -r [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[ERROR] test failed, to rerun pass `--lib`
+
+Caused by:
+  could not execute process `nonexistent-runner -r [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]` (never executed)
+
+Caused by:
+  [NOT_FOUND]
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn custom_runner_cfg_proc_macro_test() {
+    let p = proc_macro_package();
+    p.change_file(
+        ".cargo/config.toml",
+        r#"
+            [target.'cfg(all())']
+            runner = "nonexistent-runner -r"
+        "#,
+    );
+
+    p.cargo("test --lib -v")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+...
+[RUNNING] `nonexistent-runner -r [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[ERROR] test failed, to rerun pass `--lib`
+
+Caused by:
+  could not execute process `nonexistent-runner -r [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]` (never executed)
+
+Caused by:
+  [NOT_FOUND]
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn custom_runner_proc_macro_test_with_target() {
+    let target = rustc_host();
+    let p = proc_macro_package();
+    p.change_file(
+        ".cargo/config.toml",
+        &format!(
+            r#"
+            [target.{target}]
+            runner = "nonexistent-runner -r"
+        "#,
+        ),
+    );
+
+    p.cargo("test --lib -v --target")
+        .arg(&target)
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+...
+[RUNNING] `nonexistent-runner -r [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[ERROR] test failed, to rerun pass `--lib`
+
+Caused by:
+  could not execute process `nonexistent-runner -r [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]` (never executed)
+
+Caused by:
+  [NOT_FOUND]
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn custom_runner_cfg_proc_macro_test_with_target() {
+    let target = rustc_host();
+    let p = proc_macro_package();
+    p.change_file(
+        ".cargo/config.toml",
+        r#"
+            [target.'cfg(all())']
+            runner = "nonexistent-runner -r"
+        "#,
+    );
+
+    p.cargo("test --lib -v --target")
+        .arg(&target)
+        .with_stderr_data(str![[r#"
+...
+[RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+
+"#]])
+        .with_stdout_data(str![[r#"
+...
+running 1 test
+...
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn custom_runner_proc_macro_test_with_host_config() {
+    let target = rustc_host();
+    let p = proc_macro_package();
+    p.change_file(
+        ".cargo/config.toml",
+        &format!(
+            r#"
+            [host]
+            runner = "nonexistent-host-runner"
+            [target.{target}]
+            runner = "nonexistent-target-runner"
+        "#,
+        ),
+    );
+
+    p.cargo("test --lib -v -Ztarget-applies-to-host -Zhost-config --target")
+        .arg(&target)
+        .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+...
+[RUNNING] `nonexistent-target-runner [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[ERROR] test failed, to rerun pass `--lib`
+
+Caused by:
+  could not execute process `nonexistent-target-runner [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]` (never executed)
+
+Caused by:
+  [NOT_FOUND]
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn custom_runner_cfg_proc_macro_test_with_host_config() {
+    let target = rustc_host();
+    let p = proc_macro_package();
+    p.change_file(
+        ".cargo/config.toml",
+        r#"
+            [host]
+            runner = "nonexistent-host-runner"
+            [target.'cfg(all())']
+            runner = "nonexistent-cfg-runner"
+        "#,
+    );
+
+    p.cargo("test --lib -v -Ztarget-applies-to-host -Zhost-config --target")
+        .arg(&target)
+        .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+...
+[RUNNING] `nonexistent-cfg-runner [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[ERROR] test failed, to rerun pass `--lib`
+
+Caused by:
+  could not execute process `nonexistent-cfg-runner [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]` (never executed)
+
+Caused by:
+  [NOT_FOUND]
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn custom_runner_cfg_proc_macro_test_with_host_config_no_target() {
+    let p = proc_macro_package();
+    p.change_file(
+        ".cargo/config.toml",
+        r#"
+            [host]
+            runner = "nonexistent-host-runner"
+            [target.'cfg(all())']
+            runner = "nonexistent-cfg-runner"
+        "#,
+    );
+
+    p.cargo("test --lib -v -Ztarget-applies-to-host -Zhost-config")
+        .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+...
+[RUNNING] `nonexistent-cfg-runner [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[ERROR] test failed, to rerun pass `--lib`
+
+Caused by:
+  could not execute process `nonexistent-cfg-runner [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]` (never executed)
+
+Caused by:
+  [NOT_FOUND]
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn host_runner_proc_macro_test() {
+    let target = rustc_host();
+    let p = proc_macro_package();
+    p.change_file(
+        ".cargo/config.toml",
+        r#"
+            [host]
+            runner = "nonexistent-host-runner"
+        "#,
+    );
+
+    p.cargo("test --lib -v -Ztarget-applies-to-host -Zhost-config --target")
+        .arg(&target)
+        .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
+        .with_stderr_data(str![[r#"
+...
+[RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+
+"#]])
+        .with_stdout_data(str![[r#"
+...
+running 1 test
+...
+"#]])
+        .run();
+
+    p.cargo("test --lib -v -Ztarget-applies-to-host -Zhost-config")
+        .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
+        .with_stderr_data(str![[r#"
+...
+[RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+
+"#]])
+        .with_stdout_data(str![[r#"
+...
+running 1 test
+...
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn custom_runner_proc_macro_test_with_cross_target() {
+    if cross_compile_disabled() {
+        return;
+    }
+    let target = rustc_host();
+    let alternate = cross_compile_alternate();
+    let p = proc_macro_package();
+    p.change_file(
+        ".cargo/config.toml",
+        &format!(
+            r#"
+            [target.{target}]
+            runner = "nonexistent-runner -r"
+            [target.'cfg(all())']
+            runner = "nonexistent-cfg-runner"
+        "#,
+        ),
+    );
+
+    p.cargo("test --lib -v --target")
+        .arg(alternate)
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+...
+[RUNNING] `nonexistent-runner -r [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[ERROR] test failed, to rerun pass `--lib`
+
+Caused by:
+  could not execute process `nonexistent-runner -r [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]` (never executed)
+
+Caused by:
+  [NOT_FOUND]
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn custom_runner_proc_macro_test_with_cross_target_host_config() {
+    if cross_compile_disabled() {
+        return;
+    }
+    let target = rustc_host();
+    let alternate = cross_compile_alternate();
+    let p = proc_macro_package();
+    p.change_file(
+        ".cargo/config.toml",
+        &format!(
+            r#"
+            [host]
+            runner = "nonexistent-host-runner"
+            [target.{target}]
+            runner = "nonexistent-runner -r"
+            [target.'cfg(all())']
+            runner = "nonexistent-cfg-runner"
+        "#,
+        ),
+    );
+
+    p.cargo("test --lib -v -Ztarget-applies-to-host -Zhost-config --target")
+        .arg(alternate)
+        .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
+        .with_stderr_data(str![[r#"
+...
+[RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+
+"#]])
+        .with_stdout_data(str![[r#"
+...
+running 1 test
+...
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn custom_linker_env() {
     let p = project().file("src/main.rs", "fn main() {}").build();
 
@@ -518,4 +855,23 @@ fn cfg_ignored_fields() {
 
 "#]])
         .run();
+}
+
+/// Creates a bare proc-macro package with a unit test.
+fn proc_macro_package() -> Project {
+    project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                edition = "2015"
+
+                [lib]
+                proc-macro = true
+            "#,
+        )
+        .file("src/lib.rs", "#[test] fn it_works() {}")
+        .build()
 }

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -780,6 +780,281 @@ running 1 test
 }
 
 #[cargo_test]
+fn target_cfg_linker_proc_macro_with_target() {
+    let target = rustc_host();
+    let p = proc_macro_package();
+    p.change_file(
+        ".cargo/config.toml",
+        r#"
+            [target.'cfg(all())']
+            linker = "/path/to/cfg/linker"
+        "#,
+    );
+
+    p.cargo("build -v --target")
+        .arg(&target)
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.0 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]--crate-type proc-macro [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn host_linker_proc_macro() {
+    let target = rustc_host();
+    let p = proc_macro_package();
+    p.change_file(
+        ".cargo/config.toml",
+        &format!(
+            r#"
+            [host]
+            linker = "/path/to/host/linker"
+            [target.{target}]
+            linker = "/path/to/target/linker"
+        "#,
+        ),
+    );
+
+    p.cargo("build -v -Ztarget-applies-to-host -Zhost-config --target")
+        .arg(&target)
+        .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.0 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]--crate-type proc-macro [..]-C linker=[..]/path/to/host/linker [..]`
+[ERROR] linker `[..]/path/to/host/linker` not found
+...
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn target_linker_proc_macro_test() {
+    let target = rustc_host();
+    let p = proc_macro_package();
+    p.change_file(
+        ".cargo/config.toml",
+        &format!(
+            r#"
+            [target.{target}]
+            linker = "/path/to/target/linker"
+        "#,
+        ),
+    );
+
+    p.cargo("test --lib -v")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.0 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]--test [..]-C linker=[..]/path/to/target/linker [..]`
+[ERROR] linker `[..]/path/to/target/linker` not found
+...
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn target_cfg_linker_proc_macro_test() {
+    let p = proc_macro_package();
+    p.change_file(
+        ".cargo/config.toml",
+        r#"
+            [target.'cfg(all())']
+            linker = "/path/to/cfg/linker"
+        "#,
+    );
+
+    p.cargo("test --lib -v")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.0 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]--test [..]-C linker=[..]/path/to/cfg/linker [..]`
+[ERROR] linker `[..]/path/to/cfg/linker` not found
+...
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn target_linker_proc_macro_test_with_target() {
+    let target = rustc_host();
+    let p = proc_macro_package();
+    p.change_file(
+        ".cargo/config.toml",
+        &format!(
+            r#"
+            [target.{target}]
+            linker = "/path/to/target/linker"
+        "#,
+        ),
+    );
+
+    p.cargo("test --lib -v --target")
+        .arg(&target)
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.0 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]--test [..]-C linker=[..]/path/to/target/linker [..]`
+[ERROR] linker `[..]/path/to/target/linker` not found
+...
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn target_cfg_linker_proc_macro_test_with_target() {
+    let target = rustc_host();
+    let p = proc_macro_package();
+    p.change_file(
+        ".cargo/config.toml",
+        r#"
+            [target.'cfg(all())']
+            linker = "/path/to/cfg/linker"
+        "#,
+    );
+
+    p.cargo("test --lib -v --target")
+        .arg(&target)
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.0 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]--test [..]`
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+
+"#]])
+        .with_stdout_data(str![[r#"
+...
+running 1 test
+...
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn host_linker_proc_macro_test() {
+    let target = rustc_host();
+    let p = proc_macro_package();
+    p.change_file(
+        ".cargo/config.toml",
+        &format!(
+            r#"
+            [host]
+            linker = "/path/to/host/linker"
+            [target.{target}]
+            linker = "/path/to/target/linker"
+        "#,
+        ),
+    );
+
+    p.cargo("test --lib -v -Ztarget-applies-to-host -Zhost-config --target")
+        .arg(&target)
+        .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.0 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]--test [..]-C linker=[..]/path/to/host/linker [..]`
+[ERROR] linker `[..]/path/to/host/linker` not found
+...
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn target_cfg_linker_proc_macro_test_with_host_config() {
+    let target = rustc_host();
+    let p = proc_macro_package();
+    p.change_file(
+        ".cargo/config.toml",
+        r#"
+            [host]
+            linker = "/path/to/host/linker"
+            [target.'cfg(all())']
+            linker = "/path/to/cfg/linker"
+        "#,
+    );
+
+    p.cargo("test --lib -v -Ztarget-applies-to-host -Zhost-config --target")
+        .arg(&target)
+        .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.0 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]--test [..]-C linker=[..]/path/to/host/linker [..]`
+[ERROR] linker `[..]/path/to/host/linker` not found
+...
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn target_linker_proc_macro_test_with_cross_target() {
+    if cross_compile_disabled() {
+        return;
+    }
+    let target = rustc_host();
+    let alternate = cross_compile_alternate();
+    let p = proc_macro_package();
+    p.change_file(
+        ".cargo/config.toml",
+        &format!(
+            r#"
+            [target.{target}]
+            linker = "/path/to/target/linker"
+        "#,
+        ),
+    );
+
+    p.cargo("test --lib -v --target")
+        .arg(alternate)
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.0 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]--test [..]-C linker=[..]/path/to/target/linker [..]`
+[ERROR] linker `[..]/path/to/target/linker` not found
+...
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn target_linker_proc_macro_test_with_cross_target_host_config() {
+    if cross_compile_disabled() {
+        return;
+    }
+    let target = rustc_host();
+    let alternate = cross_compile_alternate();
+    let p = proc_macro_package();
+    p.change_file(
+        ".cargo/config.toml",
+        &format!(
+            r#"
+            [host]
+            linker = "/path/to/host/linker"
+            [target.{target}]
+            linker = "/path/to/target/linker"
+            [target.'cfg(all())']
+            linker = "/path/to/cfg/linker"
+        "#,
+        ),
+    );
+
+    p.cargo("test --lib -v -Ztarget-applies-to-host -Zhost-config --target")
+        .arg(alternate)
+        .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.0 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]--test [..]-C linker=[..]/path/to/host/linker [..]`
+[ERROR] linker `[..]/path/to/host/linker` not found
+...
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn custom_linker_env() {
     let p = project().file("src/main.rs", "fn main() {}").build();
 


### PR DESCRIPTION
### What does this PR try to resolve?

Related: #17200 

rust-lang/cargo#17123 made host artifacts stop picking up
`target.cfg(…).runner` and `target.cfg(…).linker`
even without `-Zhost-config`.
That silently changed stable behavior that
`target.cfg` no longer applied to proc-macro
and build script compilation under `--target <host>`,
while `target.<triple>` config still did.

The old gate reused `host_artifact_uses_only_host_config`,
which is for the documented rustflags dual behavior.
It wasn't for runner and linker.

This PR narrows the gate to `target-applies-to-host = false`
and restore to pre-#17123 stable behavior,
while keeping `-Zhost-config` fix as it is still nightly.

### How to test and review this PR?

I've added a lot of tests because I don't want to miss any edge cases again.

Here is the change table.

| test | 1.97 | 1.98-beta (rust-lang/cargo#17123) | this PR (rust-lang/cargo#17198) |
|---|---|---|---|
| `custom_runner_cfg_proc_macro_test_with_target` | applies | not | _applies_ |
| `target_cfg_linker_build_script_with_target` | applies | not | _applies_ |
| `target_cfg_linker_proc_macro_with_target` | applies | not | _applies_ |
| `target_cfg_linker_proc_macro_test_with_target` | applies | not | _applies_ |
| `target_cfg_runner_build_script_with_host_config_and_target` | applies | not | not |
| `target_cfg_linker_build_script_with_host_config_and_target` | applies | not | not |

All other added tests behave identically across 1.97, 1.98-beta, and this PR.
See rust-lang/cargo#17200 for the runner/linker inconsistency they document.


### Note

We'll need to backport this to 1.98-beta once it lands.


