### PR TITLE
Update cfg_aliases to 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,9 +655,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"


### PR DESCRIPTION
The latest nightly has started to warn that `nix` will break in the future due to `semicolon_in_expressions_from_macros`. The actual issue is related to `cfg_aliases`, which was affected by https://github.com/rust-lang/rust/pull/159222.
