### PR TITLE
fix(timings): only report units the job queue actually ran

### DIFF
--- a/src/compiler/timings/mod.rs
+++ b/src/compiler/timings/mod.rs
@@ -274,7 +274,7 @@ impl<'gctx> Timings<'gctx> {
             let filename = timings_path.join(format!("cargo-timing-{run_id}.html"));
             let mut f = BufWriter::new(paths::create(&filename)?);
 
-            let mut ctx = prepare_context(logs.into_iter(), run_id)?;
+            let mut ctx = prepare_context(logs.into_iter(), run_id, false)?;
             ctx.error = error;
             ctx.cpu_usage = &self.cpu_usage;
             report::write_html(ctx, &mut f)?;

--- a/src/ops/cargo_report/timings.rs
+++ b/src/ops/cargo_report/timings.rs
@@ -46,6 +46,8 @@ struct UnitEntry {
     data: UnitData,
     sections: IndexMap<String, CompilationSection>,
     rmeta_time: Option<f64>,
+    /// Whether the job queue actually ran this unit.
+    started: bool,
 }
 
 pub fn report_timings(
@@ -88,7 +90,7 @@ pub fn report_timings(
                 None
             }
         });
-    let ctx = prepare_context(iter, &run_id)
+    let ctx = prepare_context(iter, &run_id, true)
         .with_context(|| format!("failed to analyze log at `{}`", log.display()))?;
 
     // If we are in a workspace,
@@ -130,7 +132,11 @@ pub fn report_timings(
     Ok(())
 }
 
-pub(crate) fn prepare_context<I>(log: I, run_id: &RunId) -> CargoResult<RenderContext<'_>>
+pub(crate) fn prepare_context<I>(
+    log: I,
+    run_id: &RunId,
+    error_if_no_units: bool,
+) -> CargoResult<RenderContext<'_>>
 where
     I: Iterator<Item = LogMessage>,
 {
@@ -230,6 +236,7 @@ where
                         data,
                         sections: IndexMap::default(),
                         rmeta_time: None,
+                        started: false,
                     },
                 );
             }
@@ -241,7 +248,10 @@ where
             LogMessage::UnitStarted { index, elapsed } => {
                 units
                     .entry(index)
-                    .and_modify(|unit| unit.data.start = elapsed)
+                    .and_modify(|unit| {
+                        unit.data.start = elapsed;
+                        unit.started = true;
+                    })
                     .or_insert_with(|| {
                         unreachable!("unit {index} must have been registered first")
                     });
@@ -331,6 +341,16 @@ where
         }
     }
 
+    // A build can legitimately have no units at all, such as an idle
+    // `cargo test` with `test = false` and `doctest = false`,
+    // so `--timings` always renders its report.
+    // `cargo report timings` instead treats a unit-less
+    // log as corrupted or truncated and errors out.
+    // See https://github.com/rust-lang/cargo/issues/17212.
+    if error_if_no_units && units.is_empty() {
+        anyhow::bail!("no timing data found in log");
+    }
+
     ctx.root_units = {
         let mut root_map: IndexMap<_, Vec<_>> = IndexMap::default();
         for index in requested_units {
@@ -356,15 +376,34 @@ where
             .collect()
     };
 
+    let started: HashSet<UnitIndex> = units
+        .iter()
+        .filter(|(_, entry)| entry.started)
+        .map(|(index, _)| *index)
+        .collect();
+
+    // Units that never started, like fresh units, and
+    // units that were run outside the job queue are
+    // excluded so they don't show up as zero-duration rows.
+    // See https://github.com/rust-lang/cargo/issues/17212.
     let unit_data: Vec<_> = units
         .into_values()
+        .filter(|entry| entry.started)
         .map(
             |UnitEntry {
                  target: _,
                  mut data,
                  sections,
                  rmeta_time,
+                 started: _,
              }| {
+                // A finished unit can unblock units that never started, like
+                // fresh units. Drop them so rows never reference units absent
+                // from the report.
+                data.unblocked_units.retain(|index| started.contains(index));
+                data.unblocked_rmeta_units
+                    .retain(|index| started.contains(index));
+
                 // Post-processing for compilation sections we've collected so far.
                 data.sections = aggregate_sections(sections, data.duration, rmeta_time);
                 data.start = round_to_centisecond(data.start);
@@ -374,10 +413,6 @@ where
         )
         .sorted_unstable_by(|a, b| a.start.partial_cmp(&b.start).unwrap())
         .collect();
-
-    if unit_data.is_empty() {
-        anyhow::bail!("no timing data found in log");
-    }
 
     ctx.unit_data = unit_data;
     ctx.concurrency = compute_concurrency(&ctx.unit_data);

--- a/tests/testsuite/cargo_report_timings/mod.rs
+++ b/tests/testsuite/cargo_report_timings/mod.rs
@@ -223,10 +223,9 @@ fn all_fresh_session() {
     assert_eq!(timing_files.len(), 1);
     let html = std::fs::read_to_string(timing_files[0].as_ref().unwrap()).unwrap();
 
-    // FIXME: nothing was built in this session, but every fresh unit is
-    // reported as a zero-duration row anyway.
-    // See https://github.com/rust-lang/cargo/issues/17212.
-    assert!(html.contains(r#""name": "foo""#));
+    // Nothing was built in this session, so no units are reported.
+    assert!(html.contains("const UNIT_DATA = [];"));
+    assert!(!html.contains(r#""name": "foo""#));
 }
 
 #[cargo_test]

--- a/tests/testsuite/cargo_report_timings/mod.rs
+++ b/tests/testsuite/cargo_report_timings/mod.rs
@@ -152,6 +152,84 @@ Caused by:
 }
 
 #[cargo_test]
+fn idle_session() {
+    // A session that builds nothing, like `cargo test` with `test = false`
+    // and `doctest = false`, has no timing data to report.
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.0"
+            edition = "2015"
+
+            [lib]
+            test = false
+            doctest = false
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("test -Zbuild-analysis")
+        .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .masquerade_as_nightly_cargo(&["build-analysis"])
+        .run();
+
+    p.cargo("report timings -Zbuild-analysis")
+        .masquerade_as_nightly_cargo(&["build-analysis"])
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] failed to analyze log at `[ROOT]/home/.cargo/log/[..]T[..]Z-[..].jsonl`
+
+Caused by:
+  no timing data found in log
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn all_fresh_session() {
+    let p = project()
+        .file("Cargo.toml", &basic_manifest("foo", "0.0.0"))
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check -Zbuild-analysis")
+        .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .masquerade_as_nightly_cargo(&["build-analysis"])
+        .run();
+
+    // The second session has nothing to build; every unit is fresh.
+    p.cargo("check -Zbuild-analysis")
+        .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .masquerade_as_nightly_cargo(&["build-analysis"])
+        .run();
+
+    // The second session's log got generated, and it is the one picked.
+    let _ = paths::log_file(1);
+
+    p.cargo("report timings -Zbuild-analysis")
+        .masquerade_as_nightly_cargo(&["build-analysis"])
+        .with_stderr_data(str![[r#"
+      Timing report saved to [ROOT]/foo/target/cargo-timings/cargo-timing-[..]T[..]Z-[..].html
+
+"#]])
+        .run();
+
+    let timing_files: Vec<_> = p.glob("**/cargo-timing-*.html").collect();
+    assert_eq!(timing_files.len(), 1);
+    let html = std::fs::read_to_string(timing_files[0].as_ref().unwrap()).unwrap();
+
+    // FIXME: nothing was built in this session, but every fresh unit is
+    // reported as a zero-duration row anyway.
+    // See https://github.com/rust-lang/cargo/issues/17212.
+    assert!(html.contains(r#""name": "foo""#));
+}
+
+#[cargo_test]
 fn prefer_latest() {
     let p = project()
         .file("Cargo.toml", &basic_manifest("foo", "0.0.0"))

--- a/tests/testsuite/timings.rs
+++ b/tests/testsuite/timings.rs
@@ -80,10 +80,7 @@ fn doc_test_units_not_reported() {
     let html = p.read_file("target/cargo-timings/cargo-timing.html");
 
     assert!(html.contains(r#"\"lib\" (test)"#));
-
-    // FIXME: the doctest unit never ran, but is reported anyway.
-    // See https://github.com/rust-lang/cargo/issues/17212.
-    assert!(html.contains("(doc test)"));
+    assert!(!html.contains("(doc test)"));
 }
 
 #[cargo_test]
@@ -102,10 +99,7 @@ fn fresh_units_not_reported() {
 
     p.cargo("build --timings").run();
     let html = p.read_file("target/cargo-timings/cargo-timing.html");
-
-    // FIXME: everything is fresh, but every unit is reported anyway.
-    // See https://github.com/rust-lang/cargo/issues/17212.
-    assert!(html.contains(r#""name": "foo""#));
+    assert!(html.contains("const UNIT_DATA = [];"));
 }
 
 #[cargo_test]
@@ -130,16 +124,14 @@ fn report_generated_without_any_units() {
         .file("src/lib.rs", "")
         .build();
 
-    // This should generate an empty report instead of failing.
-    // See https://github.com/rust-lang/cargo/issues/17212.
     p.cargo("test --timings")
-        .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to render timing report
-
-Caused by:
-  no timing data found in log
+      Timing report saved to [ROOT]/foo/target/cargo-timings/cargo-timing-[..].html
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
         .run();
+
+    let html = p.read_file("target/cargo-timings/cargo-timing.html");
+    assert!(html.contains("const UNIT_DATA = [];"));
 }

--- a/tests/testsuite/timings.rs
+++ b/tests/testsuite/timings.rs
@@ -1,6 +1,7 @@
 //! Tests for --timings.
 
 use crate::prelude::*;
+use cargo_test_support::basic_manifest;
 use cargo_test_support::project;
 use cargo_test_support::registry::Package;
 use cargo_test_support::str;
@@ -53,4 +54,92 @@ fn timings_works() {
     p.cargo("clean").run();
 
     p.cargo("doc --timings").run();
+}
+
+#[cargo_test]
+fn doc_test_units_not_reported() {
+    // Doctest should not show up as zero-duration rows.
+    // See https://github.com/rust-lang/cargo/issues/17212.
+    let p = project()
+        .file("Cargo.toml", &basic_manifest("foo", "0.0.0"))
+        .file(
+            "src/lib.rs",
+            r#"
+            /// ```
+            /// assert_eq!(foo::add(1, 2), 3);
+            /// ```
+            pub fn add(a: u64, b: u64) -> u64 {
+                a + b
+            }
+            "#,
+        )
+        .build();
+
+    p.cargo("test --timings").run();
+
+    let html = p.read_file("target/cargo-timings/cargo-timing.html");
+
+    assert!(html.contains(r#"\"lib\" (test)"#));
+
+    // FIXME: the doctest unit never ran, but is reported anyway.
+    // See https://github.com/rust-lang/cargo/issues/17212.
+    assert!(html.contains("(doc test)"));
+}
+
+#[cargo_test]
+fn fresh_units_not_reported() {
+    // A rebuild where nothing is dirty should report no units,
+    // rather than a zero-duration row for every fresh unit.
+    // See https://github.com/rust-lang/cargo/issues/17212.
+    let p = project()
+        .file("Cargo.toml", &basic_manifest("foo", "0.0.0"))
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("build --timings").run();
+    let html = p.read_file("target/cargo-timings/cargo-timing.html");
+    assert!(html.contains(r#""name": "foo""#));
+
+    p.cargo("build --timings").run();
+    let html = p.read_file("target/cargo-timings/cargo-timing.html");
+
+    // FIXME: everything is fresh, but every unit is reported anyway.
+    // See https://github.com/rust-lang/cargo/issues/17212.
+    assert!(html.contains(r#""name": "foo""#));
+}
+
+#[cargo_test]
+fn report_generated_without_any_units() {
+    // `cargo test --timings` with nothing to build should still generate
+    // a report instead of failing with "no timing data found in log".
+    // See https://github.com/rust-lang/cargo/issues/17212.
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.0"
+            edition = "2015"
+
+            [lib]
+            test = false
+            doctest = false
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    // This should generate an empty report instead of failing.
+    // See https://github.com/rust-lang/cargo/issues/17212.
+    p.cargo("test --timings")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] failed to render timing report
+
+Caused by:
+  no timing data found in log
+
+"#]])
+        .run();
 }


### PR DESCRIPTION
# What Does This PR Try to Resolve?

Fixes #17212

# How to Test and Review This PR?

The first commit adds tests pinning the current behavior.

The second commit fixes the underlying issues and updates the tests as needed.