### PR TITLE
Skip expensive lockfile equality work for byte-identical files

### DIFF
--- a/src/ops/lockfile.rs
+++ b/src/ops/lockfile.rs
@@ -208,12 +208,9 @@ fn serialize_resolve(resolve: &Resolve, orig: Option<&str>) -> String {
 
 #[tracing::instrument(skip_all)]
 fn are_equal_lockfiles(orig: &str, current: &str, ws: &Workspace<'_>) -> bool {
-    if orig == current {
-        return true;
-    }
-
-    // Prefer newline-insensitive equality over TOML parse + into_resolve.
-    if orig.lines().eq(current.lines()) {
+    // Textual equality is conclusive regardless of whether lockfile updates are
+    // allowed, so avoid TOML parse + into_resolve whenever possible.
+    if are_textually_equal_lockfiles(orig, current) {
         return true;
     }
 
@@ -231,6 +228,50 @@ fn are_equal_lockfiles(orig: &str, current: &str, ws: &Workspace<'_>) -> bool {
     }
 
     false
+}
+
+fn are_textually_equal_lockfiles(orig: &str, current: &str) -> bool {
+    orig == current || orig.lines().eq(current.lines())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::are_textually_equal_lockfiles;
+
+    #[test]
+    fn lockfile_text_equality_matrix() {
+        let cases = [
+            ("byte-identical", "version = 4\n", "version = 4\n", true),
+            ("final newline", "version = 4\n", "version = 4", true),
+            (
+                "crlf",
+                "version = 4\r\n\r\n[[package]]\r\nname = \"foo\"\r\n",
+                "version = 4\n\n[[package]]\nname = \"foo\"\n",
+                true,
+            ),
+            (
+                "extra blank line",
+                "version = 4\n\n",
+                "version = 4\n",
+                false,
+            ),
+            (
+                "semantic-only equality",
+                "version=4\n",
+                "version = 4\n",
+                false,
+            ),
+            ("unequal", "version = 3\n", "version = 4\n", false),
+        ];
+
+        for (name, orig, current, expected) in cases {
+            assert_eq!(
+                are_textually_equal_lockfiles(orig, current),
+                expected,
+                "{name}"
+            );
+        }
+    }
 }
 
 fn emit_package(dep: &toml::Table, out: &mut String) {

--- a/src/ops/lockfile.rs
+++ b/src/ops/lockfile.rs
@@ -208,15 +208,22 @@ fn serialize_resolve(resolve: &Resolve, orig: Option<&str>) -> String {
 
 #[tracing::instrument(skip_all)]
 fn are_equal_lockfiles(orig: &str, current: &str, ws: &Workspace<'_>) -> bool {
-    // Byte-identical is common on warm --locked/--frozen paths; skip the
-    // expensive TOML parse + into_resolve work below.
+    // Cheapest first: common warm --locked/--frozen path is byte-identical.
     if orig == current {
         return true;
     }
 
-    // If we want to try and avoid updating the lock file, parse both and
-    // compare them; since this is somewhat expensive, don't do it in the
-    // common case where we can update lock files.
+    // Newline-insensitive equality is still much cheaper than TOML parse +
+    // into_resolve. Prefer it over the locked semantic path (see review on
+    // #17294): trailing-newline / CRLF-only differences should not pay for
+    // a full resolve comparison.
+    if orig.lines().eq(current.lines()) {
+        return true;
+    }
+
+    // Under --locked/--frozen, allow semantic equality when serialization
+    // differs beyond line endings (e.g. key order / formatting) but the
+    // resolve is unchanged — avoids rewriting a locked lockfile needlessly.
     if !ws.gctx().lock_update_allowed() {
         let res: CargoResult<bool> = (|| {
             let old: TomlLockfile = toml::from_str(orig)?;
@@ -228,7 +235,7 @@ fn are_equal_lockfiles(orig: &str, current: &str, ws: &Workspace<'_>) -> bool {
         }
     }
 
-    orig.lines().eq(current.lines())
+    false
 }
 
 fn emit_package(dep: &toml::Table, out: &mut String) {

--- a/src/ops/lockfile.rs
+++ b/src/ops/lockfile.rs
@@ -208,6 +208,12 @@ fn serialize_resolve(resolve: &Resolve, orig: Option<&str>) -> String {
 
 #[tracing::instrument(skip_all)]
 fn are_equal_lockfiles(orig: &str, current: &str, ws: &Workspace<'_>) -> bool {
+    // Byte-identical is common on warm --locked/--frozen paths; skip the
+    // expensive TOML parse + into_resolve work below.
+    if orig == current {
+        return true;
+    }
+
     // If we want to try and avoid updating the lock file, parse both and
     // compare them; since this is somewhat expensive, don't do it in the
     // common case where we can update lock files.

--- a/src/ops/lockfile.rs
+++ b/src/ops/lockfile.rs
@@ -208,22 +208,17 @@ fn serialize_resolve(resolve: &Resolve, orig: Option<&str>) -> String {
 
 #[tracing::instrument(skip_all)]
 fn are_equal_lockfiles(orig: &str, current: &str, ws: &Workspace<'_>) -> bool {
-    // Cheapest first: common warm --locked/--frozen path is byte-identical.
     if orig == current {
         return true;
     }
 
-    // Newline-insensitive equality is still much cheaper than TOML parse +
-    // into_resolve. Prefer it over the locked semantic path (see review on
-    // #17294): trailing-newline / CRLF-only differences should not pay for
-    // a full resolve comparison.
+    // Prefer newline-insensitive equality over TOML parse + into_resolve.
     if orig.lines().eq(current.lines()) {
         return true;
     }
 
     // Under --locked/--frozen, allow semantic equality when serialization
-    // differs beyond line endings (e.g. key order / formatting) but the
-    // resolve is unchanged — avoids rewriting a locked lockfile needlessly.
+    // differs beyond line endings but the resolve is unchanged.
     if !ws.gctx().lock_update_allowed() {
         let res: CargoResult<bool> = (|| {
             let old: TomlLockfile = toml::from_str(orig)?;


### PR DESCRIPTION
### What does this resolve?

When Cargo checks whether to rewrite `Cargo.lock`, `--locked` and `--frozen` could parse both lockfiles before reaching the existing newline-insensitive equality check.

This makes the inexpensive checks conclusive first:

1. `orig == current`
2. `orig.lines().eq(current.lines())`
3. locked/frozen semantic comparison
4. unequal

There was no semantic requirement for the old precedence: line-equal inputs produce the same TOML, and the old code already returned true after a failed semantic attempt. The byte check is first because it avoids both iterator work and TOML deserialization on the common warm path.

### Review feedback

- Answered @epage's precedence question directly and moved the existing line check before semantic parsing.
- Rebased and squashed the branch to one atomic commit.

### Validation

- `cargo +1.97.0 fmt --all -- --check`
- `cargo +1.97.0 check -p cargo --lib`
- `cargo +1.97.0 test -p cargo --test testsuite update::preserve_top_comment`
