### PR TITLE
Fix manual_readme lint for lower-priority README files

### DIFF
--- a/src/diagnostics/rules/manual_readme.rs
+++ b/src/diagnostics/rules/manual_readme.rs
@@ -22,6 +22,7 @@ use crate::diagnostics::workspace_rel_path;
 use crate::workspace::Package;
 use crate::workspace::Workspace;
 use crate::workspace::parser::DEFAULT_README_FILES;
+use crate::workspace::parser::default_readme_from_package_root;
 
 pub static LINT: &Lint = &Lint {
     name: "manual_readme",
@@ -109,7 +110,9 @@ fn lint_package_inner(
         return Ok(());
     };
 
-    if !DEFAULT_README_FILES.contains(&readme.as_str()) {
+    if !DEFAULT_README_FILES.contains(&readme.as_str())
+        || default_readme_from_package_root(pkg.root()).as_deref() != Some(readme)
+    {
         return Ok(());
     }
 

--- a/src/workspace/parser/mod.rs
+++ b/src/workspace/parser/mod.rs
@@ -859,7 +859,7 @@ pub const DEFAULT_README_FILES: [&str; 3] = ["README.md", "README.txt", "README"
 
 /// Checks if a file with any of the default README file names exists in the package root.
 /// If so, returns a `String` representing that name.
-fn default_readme_from_package_root(package_root: &Path) -> Option<String> {
+pub(crate) fn default_readme_from_package_root(package_root: &Path) -> Option<String> {
     for &readme_filename in DEFAULT_README_FILES.iter() {
         if package_root.join(readme_filename).is_file() {
             return Some(readme_filename.to_string());

--- a/tests/testsuite/lints/manual_readme.rs
+++ b/tests/testsuite/lints/manual_readme.rs
@@ -42,6 +42,85 @@ manual_readme = "warn"
 }
 
 #[cargo_test]
+fn lower_priority_readme() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+[package]
+name = "foo"
+version = "0.0.1"
+edition = "2015"
+authors = []
+readme = "README.txt"
+
+[lints.cargo]
+default = { level = "allow", priority = -1 }
+manual_readme = "warn"
+"#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file("README.md", "")
+        .file("README.txt", "")
+        .build();
+
+    p.cargo("fetch -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] explicit `package.readme` can be inferred
+ --> Cargo.toml:7:1
+  |
+7 | readme = "README.txt"
+  | ^^^^^^^^^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::manual_readme` is set to `warn` in `[lints]`
+[HELP] consider removing `package.readme`
+[WARNING] `foo` (manifest) generated 1 warning
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn explicit_readme_txt() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+[package]
+name = "foo"
+version = "0.0.1"
+edition = "2015"
+authors = []
+readme = "README.txt"
+
+[lints.cargo]
+default = { level = "allow", priority = -1 }
+manual_readme = "warn"
+"#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file("README.txt", "")
+        .build();
+
+    p.cargo("fetch -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] explicit `package.readme` can be inferred
+ --> Cargo.toml:7:1
+  |
+7 | readme = "README.txt"
+  | ^^^^^^^^^^^^^^^^^^^^^
+  |
+  = [NOTE] `cargo::manual_readme` is set to `warn` in `[lints]`
+[HELP] consider removing `package.readme`
+[WARNING] `foo` (manifest) generated 1 warning
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn implicit_readme() {
     let p = project()
         .file(

--- a/tests/testsuite/lints/manual_readme.rs
+++ b/tests/testsuite/lints/manual_readme.rs
@@ -66,18 +66,7 @@ manual_readme = "warn"
 
     p.cargo("fetch -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
-        .with_stderr_data(str![[r#"
-[WARNING] explicit `package.readme` can be inferred
- --> Cargo.toml:7:1
-  |
-7 | readme = "README.txt"
-  | ^^^^^^^^^^^^^^^^^^^^^
-  |
-  = [NOTE] `cargo::manual_readme` is set to `warn` in `[lints]`
-[HELP] consider removing `package.readme`
-[WARNING] `foo` (manifest) generated 1 warning
-
-"#]])
+        .with_stderr_data(str![""])
         .run();
 }
 


### PR DESCRIPTION
### What does this PR try to resolve?

Closes #17206.

`cargo::manual_readme` warned whenever `package.readme` matched any default README filename. That can be wrong when a higher-priority default README file also exists. For example, removing `readme = "README.txt"` while `README.md` is present would make Cargo infer `README.md`, changing the package metadata.

This changes the lint to compare the explicit readme value with the same package-root README inference helper used by manifest normalization, so the lint only fires when removing the field preserves the inferred README.

### How to test and review this PR?

Added coverage for both sides of the inference behavior:

- `README.txt` with `README.md` also present should not warn.
- `README.txt` as the inferred default should still warn.

Commands run:

- `cargo fmt --check`
- `cargo test -p cargo --test testsuite -- lints::manual_readme`
- `cargo test -p cargo --test testsuite -- lints::`