### PR TITLE
Remove unnecessary return at end of functions

### DIFF
--- a/src/ops/cargo_test.rs
+++ b/src/ops/cargo_test.rs
@@ -306,7 +306,7 @@ fn display_no_run_information(
             .verbose(|shell| shell.status("Executable", &cmd))?;
     }
 
-    return Ok(());
+    Ok(())
 }
 
 /// Creates a [`ProcessBuilder`] for executing a single test.

--- a/src/ops/resolve.rs
+++ b/src/ops/resolve.rs
@@ -908,7 +908,7 @@ fn emit_warnings_of_unused_patches(
         ws.gctx().shell().print_report(&warnings, false)?;
     }
 
-    return Ok(());
+    Ok(())
 }
 
 /// Informs `registry` and `version_pref` that `[patch]` entries are available


### PR DESCRIPTION
### What does this PR try to resolve?

Remove unnecessary `return` keyword at the end of two functions where the expression form `Ok(())` is idiomatic Rust style.


### How to test and review this PR?

It is a stylistic change — `return Ok(())` and `Ok(())` are semantically identical at the end of a function. Existing tests pass unchanged.