### PR TITLE
fix(test): gate trim-paths tests on split debuginfo support

### DIFF
--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -548,12 +548,14 @@ mod object_works {
         object_works_helper("off", inspect_debuginfo);
     }
 
-    #[cargo_test(requires = "readelf")]
+    // Some Linux targets, such as RISC-V, only support `off`.
+    // See https://github.com/rust-lang/cargo/issues/17255.
+    #[cargo_test(requires = "readelf", requires_host_split_debuginfo = "packed")]
     fn with_split_debuginfo_packed() {
         object_works_helper("packed", inspect_debuginfo);
     }
 
-    #[cargo_test(requires = "readelf")]
+    #[cargo_test(requires = "readelf", requires_host_split_debuginfo = "unpacked")]
     fn with_split_debuginfo_unpacked() {
         object_works_helper("unpacked", inspect_debuginfo);
     }


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes #17255.

The `profile_trim_paths::object_works` tests run the `packed` and `unpacked` cases on every Linux host. However, some Linux targets, including `riscv64gc-unknown-linux-gnu`, currently report only `off` from `rustc --print=split-debuginfo`.

Cargo correctly avoids passing an unsupported `-Csplit-debuginfo` value to rustc. The tests nevertheless expect that argument in the verbose command output, causing both cases to fail on those hosts.

This reuses the `requires_host_split_debuginfo` test requirement for the `packed` and `unpacked` cases. Unsupported hosts now report the tests as ignored with the capability as the reason, while the `off` case continues to provide `trim-paths=object` coverage. If rustc later advertises support for either mode, the corresponding test will automatically run again.

### How to test and review this PR?

Review that only the `packed` and `unpacked` Linux tests are gated, and that the `off` test remains unconditional.

Tested from `src/tools/cargo` in a rust checkout with:

```console
../../../build/x86_64-unknown-linux-gnu/rustfmt/bin/rustfmt --check tests/testsuite/profile_trim_paths.rs
RUSTC=../../../build/x86_64-unknown-linux-gnu/stage2/bin/rustc cargo test --test testsuite profile_trim_paths::object_works:: -- --nocapture
```

All three cases pass on an x86_64 Linux host that supports `off`, `packed`, and `unpacked`.

The RISC-V target capability was checked with:

```console
../../../build/x86_64-unknown-linux-gnu/stage2/bin/rustc --target riscv64gc-unknown-linux-gnu --print=split-debuginfo
off
```
