### PR TITLE
refactor(source): Clarify the name of the remote git registry

### DIFF
--- a/src/sources/registry/download.rs
+++ b/src/sources/registry/download.rs
@@ -1,7 +1,7 @@
-//! Shared download logic between [`HttpRegistry`] and [`RemoteRegistry`].
+//! Shared download logic between [`HttpRegistry`] and [`GitRegistry`].
 //!
 //! [`HttpRegistry`]: super::http_remote::HttpRegistry
-//! [`RemoteRegistry`]: super::remote::RemoteRegistry
+//! [`GitRegistry`]: super::git_remote::GitRegistry
 
 use crate::util::interning::InternedString;
 use anyhow::Context as _;

--- a/src/sources/registry/git_remote.rs
+++ b/src/sources/registry/git_remote.rs
@@ -1,4 +1,4 @@
-//! Access to a Git index based registry. See [`RemoteRegistry`] for details.
+//! Access to a Git index based registry. See [`GitRegistry`] for details.
 
 use crate::sources::git;
 use crate::sources::git::fetch::RemoteKind;
@@ -46,7 +46,7 @@ use tracing::{debug, trace};
 /// supporting Git-based index for a pretty long while.
 ///
 /// [`HttpRegistry`]: super::http_remote::HttpRegistry
-pub struct RemoteRegistry<'gctx> {
+pub struct GitRegistry<'gctx> {
     /// The name of this source, a unique string (across all sources) used as
     /// the directory name where its cached content is stored.
     name: InternedString,
@@ -76,24 +76,20 @@ pub struct RemoteRegistry<'gctx> {
     current_sha: Cell<Option<InternedString>>,
     /// Whether this registry needs to update package information.
     ///
-    /// See [`RemoteRegistry::mark_updated`] on how to make sure a registry
+    /// See [`GitRegistry::mark_updated`] on how to make sure a registry
     /// index is updated only once per session.
     needs_update: Cell<bool>,
     /// Disables status messages.
     quiet: bool,
 }
 
-impl<'gctx> RemoteRegistry<'gctx> {
+impl<'gctx> GitRegistry<'gctx> {
     /// Creates a Git-rebased remote registry for `source_id`.
     ///
     /// * `name` --- Name of a path segment where `.crate` tarballs and the
     ///   registry index are stored. Expect to be unique.
-    pub fn new(
-        source_id: SourceId,
-        gctx: &'gctx GlobalContext,
-        name: &str,
-    ) -> RemoteRegistry<'gctx> {
-        RemoteRegistry {
+    pub fn new(source_id: SourceId, gctx: &'gctx GlobalContext, name: &str) -> GitRegistry<'gctx> {
+        GitRegistry {
             name: name.into(),
             index_path: gctx.registry_index_path().join(name),
             cache_path: gctx.registry_cache_path().join(name),
@@ -185,9 +181,9 @@ impl<'gctx> RemoteRegistry<'gctx> {
         // Note that we don't actually hand out the static lifetime, instead we
         // only return a scoped one from this function. Additionally the repo
         // we loaded from (above) lives as long as this object
-        // (`RemoteRegistry`) so we then just need to ensure that the tree is
+        // (`GitRegistry`) so we then just need to ensure that the tree is
         // destroyed first in the destructor, hence the destructor on
-        // `RemoteRegistry` below.
+        // `GitRegistry` below.
         let tree = unsafe { mem::transmute::<git2::Tree<'_>, git2::Tree<'static>>(tree) };
         *self.tree.borrow_mut() = Some(tree);
         Ok(Ref::map(self.tree.borrow(), |s| s.as_ref().unwrap()))
@@ -281,7 +277,7 @@ impl<'gctx> RemoteRegistry<'gctx> {
 }
 
 #[async_trait::async_trait(?Send)]
-impl<'gctx> RegistryData for RemoteRegistry<'gctx> {
+impl<'gctx> RegistryData for GitRegistry<'gctx> {
     fn prepare(&self) -> CargoResult<()> {
         self.repo()?;
         self.gctx
@@ -339,7 +335,7 @@ impl<'gctx> RegistryData for RemoteRegistry<'gctx> {
         // in the index, so we don't need to worry about an `update_index`
         // happening in a different process.
         fn load_helper(
-            registry: &RemoteRegistry<'_>,
+            registry: &GitRegistry<'_>,
             path: &Path,
             index_version: Option<&str>,
         ) -> CargoResult<LoadResponse> {
@@ -410,7 +406,7 @@ impl<'gctx> RegistryData for RemoteRegistry<'gctx> {
     /// Read the general concept for `invalidate_cache()` on
     /// [`RegistryData::invalidate_cache`].
     ///
-    /// To fully invalidate, undo [`RemoteRegistry::mark_updated`]'s work.
+    /// To fully invalidate, undo [`GitRegistry::mark_updated`]'s work.
     fn invalidate_cache(&self) {
         self.needs_update.set(true);
     }
@@ -458,8 +454,8 @@ impl<'gctx> RegistryData for RemoteRegistry<'gctx> {
 }
 
 /// Implemented to just be sure to drop `tree` field before our other fields.
-/// See SAFETY inside [`RemoteRegistry::tree()`] for more.
-impl<'gctx> Drop for RemoteRegistry<'gctx> {
+/// See SAFETY inside [`GitRegistry::tree()`] for more.
+impl<'gctx> Drop for GitRegistry<'gctx> {
     fn drop(&mut self) {
         self.tree.borrow_mut().take();
     }

--- a/src/sources/registry/index/cache.rs
+++ b/src/sources/registry/index/cache.rs
@@ -26,7 +26,7 @@
 //! of trying to parse as little as possible.
 //!
 //! > Note that as a small aside even *loading* the JSON from the registry is
-//! > actually pretty slow. For crates.io and [`RemoteRegistry`] we don't
+//! > actually pretty slow. For crates.io and [`GitRegistry`] we don't
 //! > actually check out the git index on disk because that takes quite some
 //! > time and is quite large. Instead we use `libgit2` to read the JSON from
 //! > the raw git objects. This in turn can be slow (aka show up high in
@@ -63,7 +63,7 @@
 //! [`Dependency`]: crate::workspace::Dependency
 //! [`IndexPackage`]: super::IndexPackage
 //! [`IndexSummary::parse`]: super::IndexSummary::parse
-//! [`RemoteRegistry`]: crate::sources::registry::remote::RemoteRegistry
+//! [`GitRegistry`]: crate::sources::registry::git_remote::GitRegistry
 
 use std::cell::RefCell;
 use std::fs;

--- a/src/sources/registry/index/mod.rs
+++ b/src/sources/registry/index/mod.rs
@@ -55,7 +55,7 @@ const INDEX_V_MAX: u32 = 2;
 /// Different kinds of registries store the index differently:
 ///
 /// * [`LocalRegistry`] is a simple on-disk tree of files of the raw index.
-/// * [`RemoteRegistry`] is stored as a raw git repository.
+/// * [`GitRegistry`] is stored as a raw git repository.
 /// * [`HttpRegistry`] fills the on-disk index cache directly without keeping
 ///   any raw index.
 ///
@@ -63,7 +63,7 @@ const INDEX_V_MAX: u32 = 2;
 /// This transparently handles caching of the index in a more efficient format.
 ///
 /// [`LocalRegistry`]: super::local::LocalRegistry
-/// [`RemoteRegistry`]: super::remote::RemoteRegistry
+/// [`GitRegistry`]: super::git_remote::GitRegistry
 /// [`HttpRegistry`]: super::http_remote::HttpRegistry
 pub struct RegistryIndex<'gctx> {
     source_id: SourceId,
@@ -349,12 +349,12 @@ impl<'gctx> RegistryIndex<'gctx> {
     ///
     ///    The actual kind index file being parsed depends on which kind of
     ///    [`RegistryData`] the `load` argument is given. For example, a
-    ///    Git-based [`RemoteRegistry`] will first try a on-disk index cache
+    ///    Git-based [`GitRegistry`] will first try a on-disk index cache
     ///    file, and then try parsing registry raw index from Git repository.
     ///
     /// In effect, this is intended to be a quite cheap operation.
     ///
-    /// [`RemoteRegistry`]: super::remote::RemoteRegistry
+    /// [`GitRegistry`]: super::git_remote::GitRegistry
     async fn load_summaries(
         &self,
         name: InternedString,

--- a/src/sources/registry/mod.rs
+++ b/src/sources/registry/mod.rs
@@ -32,7 +32,7 @@
 //!
 //! * [`LocalRegistry`] --- Serves the index and package contents entirely on
 //!   a local filesystem.
-//! * [`RemoteRegistry`] --- Serves the index ahead of time from a Git
+//! * [`GitRegistry`] --- Serves the index ahead of time from a Git
 //!   repository, and package contents are downloaded as needed.
 //! * [`HttpRegistry`] --- Serves both the index and package contents on demand
 //!   over a HTTP-based registry API. This is the default starting from 1.70.0.
@@ -41,7 +41,7 @@
 //! created from either [`RegistrySource::local`] or [`RegistrySource::remote`].
 //!
 //! [`LocalRegistry`]: local::LocalRegistry
-//! [`RemoteRegistry`]: remote::RemoteRegistry
+//! [`GitRegistry`]: git_remote::GitRegistry
 //! [`HttpRegistry`]: http_remote::HttpRegistry
 //!
 //! # The Index of a Registry
@@ -401,8 +401,8 @@ mod download;
 mod http_remote;
 pub(crate) mod index;
 pub use index::IndexSummary;
+mod git_remote;
 mod local;
-mod remote;
 
 /// Generates a unique name for [`SourceId`] to have a unique path to put their
 /// index files.
@@ -424,7 +424,7 @@ fn short_name(id: SourceId, is_shallow: bool) -> String {
 impl<'gctx> RegistrySource<'gctx> {
     /// Creates a [`Source`] of a "remote" registry.
     /// It could be either an HTTP-based [`http_remote::HttpRegistry`] or
-    /// a Git-based [`remote::RemoteRegistry`].
+    /// a Git-based [`git_remote::GitRegistry`].
     pub fn remote(
         source_id: SourceId,
         gctx: &'gctx GlobalContext,
@@ -440,7 +440,7 @@ impl<'gctx> RegistrySource<'gctx> {
         let ops = if source_id.is_sparse() {
             Box::new(http_remote::HttpRegistry::new(source_id, gctx, &name)?) as Box<_>
         } else {
-            Box::new(remote::RemoteRegistry::new(source_id, gctx, &name)) as Box<_>
+            Box::new(git_remote::GitRegistry::new(source_id, gctx, &name)) as Box<_>
         };
 
         Ok(RegistrySource::new(source_id, gctx, &name, ops))


### PR DESCRIPTION
### What does this PR try to resolve?

Make the registry source's backend naming more consistent. Found this confusing when working in this area. I don't remember what I was doing here before the weekend. Maybe related to #17226?

### How to test and review this PR?
