### PR TITLE
add `frame-pointers` profile option, second attempt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util-schemas"
-version = "0.14.3"
+version = "0.15.0"
 dependencies = [
  "jiff",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ cargo-platform = { path = "crates/cargo-platform", version = "0.3.3" }
 cargo-test-macro = { version = "0.4.14", path = "crates/cargo-test-macro" }
 cargo-test-support = { version = "0.11.4", path = "crates/cargo-test-support" }
 cargo-util = { version = "0.2.32", path = "crates/cargo-util" }
-cargo-util-schemas = { version = "0.14.2", path = "crates/cargo-util-schemas" }
+cargo-util-schemas = { version = "0.15.0", path = "crates/cargo-util-schemas" }
 cargo-util-terminal = { version = "0.1.2", path = "crates/cargo-util-terminal" }
 cargo_metadata = "0.23.1"
 clap = "4.6.0"

--- a/crates/cargo-util-schemas/Cargo.toml
+++ b/crates/cargo-util-schemas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-util-schemas"
-version = "0.14.3"
+version = "0.15.0"
 rust-version = "1.97"  # MSRV:1
 edition.workspace = true
 license.workspace = true

--- a/crates/cargo-util-schemas/manifest.schema.json
+++ b/crates/cargo-util-schemas/manifest.schema.json
@@ -1437,6 +1437,13 @@
             "null"
           ],
           "default": null
+        },
+        "frame-pointers": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
         }
       }
     },

--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -941,6 +941,7 @@ pub struct TomlProfile {
     pub trim_paths: Option<TomlTrimPaths>,
     /// Unstable feature `hint-mostly-unused`
     pub hint_mostly_unused: Option<bool>,
+    pub frame_pointers: Option<String>,
 }
 
 impl TomlProfile {
@@ -1035,6 +1036,10 @@ impl TomlProfile {
 
         if let Some(v) = profile.hint_mostly_unused {
             self.hint_mostly_unused = Some(v);
+        }
+
+        if let Some(v) = &profile.frame_pointers {
+            self.frame_pointers = Some(v.clone());
         }
     }
 }

--- a/doc/book/src/CHANGELOG.md
+++ b/doc/book/src/CHANGELOG.md
@@ -342,6 +342,10 @@
 
 ### Added
 
+- 🎉 New `frame-pointers` profile option to control the compiler's
+  `-C force-frame-pointers` flag.
+  [docs](https://doc.rust-lang.org/nightly/cargo/reference/profiles.html#frame-pointers)
+  [#16742](https://github.com/rust-lang/cargo/pull/16742)
 - Support `target.'cfg(..)'.rustdocflags` in Cargo configuration.
   [#16846](https://github.com/rust-lang/cargo/pull/16846)
 - cargo-help: display manpages for nested subcommands.

--- a/doc/book/src/CHANGELOG.md
+++ b/doc/book/src/CHANGELOG.md
@@ -342,10 +342,6 @@
 
 ### Added
 
-- 🎉 New `frame-pointers` profile option to control the compiler's
-  `-C force-frame-pointers` flag.
-  [docs](https://doc.rust-lang.org/nightly/cargo/reference/profiles.html#frame-pointers)
-  [#16742](https://github.com/rust-lang/cargo/pull/16742)
 - Support `target.'cfg(..)'.rustdocflags` in Cargo configuration.
   [#16846](https://github.com/rust-lang/cargo/pull/16846)
 - cargo-help: display manpages for nested subcommands.

--- a/doc/book/src/reference/profiles.md
+++ b/doc/book/src/reference/profiles.md
@@ -258,6 +258,26 @@ whether or not [`rpath`] is enabled.
 [`-C rpath` flag]: ../../rustc/codegen-options/index.html#rpath
 [`rpath`]: https://en.wikipedia.org/wiki/Rpath
 
+### frame-pointers
+
+The `frame-pointers` setting controls the [`-C force-frame-pointers` flag]
+which controls whether frame pointers are forced in generated code. Frame
+pointers are useful for profiling as they enable reliable stack unwinding.
+
+```toml
+[profile.release]
+frame-pointers = "force-on"
+```
+
+The valid options are:
+- `"force-on"`: Force frame pointers to be enabled.
+- `"force-off"`: Don't force frame pointers (the compiler may still emit them based on target defaults).
+- `"default"`: Use the compiler's target-specific default.
+
+When not specified, the compiler's target-specific default is used.
+
+[`-C force-frame-pointers` flag]: ../../rustc/codegen-options/index.html#force-frame-pointers
+
 ## Default profiles
 
 ### dev

--- a/doc/book/src/reference/profiles.md
+++ b/doc/book/src/reference/profiles.md
@@ -266,11 +266,11 @@ pointers are useful for profiling as they enable reliable stack unwinding.
 
 ```toml
 [profile.release]
-frame-pointers = "force-on"
+frame-pointers = "on"
 ```
 
 The valid options are:
-- `"force-on"`: Force frame pointers to be enabled.
+- `"on"`: Force frame pointers to be enabled.
 - `"default"`: Use the compiler's target-specific default.
 
 When not specified, the compiler's target-specific default is used.

--- a/doc/book/src/reference/profiles.md
+++ b/doc/book/src/reference/profiles.md
@@ -271,7 +271,6 @@ frame-pointers = "force-on"
 
 The valid options are:
 - `"force-on"`: Force frame pointers to be enabled.
-- `"force-off"`: Don't force frame pointers (the compiler may still emit them based on target defaults).
 - `"default"`: Use the compiler's target-specific default.
 
 When not specified, the compiler's target-specific default is used.

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1496,7 +1496,7 @@ fn build_base_args(
 
     if let Some(frame_pointers) = frame_pointers {
         let val = match frame_pointers {
-            FramePointers::ForceOn => "on",
+            FramePointers::On => "on",
         };
         cmd.arg("-C").arg(format!("force-frame-pointers={}", val));
     }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -110,7 +110,7 @@ use crate::util::interning::InternedString;
 use crate::util::machine_message::{self, Message};
 use crate::util::{add_path_args, internal, path_args};
 use crate::workspace::manifest::TargetSourcePath;
-use crate::workspace::profiles::{PanicStrategy, Profile, StripInner};
+use crate::workspace::profiles::{FramePointers, PanicStrategy, Profile, StripInner};
 use crate::workspace::{Feature, PackageId, Target};
 
 use cargo_util::{ProcessBuilder, ProcessError, paths};
@@ -1264,6 +1264,7 @@ fn build_base_args(
         rustflags: profile_rustflags,
         trim_paths,
         hint_mostly_unused: profile_hint_mostly_unused,
+        frame_pointers,
         ..
     } = unit.profile.clone();
     let hints = unit.pkg.hints().cloned().unwrap_or_default();
@@ -1491,6 +1492,14 @@ fn build_base_args(
     let strip = strip.into_inner();
     if strip != StripInner::None {
         cmd.arg("-C").arg(format!("strip={}", strip));
+    }
+
+    if let Some(frame_pointers) = frame_pointers {
+        let val = match frame_pointers {
+            FramePointers::ForceOn => "on",
+            FramePointers::ForceOff => "off",
+        };
+        cmd.arg("-C").arg(format!("force-frame-pointers={}", val));
     }
 
     if unit.is_std {

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1497,7 +1497,6 @@ fn build_base_args(
     if let Some(frame_pointers) = frame_pointers {
         let val = match frame_pointers {
             FramePointers::ForceOn => "on",
-            FramePointers::ForceOff => "off",
         };
         cmd.arg("-C").arg(format!("force-frame-pointers={}", val));
     }

--- a/src/workspace/parser/mod.rs
+++ b/src/workspace/parser/mod.rs
@@ -2606,10 +2606,10 @@ pub fn validate_profile(
     }
 
     if let Some(frame_pointers) = &root.frame_pointers {
-        if frame_pointers != "force-on" && frame_pointers != "default" {
+        if frame_pointers != "on" && frame_pointers != "default" {
             bail!(
                 "`frame-pointers` setting of `{frame_pointers}` is not a valid setting, \
-                     must be `\"force-on\"` or `\"default\"`.",
+                     must be `\"on\"` or `\"default\"`.",
             );
         }
     }

--- a/src/workspace/parser/mod.rs
+++ b/src/workspace/parser/mod.rs
@@ -2606,13 +2606,10 @@ pub fn validate_profile(
     }
 
     if let Some(frame_pointers) = &root.frame_pointers {
-        if frame_pointers != "force-on"
-            && frame_pointers != "force-off"
-            && frame_pointers != "default"
-        {
+        if frame_pointers != "force-on" && frame_pointers != "default" {
             bail!(
                 "`frame-pointers` setting of `{frame_pointers}` is not a valid setting, \
-                     must be `\"force-on\"`, `\"force-off\"`, or `\"default\"`.",
+                     must be `\"force-on\"` or `\"default\"`.",
             );
         }
     }

--- a/src/workspace/parser/mod.rs
+++ b/src/workspace/parser/mod.rs
@@ -2605,6 +2605,18 @@ pub fn validate_profile(
         }
     }
 
+    if let Some(frame_pointers) = &root.frame_pointers {
+        if frame_pointers != "force-on"
+            && frame_pointers != "force-off"
+            && frame_pointers != "default"
+        {
+            bail!(
+                "`frame-pointers` setting of `{frame_pointers}` is not a valid setting, \
+                     must be `\"force-on\"`, `\"force-off\"`, or `\"default\"`.",
+            );
+        }
+    }
+
     Ok(())
 }
 

--- a/src/workspace/profiles.rs
+++ b/src/workspace/profiles.rs
@@ -587,6 +587,15 @@ fn merge_profile(profile: &mut Profile, toml: &TomlProfile) {
     if let Some(hint_mostly_unused) = toml.hint_mostly_unused {
         profile.hint_mostly_unused = Some(hint_mostly_unused);
     }
+    if let Some(ref frame_pointers) = toml.frame_pointers {
+        profile.frame_pointers = match frame_pointers.as_str() {
+            "force-on" => Some(FramePointers::ForceOn),
+            "force-off" => Some(FramePointers::ForceOff),
+            "default" => None,
+            // This should be validated in TomlProfile::validate
+            _ => panic!("invalid frame-pointers value `{}`", frame_pointers),
+        };
+    }
     profile.strip = match toml.strip {
         Some(StringOrBool::Bool(true)) => Strip::Resolved(StripInner::Named("symbols".into())),
         Some(StringOrBool::Bool(false)) => Strip::Resolved(StripInner::None),
@@ -638,6 +647,8 @@ pub struct Profile {
     pub trim_paths: Option<TomlTrimPaths>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hint_mostly_unused: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub frame_pointers: Option<FramePointers>,
 }
 
 impl Default for Profile {
@@ -660,6 +671,7 @@ impl Default for Profile {
             rustflags: vec![],
             trim_paths: None,
             hint_mostly_unused: None,
+            frame_pointers: None,
         }
     }
 }
@@ -690,6 +702,7 @@ compact_debug! {
                 rustflags
                 trim_paths
                 hint_mostly_unused
+                frame_pointers
             )]
         }
     }
@@ -756,7 +769,12 @@ impl Profile {
             self.debug_assertions,
             self.overflow_checks,
             self.rpath,
-            (self.incremental, self.panic, self.strip),
+            (
+                self.incremental,
+                self.panic,
+                self.strip,
+                self.frame_pointers,
+            ),
             &self.rustflags,
             &self.trim_paths,
         )
@@ -975,6 +993,26 @@ impl PartialOrd for Strip {
 impl Ord for Strip {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.into_inner().cmp(&other.into_inner())
+    }
+}
+
+/// The setting for controlling frame pointers in generated code.
+#[derive(
+    Clone, Copy, PartialEq, Eq, Debug, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum FramePointers {
+    ForceOn,
+    ForceOff,
+}
+
+impl fmt::Display for FramePointers {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            FramePointers::ForceOn => "force-on",
+            FramePointers::ForceOff => "force-off",
+        }
+        .fmt(f)
     }
 }
 

--- a/src/workspace/profiles.rs
+++ b/src/workspace/profiles.rs
@@ -589,7 +589,7 @@ fn merge_profile(profile: &mut Profile, toml: &TomlProfile) {
     }
     if let Some(ref frame_pointers) = toml.frame_pointers {
         profile.frame_pointers = match frame_pointers.as_str() {
-            "force-on" => Some(FramePointers::ForceOn),
+            "on" => Some(FramePointers::On),
             "default" => None,
             // This should be validated in TomlProfile::validate
             _ => panic!("invalid frame-pointers value `{}`", frame_pointers),
@@ -1001,13 +1001,13 @@ impl Ord for Strip {
 )]
 #[serde(rename_all = "kebab-case")]
 pub enum FramePointers {
-    ForceOn,
+    On,
 }
 
 impl fmt::Display for FramePointers {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            FramePointers::ForceOn => "force-on",
+            FramePointers::On => "on",
         }
         .fmt(f)
     }

--- a/src/workspace/profiles.rs
+++ b/src/workspace/profiles.rs
@@ -590,7 +590,6 @@ fn merge_profile(profile: &mut Profile, toml: &TomlProfile) {
     if let Some(ref frame_pointers) = toml.frame_pointers {
         profile.frame_pointers = match frame_pointers.as_str() {
             "force-on" => Some(FramePointers::ForceOn),
-            "force-off" => Some(FramePointers::ForceOff),
             "default" => None,
             // This should be validated in TomlProfile::validate
             _ => panic!("invalid frame-pointers value `{}`", frame_pointers),
@@ -1003,14 +1002,12 @@ impl Ord for Strip {
 #[serde(rename_all = "kebab-case")]
 pub enum FramePointers {
     ForceOn,
-    ForceOff,
 }
 
 impl fmt::Display for FramePointers {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             FramePointers::ForceOn => "force-on",
-            FramePointers::ForceOff => "force-off",
         }
         .fmt(f)
     }

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -1677,6 +1677,7 @@ fn all_profile_options() {
         rustflags: None,
         trim_paths: None,
         hint_mostly_unused: None,
+        frame_pointers: Some("force-on".to_string()),
     };
     let mut overrides = BTreeMap::new();
     let key = cargo_toml::ProfilePackageSpec::Spec(PackageIdSpec::parse("foo").unwrap());

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -1677,7 +1677,7 @@ fn all_profile_options() {
         rustflags: None,
         trim_paths: None,
         hint_mostly_unused: None,
-        frame_pointers: Some("force-on".to_string()),
+        frame_pointers: Some("on".to_string()),
     };
     let mut overrides = BTreeMap::new();
     let key = cargo_toml::ProfilePackageSpec::Spec(PackageIdSpec::parse("foo").unwrap());

--- a/tests/testsuite/profile_settings.rs
+++ b/tests/testsuite/profile_settings.rs
@@ -987,34 +987,6 @@ fn frame_pointers_force_on() {
 }
 
 #[cargo_test]
-fn frame_pointers_force_off() {
-    let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-                [package]
-                name = "foo"
-                version = "0.1.0"
-                edition = "2015"
-
-                [profile.release]
-                frame-pointers = "force-off"
-            "#,
-        )
-        .file("src/main.rs", "fn main() {}")
-        .build();
-
-    p.cargo("build --release -v")
-        .with_stderr_data(str![[r#"
-[COMPILING] foo v0.1.0 ([ROOT]/foo)
-[RUNNING] `rustc [..] -C force-frame-pointers=off [..]`
-[FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-
-"#]])
-        .run();
-}
-
-#[cargo_test]
 fn frame_pointers_unspecified() {
     let p = project()
         .file(
@@ -1085,7 +1057,7 @@ fn frame_pointers_invalid_value() {
 [ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
 
 Caused by:
-  `frame-pointers` setting of `invalid` is not a valid setting, must be `"force-on"`, `"force-off"`, or `"default"`.
+  `frame-pointers` setting of `invalid` is not a valid setting, must be `"force-on"` or `"default"`.
 
 "#]])
         .run();

--- a/tests/testsuite/profile_settings.rs
+++ b/tests/testsuite/profile_settings.rs
@@ -959,7 +959,7 @@ fn profile_hint_mostly_unused_nightly() {
 }
 
 #[cargo_test]
-fn frame_pointers_force_on() {
+fn frame_pointers_on() {
     let p = project()
         .file(
             "Cargo.toml",
@@ -970,7 +970,7 @@ fn frame_pointers_force_on() {
                 edition = "2015"
 
                 [profile.release]
-                frame-pointers = "force-on"
+                frame-pointers = "on"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -1018,7 +1018,7 @@ fn frame_pointers_default_overrides_parent() {
                 edition = "2015"
 
                 [profile.release]
-                frame-pointers = "force-on"
+                frame-pointers = "on"
 
                 [profile.myprofile]
                 inherits = "release"
@@ -1057,7 +1057,7 @@ fn frame_pointers_invalid_value() {
 [ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
 
 Caused by:
-  `frame-pointers` setting of `invalid` is not a valid setting, must be `"force-on"` or `"default"`.
+  `frame-pointers` setting of `invalid` is not a valid setting, must be `"on"` or `"default"`.
 
 "#]])
         .run();

--- a/tests/testsuite/profile_settings.rs
+++ b/tests/testsuite/profile_settings.rs
@@ -957,3 +957,136 @@ fn profile_hint_mostly_unused_nightly() {
         )
         .run();
 }
+
+#[cargo_test]
+fn frame_pointers_force_on() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2015"
+
+                [profile.release]
+                frame-pointers = "force-on"
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build --release -v")
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.1.0 ([ROOT]/foo)
+[RUNNING] `rustc [..] -C force-frame-pointers=on [..]`
+[FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn frame_pointers_force_off() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2015"
+
+                [profile.release]
+                frame-pointers = "force-off"
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build --release -v")
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.1.0 ([ROOT]/foo)
+[RUNNING] `rustc [..] -C force-frame-pointers=off [..]`
+[FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn frame_pointers_unspecified() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2015"
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build -v")
+        .with_stderr_does_not_contain("[RUNNING] `rustc [..] -C force-frame-pointers[..]`")
+        .run();
+}
+
+#[cargo_test]
+fn frame_pointers_default_overrides_parent() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2015"
+
+                [profile.release]
+                frame-pointers = "force-on"
+
+                [profile.myprofile]
+                inherits = "release"
+                frame-pointers = "default"
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build --profile myprofile -v")
+        .with_stderr_does_not_contain("[RUNNING] `rustc [..] -C force-frame-pointers[..]`")
+        .run();
+}
+
+#[cargo_test]
+fn frame_pointers_invalid_value() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2015"
+
+                [profile.release]
+                frame-pointers = "invalid"
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build --release")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
+
+Caused by:
+  `frame-pointers` setting of `invalid` is not a valid setting, must be `"force-on"`, `"force-off"`, or `"default"`.
+
+"#]])
+        .run();
+}


### PR DESCRIPTION
It's a retry of #16742, which was reverted in #16999 because of a concern about the option name. This pull request reverts #16999, removes confusing `force-off` and renames `force-on` to `on`.

cc @enricobolzonello (original author)
cc @bjorn3

The following content is almost copied from #16742.

### What does this PR try to resolve?

Allow turning on frame pointers for a particular profile in `Cargo.toml` by add `frame-pointers` as a profile setting that maps to `-C force-frame-pointers`.

Values:
- `"on"` -> `-C force-frame-pointers=on`
- `"default"` -> no-op

Fixes #15333.

### How to test and review this PR?

Run the tests in `tests/testsuite/profiles.rs`:
- `frame_pointers_on`
- `frame_pointers_unspecified`
- `frame_pointers_invalid_value`
