### PR TITLE
refactor(context): normalize in `homedir` instead

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -2185,7 +2185,12 @@ impl GlobalContext {
 }
 
 pub fn homedir(cwd: &Path) -> Option<PathBuf> {
-    ::home::cargo_home_with_cwd(cwd).ok()
+    ::home::cargo_home_with_cwd(cwd)
+        .ok()
+        // https://github.com/rust-lang/cargo/issues/15981
+        // This is so everything shares one spelling and
+        // isn't incorrectly seen as distinct.
+        .map(|home| paths::normalize_path(&home))
 }
 
 pub fn save_credentials(

--- a/src/sources/path.rs
+++ b/src/sources/path.rs
@@ -991,10 +991,6 @@ fn read_packages(
     source_id: SourceId,
     gctx: &GlobalContext,
 ) -> CargoResult<HashMap<PackageId, Vec<Package>>> {
-    // Normalize for consistency.
-    // See https://github.com/rust-lang/cargo/issues/15981
-    // Otherwise, a `CARGO_HOME` with `..` can collect a package twice and incorrectly warn about a duplicate.
-    let path = &paths::normalize_path(path);
     let mut all_packages = HashMap::default();
     let mut visited = HashSet::<PathBuf>::default();
     let mut errors = Vec::<anyhow::Error>::new();


### PR DESCRIPTION
# What Does This PR Try to Resolve?

This is a follow-up to #17204.

That fix normalized inside `read_packages`.

As noted in review, Cargo prefers to normalize at the exterior and assume interiors are clean.

This change moves the `normalize_path` to `homedir`, and removes the interior normalization.

# How to Test and Review This PR?

- `config_symlink_home_duplicate_load` and `install_git_with_symlink_home` pass. Symlink handling appears undisturbed.
- `no_duplicate_package_warning_with_dotdot_cargo_home` (added in #17204) still passes. The exterior placement fixes the same issue.

```
cargo test --test testsuite -- no_duplicate_package_warning_with_dotdot_cargo_home config_symlink_home_duplicate_load install_git_with_symlink_home
```