### PR TITLE
feat(profile): Add built-in profile debug 

### DIFF
--- a/crates/cargo-util-schemas/src/restricted_names.rs
+++ b/crates/cargo-util-schemas/src/restricted_names.rs
@@ -137,14 +137,6 @@ pub(crate) fn validate_profile_name(name: &str) -> Result<()> {
     }
 
     let lower_name = name.to_lowercase();
-    if lower_name == "debug" {
-        return Err(ErrorKind::ProfileNameReservedKeyword {
-            name: name.into(),
-            help: "To configure the default development profile, \
-                use the name `dev` as in [profile.dev]",
-        }
-        .into());
-    }
     if lower_name == "build-override" {
         return Err(ErrorKind::ProfileNameReservedKeyword {
             name: name.into(),

--- a/doc/book/src/commands/cargo-bench.md
+++ b/doc/book/src/commands/cargo-bench.md
@@ -46,8 +46,8 @@ function to handle running benchmarks.
 
 By default, `cargo bench` uses the [`bench` profile], which enables
 optimizations and disables debugging information. If you need to debug a
-benchmark, you can use the `--profile=dev` command-line option to switch to
-the dev profile. You can then run the debug-enabled benchmark within a
+benchmark, you can use the `--profile=debug` command-line option to switch to
+the debug profile. You can then run the debug-enabled benchmark within a
 debugger.
 
 [`bench` profile]: ../reference/profiles.html#bench

--- a/doc/book/src/commands/cargo-install.md
+++ b/doc/book/src/commands/cargo-install.md
@@ -260,7 +260,7 @@ is specified.</p>
 
 
 <dt class="option-term" id="option-cargo-install---debug"><a class="option-anchor" href="#option-cargo-install---debug"><code>--debug</code></a></dt>
-<dd class="option-desc"><p>Build with the <code>dev</code> profile instead of the <code>release</code> profile.
+<dd class="option-desc"><p>Build with the <code>debug</code> profile instead of the <code>release</code> profile.
 See also the <code>--profile</code> option for choosing a specific profile by name.</p>
 </dd>
 

--- a/doc/book/src/commands/cargo-test.md
+++ b/doc/book/src/commands/cargo-test.md
@@ -38,7 +38,10 @@ manifest settings, in which case your code will need to provide its own `main`
 function to handle running tests.
 
 By default, `cargo test` uses the [`test` profile], which enables
-debugging.
+some optimizations and disables debugging information for fast feedback. If you need to debug a
+test, you can use the `--profile=debug` command-line option to switch to
+the debug profile. You can then run the debug-enabled test within a
+debugger.
 
 [`test` profile]: ../reference/profiles.html#test
 

--- a/doc/book/src/reference/profiles.md
+++ b/doc/book/src/reference/profiles.md
@@ -262,8 +262,8 @@ whether or not [`rpath`] is enabled.
 
 ### dev
 
-The `dev` profile is used for normal development and debugging. It is the
-default for build commands like [`cargo build`], and is used for `cargo install --debug`.
+The `dev` profile is used for normal development. It is the
+default for build commands like [`cargo build`], and is used for `cargo install --profile dev`.
 
 The default settings for the `dev` profile are:
 
@@ -280,6 +280,17 @@ panic = 'unwind'
 incremental = true
 codegen-units = 256
 rpath = false
+```
+
+### debug
+
+The `debug` profile is used for creating binaries to run with a debugger. It is used with `cargo build --profile debug` and `cargo install --debug`.
+
+The default settings for the `debug` profile are:
+
+```toml
+[profile.debug]
+inherits = "dev"
 ```
 
 ### release

--- a/doc/man/cargo-bench.md
+++ b/doc/man/cargo-bench.md
@@ -51,8 +51,8 @@ function to handle running benchmarks.
 
 By default, `cargo bench` uses the [`bench` profile], which enables
 optimizations and disables debugging information. If you need to debug a
-benchmark, you can use the `--profile=dev` command-line option to switch to
-the dev profile. You can then run the debug-enabled benchmark within a
+benchmark, you can use the `--profile=debug` command-line option to switch to
+the debug profile. You can then run the debug-enabled benchmark within a
 debugger.
 
 [`bench` profile]: ../reference/profiles.html#bench

--- a/doc/man/cargo-install.md
+++ b/doc/man/cargo-install.md
@@ -178,7 +178,7 @@ Directory to install packages into.
 {{> options-target-dir }}
 
 {{#option "`--debug`" }}
-Build with the `dev` profile instead of the `release` profile.
+Build with the `debug` profile instead of the `release` profile.
 See also the `--profile` option for choosing a specific profile by name.
 {{/option}}
 

--- a/doc/man/cargo-test.md
+++ b/doc/man/cargo-test.md
@@ -43,7 +43,10 @@ manifest settings, in which case your code will need to provide its own `main`
 function to handle running tests.
 
 By default, `cargo test` uses the [`test` profile], which enables
-debugging.
+some optimizations and disables debugging information for fast feedback. If you need to debug a
+test, you can use the `--profile=debug` command-line option to switch to
+the debug profile. You can then run the debug-enabled test within a
+debugger.
 
 [`test` profile]: ../reference/profiles.html#test
 

--- a/doc/man/generated_txt/cargo-bench.txt
+++ b/doc/man/generated_txt/cargo-bench.txt
@@ -46,9 +46,9 @@ DESCRIPTION
        By default, cargo bench uses the bench profile
        <https://doc.rust-lang.org/cargo/reference/profiles.html#bench>, which
        enables optimizations and disables debugging information. If you need to
-       debug a benchmark, you can use the --profile=dev command-line option to
-       switch to the dev profile. You can then run the debug-enabled benchmark
-       within a debugger.
+       debug a benchmark, you can use the --profile=debug command-line option
+       to switch to the debug profile. You can then run the debug-enabled
+       benchmark within a debugger.
 
    Working directory of benchmarks
        The working directory of every benchmark is set to the root directory of

--- a/doc/man/generated_txt/cargo-install.txt
+++ b/doc/man/generated_txt/cargo-install.txt
@@ -226,8 +226,8 @@ OPTIONS
            workspace of the local crate unless --target-dir is specified.
 
        --debug
-           Build with the dev profile instead of the release profile. See also
-           the --profile option for choosing a specific profile by name.
+           Build with the debug profile instead of the release profile. See
+           also the --profile option for choosing a specific profile by name.
 
        --profile name
            Install with the given profile. See the reference

--- a/doc/man/generated_txt/cargo-test.txt
+++ b/doc/man/generated_txt/cargo-test.txt
@@ -38,7 +38,10 @@ DESCRIPTION
 
        By default, cargo test uses the test profile
        <https://doc.rust-lang.org/cargo/reference/profiles.html#test>, which
-       enables debugging.
+       enables some optimizations and disables debugging information for fast
+       feedback. If you need to debug a test, you can use the --profile=debug
+       command-line option to switch to the debug profile. You can then run the
+       debug-enabled test within a debugger.
 
    Documentation tests
        Documentation tests are also run by default, which is handled by

--- a/etc/man/cargo-bench.1
+++ b/etc/man/cargo-bench.1
@@ -54,8 +54,8 @@ running benchmarks on the stable channel, such as
 .sp
 By default, \fBcargo bench\fR uses the \fI\f(BIbench\fI profile\fR <https://doc.rust\-lang.org/cargo/reference/profiles.html#bench>, which enables
 optimizations and disables debugging information. If you need to debug a
-benchmark, you can use the \fB\-\-profile=dev\fR command\-line option to switch to
-the dev profile. You can then run the debug\-enabled benchmark within a
+benchmark, you can use the \fB\-\-profile=debug\fR command\-line option to switch to
+the debug profile. You can then run the debug\-enabled benchmark within a
 debugger.
 .SS "Working directory of benchmarks"
 The working directory of every benchmark is set to the root directory of the

--- a/etc/man/cargo-install.1
+++ b/etc/man/cargo-install.1
@@ -281,7 +281,7 @@ is specified.
 .sp
 \fB\-\-debug\fR
 .RS 4
-Build with the \fBdev\fR profile instead of the \fBrelease\fR profile.
+Build with the \fBdebug\fR profile instead of the \fBrelease\fR profile.
 See also the \fB\-\-profile\fR option for choosing a specific profile by name.
 .RE
 .sp

--- a/etc/man/cargo-test.1
+++ b/etc/man/cargo-test.1
@@ -41,7 +41,10 @@ manifest settings, in which case your code will need to provide its own \fBmain\
 function to handle running tests.
 .sp
 By default, \fBcargo test\fR uses the \fI\f(BItest\fI profile\fR <https://doc.rust\-lang.org/cargo/reference/profiles.html#test>, which enables
-debugging.
+some optimizations and disables debugging information for fast feedback. If you need to debug a
+test, you can use the \fB\-\-profile=debug\fR command\-line option to switch to
+the debug profile. You can then run the debug\-enabled test within a
+debugger.
 .SS "Documentation tests"
 Documentation tests are also run by default, which is handled by \fBrustdoc\fR\&. It
 extracts code samples from documentation comments of the library target, and

--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -92,12 +92,9 @@ pub fn cli() -> Command {
         .arg_features()
         .arg_parallel()
         .arg(
-            flag(
-                "debug",
-                "Build in debug mode (with the 'dev' profile) instead of release mode",
-            )
-            .conflicts_with("profile")
-            .help_heading(heading::COMPILATION_OPTIONS),
+            flag("debug", "Build in debug mode instead of release mode")
+                .conflicts_with("profile")
+                .help_heading(heading::COMPILATION_OPTIONS),
         )
         .arg_redundant_default_mode("release", "install", "debug")
         .arg_profile("Install artifacts with the specified profile")

--- a/src/util/command_prelude.rs
+++ b/src/util/command_prelude.rs
@@ -709,7 +709,7 @@ Run `{cmd}` to see possible targets."
         ) {
             (false, false, None) => default,
             (true, _, None) => "release",
-            (_, true, None) => "dev",
+            (_, true, None) => "debug",
             // `doc` is separate from all the other reservations because
             // [profile.doc] was historically allowed, but is deprecated and
             // has no effect. To avoid potentially breaking projects, it is a

--- a/src/workspace/parser/mod.rs
+++ b/src/workspace/parser/mod.rs
@@ -2564,15 +2564,6 @@ pub fn validate_profile(
         );
     }
 
-    // `inherits` validation
-    if matches!(root.inherits.as_deref(), Some("debug")) {
-        bail!(
-            "profile.{}.inherits=\"debug\" should be profile.{}.inherits=\"dev\"",
-            name,
-            name
-        );
-    }
-
     match name {
         "doc" => {
             warnings.push("profile `doc` is deprecated and has no effect".to_string());

--- a/src/workspace/profiles.rs
+++ b/src/workspace/profiles.rs
@@ -157,6 +157,13 @@ impl Profiles {
     fn predefined_profiles() -> Vec<(&'static str, TomlProfile)> {
         vec![
             (
+                "debug",
+                TomlProfile {
+                    inherits: Some(String::from("dev")),
+                    ..TomlProfile::default()
+                },
+            ),
+            (
                 "bench",
                 TomlProfile {
                     inherits: Some(String::from("release")),
@@ -1298,7 +1305,7 @@ fn merge_config_profiles(
     }
     // Add the built-in profiles. This is important for things like `cargo
     // test` which implicitly use the "dev" profile for dependencies.
-    for name in ["dev", "release", "test", "bench"] {
+    for name in ["dev", "release", "debug", "test", "bench"] {
         check_to_add.insert(name.into());
     }
     // Add config-only profiles.

--- a/tests/testsuite/cargo_install/help/stdout.term.svg
+++ b/tests/testsuite/cargo_install/help/stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="860px" height="1100px" xmlns="http://www.w3.org/2000/svg">
+<svg width="827px" height="1100px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -124,7 +124,7 @@
 </tspan>
     <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--keep-going</tspan><tspan>              Do not abort the build as soon as there is an error</tspan>
 </tspan>
-    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--debug</tspan><tspan>                   Build in debug mode (with the 'dev' profile) instead of release mode</tspan>
+    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--debug</tspan><tspan>                   Build in debug mode instead of release mode</tspan>
 </tspan>
     <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Install artifacts with the specified profile</tspan>
 </tspan>

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -2839,7 +2839,7 @@ fn install_with_debug_profile() {
 [DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
 [INSTALLING] foo v0.0.1
 [COMPILING] foo v0.0.1
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[FINISHED] `debug` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
 [INSTALLED] package `foo v0.0.1` (executable `foo[EXE]`)
 [WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries

--- a/tests/testsuite/profile_custom.rs
+++ b/tests/testsuite/profile_custom.rs
@@ -599,35 +599,6 @@ See https://doc.rust-lang.org/cargo/reference/profiles.html for more on configur
             ))
             .run();
     }
-
-    p.change_file(
-        "Cargo.toml",
-        r#"
-               [package]
-               name = "foo"
-               version = "0.1.0"
-               edition = "2015"
-               authors = []
-
-               [profile.debug]
-               debug = 1
-               inherits = "dev"
-            "#,
-    );
-
-    p.cargo("build")
-        .with_status(101)
-        .with_stderr_data(str![[r#"
-[ERROR] profile name `debug` is reserved
-       To configure the default development profile, use the name `dev` as in [profile.dev]
-       See https://doc.rust-lang.org/cargo/reference/profiles.html for more on configuring profiles.
- --> Cargo.toml:8:25
-  |
-8 |                [profile.debug]
-  |                         ^^^^^
-
-"#]])
-        .run();
 }
 
 #[cargo_test]
@@ -788,6 +759,41 @@ fn request_test_profile() {
         .with_stderr_data(str![[r#"
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn override_debug_propfile() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+               [package]
+               name = "foo"
+               version = "0.1.0"
+               edition = "2015"
+               authors = []
+
+               [profile.debug]
+               debug = 1
+               inherits = "dev"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("build")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] profile name `debug` is reserved
+       To configure the default development profile, use the name `dev` as in [profile.dev]
+       See https://doc.rust-lang.org/cargo/reference/profiles.html for more on configuring profiles.
+ --> Cargo.toml:8:25
+  |
+8 |                [profile.debug]
+  |                         ^^^^^
 
 "#]])
         .run();

--- a/tests/testsuite/profile_custom.rs
+++ b/tests/testsuite/profile_custom.rs
@@ -766,35 +766,62 @@ fn request_test_profile() {
 }
 
 #[cargo_test]
-fn override_debug_propfile() {
+fn debug_inherits_dev() {
     let p = project()
         .file(
             "Cargo.toml",
             r#"
-               [package]
-               name = "foo"
-               version = "0.1.0"
-               edition = "2015"
-               authors = []
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            edition = "2015"
 
-               [profile.debug]
-               debug = 1
-               inherits = "dev"
+            [profile.dev]
+            debug = 0
             "#,
         )
         .file("src/lib.rs", "")
         .build();
+    p.cargo("check --profile=dev -v")
+        .with_stderr_data(str![[r#"
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]`
+[FINISHED] `dev` profile [unoptimized] target(s) in [ELAPSED]s
 
-    p.cargo("build")
+"#]])
+        .with_stderr_does_not_contain("[..] -C debuginfo=0[..]")
+        .with_stderr_does_not_contain("[..] -C opt-level=0[..]")
+        .run();
+}
+
+#[cargo_test]
+fn change_debug_inheritance() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            edition = "2015"
+
+            [profile.debug]
+            inherits = "release"
+            debug = true
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+    p.cargo("check --profile=debug")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] profile name `debug` is reserved
        To configure the default development profile, use the name `dev` as in [profile.dev]
        See https://doc.rust-lang.org/cargo/reference/profiles.html for more on configuring profiles.
- --> Cargo.toml:8:25
+ --> Cargo.toml:7:22
   |
-8 |                [profile.debug]
-  |                         ^^^^^
+7 |             [profile.debug]
+  |                      ^^^^^
 
 "#]])
         .run();

--- a/tests/testsuite/profile_custom.rs
+++ b/tests/testsuite/profile_custom.rs
@@ -709,8 +709,9 @@ fn test_inherits_dev() {
 [EXECUTABLE] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
 
 "#]])
-        .with_stdout_does_not_contain("[..] -C debuginfo=0[..]")
-        .with_stdout_does_not_contain("[..] -C opt-level=0[..]")
+        .with_stderr_does_not_contain("[..] -C debuginfo=0[..]")
+        .with_stderr_does_not_contain("[..] -C opt-level=0[..]")
+        .with_stderr_contains("[..] -C opt-level=3[..]")
         .run();
 }
 

--- a/tests/testsuite/profile_custom.rs
+++ b/tests/testsuite/profile_custom.rs
@@ -778,19 +778,23 @@ fn debug_inherits_dev() {
 
             [profile.dev]
             debug = 0
+
+            [profile.debug]
+            opt-level = 3
             "#,
         )
         .file("src/lib.rs", "")
         .build();
-    p.cargo("check --profile=dev -v")
+    p.cargo("check --profile=debug -v")
         .with_stderr_data(str![[r#"
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo [..]`
-[FINISHED] `dev` profile [unoptimized] target(s) in [ELAPSED]s
+[FINISHED] `debug` profile [optimized] target(s) in [ELAPSED]s
 
 "#]])
         .with_stderr_does_not_contain("[..] -C debuginfo=0[..]")
         .with_stderr_does_not_contain("[..] -C opt-level=0[..]")
+        .with_stderr_contains("[..] -C opt-level=3[..]")
         .run();
 }
 
@@ -813,15 +817,9 @@ fn change_debug_inheritance() {
         .file("src/lib.rs", "")
         .build();
     p.cargo("check --profile=debug")
-        .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] profile name `debug` is reserved
-       To configure the default development profile, use the name `dev` as in [profile.dev]
-       See https://doc.rust-lang.org/cargo/reference/profiles.html for more on configuring profiles.
- --> Cargo.toml:7:22
-  |
-7 |             [profile.debug]
-  |                      ^^^^^
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `debug` profile [optimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

Key points:
- It inherits from `dev`
  - Conceptually, debugging is part of the development process
  - The hope is this will smooth out the transition for people
- `cargo install --debug` now uses `debug` instead of `dev`
- `debug` changes nothing from `dev` right now.
  `dev` will evolve in the future
  (with `debug` overriding those values to leave it effectively unchanged)
  but that is deferred out to offer a transition period where `debug`
  can be used without but isn't required for debugging as people deal
  with multiple Rust versions. This also shrinks the change and
  decouples what the conversation around what the settings should be.
- `dev` still uses `target/debug`: this does not change any calculation for the transition cost and any conflicts between the profiles should mostly be in the artifact-dir (which are just hard links), especially once the new build layout lands
- `--dev`/`--debug` flags are deferred out, needing more evaluation  to decide if they are worth it

See also https://github.com/rust-lang/cargo-team/blob/main/meetings/sync-meeting/2026-07-14.md#splitting-dev-and-debug-profiles

### How to test and review this PR?

This is part of #15931
- `build.profile` will be a follow up (#17215)
- `dev` profile changes are deferred for 1+ releases