### PR TITLE
chore(ci): reflect doc folder move in book deployment

### DIFF
--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         GENERATE_PY="$(pwd)/ci/generate.py"
 
-        cd src/doc/contrib
+        cd doc/contrib
         mdbook build
 
         mkdir gh-pages
@@ -40,7 +40,7 @@ jobs:
     - name: Upload Artifact
       uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
       with:
-        path: src/doc/contrib/gh-pages
+        path: doc/contrib/gh-pages
 
   deploy:
     needs: build


### PR DESCRIPTION
This was an oversight.

See <https://github.com/rust-lang/cargo/actions/runs/29613326618/job/87992788277>.

```
Run GENERATE_PY="$(pwd)/ci/generate.py"
GENERATE_PY="$(pwd)/ci/generate.py"

cd src/doc/contrib
mdbook build

mkdir gh-pages
cd gh-pages
mv ../book contrib

# Generate HTML for link redirections.
python3 "$GENERATE_PY"
shell: /usr/bin/bash -e {0}
env:
  MDBOOK_VERSION: 0.5.1
/home/runner/work/_temp/93806891-6da8-477e-8143-9775c64af302.sh: line 3: cd: src/doc/contrib: No such file or directory
```