### PR TITLE
fix(completions): complete paths for cargo run arguments

### DIFF
--- a/src/bin/cargo/commands/run.rs
+++ b/src/bin/cargo/commands/run.rs
@@ -21,6 +21,7 @@ pub fn cli() -> Command {
                 .value_name("ARGS")
                 .help("Arguments for the binary or example to run")
                 .value_parser(value_parser!(OsString))
+                .value_hint(clap::ValueHint::AnyPath)
                 .num_args(0..)
                 .trailing_var_arg(true),
         )


### PR DESCRIPTION


### What does this PR try to resolve?

Fixes #17280.

Native shell completions did not suggest files or directories for arguments passed to a binary after `cargo run --`. The trailing `ARGS` positional did not provide a value hint to `clap_complete`.

Set `ValueHint::AnyPath` on `ARGS` so shells such as fish can offer path candidates. This only affects completion metadata; argument parsing and execution are unchanged.

### How to test and review this PR?


Run:

```console
cargo +nightly test -p cargo --bin cargo
```

I also queried the fish dynamic completion backend directly:

```console
CARGO_COMPLETE=fish target/debug/cargo -- cargo run --bin cargo -- command --path Cargo.
```

It returns path candidates including `Cargo.lock` and `Cargo.toml`.