### PR TITLE
fix(diag): bound transitive unused dependency traversal

### DIFF
--- a/src/diagnostics/rules/unused_dependencies.rs
+++ b/src/diagnostics/rules/unused_dependencies.rs
@@ -1,6 +1,7 @@
+use std::collections::VecDeque;
 use std::path::Path;
 
-use crate::util::data_structures::IndexMap;
+use crate::util::data_structures::{HashSet, IndexMap};
 use cargo_util_schemas::manifest;
 use cargo_util_schemas::manifest::TomlPackageBuild;
 use cargo_util_terminal::report::AnnotationKind;
@@ -366,7 +367,8 @@ fn is_transitive_dep(
     seen_units: &Vec<Unit>,
     bcx: &BuildContext<'_, '_>,
 ) -> bool {
-    let mut queue = std::collections::VecDeque::new();
+    let mut queue = VecDeque::new();
+    let mut visited: HashSet<&Unit> = HashSet::default();
     for root_unit in seen_units {
         for unit_dep in &bcx.unit_graph[root_unit] {
             if root_unit.pkg.package_id() == unit_dep.unit.pkg.package_id() {
@@ -375,7 +377,9 @@ fn is_transitive_dep(
             if unit_dep.unit == *direct_dep_unit {
                 continue;
             }
-            queue.push_back(&unit_dep.unit);
+            if visited.insert(&unit_dep.unit) {
+                queue.push_back(&unit_dep.unit);
+            }
         }
     }
 
@@ -384,7 +388,9 @@ fn is_transitive_dep(
             if unit_dep.unit == *direct_dep_unit {
                 return true;
             }
-            queue.push_back(&unit_dep.unit);
+            if visited.insert(&unit_dep.unit) {
+                queue.push_back(&unit_dep.unit);
+            }
         }
     }
 


### PR DESCRIPTION
Note: this is a rebase of #17165

### What does this PR try to resolve?

Fixes #17154 
Closes #17165

The `cargo::unused_dependencies` transitive dependency check queued every path through the unit graph. For shared dependency graphs, the same unit could be enqueued many times, causing the traversal to grow with the number of paths instead of the number of units.

This bounds the traversal by tracking visited units while keeping the existing breadth-first search behavior.

### How to test and review this PR?

The implementation change is limited to `is_transitive_dep` in `src/cargo/diagnostics/rules/unused_dependencies.rs`. Reviewers should check that the traversal still skips the direct dependency as before, while only enqueueing each reachable unit once.