### PR TITLE
chore: bump to `libgit2-sys@0.18.7+1.9.6`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3011,9 +3011,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.5+1.9.4"
+version = "0.18.7+1.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
+checksum = "23c7391e4b9f4ffab1a624223cc1d7385ff9a678f490768add717de7ea2f4d89"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
These include some vulnerability fixes.

See:

* https://github.com/libgit2/libgit2/releases/tag/v1.9.6
* https://github.com/libgit2/libgit2/releases/tag/v1.9.5