### PR TITLE
fix: Add haiku's dylib path

### DIFF
--- a/crates/cargo-util/src/paths.rs
+++ b/crates/cargo-util/src/paths.rs
@@ -57,6 +57,8 @@ pub fn dylib_path_envvar() -> &'static str {
         "DYLD_FALLBACK_LIBRARY_PATH"
     } else if cfg!(target_os = "aix") {
         "LIBPATH"
+    } else if cfg!(target_os = "haiku") {
+        "LIBRARY_PATH"
     } else {
         "LD_LIBRARY_PATH"
     }


### PR DESCRIPTION
* Haiku doesn't use LD_LIBRARY_PATH and uses LIBRARY_PATH.
* Without this, code doing prefer-dynamic will not be able to find things like rustlib's libstd-*.so

See https://github.com/rust-lang/rust/issues/159661 for example