### PR TITLE
add context to lints documentation

### DIFF
--- a/crates/xtask-lint-docs/src/main.rs
+++ b/crates/xtask-lint-docs/src/main.rs
@@ -40,7 +40,16 @@ fn main() -> anyhow::Result<()> {
     writeln!(buf, "# Lints\n")?;
     writeln!(
         buf,
-        "Note: [Cargo's linting system is unstable](unstable.md#lintscargo) and can only be used on nightly toolchains"
+        "> [!NOTE]
+> This chapter is about lints emitted by `cargo` itself.
+>
+> See [the lints section in the Manifest Format
+> chapter](manifest.md#the-lints-section) to configure lint levels for tools
+> such as `rustc` or `clippy`.
+
+> [!WARNING]
+> [Cargo's linting system is unstable](unstable.md#lintscargo) and can only be used on nightly
+> toolchains."
     )?;
     writeln!(buf)?;
 

--- a/doc/book/src/reference/lints.md
+++ b/doc/book/src/reference/lints.md
@@ -1,6 +1,15 @@
 # Lints
 
-Note: [Cargo's linting system is unstable](unstable.md#lintscargo) and can only be used on nightly toolchains
+> [!NOTE]
+> This chapter is about lints emitted by `cargo` itself.
+>
+> See [the lints section in the Manifest Format
+> chapter](manifest.md#the-lints-section) to configure lint levels for tools
+> such as `rustc` or `clippy`.
+
+> [!WARNING]
+> [Cargo's linting system is unstable](unstable.md#lintscargo) and can only be used on nightly
+> toolchains.
 
 
 


### PR DESCRIPTION
### What does this PR try to resolve?

When searching for cargo lint configuration, the "Lints" chapter is the first result that comes up, and it probably doesn't contain the information that the reader is looking for. This PR adds a link to the manifest lints section from this page.

### How to test and review this PR?

N/A
