### PR TITLE
Enable build-dir layout v2 on nightly by default

### DIFF
--- a/src/workspace/features.rs
+++ b/src/workspace/features.rs
@@ -844,11 +844,17 @@ macro_rules! unstable_cli_options {
         }
         impl Default for CliUnstable {
             fn default() -> Self {
-                Self {
+                let mut unstable = Self {
                     $(
                         $element: Default::default()
                     ),*
-                }
+                };
+
+                // Defaults to enabled on nightly unless explicitly opted out.
+                unstable.build_dir_new_layout =
+                    matches!(crate::version().release_channel.as_deref(), Some("nightly" | "dev"));
+
+                return unstable;
             }
         }
 

--- a/src/workspace/features.rs
+++ b/src/workspace/features.rs
@@ -826,7 +826,7 @@ macro_rules! unstable_cli_options {
         /// Cargo, like `rustc`, accepts a suite of `-Z` flags which are intended for
         /// gating unstable functionality to Cargo. These flags are only available on
         /// the nightly channel of Cargo.
-        #[derive(Default, Debug, Deserialize)]
+        #[derive(Debug, Deserialize)]
         #[serde(default, rename_all = "kebab-case")]
         pub struct CliUnstable {
             $(
@@ -840,6 +840,15 @@ macro_rules! unstable_cli_options {
             pub fn help() -> Vec<(&'static str, Option<&'static str>)> {
                 let fields = vec![$((stringify!($element), None$(.or(Some($help)))?)),*];
                 fields
+            }
+        }
+        impl Default for CliUnstable {
+            fn default() -> Self {
+                Self {
+                    $(
+                        $element: Default::default()
+                    ),*
+                }
             }
         }
 


### PR DESCRIPTION
### What does this PR try to resolve?

This PR enables the new `build-dir` on nightly by default. 

The majority of changes were taken/adapted from https://github.com/rust-lang/cargo/pull/16807

Tracked in https://github.com/rust-lang/cargo/issues/15010

### How to test and review this PR?

Same as the original stabilization PR.
The notable changes are:
* A handful of tests may recompile crates when test's `p.cargo()` use a mixture of stable and nightly
  * For checksum freshness specifically,  I enabled nightly on all of the `p.cargo()` as the tests are specifically testing for rebuilds.
