### PR TITLE
Remove redundant double call .to_string()

### DIFF
--- a/src/ops/cargo_new.rs
+++ b/src/ops/cargo_new.rs
@@ -1041,7 +1041,7 @@ fn update_manifest_with_new_member(
 
     write_atomic(
         &root_manifest_path,
-        workspace_document.to_string().to_string().as_bytes(),
+        workspace_document.to_string().as_bytes(),
     )?;
     Ok(true)
 }


### PR DESCRIPTION
### Problem

In src/ops/cargo_new.rs at line 1044, there's a redundant double .to_string() call:

```
write_atomic(
    &root_manifest_path,
    workspace_document.to_string().to_string().as_bytes(),
)?;
```

### Fix

Remove extra .to_string()

### Test

Single-line change with no behavioral difference. Existing test cover the code path.