### PR TITLE
make __CARGO_TEST_FORCE_ARGFILE available in distributed builds

### DIFF
--- a/crates/cargo-util/src/process_builder.rs
+++ b/crates/cargo-util/src/process_builder.rs
@@ -561,7 +561,7 @@ impl ProcessBuilder {
 ///
 /// You should set `__CARGO_TEST_FORCE_ARGFILE` to enable this.
 fn debug_force_argfile(retry_enabled: bool) -> bool {
-    cfg!(debug_assertions) && env::var("__CARGO_TEST_FORCE_ARGFILE").is_ok() && retry_enabled
+    retry_enabled && env::var("__CARGO_TEST_FORCE_ARGFILE").is_ok()
 }
 
 /// Creates new pipes for stderr, stdout, and optionally stdin.


### PR DESCRIPTION
cargo-miri (and every other cargo wrapper) will apparently need to learn to deal with argfiles. As part of that it would be really nice if we had any way of testing argfiles that does not involve having to add a gigantic amount of dependencies (I don't even know how many I'd have to add on my Linux system). So if we could have an env var to force argfile usage that'd be great. I'm happy to restrict this to nightly builds if you tell me how. ;)

Context: https://github.com/rust-lang/miri/issues/5234