### PR TITLE
A note that build.warnings and CARGO_BUILD_WARNINGS don't apply to MIRI

### DIFF
--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -473,6 +473,7 @@ Allowed levels are:
 
 Only warnings that are lints (i.e. level is adjustable) are affected,
 e.g. leaving as-is non-lint warnings or warnings from dependencies visible through `--verbose --verbose`.
+`build.warnings` and `CARGO_BUILD_WARNINGS` do not apply to MIRI.
 
 > **MSRV:** Respected as of 1.97.
 


### PR DESCRIPTION
_Thanks for the pull request 🎉!_
_Please read the contribution guide: <https://doc.crates.io/contrib/>._

### What does this PR try to resolve?

https://github.com/rust-lang/miri/issues/5202
