### PR TITLE
fix: prevent panic when `package.build` is empty

### DIFF
--- a/src/workspace/parser/targets.rs
+++ b/src/workspace/parser/targets.rs
@@ -112,7 +112,7 @@ pub(super) fn to_targets(
                 script_path
                     .file_stem()
                     .and_then(|s| s.to_str())
-                    .unwrap_or("")
+                    .expect("previously normalized")
             );
             targets.push(Target::custom_build_target(
                 &name,
@@ -906,7 +906,10 @@ fn validate_unique_names(targets: &[TomlTarget], target_kind: &str) -> CargoResu
 fn validate_unique_build_scripts(scripts: &[String]) -> CargoResult<()> {
     let mut seen = HashMap::default();
     for script in scripts {
-        let stem = Path::new(script).file_stem().unwrap().to_str().unwrap();
+        let stem = Path::new(script)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .expect("previously normalized");
         seen.entry(stem)
             .or_insert_with(Vec::new)
             .push(script.as_str());
@@ -1109,6 +1112,7 @@ pub fn normalize_build(
         // Explicitly no build script.
         Some(TomlPackageBuild::Auto(false)) => Ok(build.cloned()),
         Some(TomlPackageBuild::SingleScript(build_file)) => {
+            validate_build_name(build_file)?;
             let build_file = paths::normalize_path(Path::new(build_file));
             let build = build_file.into_os_string().into_string().expect(
                 "`build_file` started as a String and `normalize_path` shouldn't have changed that",
@@ -1118,8 +1122,20 @@ pub fn normalize_build(
         Some(TomlPackageBuild::Auto(true)) => {
             Ok(Some(TomlPackageBuild::SingleScript(BUILD_RS.to_owned())))
         }
-        Some(TomlPackageBuild::MultipleScript(_scripts)) => Ok(build.cloned()),
+        Some(TomlPackageBuild::MultipleScript(scripts)) => {
+            for script in scripts {
+                validate_build_name(script)?;
+            }
+            Ok(build.cloned())
+        }
     }
+}
+
+fn validate_build_name(build: &str) -> CargoResult<()> {
+    if Path::new(build).file_stem().is_none() {
+        anyhow::bail!("invalid `package.build` file name");
+    }
+    Ok(())
 }
 
 fn name_or_panic(target: &TomlTarget) -> &str {

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -1441,10 +1441,10 @@ fn build_script_empty() {
     p.cargo("check")
         .with_status(101)
         .with_stderr_data(str![[r#"
+[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
 
-thread 'main'[..]panicked at src/workspace/parser/targets.rs:[..]
-called `Option::unwrap()` on a `None` value
-[NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+Caused by:
+  invalid `package.build` file name
 
 "#]])
         .run();

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -1423,6 +1423,34 @@ Caused by:
 }
 
 #[cargo_test]
+fn build_script_empty() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2024"
+                build = ""
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+
+thread 'main'[..]panicked at src/workspace/parser/targets.rs:[..]
+called `Option::unwrap()` on a `None` value
+[NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn links_duplicates() {
     // this tests that the links_duplicates are caught at resolver time
     let p = project()


### PR DESCRIPTION
Validate `package.build` during `normalize_build()` so invalid build script paths are rejected before target construction.

Fixes #17261.