### PR TITLE
Fix manifest schema generation: `TomlDebugInfo` enum-variants doesn't renamed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util-schemas"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "jiff",
  "schemars",

--- a/crates/cargo-util-schemas/Cargo.toml
+++ b/crates/cargo-util-schemas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-util-schemas"
-version = "0.14.2"
+version = "0.14.3"
 rust-version = "1.96"  # MSRV:1
 edition.workspace = true
 license.workspace = true

--- a/crates/cargo-util-schemas/manifest.schema.json
+++ b/crates/cargo-util-schemas/manifest.schema.json
@@ -1444,13 +1444,18 @@
       "type": "string"
     },
     "TomlDebugInfo": {
-      "type": "string",
+      "type": ["string", "integer", "boolean"],
       "enum": [
-        "None",
-        "LineDirectivesOnly",
-        "LineTablesOnly",
-        "Limited",
-        "Full"
+        "none",
+        "line-directives-only",
+        "line-tables-only",
+        "limited",
+        "full",
+        0,
+        1,
+        2,
+        false,
+        true
       ]
     },
     "PackageIdSpec": {

--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -1122,12 +1122,38 @@ impl<'de> de::Deserialize<'de> for TomlOptLevel {
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "unstable-schema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "unstable-schema", schemars(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "unstable-schema", schemars(transform = Self::schema_add_aliases))]
 pub enum TomlDebugInfo {
     None,
     LineDirectivesOnly,
     LineTablesOnly,
     Limited,
     Full,
+}
+
+#[cfg(feature = "unstable-schema")]
+impl TomlDebugInfo {
+    fn schema_add_aliases(schema: &mut schemars::Schema) {
+        use serde_json::Value;
+
+        if let Some(obj) = schema.as_object_mut() {
+            obj.get_mut("type").map(|v| match v {
+                Value::Array(v) => v.extend_from_slice(&["integer".into(), "boolean".into()]),
+                Value::String(s) => {
+                    let s = std::mem::replace(s, String::with_capacity(0));
+                    *v = Value::Array(vec![s.into(), "integer".into(), "boolean".into()])
+                }
+                _ => *v = Value::Array(vec!["string".into(), "integer".into(), "boolean".into()]),
+            });
+
+            if let Some(variants) = obj.get_mut("enum").and_then(|v| v.as_array_mut()) {
+                variants.reserve(5);
+                variants.extend((0..=2).map(Into::into));
+                variants.extend_from_slice(&[false.into(), true.into()]);
+            }
+        }
+    }
 }
 
 impl Display for TomlDebugInfo {


### PR DESCRIPTION
fixes #17201, no breaking changes.

Fixes manifest schema and attributes used for its generation — missed `rename`-attr for `TomlDebugInfo`.

- added `schemars(rename_all = "kebab-case")` for `TomlDebugInfo`
- fixed case in the schema used in test

### What does this PR try to resolve?

issue: https://github.com/rust-lang/cargo/issues/17201

#### Motivation

1. Public schema in master branch is wrong and currently should not be used for manifest validation.
1. Schema-generation should be fixed.
1. I want to fix it madly _(I heavily using nightly toolchain, schemas everywhere and I suffer from this error)_.


### How to test and review this PR?

1. get `taplo` _(or any tool that you prefer to validate vs. schemas)_
2. `cargo init`
3. add to `Cargo.toml` options that is `TomlDebugInfo`'s enum-variants:
  `[profile.dev]`
  `debug = "Full"`
4. validate any your `Cargo.toml` with `taplo`:
  ```sh
  taplo check Cargo.toml —verbose \
    --schema=https://raw.githubusercontent.com/rust-lang/cargo/refs/heads/master/crates/cargo-util-schemas/manifest.schema.json
  ```

5. ☝🏻this shows that `Cargo.toml` (from step 2) is valid for scheme that is currently in master-branch
6. validate any your `Cargo.toml` with `cargo`:
  run `cargo check` for a crate with that `Cargo.toml` (from steps 2, 3) — cargo must throw deserialization error, so __manifest is invalid__

After applying this patch (PR) with fixed schema, that manifest will be invalid in same way as for cargo.


- - -

_LLM/ML/AI usage disclosure: I'm a retrograde, Luddite kind of person who loves to write code by hand and using my brain; I don't use models, I make decisions and make mistakes on my own, I've been writing code for over twenty years, and I respect myself and other engineers, so_ AI was not used.