### PR TITLE
Remove unnecessary to_path_buf

### DIFF
--- a/src/compiler/layout.rs
+++ b/src/compiler/layout.rs
@@ -466,7 +466,7 @@ impl BuildDirLayout {
         if self.is_new_layout {
             self.build_unit(pkg_dir).join("fingerprint")
         } else {
-            self.legacy_fingerprint().to_path_buf().join(pkg_dir)
+            self.legacy_fingerprint().join(pkg_dir)
         }
     }
     /// Fetch the fingerprint path. (old layout)


### PR DESCRIPTION
### What does this PR try to resolve?

Remove unnecessary `.to_path_buf()` call before `.join()` in `layout.rs`.


### How to test and review this PR?

Single-line change removing an unnecessary heap allocation. Behavior is identical and produces the same result.