### PR TITLE
feat: cross-crate dead-function elimination via binary-unit split (-Zdead-fn-elimination)

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1221,6 +1221,45 @@ fn add_error_format_and_color(build_runner: &BuildRunner<'_, '_>, cmd: &mut Proc
     }
 }
 
+/// Is `unit` a *build-time* unit — reachable from any proc-macro target or build-script
+/// (`RunCustomBuild`) unit in the current unit graph? Such a library's callers run at build time,
+/// so the runtime binary's used-set does not observe them and it must not be pruned (see the
+/// `strsim`/`darling` case). Used by the cross-crate dead-fn-elimination gate.
+fn unit_is_build_time(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> bool {
+    let graph = &build_runner.bcx.unit_graph;
+    let mut seen: std::collections::HashSet<&Unit> = std::collections::HashSet::new();
+    let mut stack: Vec<&Unit> = graph
+        .keys()
+        .filter(|u| u.target.for_host() || u.mode.is_run_custom_build())
+        .collect();
+    while let Some(u) = stack.pop() {
+        if let Some(deps) = graph.get(u) {
+            for d in deps {
+                if &d.unit == unit {
+                    return true;
+                }
+                if seen.insert(&d.unit) {
+                    stack.push(&d.unit);
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Number of cross-crate dead-fn-elimination *probe* units (Check-mode, non-host, non-build)
+/// in the whole unit graph — i.e. how many compiles will append to the used-sets. Consumers use
+/// this as the barrier count: they wait until this many probes have registered as done before
+/// reading a used-set, so no consumer ever reads a partially-written one.
+fn dead_fn_probe_total(build_runner: &BuildRunner<'_, '_>) -> usize {
+    build_runner
+        .bcx
+        .unit_graph
+        .keys()
+        .filter(|u| u.mode.is_check() && !u.target.for_host() && !u.target.is_custom_build())
+        .count()
+}
+
 /// Adds essential rustc flags and environment variables to the command to execute.
 fn build_base_args(
     build_runner: &BuildRunner<'_, '_>,
@@ -1308,6 +1347,72 @@ fn build_base_args(
             cmd.arg("--emit=dep-info,metadata,link");
         } else {
             cmd.arg("--emit=dep-info,link");
+        }
+    }
+
+    // Cross-crate dead-function elimination (option 1). Every Check-mode probe unit (the binary
+    // and — via `inject_dead_fn_probe_units` — the check form of each library dependency) emits
+    // its extern-fn references into the per-dependency used-sets during its frontend. This forms
+    // the transitive union: `main`'s probe names `a::f`, `a`'s probe names `b::used`. Each
+    // eliminable dependency library `Build` unit, scheduled after the probes, then prunes against
+    // its accumulated used-set.
+    if bcx.gctx.cli_unstable().dead_fn_elimination {
+        let xdce_dir = build_runner
+            .files()
+            .layout(unit.kind)
+            .build_dir()
+            .root()
+            .join("xdce");
+        let is_lib = unit
+            .target
+            .rustc_crate_types()
+            .iter()
+            .any(|t| matches!(t, CrateType::Lib | CrateType::Rlib));
+        // Completeness barrier: a library's used-set is appended to (concurrently) by every probe
+        // that calls it; the consumer must not read it until *all* probes are done, or it will
+        // miss late appends (a `pub fn` present in the file but written after the read is pruned →
+        // undefined symbol). Count the probe (check) units once; each probe records completion in
+        // `xdce/.probes_done`; each consumer waits until that many probes have finished.
+        let probe_total = dead_fn_probe_total(build_runner);
+        let done_file = xdce_dir.join(".probes_done");
+        if unit.mode.is_check() && !unit.target.for_host() && !unit.target.is_custom_build() {
+            // A probe (binary or library check unit): walk its MIR, append to each dependency's
+            // used-set, then register completion in the barrier file.
+            cmd.arg(format!("-Zdead-fn-emit-used-set={}", xdce_dir.display()));
+            cmd.arg(format!("-Zdead-fn-probe-done={}", done_file.display()));
+            // Encode full MIR into the check unit's `rmeta`. The *binary's* probe runs the
+            // monomorphization collector to catch functions reached only through generic
+            // instantiation (a ZST fn item passed to a combinator, called in its monomorphized
+            // body). The collector must read the callees' MIR cross-crate; without this a
+            // dependency's check rmeta omits it and the collector errors "missing optimized MIR".
+            cmd.arg("-Zalways-encode-mir");
+        } else if unit.mode == CompileMode::Build
+            && is_lib
+            && !unit.target.is_custom_build()
+            && !unit.target.for_host()
+            && !unit_is_build_time(build_runner, unit)
+        {
+            // A *runtime* library dependency: prune against its used-set. Ordering is enforced
+            // purely by the graph edges `inject_dead_fn_probe_units` adds (this Build unit depends
+            // on every probe that can append to its used-set), so by the time Cargo *schedules*
+            // this unit, the used-set is already complete. We deliberately do NOT block in-process
+            // on a barrier: a blocked rustc holds a Cargo job slot, and at scale enough dependency
+            // Build units block to starve the probe that would release them (a job-slot deadlock).
+            // Build-time deps (proc-macro / build-script closures) are excluded above. A short
+            // `wait-used-set` only smooths filesystem latency; a missing used-set keeps the full
+            // closure.
+            let usedset = xdce_dir.join(format!("{}.usedset", unit.target.crate_name()));
+            cmd.arg("-Zdead-fn-elimination");
+            cmd.arg(format!("-Zdead-fn-used-set={}", usedset.display()));
+            let _ = (probe_total, &done_file);
+            // Short filesystem-latency safety net: the used-set file is already complete by graph
+            // ordering, this only covers the rare case of a not-yet-flushed write.
+            // Bounded wait for the per-crate `.done` completeness marker (written by the binary's
+            // collector probe). Graph edges already order most dependencies after that probe, so
+            // the marker is normally present with no wait. A dependency that raced ahead waits up
+            // to this long, then keeps its full closure (sound) — bounded so a cluster of waiters
+            // cannot starve the probe into a deadlock.
+            cmd.arg("-Zdead-fn-wait-used-set=30");
         }
     }
 
@@ -1975,6 +2080,13 @@ pub fn extern_args(
     };
 
     for dep in deps {
+        // Skip cross-crate dead-fn-elimination ordering-only edges: they sequence the build
+        // (probe before prune) and must not become an `--extern`.
+        if dep.extern_crate_name.as_str()
+            == crate::core::compiler::unit_dependencies::DCE_ORDER_ONLY_EXTERN_NAME
+        {
+            continue;
+        }
         if dep.unit.target.is_linkable() && !dep.unit.mode.is_doc() {
             link_to(dep, dep.extern_crate_name, dep.noprelude, dep.nounused)?;
         }

--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -40,6 +40,13 @@ use crate::util::interning::InternedString;
 
 const IS_NO_ARTIFACT_DEP: Option<&'static Artifact> = None;
 
+/// Sentinel `extern_crate_name` for the cross-crate dead-fn-elimination ordering edges that
+/// `inject_dead_fn_probe_units` adds from a pruned library's `Build` unit to the used-set-emitting
+/// probe/check units. Such an edge exists only to sequence the build (probe before prune); it must
+/// never contribute an `--extern`. The rustc-args builder (`add_deps_extern`) skips deps whose
+/// `extern_crate_name` equals this value. Not a valid crate identifier, so it never collides.
+pub(crate) const DCE_ORDER_ONLY_EXTERN_NAME: &str = "\u{0}dce-order-only";
+
 /// Collection of stuff used while creating the [`UnitGraph`].
 struct State<'a, 'gctx> {
     ws: &'a Workspace<'gctx>,
@@ -140,6 +147,12 @@ pub fn build_unit_dependencies<'a, 'gctx>(
     }
 
     connect_run_custom_build_deps(&mut state);
+
+    // Cross-crate dead-function elimination (option 1): split each binary unit into a
+    // frontend/probe pass (emits per-dependency used-sets) scheduled before dependency codegen.
+    if state.gctx.cli_unstable().dead_fn_elimination {
+        inject_dead_fn_probe_units(&mut state);
+    }
 
     // Dependencies are used in tons of places throughout the backend, many of
     // which affect the determinism of the build itself. As a result be sure
@@ -837,6 +850,320 @@ fn dep_build_script(
 }
 
 /// Choose the correct mode for dependencies.
+/// Cross-crate dead-function elimination, option 1: the binary-unit split.
+///
+/// A first-build codegen cut needs each dependency's used-set - which of its functions the
+/// build reaches - to exist BEFORE that dependency codegens. The used-set comes from the
+/// binary's frontend, but a binary links its dependencies, so cargo normally schedules it
+/// last. This pass rewires the graph so the ordering is
+///
+///     dependency rmeta (check)  ->  binary probe (emits used-sets)
+///                               ->  dependency codegen (pruned)  ->  binary link
+///
+/// For each binary `Build` unit it interns a **probe**: a `Check`-mode clone of the same binary
+/// whose frontend runs rustc's `-Zdead-fn-emit-used-set`. The probe depends on the *check*
+/// units of the binary's library dependencies (rmeta only). Each eliminable dependency library
+/// `Build` unit then depends on the probe and prunes against its used-set. The binary's own
+/// `Build`/link unit depends on the probe too. The result is acyclic:
+///
+///     dep(check)  ->  probe  ->  dep(build, pruned)  ->  bin(build/link)
+///
+/// The used-set is keyed by crate-relative def-path (metadata-invariant), so the fact that a
+/// dependency's check unit and build unit are compiled with different `-Cmetadata` does not
+/// matter: both compute the same key for a given function.
+fn inject_dead_fn_probe_units(state: &mut State<'_, '_>) {
+    let graph = &state.unit_dependencies;
+    let bins: Vec<Unit> = graph
+        .keys()
+        .filter(|u| u.mode == CompileMode::Build && u.target.is_bin())
+        .cloned()
+        .collect();
+    if bins.is_empty() {
+        return;
+    }
+    // Compute the set of *build-time* units: the transitive closure of every proc-macro target
+    // and every build-script (`RunCustomBuild`) unit. A library reachable from one of these runs
+    // (or feeds code that runs) at build time, so the runtime binary's used-set does not see its
+    // callers — pruning it would drop functions a proc-macro needs (e.g. `strsim` under
+    // `darling`). We must never prune these. NOTE: `kind.is_host()` is NOT a usable proxy — in a
+    // normal (non-cross) build cargo marks the *entire* graph `CompileKind::Host`.
+    let build_time: std::collections::HashSet<Unit> = {
+        let mut seen = std::collections::HashSet::new();
+        let mut stack: Vec<Unit> = graph
+            .keys()
+            .filter(|u| u.target.for_host() || u.mode.is_run_custom_build())
+            .cloned()
+            .collect();
+        while let Some(u) = stack.pop() {
+            if let Some(deps) = graph.get(&u) {
+                for d in &*deps {
+                    if seen.insert(d.unit.clone()) {
+                        stack.push(d.unit.clone());
+                    }
+                }
+            }
+        }
+        seen
+    };
+
+    let is_eliminable_lib = |u: &Unit| {
+        u.mode == CompileMode::Build
+            && !u.target.is_bin()
+            && !u.target.is_custom_build()
+            && !u.target.for_host() // not a proc-macro / plugin target
+            && !build_time.contains(u) // not a build-time dependency (see `build_time` above)
+            && u.target
+                .rustc_crate_types()
+                .iter()
+                .any(|t| matches!(t, CrateType::Lib | CrateType::Rlib))
+    };
+    let elim_libs: Vec<Unit> = graph.keys().filter(|u| is_eliminable_lib(u)).cloned().collect();
+
+    // Intern the Check-mode form of a Build unit (same fields, mode = Check).
+    let as_check = |state: &State<'_, '_>, u: &Unit| -> Unit {
+        state.interner.intern(
+            &u.pkg,
+            &u.target,
+            u.profile.clone(),
+            u.kind,
+            CompileMode::Check { test: false },
+            u.features.clone(),
+            u.rustflags.clone(),
+            u.rustdocflags.clone(),
+            u.links_overrides.clone(),
+            u.is_std,
+            u.dep_hash,
+            u.artifact,
+            u.artifact_target_for_features,
+            u.skip_non_compile_time_dep,
+        )
+    };
+
+    let mut new_units: Vec<(Unit, Vec<UnitDep>)> = Vec::new();
+    // Deferred wait-edges: (dependency-Build-unit, probe). Added only after we know each probe's
+    // transitive closure, so we never create a `dep -> probe` edge for a `dep` the probe already
+    // depends on (which would be a cycle — notably via build-script chains like
+    // `num-traits(check) -> build-script -> autocfg(build)`).
+    let mut extra_edges: Vec<(Unit, UnitDep)> = Vec::new();
+    let mut want_check: Vec<Unit> = Vec::new();
+    let mut probes: Vec<Unit> = Vec::new();
+
+    for bin in &bins {
+        let probe = as_check(state, bin);
+        probes.push(probe.clone());
+
+        // Probe depends on the check form of each eliminable library dep (rmeta only); other
+        // deps (build scripts, proc macros) pass through unchanged. Guard against self-loops: a
+        // binary can depend on its own package's lib, whose check form could coincide with the
+        // probe — never let the probe depend on itself.
+        let bin_deps = state.unit_dependencies[bin].clone();
+        let mut probe_deps: Vec<UnitDep> = Vec::new();
+        for dep in &bin_deps {
+            if is_eliminable_lib(&dep.unit) && as_check(state, &dep.unit) != probe {
+                let cu = as_check(state, &dep.unit);
+                want_check.push(dep.unit.clone());
+                probe_deps.push(UnitDep {
+                    unit: cu,
+                    unit_for: dep.unit_for,
+                    extern_crate_name: dep.extern_crate_name,
+                    dep_name: dep.dep_name,
+                    public: dep.public,
+                    noprelude: dep.noprelude,
+                    nounused: dep.nounused,
+                    manifest_deps: Unhashed(None),
+                });
+            } else {
+                probe_deps.push(dep.clone());
+            }
+        }
+        new_units.push((probe.clone(), probe_deps));
+
+        // Binary link waits on the probe.
+        extra_edges.push((
+            bin.clone(),
+            UnitDep {
+                unit: probe.clone(),
+                unit_for: UnitFor::new_normal(bin.kind),
+                extern_crate_name: bin.pkg.name(),
+                dep_name: None,
+                public: false,
+                noprelude: false,
+                nounused: true,
+                manifest_deps: Unhashed(None),
+            },
+        ));
+
+    }
+
+    // Materialise the check units the probes depend on, plus their transitive check subgraph, so
+    // cargo knows how to build them (they mirror the Build units' library dep edges, in check).
+    let mut check_graph: HashMap<Unit, Vec<UnitDep>> = HashMap::new();
+    for u in &want_check {
+        build_check_subgraph(state, u, &as_check, &is_eliminable_lib, &mut check_graph);
+    }
+    let check_graph_keys: Vec<Unit> = check_graph.keys().cloned().collect();
+
+    for (probe, deps) in new_units {
+        state.unit_dependencies.entry(probe).or_insert(deps);
+    }
+    for (unit, deps) in check_graph {
+        state.unit_dependencies.entry(unit).or_insert(deps);
+    }
+    for (unit, dep) in extra_edges {
+        if let Some(list) = state.unit_dependencies.get_mut(&unit) {
+            list.push(dep);
+        }
+    }
+
+    // A library's used-set is the *union* over every crate that calls it, and each such crate
+    // contributes during its own frontend probe (the bin probe or a dependency's check unit). So a
+    // library's pruned `Build` must wait for ALL of those probes to finish — not just the binary's.
+    // Make every eliminable library `Build` unit depend on every used-set-emitting unit (all bin
+    // probes + all check units), skipping any emitter reachable *from* the library (that would be a
+    // cycle: the emitter needs this library's rmeta). A skipped emitter just means this library
+    // keeps a slightly larger closure — always sound.
+    // Emitters to wait on: every used-set-emitting unit — the binary probes AND every library
+    // check unit. Waiting on the bin probe alone is not enough in a large graph: a library's
+    // used-set is appended to (concurrently) by each caller's check unit, and the consumer reads
+    // the file ONCE, so the library must not codegen until every emitter has finished appending.
+    // These edges to check units are marked (see `DCE_ORDER_ONLY`) and dropped from `--extern`.
+    let emitters: Vec<Unit> = probes
+        .iter()
+        .cloned()
+        .chain(check_graph_keys.iter().cloned())
+        .collect();
+    let closure_of = |start: &Unit, g: &UnitGraph| -> std::collections::HashSet<Unit> {
+        let mut seen = std::collections::HashSet::new();
+        let mut stack = vec![start.clone()];
+        while let Some(u) = stack.pop() {
+            if let Some(deps) = g.get(&u) {
+                for d in deps {
+                    if seen.insert(d.unit.clone()) {
+                        stack.push(d.unit.clone());
+                    }
+                }
+            }
+        }
+        seen
+    };
+    // Precompute the closure of each library (to detect emitter-in-closure = would-be cycle).
+    let mut lib_closures: HashMap<Unit, std::collections::HashSet<Unit>> = HashMap::new();
+    for lib in &elim_libs {
+        lib_closures.insert(lib.clone(), closure_of(lib, &state.unit_dependencies));
+    }
+    for lib in &elim_libs {
+        let lib_closure = &lib_closures[lib];
+        for emitter in &emitters {
+            if emitter == lib || lib_closure.contains(emitter) {
+                continue; // emitter depends on this lib (or is it) -> cycle; skip
+            }
+            if let Some(list) = state.unit_dependencies.get_mut(lib) {
+                list.push(UnitDep {
+                    unit: emitter.clone(),
+                    unit_for: UnitFor::new_normal(lib.kind),
+                    // Ordering-only edge (see `DCE_ORDER_ONLY_EXTERN_NAME`): scheduling only, never
+                    // an `--extern`. The rustc-args builder drops deps carrying this sentinel name.
+                    extern_crate_name: DCE_ORDER_ONLY_EXTERN_NAME.into(),
+                    dep_name: None,
+                    public: false,
+                    noprelude: false,
+                    nounused: true,
+                    manifest_deps: Unhashed(None),
+                });
+            }
+        }
+    }
+
+    // Debug: detect any cycle we introduced (DFS with a recursion stack), and report the path.
+    if std::env::var_os("XDCE_CYCLE_CHECK").is_some() {
+        let g = &state.unit_dependencies;
+        let mut color: HashMap<*const (), u8> = HashMap::new();
+        let mut path: Vec<String> = Vec::new();
+        fn dfs(
+            u: &Unit,
+            g: &UnitGraph,
+            color: &mut HashMap<*const (), u8>,
+            path: &mut Vec<String>,
+        ) -> bool {
+            let key = std::ptr::from_ref(&**u) as *const ();
+            let label = format!("{}:{:?}:{}", u.pkg.name(), u.mode, u.target.name());
+            match color.get(&key) {
+                Some(1) => {
+                    path.push(label);
+                    return true; // back-edge -> cycle
+                }
+                Some(2) => return false,
+                _ => {}
+            }
+            color.insert(key, 1);
+            path.push(label);
+            if let Some(deps) = g.get(u) {
+                for d in deps {
+                    if dfs(&d.unit, g, color, path) {
+                        return true;
+                    }
+                }
+            }
+            path.pop();
+            color.insert(key, 2);
+            false
+        }
+        for u in g.keys() {
+            let key = std::ptr::from_ref(&**u) as *const ();
+            if !color.contains_key(&key) {
+                path.clear();
+                if dfs(u, g, &mut color, &mut path) {
+                    panic!("XDCE introduced a unit-graph cycle:\n  {}", path.join("\n  -> "));
+                }
+            }
+        }
+    }
+}
+
+/// Given a library `Build` unit, materialise its Check-mode form's dependency edges (the check
+/// forms of its own library deps), recursing so the probe's rmeta subgraph is fully present.
+fn build_check_subgraph(
+    state: &State<'_, '_>,
+    build_unit: &Unit,
+    as_check: &dyn Fn(&State<'_, '_>, &Unit) -> Unit,
+    is_eliminable_lib: &dyn Fn(&Unit) -> bool,
+    out: &mut HashMap<Unit, Vec<UnitDep>>,
+) {
+    let check_unit = as_check(state, build_unit);
+    if out.contains_key(&check_unit) {
+        return;
+    }
+    // Build this unit's check-dep list and record which children to recurse into. Insert the
+    // node into `out` BEFORE recursing so that a dependency cycle (which large graphs have, e.g.
+    // via shared or dev dependencies) terminates instead of overflowing the stack.
+    let mut deps: Vec<UnitDep> = Vec::new();
+    let mut recurse_into: Vec<Unit> = Vec::new();
+    if let Some(build_deps) = state.unit_dependencies.get(build_unit) {
+        for dep in build_deps {
+            if is_eliminable_lib(&dep.unit) {
+                let cu = as_check(state, &dep.unit);
+                deps.push(UnitDep {
+                    unit: cu,
+                    unit_for: dep.unit_for,
+                    extern_crate_name: dep.extern_crate_name,
+                    dep_name: dep.dep_name,
+                    public: dep.public,
+                    noprelude: dep.noprelude,
+                    nounused: dep.nounused,
+                    manifest_deps: Unhashed(None),
+                });
+                recurse_into.push(dep.unit.clone());
+            } else {
+                deps.push(dep.clone());
+            }
+        }
+    }
+    out.insert(check_unit, deps);
+    for child in recurse_into {
+        build_check_subgraph(state, &child, as_check, is_eliminable_lib, out);
+    }
+}
+
 fn check_or_build_mode(mode: CompileMode, target: &Target) -> CompileMode {
     match mode {
         CompileMode::Check { .. } | CompileMode::Doc { .. } | CompileMode::Docscrape => {

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -890,6 +890,7 @@ unstable_cli_options!(
     min_publish_age: bool = ("Enable the `min-publish-age` configuration for dependency version age filtering"),
     minimal_versions: bool = ("Resolve minimal dependency versions instead of maximum"),
     msrv_policy: bool = ("Enable rust-version aware policy within cargo"),
+    dead_fn_elimination: bool = ("Cross-crate dead-function elimination: probe the binary's frontend for a per-dependency used-set, then codegen each dependency pruned"),
     mtime_on_use: bool = ("Configure Cargo to update the mtime of used files"),
     next_lockfile_bump: bool,
     no_embed_metadata: bool = ("Avoid embedding metadata in library artifacts"),
@@ -1434,6 +1435,7 @@ impl CliUnstable {
             "json-target-spec" => self.json_target_spec = parse_empty(k, v)?,
             "min-publish-age" => self.min_publish_age = parse_empty(k, v)?,
             "next-lockfile-bump" => self.next_lockfile_bump = parse_empty(k, v)?,
+            "dead-fn-elimination" => self.dead_fn_elimination = parse_empty(k, v)?,
             "minimal-versions" => self.minimal_versions = parse_empty(k, v)?,
             "msrv-policy" => self.msrv_policy = parse_empty(k, v)?,
             // can also be set in .cargo/config or with and ENV


### PR DESCRIPTION
> **Draft — depends on an unlanded rustc change.** This demonstrates the Cargo side of
> cross-crate dead-function elimination and is contingent on the rustc `-Zdead-fn-*` flags
> (branch [`yijunyu/rust@dfe-flag-clean`](https://github.com/yijunyu/rust/tree/dfe-flag-clean),
> follow-up to rust-lang/rust#158220). It will not build or pass CI here without that toolchain.
> Opening as a draft for design discussion, not for merge.

## What this is

A follow-up to rust-lang/rust#158220 and the #t-compiler discussion on cross-crate dead-function
elimination. #158220's binary-only `-Zdead-fn-elimination` is a no-op — a binary's
monomorphization collector is already exact. The real slack is **cross-crate**: a library is
compiled before its callers, so on its own it must emit its whole `pub` closure, 55–85% of which
a given binary never calls (measured via `nm` rlib-vs-binary on nix/socket2/rustix/gix across
nushell/helix/zed/zeroclaw).

This PR implements the **binary-unit split** — the Cargo-side scheduling change that lets a
single `cargo build -Zdead-fn-elimination` produce a *pruned first build* (no LTO, no second
pass).

## Approach

For each binary `Build` unit, a **probe** is interned: a `Check`-mode clone of the same binary.
The probe runs the frontend + monomorphization collector and emits a per-dependency *used-set*
(which of the dependency's functions the build reaches). It depends only on dependency `rmeta`,
so it runs early. Each eliminable dependency `Build` unit then depends on the probe and prunes
against its used-set. The graph stays acyclic:

```
dep(check/rmeta)  ->  probe(emits used-sets)  ->  dep(build, pruned)  ->  bin(link)
```

## Changes

- `core/features.rs` — `-Zdead-fn-elimination` unstable flag.
- `core/compiler/unit_dependencies.rs` — `inject_dead_fn_probe_units`: the binary-unit split,
  probe interning, cycle-safe ordering edges, and build-time-dependency exclusion (a lib reachable
  from a proc-macro / build script is never pruned).
- `core/compiler/mod.rs` — flag wiring: `-Zdead-fn-emit-used-set` on check units,
  `-Zdead-fn-elimination` + used-set consumption on eliminable dependency Build units, and
  `-Zalways-encode-mir` on check units so the binary probe's collector can read dependency MIR.

+441 lines, 3 files.

## Result

Measured on `zeroclaw` (~330-unit workspace): one `cargo build -Zdead-fn-elimination` links a
**working** binary that runs, with **2900 functions excluded** on the first build — 0 undefined
symbols, 0 ICE, 0 graph cycles, no job-slot deadlock. Validated end-to-end (0 undefined symbols,
binary builds and runs correctly) on: a 2000-fn synthetic (Main→A→B), two `clap` binaries, an
`.or_else(fn)` higher-order case, a closure-call case, and an IMAP parser (nom combinators,
`imap-proto` 0.10 and 0.16 — parses correctly).

Wherever completeness can't be guaranteed (missing used-set or an absent per-crate completeness
marker) the pass keeps the full public closure, so the binary always links and runs; correctness
takes priority over maximum elimination.

Full design document and measurements are available on request. Feedback on the scheduling
approach is very welcome.
