### PR TITLE
Do not include proc-macro deps in rustc search path args

### DIFF
--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1859,6 +1859,13 @@ fn add_dep_arg<'a, 'b: 'a>(
             continue;
         }
         map.insert(&dep.unit, build_runner.files().deps_dir(&dep.unit));
+
+        // Proc macros are statically linked, so when including a proc-macro dependency we can skip
+        // adding it's dependencies. Note that we still do add them when we are compiling the
+        // proc-macro itself.
+        if dep.unit.target.proc_macro() {
+            continue;
+        }
         add_dep_arg(map, build_runner, &dep.unit);
     }
 }

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -6736,3 +6736,107 @@ qux (cdylib) on search path: true
 "#]])
         .run();
 }
+
+#[cargo_test(
+    nightly,
+    reason = "Depends on https://github.com/rust-lang/rust/pull/155439/changes/61f3e086acc1c187bb262ab43cac71f44018c397"
+)]
+fn should_not_include_proc_macro_deps_paths_in_rustc_args() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                edition = "2021"
+                authors = []
+                resolver = "2"
+
+                [dependencies]
+                my-proc-macro = { path = "my-proc-macro" }
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file(
+            "my-dylib/Cargo.toml",
+            r#"
+                [package]
+                name = "my-dylib"
+                version = "0.1.0"
+                edition = "2021"
+                authors = []
+
+                [lib]
+                crate-type = ["dylib"]
+            "#,
+        )
+        .file(
+            "my-dylib/src/lib.rs",
+            r#"pub fn value_from_dylib() -> i32 { 100 }"#,
+        )
+        .file(
+            "my-rlib/Cargo.toml",
+            r#"
+                [package]
+                name = "my-rlib"
+                version = "0.1.0"
+                edition = "2021"
+                authors = []
+            "#,
+        )
+        .file(
+            "my-rlib/src/lib.rs",
+            r#"pub fn value_from_rlib() -> i32 { 200 }"#,
+        )
+        .file(
+            "my-proc-macro/Cargo.toml",
+            r#"
+                [package]
+                name = "my-proc-macro"
+                version = "0.1.0"
+                edition = "2021"
+                authors = []
+
+                [lib]
+                proc-macro = true
+
+                [dependencies]
+                my-dylib = { path = "../my-dylib" }
+                my-rlib = { path = "../my-rlib" }
+            "#,
+        )
+        .file(
+            "my-proc-macro/src/lib.rs",
+            r#"
+                use proc_macro::TokenStream;
+                use my_dylib::value_from_dylib;
+                use my_rlib::value_from_rlib;
+
+                #[proc_macro]
+                pub fn make_bar(_item: TokenStream) -> TokenStream {
+                    let val = value_from_dylib() + value_from_rlib();
+                    format!("fn bar() -> u32 {{ {val} }}").parse().unwrap()
+                }
+        "#,
+        )
+        .build();
+
+    p.cargo("-Zbuild-dir-new-layout -v build")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .enable_mac_dsym()
+        .with_stderr_data(str![[r#"
+[LOCKING] 3 packages to latest compatible versions
+[COMPILING] my-dylib v0.1.0 ([ROOT]/foo/my-dylib)
+[RUNNING] `rustc --crate-name my_dylib [..]`
+[COMPILING] my-rlib v0.1.0 ([ROOT]/foo/my-rlib)
+[RUNNING] `rustc --crate-name my_rlib [..]`
+[COMPILING] my-proc-macro v0.1.0 ([ROOT]/foo/my-proc-macro)
+[RUNNING] `rustc --crate-name my_proc_macro [..]`
+[COMPILING] foo v0.0.0 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/my-dylib/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/my-proc-macro/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/my-rlib/[HASH]/out --extern my_proc_macro=[ROOT]/foo/target/debug/build/my-proc-macro/[HASH]/out/[..] --verbose`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]].unordered())
+        .run();
+}

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -6825,6 +6825,8 @@ fn should_not_include_proc_macro_deps_paths_in_rustc_args() {
     p.cargo("-Zbuild-dir-new-layout -v build")
         .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .enable_mac_dsym()
+        // Verify that the proc-macro dependencies (my-rlib and my-dylib) are not added to the rustc
+        // invocation for the `foo` crate as `-L` args.
         .with_stderr_data(str![[r#"
 [LOCKING] 3 packages to latest compatible versions
 [COMPILING] my-dylib v0.1.0 ([ROOT]/foo/my-dylib)
@@ -6834,7 +6836,7 @@ fn should_not_include_proc_macro_deps_paths_in_rustc_args() {
 [COMPILING] my-proc-macro v0.1.0 ([ROOT]/foo/my-proc-macro)
 [RUNNING] `rustc --crate-name my_proc_macro [..]`
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo [..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/my-dylib/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/my-proc-macro/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/my-rlib/[HASH]/out --extern my_proc_macro=[ROOT]/foo/target/debug/build/my-proc-macro/[HASH]/out/[..] --verbose`
+[RUNNING] `rustc --crate-name foo [..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/my-proc-macro/[HASH]/out --extern my_proc_macro=[ROOT]/foo/target/debug/build/my-proc-macro/[HASH]/out/[..] --verbose`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]].unordered())


### PR DESCRIPTION
### What does this PR try to resolve?

This is another optimization to reduce the amount of args we pass to rustc when the new build-dir layout is enabled.

Discussed in https://github.com/rust-lang/cargo/issues/17183#issuecomment-5004600669, this reduce the total `-L` arg length by ~16% in the case of Zed. 

### How to test and review this PR?

* Tested this on Zed on windows and was able to compile it fine
* Created a testsuite case for this.