### PR TITLE
refactor: move sysroot lookup to GlobalContext

### DIFF
--- a/src/compiler/build_context/mod.rs
+++ b/src/compiler/build_context/mod.rs
@@ -169,9 +169,12 @@ impl<'a, 'gctx> BuildContext<'a, 'gctx> {
     ///
     /// Helper function that uses GlobalContext.
     pub fn get_sysroot(&self) -> &'gctx Path {
-        self.gctx
-            .get_sysroot(Some(self.ws))
-            .expect("able to invoke rustc")
+        // cfg::bad_cfg_discovery tests that these panics aren't reachable
+        let rustc = self
+            .gctx
+            .load_global_rustc(Some(self.ws))
+            .expect("rustc load ok");
+        self.gctx.get_sysroot(&rustc).expect("sysroot fetch ok")
     }
 }
 

--- a/src/compiler/build_context/mod.rs
+++ b/src/compiler/build_context/mod.rs
@@ -1,5 +1,7 @@
 //! [`BuildContext`] is a (mostly) static information about a build task.
 
+use std::path::Path;
+
 use crate::compiler::BuildConfig;
 use crate::compiler::CompileKind;
 use crate::compiler::Unit;
@@ -161,6 +163,15 @@ impl<'a, 'gctx> BuildContext<'a, 'gctx> {
     /// `cargo rustc` or `cargo rustdoc`.
     pub fn extra_args_for(&self, unit: &Unit) -> Option<&Vec<String>> {
         self.extra_compiler_args.get(unit)
+    }
+
+    /// Gets the path to the sysroot.
+    ///
+    /// Helper function that uses GlobalContext.
+    pub fn get_sysroot(&self) -> &'gctx Path {
+        self.gctx
+            .get_sysroot(Some(self.ws))
+            .expect("able to invoke rustc")
     }
 }
 

--- a/src/compiler/build_context/target_info.rs
+++ b/src/compiler/build_context/target_info.rs
@@ -53,8 +53,6 @@ pub struct TargetInfo {
     pub supports_std: Option<bool>,
     /// Supported values for `-Csplit-debuginfo=` flag, queried from rustc
     support_split_debuginfo: Vec<String>,
-    /// Path to the sysroot.
-    pub sysroot: PathBuf,
     /// Path to the "lib" directory in the sysroot which rustc uses for linking
     /// target libraries.
     pub sysroot_target_libdir: PathBuf,
@@ -352,7 +350,6 @@ impl TargetInfo {
             return Ok(TargetInfo {
                 crate_type_process,
                 crate_types: RefCell::new(map),
-                sysroot,
                 sysroot_target_libdir,
                 rustflags: rustflags.into(),
                 rustdocflags: extra_args(

--- a/src/compiler/build_context/target_info.rs
+++ b/src/compiler/build_context/target_info.rs
@@ -163,6 +163,8 @@ impl TargetInfo {
     /// invocation is cached by [`Rustc::cached_output`].
     ///
     /// Search `Tricky` to learn why querying `rustc` several times is needed.
+    ///
+    /// When a Workspace is provided,
     #[tracing::instrument(skip_all)]
     pub fn new(
         gctx: &GlobalContext,
@@ -172,15 +174,25 @@ impl TargetInfo {
     ) -> CargoResult<TargetInfo> {
         let mut rustflags =
             extra_args(gctx, requested_kinds, &rustc.host, None, kind, Flags::Rust)?;
+
+        let sysroot = gctx.get_sysroot(rustc)?;
+        let sysroot_target_libdir = sysroot
+            .join("lib")
+            .join("rustlib")
+            .join(match &kind {
+                CompileKind::Host => rustc.host.as_str(),
+                CompileKind::Target(target) => target.short_name(),
+            })
+            .join("lib");
+
         let mut turn = 0;
         loop {
             let extra_fingerprint = kind.fingerprint_hash();
 
             // Query rustc for several kinds of info from each line of output:
             // 0) file-names (to determine output file prefix/suffix for given crate type)
-            // 1) sysroot
-            // 2) split-debuginfo
-            // 3) cfg
+            // 1) split-debuginfo
+            // 2) cfg
             //
             // Search `--print` to see what we query so far.
             let mut process = rustc.workspace_process();
@@ -214,7 +226,6 @@ impl TargetInfo {
                 process.arg("--crate-type").arg(crate_type.as_str());
             }
 
-            process.arg("--print=sysroot");
             process.arg("--print=split-debuginfo");
             process.arg("--print=crate-name"); // `___` as a delimiter.
             process.arg("--print=cfg");
@@ -235,22 +246,6 @@ impl TargetInfo {
                 let out = parse_crate_type(crate_type, &process, &output, &error, &mut lines)?;
                 map.insert(crate_type.clone(), out);
             }
-
-            let Some(line) = lines.next() else {
-                return error_missing_print_output("sysroot", &process, &output, &error);
-            };
-            let sysroot = PathBuf::from(line);
-            let sysroot_target_libdir = {
-                let mut libdir = sysroot.clone();
-                libdir.push("lib");
-                libdir.push("rustlib");
-                libdir.push(match &kind {
-                    CompileKind::Host => rustc.host.as_str(),
-                    CompileKind::Target(target) => target.short_name(),
-                });
-                libdir.push("lib");
-                libdir
-            };
 
             let support_split_debuginfo = {
                 // HACK: abuse `--print=crate-name` to use `___` as a delimiter.

--- a/src/compiler/build_runner/compilation_files.rs
+++ b/src/compiler/build_runner/compilation_files.rs
@@ -735,7 +735,7 @@ fn compute_metadata(
         // SourceId for stdlib crates is an absolute path inside the sysroot.
         // Pass the sysroot as workspace root so that we hash a relative path.
         // This avoids the metadata hash changing depending on where the user installed rustc.
-        &bcx.target_data.get_info(unit.kind).unwrap().sysroot
+        &bcx.get_sysroot()
     } else {
         bcx.ws.root()
     };

--- a/src/compiler/rustdoc.rs
+++ b/src/compiler/rustdoc.rs
@@ -1,8 +1,8 @@
 //! Utilities for building with rustdoc.
 
+use crate::compiler::BuildContext;
 use crate::compiler::build_runner::BuildRunner;
 use crate::compiler::unit::Unit;
-use crate::compiler::{BuildContext, CompileKind};
 use crate::sources::CRATES_IO_REGISTRY;
 use crate::util::data_structures::HashMap;
 use crate::util::data_structures::HashSet;
@@ -208,7 +208,7 @@ pub fn add_root_urls(
     let std_url = match &map.std {
         None | Some(RustdocExternMode::Remote) => None,
         Some(RustdocExternMode::Local) => {
-            let sysroot = &build_runner.bcx.target_data.info(CompileKind::Host).sysroot;
+            let sysroot = build_runner.bcx.get_sysroot();
             let html_root = sysroot.join("share").join("doc").join("rust").join("html");
             if html_root.exists() {
                 let url = Url::from_file_path(&html_root).map_err(|()| {

--- a/src/compiler/standard_lib.rs
+++ b/src/compiler/standard_lib.rs
@@ -54,7 +54,7 @@ pub fn resolve_std<'gctx>(
     crates: &[String],
     kinds: &[CompileKind],
 ) -> CargoResult<(PackageSet<'gctx>, Resolve, ResolvedFeatures)> {
-    let src_path = detect_sysroot_src_path(target_data)?;
+    let src_path = detect_sysroot_src_path(ws)?;
     let std_ws_manifest_path = src_path.join("Cargo.toml");
     let gctx = ws.gctx();
     // TODO: Consider doing something to enforce --locked? Or to prevent the
@@ -217,15 +217,16 @@ fn generate_roots(
     Ok(())
 }
 
-fn detect_sysroot_src_path(target_data: &RustcTargetData<'_>) -> CargoResult<PathBuf> {
-    if let Some(s) = target_data.gctx.get_env_os("__CARGO_TESTS_ONLY_SRC_ROOT") {
+fn detect_sysroot_src_path(ws: &Workspace<'_>) -> CargoResult<PathBuf> {
+    if let Some(s) = ws.gctx().get_env_os("__CARGO_TESTS_ONLY_SRC_ROOT") {
         return Ok(s.into());
     }
 
     // NOTE: This is temporary until we figure out how to acquire the source.
-    let src_path = target_data
-        .info(CompileKind::Host)
-        .sysroot
+    let src_path = ws
+        .gctx()
+        .get_sysroot(Some(ws))
+        .expect("able to invoke rustc")
         .join("lib")
         .join("rustlib")
         .join("src")
@@ -238,7 +239,7 @@ fn detect_sysroot_src_path(target_data: &RustcTargetData<'_>) -> CargoResult<Pat
              library, try:\n        rustup component add rust-src",
             lock
         );
-        match target_data.gctx.get_env("RUSTUP_TOOLCHAIN") {
+        match ws.gctx().get_env("RUSTUP_TOOLCHAIN") {
             Ok(rustup_toolchain) => {
                 anyhow::bail!("{} --toolchain {}", msg, rustup_toolchain);
             }

--- a/src/compiler/standard_lib.rs
+++ b/src/compiler/standard_lib.rs
@@ -223,9 +223,10 @@ fn detect_sysroot_src_path(ws: &Workspace<'_>) -> CargoResult<PathBuf> {
     }
 
     // NOTE: This is temporary until we figure out how to acquire the source.
+    let rustc = ws.gctx().load_global_rustc(Some(ws))?;
     let src_path = ws
         .gctx()
-        .get_sysroot(Some(ws))
+        .get_sysroot(&rustc)
         .expect("able to invoke rustc")
         .join("lib")
         .join("rustlib")

--- a/src/compiler/trim_paths.rs
+++ b/src/compiler/trim_paths.rs
@@ -85,7 +85,7 @@ pub(crate) fn trim_paths_remap(build_runner: &BuildRunner<'_, '_>, unit: &Unit) 
     [
         package_remap(build_runner, unit),
         build_dir_remap(build_runner),
-        sysroot_remap(build_runner, unit),
+        sysroot_remap(build_runner),
     ]
 }
 
@@ -93,16 +93,16 @@ pub(crate) fn trim_paths_remap(build_runner: &BuildRunner<'_, '_>, unit: &Unit) 
 ///
 /// This remap logic aligns with rustc:
 /// <https://github.com/rust-lang/rust/blob/c2ef3516/src/bootstrap/src/lib.rs#L1113-L1116>
-fn sysroot_remap(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> OsString {
+fn sysroot_remap(build_runner: &BuildRunner<'_, '_>) -> OsString {
     let mut remap = OsString::new();
     remap.push({
-        // See also `detect_sysroot_src_path()`.
-        let mut sysroot = build_runner.bcx.target_data.info(unit.kind).sysroot.clone();
-        sysroot.push("lib");
-        sysroot.push("rustlib");
-        sysroot.push("src");
-        sysroot.push("rust");
-        sysroot
+        build_runner
+            .bcx
+            .get_sysroot()
+            .join("lib")
+            .join("rustlib")
+            .join("src")
+            .join("rust")
     });
     remap.push("=");
     remap.push("/rustc/");

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -614,15 +614,9 @@ impl GlobalContext {
     }
 
     /// Get the sysroot path.
-    pub fn get_sysroot<'gctx>(
-        &'gctx self,
-        ws: Option<&Workspace<'gctx>>,
-    ) -> CargoResult<&'gctx Path> {
+    pub fn get_sysroot<'gctx>(&'gctx self, rustc: &Rustc) -> CargoResult<&'gctx Path> {
         self.sysroot
-            .try_borrow_with(|| {
-                let rustc = self.load_global_rustc(ws)?;
-                rustc.sysroot(self)
-            })
+            .try_borrow_with(|| rustc.sysroot(self))
             .map(AsRef::as_ref)
     }
 

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -614,11 +614,16 @@ impl GlobalContext {
     }
 
     /// Get the sysroot path.
-    pub fn get_sysroot<'gctx>(&'gctx self, ws: Option<&Workspace<'gctx>>) -> CargoResult<&PathBuf> {
-        self.sysroot.try_borrow_with(|| {
-            let rustc = self.load_global_rustc(ws)?;
-            rustc.sysroot(self)
-        })
+    pub fn get_sysroot<'gctx>(
+        &'gctx self,
+        ws: Option<&Workspace<'gctx>>,
+    ) -> CargoResult<&'gctx Path> {
+        self.sysroot
+            .try_borrow_with(|| {
+                let rustc = self.load_global_rustc(ws)?;
+                rustc.sysroot(self)
+            })
+            .map(AsRef::as_ref)
     }
 
     /// Which package sources have been updated, used to ensure it is only done once.

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -225,6 +225,8 @@ pub struct GlobalContext {
     cargo_exe: OnceLock<PathBuf>,
     /// The location of the rustdoc executable
     rustdoc: OnceLock<PathBuf>,
+    /// The path to the sysroot
+    sysroot: OnceLock<PathBuf>,
     /// Whether we are printing extra verbose messages
     extra_verbose: bool,
     /// `frozen` is the same as `locked`, but additionally will not access the
@@ -379,6 +381,7 @@ impl GlobalContext {
             cli_config: None,
             cargo_exe: Default::default(),
             rustdoc: Default::default(),
+            sysroot: Default::default(),
             extra_verbose: false,
             frozen: false,
             locked: false,
@@ -608,6 +611,14 @@ impl GlobalContext {
                 Ok(exe)
             })
             .map(AsRef::as_ref)
+    }
+
+    /// Get the sysroot path.
+    pub fn get_sysroot<'gctx>(&'gctx self, ws: Option<&Workspace<'gctx>>) -> CargoResult<&PathBuf> {
+        self.sysroot.try_borrow_with(|| {
+            let rustc = self.load_global_rustc(ws)?;
+            rustc.sysroot(self)
+        })
     }
 
     /// Which package sources have been updated, used to ensure it is only done once.

--- a/src/ops/cargo_fix/mod.rs
+++ b/src/ops/cargo_fix/mod.rs
@@ -184,9 +184,8 @@ pub fn fix(
         wrapper.env(IDIOMS_ENV_INTERNAL, "1");
     }
 
-    let sysroot = gctx
-        .get_sysroot(Some(original_ws))
-        .expect("able to invoke rustc");
+    let rustc = gctx.load_global_rustc(Some(original_ws))?;
+    let sysroot = gctx.get_sysroot(&rustc).expect("able to invoke rustc");
     if sysroot.is_dir() {
         wrapper.env(SYSROOT_INTERNAL, sysroot);
     }

--- a/src/ops/cargo_fix/mod.rs
+++ b/src/ops/cargo_fix/mod.rs
@@ -53,7 +53,6 @@ use semver::Version;
 use tracing::{debug, trace, warn};
 
 pub use self::fix_edition::fix_edition;
-use crate::compiler::CompileKind;
 use crate::compiler::RustcTargetData;
 use crate::ops::resolve::WorkspaceResolve;
 use crate::ops::{self, CompileOptions};
@@ -185,7 +184,9 @@ pub fn fix(
         wrapper.env(IDIOMS_ENV_INTERNAL, "1");
     }
 
-    let sysroot = &target_data.info(CompileKind::Host).sysroot;
+    let sysroot = gctx
+        .get_sysroot(Some(original_ws))
+        .expect("able to invoke rustc");
     if sysroot.is_dir() {
         wrapper.env(SYSROOT_INTERNAL, sysroot);
     }

--- a/src/util/rustc.rs
+++ b/src/util/rustc.rs
@@ -4,7 +4,7 @@ use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
-use anyhow::Context as _;
+use anyhow::{Context as _, bail};
 use cargo_util::{ProcessBuilder, ProcessError, paths};
 use filetime::FileTime;
 use serde::{Deserialize, Serialize};
@@ -169,7 +169,11 @@ impl Rustc {
         cmd.arg("--print=sysroot");
 
         let (stdout, _) = self.cached_output(&cmd, 0)?;
-        Ok(stdout.trim().into())
+        let path: PathBuf = stdout.trim().into();
+        if !path.exists() {
+            bail!("sysroot path \"{}\" does not exist", path.display());
+        }
+        Ok(path)
     }
 }
 

--- a/src/util/rustc.rs
+++ b/src/util/rustc.rs
@@ -64,6 +64,7 @@ impl Rustc {
             .wrapped(wrapper.as_deref());
         apply_env_config(gctx, &mut cmd)?;
         cmd.env(crate::CARGO_ENV, gctx.cargo_exe()?);
+
         cmd.arg("-vV");
         let verbose_version = cache.cached_output(&cmd, 0)?.0;
 
@@ -158,6 +159,17 @@ impl Rustc {
             .lock()
             .unwrap()
             .cached_output(cmd, extra_fingerprint)
+    }
+
+    /// Use the rustc executable to fetch the sysroot path.
+    pub fn sysroot(&self, gctx: &GlobalContext) -> CargoResult<PathBuf> {
+        let mut cmd = self.workspace_process();
+        apply_env_config(gctx, &mut cmd)?;
+        cmd.env(crate::CARGO_ENV, gctx.cargo_exe()?);
+        cmd.arg("--print=sysroot");
+
+        let (stdout, _) = self.cached_output(&cmd, 0)?;
+        Ok(stdout.trim().into())
     }
 }
 

--- a/tests/testsuite/cfg.rs
+++ b/tests/testsuite/cfg.rs
@@ -347,6 +347,13 @@ fn bad_cfg_discovery() {
                     print!("{}", run_rustc());
                     return;
                 }
+                if mode == "no-sysroot" {
+                    return;
+                }
+                if std::env::args_os().any(|a| a == "--print=sysroot") {
+                    print!("{}", run_rustc());
+                    return;
+                }
                 if mode == "no-crate-types" {
                     return;
                 }
@@ -356,24 +363,19 @@ fn bad_cfg_discovery() {
                 }
                 let output = run_rustc();
                 let mut lines = output.lines();
-                let sysroot = loop {
+                let mut line = loop {
                     let line = lines.next().unwrap();
                     if line.contains("___") {
-                        println!("{}", line);
+                        println!("{line}");
                     } else {
                         break line;
                     }
                 };
-                if mode == "no-sysroot" {
-                    return;
-                }
-                println!("{}", sysroot);
 
                 if mode == "no-split-debuginfo" {
                     return;
                 }
                 loop {
-                    let line = lines.next().unwrap();
                     if line == "___" {
                         println!("\n{line}");
                         break;
@@ -382,6 +384,7 @@ fn bad_cfg_discovery() {
                         // concat them into one line.
                         print!("{line},");
                     }
+                    line = lines.next().unwrap();
                 };
 
                 if mode != "bad-cfg" {
@@ -411,32 +414,22 @@ foo
 
     p.cargo("check")
         .env("RUSTC", &funky_rustc)
-        .env("FUNKY_MODE", "no-crate-types")
+        .env("FUNKY_MODE", "no-sysroot")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] malformed output when learning about crate-type bin information
-command was: `[ROOT]/compiler/target/debug/compiler[..] --crate-name ___ [..]`
-(no output received)
+[ERROR] sysroot path "" does not exist
 
 "#]])
         .run();
 
     p.cargo("check")
         .env("RUSTC", &funky_rustc)
-        .env("FUNKY_MODE", "no-sysroot")
+        .env("FUNKY_MODE", "no-crate-types")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] output of --print=sysroot missing when learning about target-specific information from rustc
-command was: `[ROOT]/compiler/target/debug/compiler[..]--crate-type [..]`
-
---- stdout
-___[EXE]
-lib___.rlib
-[..]___.[..]
-[..]___.[..]
-[..]___.[..]
-[..]___.[..]
-
+[ERROR] malformed output when learning about crate-type bin information
+command was: `[ROOT]/compiler/target/debug/compiler[..] --crate-name ___ [..]`
+(no output received)
 
 "#]])
         .run();
@@ -456,7 +449,6 @@ lib___.rlib
 [..]___.[..]
 [..]___.[..]
 [..]___.[..]
-[..]
 
 
 "#]])
@@ -474,7 +466,6 @@ lib___.rlib
 [..]___.[..]
 [..]___.[..]
 [..]___.[..]
-[..]
 [..],[..]
 ___
 123


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/cargo/pull/17276)*

### What does this PR try to resolve?

I split this out from a refactor of https://github.com/rust-lang/cargo/pull/16675, as part of work on [build-std=always](https://github.com/rust-lang/rust/issues/155363). In this PR, and in other build-std work I have in progress, it's useful to know the sysroot path earlier than the `compiler/` stage of Cargo. Because there's one rustc instance per Cargo invocation, and because the sysroot path remains fixed per rustc and isn't dependent on the target, this should be safe to move out of TargetInfo.

### How to test and review this PR?

The first commit shows the logic being moved, and the second commit shows updating all the users of this logic.

The third removes the actual `--print` lookup in `TargetInfo`, which necessitated some test changes and a refactor to ensure the rustc info cache can be written to.

Getting the sysroot is already heavily tested in Cargo, hence why I didn't add a new test for just this.