### PR TITLE
feat(profile): Disable incremental compilation under CI by default

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1439,6 +1439,7 @@ pub trait TestEnvCommandExt: Sized {
             .env("CARGO_INCREMENTAL", "0")
             // Don't read the system git config which is out of our control.
             .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env_remove("CI")
             .env_remove("__CARGO_DEFAULT_LIB_METADATA")
             .env_remove("ALL_PROXY")
             .env_remove("EMAIL")

--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -31,6 +31,7 @@ use crate::util::interning::InternedString;
 use crate::util::toml::validate_profile;
 use crate::util::{CargoResult, GlobalContext, closest_msg, context};
 use anyhow::{Context as _, bail};
+use cargo_util::is_ci;
 use cargo_util_schemas::manifest::TomlTrimPaths;
 use cargo_util_schemas::manifest::TomlTrimPathsValue;
 use cargo_util_schemas::manifest::{
@@ -72,7 +73,10 @@ impl Profiles {
         let gctx = ws.gctx();
         let incremental = match gctx.get_env_os("CARGO_INCREMENTAL") {
             Some(v) => Some(v == "1"),
-            None => gctx.build_config()?.incremental,
+            None => gctx
+                .build_config()?
+                .incremental
+                .or_else(|| is_ci().then_some(false)),
         };
         let mut profiles = merge_config_profiles(ws, requested_profile)?;
         let rustc_host = ws.gctx().load_global_rustc(Some(ws))?.host;

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -641,9 +641,10 @@ Additional flags may also be passed with the [`cargo rustdoc`] command.
 * Default: from profile
 * Environment: `CARGO_BUILD_INCREMENTAL` or `CARGO_INCREMENTAL`
 
-Whether or not to perform [incremental compilation]. The default if not set is
-to use the value from the [profile](profiles.md#incremental). Otherwise this overrides the setting of
-all profiles.
+Whether or not to perform [incremental compilation].
+
+In environments with `CI` set, the default if not set is `CARGO_BUILD_INCREMENTAL=false`.
+Otherwise, the default is to use the value from the [profile](profiles.md#incremental).
 
 The `CARGO_INCREMENTAL` environment variable can be set to `1` to force enable
 incremental compilation for all profiles, or `0` to disable it. This env var

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -202,6 +202,26 @@ fn incremental_config() {
 }
 
 #[cargo_test]
+fn ci_implies_no_cargo_incremental() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/main.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
+
+    p.cargo("build -v")
+        .env("CI", "1")
+        .env_remove("CARGO_INCREMENTAL")
+        .with_stderr_does_not_contain("[..]C incremental=[..]")
+        .run();
+
+    p.cargo("test -v")
+        .env("CI", "1")
+        .env_remove("CARGO_INCREMENTAL")
+        .with_stderr_does_not_contain("[..]C incremental=[..]")
+        .run();
+}
+
+#[cargo_test]
 fn cargo_compile_with_redundant_default_mode() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))


### PR DESCRIPTION
### What does this PR try to resolve?

Incremental compilation has two potential negative impacts on CI
- Without caching or low cache reuse, time is wasted serializing state, writing it to disk,
  and managing the cache
- With caching, incremental compilation dramatically increases the cache
  size which and cause the cache overhead (network, compression) to
  outweigh the build speed ups

This slots into layers at
1. `CARGO_INCREMENTAL`
2. `build.incremental`
3. !`CI`
4. `profile.*.incremental`

While common actions have this built in,
- this helps those not using a CI action (like the Cargo team or people on
  a bespoke CI runner)
- this reduces the value of CI actions, giving more people the option to
  reduce their CI dependency tree and risk profile

Fixes https://github.com/rust-lang/cargo/issues/11853

### How to test and review this PR?
