### PR TITLE
fix(git): Hide git fetch output without progress 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,6 +607,7 @@ dependencies = [
  "anstyle-hyperlink",
  "anstyle-progress",
  "anyhow",
+ "cargo-util",
  "libc",
  "serde",
  "serde_json",

--- a/crates/cargo-util-terminal/Cargo.toml
+++ b/crates/cargo-util-terminal/Cargo.toml
@@ -14,6 +14,7 @@ anstyle.workspace = true
 anstyle-hyperlink = { workspace = true, features = ["file"] }
 anstyle-progress.workspace = true
 anyhow.workspace = true
+cargo-util.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["raw_value"] }
 supports-hyperlinks.workspace = true

--- a/crates/cargo-util-terminal/src/shell.rs
+++ b/crates/cargo-util-terminal/src/shell.rs
@@ -363,6 +363,21 @@ impl Shell {
         url.map(|u| self.err_hyperlink(u)).unwrap_or_default()
     }
 
+    /// Query terminal capability, independent of user configuration
+    pub fn progress_supported(&self) -> bool {
+        // report no progress when -q (for quiet) or TERM=dumb are set
+        // or if running on Continuous Integration service like Travis where the
+        // output logs get mangled.
+        if self.verbosity == Verbosity::Quiet
+            || std::env::var("TERM").as_deref() == Ok("dumb")
+            || cargo_util::is_ci()
+        {
+            false
+        } else {
+            true
+        }
+    }
+
     fn unstable_flags_rustc_unicode(&self) -> bool {
         match &self.output {
             ShellOut::Write(_) => false,

--- a/src/sources/git/utils.rs
+++ b/src/sources/git/utils.rs
@@ -1,6 +1,7 @@
 //! Utilities for handling git repositories, mainly around
 //! authentication/cloning.
 
+use crate::context::ProgressWhen;
 use crate::sources::git::fetch::RemoteKind;
 use crate::sources::git::oxide;
 use crate::sources::git::oxide::cargo_config_to_gitoxide_overrides;
@@ -1156,15 +1157,25 @@ fn fetch_with_cli(
         let depth = 0i32.saturating_add_unsigned(depth.get());
         cmd.arg(format!("--depth={depth}"));
     }
-    match gctx.shell().verbosity() {
-        Verbosity::Normal => {}
-        Verbosity::Verbose => {
-            cmd.arg("--verbose");
+
+    let progress_config = gctx.progress_config();
+    let progress = match progress_config.when {
+        ProgressWhen::Always => true,
+        ProgressWhen::Never => false,
+        ProgressWhen::Auto => {
+            // Recreate the same conditions used with `Progress`
+            let width = progress_config
+                .width
+                .or_else(|| gctx.shell().err_width().progress_max_width());
+            gctx.shell().progress_supported() && width.is_some()
         }
-        Verbosity::Quiet => {
-            cmd.arg("--quiet");
-        }
+    };
+    if gctx.shell().verbosity() == Verbosity::Verbose {
+        cmd.arg("--verbose");
+    } else if !progress {
+        cmd.arg("--quiet");
     }
+
     cmd.arg("--force") // handle force pushes
         .arg("--update-head-ok") // see discussion in #2078
         .arg(url)

--- a/src/util/progress.rs
+++ b/src/util/progress.rs
@@ -56,6 +56,12 @@ impl<'gctx> Progress<'gctx> {
         style: ProgressStyle,
         gctx: &'gctx GlobalContext,
     ) -> Progress<'gctx> {
+        let progress_config = gctx.progress_config();
+        match progress_config.when {
+            ProgressWhen::Always => return Progress::new_priv(name, style, gctx),
+            ProgressWhen::Never => return Progress { gctx, state: None },
+            ProgressWhen::Auto => {}
+        }
         // report no progress when -q (for quiet) or TERM=dumb are set
         // or if running on Continuous Integration service like Travis where the
         // output logs get mangled.
@@ -63,12 +69,6 @@ impl<'gctx> Progress<'gctx> {
             Ok(term) => term == "dumb",
             Err(_) => false,
         };
-        let progress_config = gctx.progress_config();
-        match progress_config.when {
-            ProgressWhen::Always => return Progress::new_priv(name, style, gctx),
-            ProgressWhen::Never => return Progress { gctx, state: None },
-            ProgressWhen::Auto => {}
-        }
         if gctx.shell().verbosity() == Verbosity::Quiet || dumb || is_ci() {
             return Progress { gctx, state: None };
         }

--- a/src/util/progress.rs
+++ b/src/util/progress.rs
@@ -73,7 +73,8 @@ impl<'gctx> Progress<'gctx> {
         // report no progress when -q (for quiet) or TERM=dumb are set
         // or if running on Continuous Integration service like Travis where the
         // output logs get mangled.
-        let dumb = match gctx.get_env("TERM") {
+        #[allow(clippy::disallowed_methods, reason = "not a cargo env")]
+        let dumb = match std::env::var("TERM") {
             Ok(term) => term == "dumb",
             Err(_) => false,
         };

--- a/src/util/progress.rs
+++ b/src/util/progress.rs
@@ -57,22 +57,29 @@ impl<'gctx> Progress<'gctx> {
         gctx: &'gctx GlobalContext,
     ) -> Progress<'gctx> {
         let progress_config = gctx.progress_config();
-        match progress_config.when {
-            ProgressWhen::Always => return Progress::new_priv(name, style, gctx),
-            ProgressWhen::Never => return Progress { gctx, state: None },
-            ProgressWhen::Auto => {}
-        }
-        // report no progress when -q (for quiet) or TERM=dumb are set
-        // or if running on Continuous Integration service like Travis where the
-        // output logs get mangled.
-        let dumb = match gctx.get_env("TERM") {
-            Ok(term) => term == "dumb",
-            Err(_) => false,
+        let progress = match progress_config.when {
+            ProgressWhen::Always => true,
+            ProgressWhen::Never => false,
+            ProgressWhen::Auto => {
+                // report no progress when -q (for quiet) or TERM=dumb are set
+                // or if running on Continuous Integration service like Travis where the
+                // output logs get mangled.
+                let dumb = match gctx.get_env("TERM") {
+                    Ok(term) => term == "dumb",
+                    Err(_) => false,
+                };
+                if gctx.shell().verbosity() == Verbosity::Quiet || dumb || is_ci() {
+                    false
+                } else {
+                    true
+                }
+            }
         };
-        if gctx.shell().verbosity() == Verbosity::Quiet || dumb || is_ci() {
+        if progress {
+            Progress::new_priv(name, style, gctx)
+        } else {
             return Progress { gctx, state: None };
         }
-        Progress::new_priv(name, style, gctx)
     }
 
     fn new_priv(name: &str, style: ProgressStyle, gctx: &'gctx GlobalContext) -> Progress<'gctx> {

--- a/src/util/progress.rs
+++ b/src/util/progress.rs
@@ -60,25 +60,27 @@ impl<'gctx> Progress<'gctx> {
         let progress = match progress_config.when {
             ProgressWhen::Always => true,
             ProgressWhen::Never => false,
-            ProgressWhen::Auto => {
-                // report no progress when -q (for quiet) or TERM=dumb are set
-                // or if running on Continuous Integration service like Travis where the
-                // output logs get mangled.
-                let dumb = match gctx.get_env("TERM") {
-                    Ok(term) => term == "dumb",
-                    Err(_) => false,
-                };
-                if gctx.shell().verbosity() == Verbosity::Quiet || dumb || is_ci() {
-                    false
-                } else {
-                    true
-                }
-            }
+            ProgressWhen::Auto => Self::progress_supported(gctx),
         };
         if progress {
             Progress::new_priv(name, style, gctx)
         } else {
             return Progress { gctx, state: None };
+        }
+    }
+
+    fn progress_supported(gctx: &'gctx GlobalContext) -> bool {
+        // report no progress when -q (for quiet) or TERM=dumb are set
+        // or if running on Continuous Integration service like Travis where the
+        // output logs get mangled.
+        let dumb = match gctx.get_env("TERM") {
+            Ok(term) => term == "dumb",
+            Err(_) => false,
+        };
+        if gctx.shell().verbosity() == Verbosity::Quiet || dumb || is_ci() {
+            false
+        } else {
+            true
         }
     }
 

--- a/src/util/progress.rs
+++ b/src/util/progress.rs
@@ -6,9 +6,7 @@ use std::time::{Duration, Instant};
 use crate::context::ProgressWhen;
 use crate::util::{CargoResult, GlobalContext};
 use anstyle_progress::TermProgress;
-use cargo_util::is_ci;
 use cargo_util_terminal::Shell;
-use cargo_util_terminal::Verbosity;
 use unicode_width::UnicodeWidthChar;
 
 /// CLI progress bar.
@@ -60,27 +58,12 @@ impl<'gctx> Progress<'gctx> {
         let progress = match progress_config.when {
             ProgressWhen::Always => true,
             ProgressWhen::Never => false,
-            ProgressWhen::Auto => Self::progress_supported(gctx),
+            ProgressWhen::Auto => gctx.shell().progress_supported(),
         };
         if progress {
             Progress::new_priv(name, style, gctx)
         } else {
             return Progress { gctx, state: None };
-        }
-    }
-
-    fn progress_supported(gctx: &'gctx GlobalContext) -> bool {
-        // report no progress when -q (for quiet) or TERM=dumb are set
-        // or if running on Continuous Integration service like Travis where the
-        // output logs get mangled.
-        #[allow(clippy::disallowed_methods, reason = "not a cargo env")]
-        if gctx.shell().verbosity() == Verbosity::Quiet
-            || std::env::var("TERM").as_deref() == Ok("dumb")
-            || is_ci()
-        {
-            false
-        } else {
-            true
         }
     }
 

--- a/src/util/progress.rs
+++ b/src/util/progress.rs
@@ -74,11 +74,10 @@ impl<'gctx> Progress<'gctx> {
         // or if running on Continuous Integration service like Travis where the
         // output logs get mangled.
         #[allow(clippy::disallowed_methods, reason = "not a cargo env")]
-        let dumb = match std::env::var("TERM") {
-            Ok(term) => term == "dumb",
-            Err(_) => false,
-        };
-        if gctx.shell().verbosity() == Verbosity::Quiet || dumb || is_ci() {
+        if gctx.shell().verbosity() == Verbosity::Quiet
+            || std::env::var("TERM").as_deref() == Ok("dumb")
+            || is_ci()
+        {
             false
         } else {
             true

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -4237,11 +4237,11 @@ fn github_fastpath_error_message() {
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `https://github.com/rust-lang/bitflags.git`
 fatal: remote [ERROR] upload-pack: not our ref 11111b376b93484341c68fbca3ca110ae5cd2790
-[WARNING] spurious network error (3 tries remaining): process didn't exit successfully: `git fetch --no-tags --force --update-head-ok [..]
+[WARNING] spurious network error (3 tries remaining): process didn't exit successfully: `git fetch --no-tags --quiet --force --update-head-ok [..]
 fatal: remote [ERROR] upload-pack: not our ref 11111b376b93484341c68fbca3ca110ae5cd2790
-[WARNING] spurious network error (2 tries remaining): process didn't exit successfully: `git fetch --no-tags --force --update-head-ok [..]
+[WARNING] spurious network error (2 tries remaining): process didn't exit successfully: `git fetch --no-tags --quiet --force --update-head-ok [..]
 fatal: remote [ERROR] upload-pack: not our ref 11111b376b93484341c68fbca3ca110ae5cd2790
-[WARNING] spurious network error (1 try remaining): process didn't exit successfully: `git fetch --no-tags --force --update-head-ok [..]
+[WARNING] spurious network error (1 try remaining): process didn't exit successfully: `git fetch --no-tags --quiet --force --update-head-ok [..]
 fatal: remote [ERROR] upload-pack: not our ref 11111b376b93484341c68fbca3ca110ae5cd2790
 [ERROR] failed to get `bitflags` as a dependency of package `foo v0.1.0 ([ROOT]/foo)`
 
@@ -4258,7 +4258,7 @@ Caused by:
   revision 11111b376b93484341c68fbca3ca110ae5cd2790 not found
 
 Caused by:
-  process didn't exit successfully: `git fetch --no-tags --force --update-head-ok [..]
+  process didn't exit successfully: `git fetch --no-tags --quiet --force --update-head-ok [..]
 
 "#]])
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

The main benefit I see to `git fetch`s output is the progress
reporting.
The motivating reason to remove it unless progress is being reported is
that this is making it annoying to update the test suite to
`net.git-fetch-with-cli = true`.  This is admittedly a relatively weak reason.

This is part of #17227.

### How to test and review this PR?

This is pointing out a UX regression if we move forward with #17227. When progress is enabled, users will see git's percent progress per implemention-focused step, and not any of our progress bars, and then left with at least:
```
From [ROOTURL]/registry
 * [new ref]         HEAD       -> origin/HEAD
```