### PR TITLE
Include SBOM outputs in fingerprints

### DIFF
--- a/src/cargo/core/compiler/fingerprint/mod.rs
+++ b/src/cargo/core/compiler/fingerprint/mod.rs
@@ -1611,12 +1611,7 @@ fn calculate_normal(
     let outputs = build_runner
         .outputs(unit)?
         .iter()
-        .filter(|output| {
-            !matches!(
-                output.flavor,
-                FileFlavor::DebugInfo | FileFlavor::Auxiliary | FileFlavor::Sbom
-            )
-        })
+        .filter(|output| !matches!(output.flavor, FileFlavor::DebugInfo | FileFlavor::Auxiliary))
         .map(|output| output.path.clone())
         .collect();
 

--- a/tests/testsuite/sbom.rs
+++ b/tests/testsuite/sbom.rs
@@ -95,6 +95,39 @@ fn simple() {
 }
 
 #[cargo_test]
+fn enabling_sbom_invalidates_fingerprint() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/main.rs", r#"fn main() {}"#)
+        .build();
+
+    p.cargo("build").run();
+
+    let file = append_sbom_suffix(&p.bin("foo"));
+    assert!(!file.exists());
+
+    p.cargo("build -Zsbom")
+        .env("CARGO_BUILD_SBOM", "true")
+        .masquerade_as_nightly_cargo(&["sbom"])
+        .with_stderr_data(cargo_test_support::str![[r#"
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+
+    assert!(!file.exists());
+
+    p.cargo("build -Zsbom")
+        .env("CARGO_BUILD_SBOM", "true")
+        .masquerade_as_nightly_cargo(&["sbom"])
+        .with_stderr_data(cargo_test_support::str![[r#"
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn with_multiple_crate_types() {
     let p = project()
         .file(

--- a/tests/testsuite/sbom.rs
+++ b/tests/testsuite/sbom.rs
@@ -110,12 +110,13 @@ fn enabling_sbom_invalidates_fingerprint() {
         .env("CARGO_BUILD_SBOM", "true")
         .masquerade_as_nightly_cargo(&["sbom"])
         .with_stderr_data(cargo_test_support::str![[r#"
+[COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
         .run();
 
-    assert!(!file.exists());
+    assert!(file.is_file());
 
     p.cargo("build -Zsbom")
         .env("CARGO_BUILD_SBOM", "true")


### PR DESCRIPTION
### What does this PR try to resolve?

Cargo currently excludes SBOM outputs when calculating a unit fingerprint. After a build without SBOM, rebuilding the same unit with `CARGO_BUILD_SBOM=true` and `-Zsbom` can reuse the cached unit and leave the expected SBOM precursor missing.

This keeps the existing unit output and uplift path, but includes SBOM in the output set used for fingerprints so enabling SBOM invalidates the earlier build.

Close rust-lang/cargo#15695

### How to test and review this PR?

The regression test builds once without SBOM, enables it for the next build, and checks that the precursor appears in the top-level target output. The complete SBOM test module passes.
