### PR TITLE
Reworked how we enable the new build-dir layout on nightly

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1439,6 +1439,10 @@ pub trait TestEnvCommandExt: Sized {
             .env("CARGO_INCREMENTAL", "0")
             // Don't read the system git config which is out of our control.
             .env("GIT_CONFIG_NOSYSTEM", "1")
+            // See: https://github.com/rust-lang/rust/pull/159857#issuecomment-5119325932
+            // This should be removed once the new build-dir layout is stabilized and the old layout
+            // is removed.
+            .env("__CARGO_TEMPORARY_BUILD_DIR_NEW_LAYOUT_OPT_OUT", "1")
             .env_remove("CI")
             .env_remove("__CARGO_DEFAULT_LIB_METADATA")
             .env_remove("ALL_PROXY")

--- a/src/workspace/features.rs
+++ b/src/workspace/features.rs
@@ -839,8 +839,10 @@ macro_rules! unstable_cli_options {
                 };
 
                 // Defaults to enabled on nightly unless explicitly opted out.
-                unstable.build_dir_new_layout =
-                    matches!(crate::version().release_channel.as_deref(), Some("nightly" | "dev"));
+                if !is_new_build_dir_layout_opt_out() {
+                    unstable.build_dir_new_layout =
+                        matches!(crate::version().release_channel.as_deref(), Some("nightly" | "dev"));
+                }
 
                 return unstable;
             }
@@ -1284,12 +1286,6 @@ impl CliUnstable {
 
         if self.gitoxide.is_none() && cargo_use_gitoxide_instead_of_git2() {
             self.gitoxide = GitoxideFeatures::safe().into();
-        }
-
-        // NOTE: We set this before `implicitly_enable_features_if_needed` as `-Zfine-grain-locking`
-        //       must use the new layout so that takes priority.
-        if is_new_build_dir_layout_opt_out() {
-            self.build_dir_new_layout = false;
         }
 
         self.implicitly_enable_features_if_needed();

--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -1430,9 +1430,9 @@ fn new_layout_opt_out_nightly() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout build")
+    p.cargo("build")
         .env("__CARGO_TEMPORARY_BUILD_DIR_NEW_LAYOUT_OPT_OUT", "1")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .masquerade_as_nightly_cargo(&["new build-dir layout enabled by default on nightly"])
         .enable_mac_dsym()
         .run();
 


### PR DESCRIPTION
### What does this PR try to resolve?

This reworks how the new build-dir layout is enabled on nightly by default as suggested in https://github.com/rust-lang/rust/pull/159857#issuecomment-5119325932

The motivation is to fix the CI issue in rust-lang/rust and unblock the submodule update.

### How to test and review this PR?

I did a `cargo test` and tested passed.

r? @weihanglo 