### PR TITLE
fix(frontmatter): Don't panic on a short closing fence before a non-ASCII char

### DIFF
--- a/src/util/frontmatter.rs
+++ b/src/util/frontmatter.rs
@@ -105,15 +105,19 @@ impl<'s> ScriptSource<'s> {
         // Ends with a line that starts with a matching number of `-` only followed by whitespace
         let nl_fence_pattern = format!("\n{fence_pattern}");
         let Some(frontmatter_nl) = input.find_slice(nl_fence_pattern.as_str()) else {
-            for len in (2..(nl_fence_pattern.len() - 1)).rev() {
-                let Some(frontmatter_nl) = input.find_slice(&nl_fence_pattern[0..len]) else {
+            for prefix_len in (2..(nl_fence_pattern.len() - 1)).rev() {
+                let Some(frontmatter_nl) = input.find_slice(&nl_fence_pattern[0..prefix_len])
+                else {
                     continue;
                 };
-                let _ = input.next_slice(frontmatter_nl.start + 1);
+                let nl_len = "\n".len();
+                let close_len = prefix_len;
+
+                let _ = input.next_slice(frontmatter_nl.start + nl_len);
                 let close_start = input.current_token_start();
-                let _ = input.next_slice(len);
+                let _ = input.next_slice(close_len);
                 let close_end = input.current_token_start();
-                let fewer_dashes = fence_length - len;
+                let fewer_dashes = fence_length - close_len;
                 return Err(FrontmatterError::new(
                     format!(
                         "closing code fence has {fewer_dashes} less `-` than the opening fence"

--- a/src/util/frontmatter.rs
+++ b/src/util/frontmatter.rs
@@ -395,11 +395,24 @@ mod test {
     }
 
     #[track_caller]
-    fn assert_source_err(source: &str, err: impl IntoData) {
+    fn assert_source_err(source: &str, expected: impl IntoData) {
         match ScriptSource::parse(source) {
             Ok(d) => panic!("unexpected Ok({d:#?})"),
-            Err(actual) => {
-                snapbox::assert_data_eq!(actual.to_string(), err.raw())
+            Err(err) => {
+                let report = &[annotate_snippets::Level::ERROR
+                    .primary_title(err.to_string())
+                    .element(
+                        annotate_snippets::Snippet::source(source)
+                            .annotation(
+                                annotate_snippets::AnnotationKind::Primary.span(err.primary_span()),
+                            )
+                            .annotations(err.visible_spans().iter().map(|s| {
+                                annotate_snippets::AnnotationKind::Context.span(s.clone())
+                            })),
+                    )];
+                let renderer = annotate_snippets::Renderer::plain();
+                let actual = renderer.render(report);
+                snapbox::assert_data_eq!(actual, expected.raw())
             }
         }
     }
@@ -585,7 +598,15 @@ time="0.1.25"
 --
 fn main() {}
 "#,
-            str!["found 2 `-` in rust frontmatter, expected at least 3"],
+            str![[r#"
+error: found 2 `-` in rust frontmatter, expected at least 3
+  |
+2 | --
+  | --
+...
+6 | fn main() {}
+  |             ^
+"#]],
         );
     }
 
@@ -642,7 +663,14 @@ content: "\nfn main() {}\n"
 
 fn main() {}
 "#,
-            str!["closing code fence has 2 more `-` than the opening fence"],
+            str![[r#"
+error: closing code fence has 2 more `-` than the opening fence
+  |
+2 | ---
+  | ---
+3 | -----
+  |    ^^
+"#]],
         );
     }
 
@@ -677,7 +705,15 @@ time="0.1.25"
 ----
 fn main() {}
 "#,
-            str!["closing code fence has 1 more `-` than the opening fence"],
+            str![[r#"
+error: closing code fence has 1 more `-` than the opening fence
+  |
+2 | ---
+  | ---
+...
+5 | ----
+  |    ^
+"#]],
         );
     }
 
@@ -690,7 +726,15 @@ fn main() {}
 time="0.1.25"
 fn main() {}
 "#,
-            str!["unclosed frontmatter; expected `---`"],
+            str![[r#"
+error: unclosed frontmatter; expected `---`
+  |
+2 | ---
+  | ---
+...
+5 | fn main() {}
+  |             ^
+"#]],
         );
     }
 }

--- a/src/util/frontmatter.rs
+++ b/src/util/frontmatter.rs
@@ -111,7 +111,7 @@ impl<'s> ScriptSource<'s> {
                     continue;
                 };
                 let nl_len = "\n".len();
-                let close_len = prefix_len;
+                let close_len = prefix_len - nl_len;
 
                 let _ = input.next_slice(frontmatter_nl.start + nl_len);
                 let close_start = input.current_token_start();
@@ -751,14 +751,13 @@ error: unclosed frontmatter; expected `---`
 fn main() {}
 "#,
             str![[r#"
-error: closing code fence has 1 less `-` than the opening fence
+error: closing code fence has 2 less `-` than the opening fence
   |
-1 |   ----
-  |   ----
-2 |   [dependencies]
-3 | / --
-4 | | fn main() {}
-  | |_^
+1 | ----
+  | ----
+2 | [dependencies]
+3 | --
+  | ^^
 "#]],
         );
     }
@@ -772,26 +771,32 @@ error: closing code fence has 1 less `-` than the opening fence
 fn main() {}
 "#,
             str![[r#"
-error: closing code fence has 1 less `-` than the opening fence
+error: closing code fence has 2 less `-` than the opening fence
   |
 1 | ----
   | ----
 2 | [dependencies]
 3 | ---
-  | ^^^
+  | ^^
 "#]],
         );
     }
 
     #[test]
-    #[should_panic = "is not a char boundary"]
     fn split_fewer_dashes_before_non_ascii() {
         // The byte after the short closing fence starts a multi-byte char.
         assert_source_err(
             "---
 -\u{2502}
 ",
-            str![""],
+            str![[r#"
+error: closing code fence has 2 less `-` than the opening fence
+  |
+1 | ---
+  | ---
+2 | -│
+  | ^
+"#]],
         );
     }
 }

--- a/src/util/frontmatter.rs
+++ b/src/util/frontmatter.rs
@@ -737,4 +737,57 @@ error: unclosed frontmatter; expected `---`
 "#]],
         );
     }
+
+    #[test]
+    fn split_fewer_dashes() {
+        assert_source_err(
+            r#"----
+[dependencies]
+--
+fn main() {}
+"#,
+            str![[r#"
+error: closing code fence has 1 less `-` than the opening fence
+  |
+1 |   ----
+  |   ----
+2 |   [dependencies]
+3 | / --
+4 | | fn main() {}
+  | |_^
+"#]],
+        );
+    }
+
+    #[test]
+    fn split_fewer_dashes_by_one() {
+        assert_source_err(
+            r#"----
+[dependencies]
+---
+fn main() {}
+"#,
+            str![[r#"
+error: closing code fence has 1 less `-` than the opening fence
+  |
+1 | ----
+  | ----
+2 | [dependencies]
+3 | ---
+  | ^^^
+"#]],
+        );
+    }
+
+    #[test]
+    #[should_panic = "is not a char boundary"]
+    fn split_fewer_dashes_before_non_ascii() {
+        // The byte after the short closing fence starts a multi-byte char.
+        assert_source_err(
+            "---
+-\u{2502}
+",
+            str![""],
+        );
+    }
 }

--- a/src/util/frontmatter.rs
+++ b/src/util/frontmatter.rs
@@ -702,4 +702,41 @@ fn main() {}
             str!["unclosed frontmatter; expected `---`"],
         );
     }
+    #[test]
+    fn split_fewer_dashes() {
+        assert_err(
+            ScriptSource::parse(
+                r#"----
+[dependencies]
+--
+fn main() {}
+"#,
+            ),
+            str!["closing code fence has 1 less `-` than the opening fence"],
+        );
+    }
+
+    #[test]
+    fn split_fewer_dashes_by_one() {
+        assert_err(
+            ScriptSource::parse(
+                r#"----
+[dependencies]
+---
+fn main() {}
+"#,
+            ),
+            str!["closing code fence has 1 less `-` than the opening fence"],
+        );
+    }
+
+    #[test]
+    #[should_panic = "is not a char boundary"]
+    fn split_fewer_dashes_before_non_ascii() {
+        // The byte after the short closing fence starts a multi-byte char.
+        assert_err(
+            ScriptSource::parse("---  \n-\u{2502}\n"),
+            str!["closing code fence has 2 less `-` than the opening fence"],
+        );
+    }
 }

--- a/src/util/frontmatter.rs
+++ b/src/util/frontmatter.rs
@@ -105,15 +105,16 @@ impl<'s> ScriptSource<'s> {
         // Ends with a line that starts with a matching number of `-` only followed by whitespace
         let nl_fence_pattern = format!("\n{fence_pattern}");
         let Some(frontmatter_nl) = input.find_slice(nl_fence_pattern.as_str()) else {
-            for len in (2..(nl_fence_pattern.len() - 1)).rev() {
-                let Some(frontmatter_nl) = input.find_slice(&nl_fence_pattern[0..len]) else {
+            for close_len in (1..fence_length).rev() {
+                // `nl_fence_pattern[..=close_len]` is the newline plus `close_len` dashes.
+                let Some(frontmatter_nl) = input.find_slice(&nl_fence_pattern[..=close_len]) else {
                     continue;
                 };
                 let _ = input.next_slice(frontmatter_nl.start + 1);
                 let close_start = input.current_token_start();
-                let _ = input.next_slice(len);
+                let _ = input.next_slice(close_len);
                 let close_end = input.current_token_start();
-                let fewer_dashes = fence_length - len;
+                let fewer_dashes = fence_length - close_len;
                 return Err(FrontmatterError::new(
                     format!(
                         "closing code fence has {fewer_dashes} less `-` than the opening fence"
@@ -712,7 +713,7 @@ fn main() {}
 fn main() {}
 "#,
             ),
-            str!["closing code fence has 1 less `-` than the opening fence"],
+            str!["closing code fence has 2 less `-` than the opening fence"],
         );
     }
 
@@ -731,7 +732,6 @@ fn main() {}
     }
 
     #[test]
-    #[should_panic = "is not a char boundary"]
     fn split_fewer_dashes_before_non_ascii() {
         // The byte after the short closing fence starts a multi-byte char.
         assert_err(

--- a/src/util/frontmatter.rs
+++ b/src/util/frontmatter.rs
@@ -395,13 +395,12 @@ mod test {
     }
 
     #[track_caller]
-    fn assert_err(
-        result: Result<impl std::fmt::Debug, impl std::fmt::Display>,
-        err: impl IntoData,
-    ) {
-        match result {
+    fn assert_source_err(source: &str, err: impl IntoData) {
+        match ScriptSource::parse(source) {
             Ok(d) => panic!("unexpected Ok({d:#?})"),
-            Err(actual) => snapbox::assert_data_eq!(actual.to_string(), err.raw()),
+            Err(actual) => {
+                snapbox::assert_data_eq!(actual.to_string(), err.raw())
+            }
         }
     }
 
@@ -578,16 +577,14 @@ content: "\nfn main() {}"
 
     #[test]
     fn split_too_few_dashes() {
-        assert_err(
-            ScriptSource::parse(
-                r#"#!/usr/bin/env cargo
+        assert_source_err(
+            r#"#!/usr/bin/env cargo
 --
 [dependencies]
 time="0.1.25"
 --
 fn main() {}
 "#,
-            ),
             str!["found 2 `-` in rust frontmatter, expected at least 3"],
         );
     }
@@ -636,9 +633,8 @@ content: "\nfn main() {}\n"
 
     #[test]
     fn split_invalid_escaped() {
-        assert_err(
-            ScriptSource::parse(
-                r#"#!/usr/bin/env cargo
+        assert_source_err(
+            r#"#!/usr/bin/env cargo
 ---
 -----
 -----
@@ -646,7 +642,6 @@ content: "\nfn main() {}\n"
 
 fn main() {}
 "#,
-            ),
             str!["closing code fence has 2 more `-` than the opening fence"],
         );
     }
@@ -674,31 +669,27 @@ content: "\nfn main() {}\n"
 
     #[test]
     fn split_mismatched_dashes() {
-        assert_err(
-            ScriptSource::parse(
-                r#"#!/usr/bin/env cargo
+        assert_source_err(
+            r#"#!/usr/bin/env cargo
 ---
 [dependencies]
 time="0.1.25"
 ----
 fn main() {}
 "#,
-            ),
             str!["closing code fence has 1 more `-` than the opening fence"],
         );
     }
 
     #[test]
     fn split_missing_close() {
-        assert_err(
-            ScriptSource::parse(
-                r#"#!/usr/bin/env cargo
+        assert_source_err(
+            r#"#!/usr/bin/env cargo
 ---
 [dependencies]
 time="0.1.25"
 fn main() {}
 "#,
-            ),
             str!["unclosed frontmatter; expected `---`"],
         );
     }

--- a/src/util/frontmatter.rs
+++ b/src/util/frontmatter.rs
@@ -105,7 +105,7 @@ impl<'s> ScriptSource<'s> {
         // Ends with a line that starts with a matching number of `-` only followed by whitespace
         let nl_fence_pattern = format!("\n{fence_pattern}");
         let Some(frontmatter_nl) = input.find_slice(nl_fence_pattern.as_str()) else {
-            for prefix_len in (2..(nl_fence_pattern.len() - 1)).rev() {
+            for prefix_len in (2..=(nl_fence_pattern.len() - 1)).rev() {
                 let Some(frontmatter_nl) = input.find_slice(&nl_fence_pattern[0..prefix_len])
                 else {
                     continue;
@@ -771,13 +771,13 @@ error: closing code fence has 2 less `-` than the opening fence
 fn main() {}
 "#,
             str![[r#"
-error: closing code fence has 2 less `-` than the opening fence
+error: closing code fence has 1 less `-` than the opening fence
   |
 1 | ----
   | ----
 2 | [dependencies]
 3 | ---
-  | ^^
+  | ^^^
 "#]],
         );
     }


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes #17270.

`cargo -Zscript` panics on a frontmatter whose closing fence is shorter than the opening one and is followed by a non-ASCII char:

```
---
-│
```

```
thread 'main' panicked at library/core/src/str/mod.rs:861:21:
end byte index 2 is not a char boundary; it is inside '│' (bytes 1..4 of string)
```

The cause is an off-by-one in the "closing fence has fewer dashes" recovery path in `src/util/frontmatter.rs`. `nl_fence_pattern` is `"\n"` plus the opening dashes, so the search slice `&nl_fence_pattern[0..len]` is a newline followed by `len - 1` dashes. After the newline is consumed, only `len - 1` dashes are guaranteed to be present, but the code consumed `len` bytes — the extra byte is whatever text follows the short fence, and slicing there splits a multi-byte char.

The same confusion between "length of a pattern that embeds a newline" and "number of dashes" appears in two more places in that loop, so this treats `len - 1` as the dash count in all three:

- `fewer_dashes = fence_length - len` under-reports the difference. `----\n[dependencies]\n--\n` says "1 less" for a fence that is 2 short. The count was one too low whenever the closing fence is short by two or more; it happened to come out right when short by exactly one.
- The loop range stopped at `nl_fence_pattern.len() - 1`, so `len` never reached the value that matches a fence exactly one dash short.

rust-analyzer vendors this file, so the same panic is reported there as rust-lang/rust-analyzer#22880; this should resolve it on their next sync.

### How to test and review this PR?

The fewer-dashes path had no test coverage, so this adds three to `src/util/frontmatter.rs`:

- `split_fewer_dashes_before_non_ascii` — the panic from the issue; fails on `master` with the char-boundary panic above.
- `split_fewer_dashes` and `split_fewer_dashes_by_one` — the reported dash count for a fence 2 short and 1 short. The first fails on `master` ("1 less" instead of "2 less").

```
cargo test --lib util::frontmatter
```

I also checked the count against every opening/closing combination of 4/3, 4/2, 4/1, 3/2, 3/1, 5/4 and 5/1, and the existing frontmatter tests are unchanged.
