### PR TITLE
Allow setting `-Zembed-metadata` value from the config

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -134,7 +134,6 @@ mod environment;
 use environment::Env;
 
 mod schema;
-use crate::workspace::features::EmbedMetadata;
 pub use schema::*;
 
 /// Helper macro for creating typed access methods.
@@ -1261,11 +1260,7 @@ impl GlobalContext {
     }
 
     pub fn should_embed_metadata(&self) -> bool {
-        match self.cli_unstable().embed_metadata {
-            EmbedMetadata::Embed => true,
-            EmbedMetadata::DoNotEmbed => false,
-            EmbedMetadata::Unset => true,
-        }
+        self.cli_unstable().embed_metadata.unwrap_or(true)
     }
 
     pub fn network_allowed(&self) -> bool {

--- a/src/workspace/features.rs
+++ b/src/workspace/features.rs
@@ -124,15 +124,14 @@ use std::fmt::{self, Write};
 use std::path::PathBuf;
 use std::str::FromStr;
 
-use anyhow::{Error, bail};
-use cargo_util::ProcessBuilder;
-use serde::{Deserialize, Serialize};
-use tracing::debug;
-
 use crate::GlobalContext;
 use crate::resolver::ResolveBehavior;
 use crate::util::errors::CargoResult;
 use crate::util::indented_lines;
+use anyhow::{Error, bail};
+use cargo_util::ProcessBuilder;
+use serde::{Deserialize, Serialize};
+use tracing::debug;
 
 pub const SEE_CHANNELS: &str = "See https://doc.rust-lang.org/book/appendix-07-nightly-rust.html for more information \
      about Rust release channels.";
@@ -409,7 +408,7 @@ enum Status {
 }
 
 /// Config for the `-Zembed-metadata` option.
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default)]
 pub enum EmbedMetadata {
     /// Embed metadata in .rlib files, the original rustc behavior.
     Embed,
@@ -883,6 +882,7 @@ macro_rules! unstable_cli_options {
 unstable_cli_options!(
     // Permanently unstable features:
     allow_features: Option<AllowFeatures> = ("Allow *only* the listed unstable features"),
+    #[serde(deserialize_with = "deserialize_embed_metadata")]
     embed_metadata: EmbedMetadata = ("Avoid embedding metadata in library artifacts"),
     print_im_a_teapot: bool,
 
@@ -1049,6 +1049,18 @@ where
         .map(String::from)
         .collect();
     Ok(Some(v))
+}
+
+fn deserialize_embed_metadata<'de, D>(deserializer: D) -> Result<EmbedMetadata, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let data = Option::<bool>::deserialize(deserializer)?;
+    match data {
+        Some(true) => Ok(EmbedMetadata::Embed),
+        Some(false) => Ok(EmbedMetadata::DoNotEmbed),
+        None => Ok(EmbedMetadata::Unset),
+    }
 }
 
 #[derive(Debug, Copy, Clone, Default, Deserialize, Ord, PartialOrd, Eq, PartialEq)]

--- a/src/workspace/features.rs
+++ b/src/workspace/features.rs
@@ -124,14 +124,15 @@ use std::fmt::{self, Write};
 use std::path::PathBuf;
 use std::str::FromStr;
 
-use crate::GlobalContext;
-use crate::resolver::ResolveBehavior;
-use crate::util::errors::CargoResult;
-use crate::util::indented_lines;
 use anyhow::{Error, bail};
 use cargo_util::ProcessBuilder;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
+
+use crate::GlobalContext;
+use crate::resolver::ResolveBehavior;
+use crate::util::errors::CargoResult;
+use crate::util::indented_lines;
 
 pub const SEE_CHANNELS: &str = "See https://doc.rust-lang.org/book/appendix-07-nightly-rust.html for more information \
      about Rust release channels.";
@@ -405,18 +406,6 @@ enum Status {
     Stable,
     Unstable,
     Removed,
-}
-
-/// Config for the `-Zembed-metadata` option.
-#[derive(Debug, Default)]
-pub enum EmbedMetadata {
-    /// Embed metadata in .rlib files, the original rustc behavior.
-    Embed,
-    /// Do not embed metadata in .rlib files.
-    DoNotEmbed,
-    /// The `-Zembed-metadata` flag wasn't set.
-    #[default]
-    Unset,
 }
 
 /// A listing of stable and unstable new syntax in Cargo.toml.
@@ -882,8 +871,7 @@ macro_rules! unstable_cli_options {
 unstable_cli_options!(
     // Permanently unstable features:
     allow_features: Option<AllowFeatures> = ("Allow *only* the listed unstable features"),
-    #[serde(deserialize_with = "deserialize_embed_metadata")]
-    embed_metadata: EmbedMetadata = ("Avoid embedding metadata in library artifacts"),
+    embed_metadata: Option<bool> = ("Avoid embedding metadata in library artifacts"),
     print_im_a_teapot: bool,
 
     // All other unstable features.
@@ -1049,18 +1037,6 @@ where
         .map(String::from)
         .collect();
     Ok(Some(v))
-}
-
-fn deserialize_embed_metadata<'de, D>(deserializer: D) -> Result<EmbedMetadata, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let data = Option::<bool>::deserialize(deserializer)?;
-    match data {
-        Some(true) => Ok(EmbedMetadata::Embed),
-        Some(false) => Ok(EmbedMetadata::DoNotEmbed),
-        None => Ok(EmbedMetadata::Unset),
-    }
 }
 
 #[derive(Debug, Copy, Clone, Default, Deserialize, Ord, PartialOrd, Eq, PartialEq)]
@@ -1334,11 +1310,11 @@ impl CliUnstable {
             }
         }
 
-        fn parse_embed_metadata(key: &str, value: Option<&str>) -> CargoResult<EmbedMetadata> {
+        fn parse_option_bool(key: &str, value: Option<&str>) -> CargoResult<Option<bool>> {
             match value {
-                None => Ok(EmbedMetadata::Unset),
-                Some("yes") => Ok(EmbedMetadata::Embed),
-                Some("no") => Ok(EmbedMetadata::DoNotEmbed),
+                None => Ok(None),
+                Some("yes") => Ok(Some(true)),
+                Some("no") => Ok(Some(false)),
                 Some(s) => bail!("flag -Z{key} expected `no` or `yes`, found: `{s}`"),
             }
         }
@@ -1394,7 +1370,7 @@ impl CliUnstable {
             // Permanently unstable features
             // Sorted alphabetically:
             "allow-features" => self.allow_features = Some(parse_list(v).into_iter().collect()),
-            "embed-metadata" => self.embed_metadata = parse_embed_metadata(k, v)?,
+            "embed-metadata" => self.embed_metadata = parse_option_bool(k, v)?,
             "print-im-a-teapot" => self.print_im_a_teapot = parse_bool(k, v)?,
 
             // Stabilized features

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -2651,3 +2651,21 @@ rustdocflags = ["--default-theme=dark"]
         .env("CARGO_HOME", &cargo_home)
         .run();
 }
+
+#[cargo_test]
+fn unstable_embed_metadata() {
+    write_config_toml(
+        "\
+[unstable]
+embed-metadata = false
+",
+    );
+
+    let gctx = new_gctx();
+
+    let value = gctx
+        .get::<Option<bool>>("unstable.embed-metadata")
+        .unwrap()
+        .unwrap();
+    assert!(!value);
+}


### PR DESCRIPTION
Using a boolean value.

Noted [here](https://github.com/rust-lang/cargo/issues/15495#issuecomment-5094417172).

Why not just use `bool`? The third variant is needed for enabling the flag by default on nightly, to recognize if the flag was set by the user or not.

r? @weihanglo
