### PR TITLE
feat(diag): Stabilize cargo-lints 

### DIFF
--- a/crates/xtask-lint-docs/src/main.rs
+++ b/crates/xtask-lint-docs/src/main.rs
@@ -45,11 +45,7 @@ fn main() -> anyhow::Result<()> {
 >
 > See [the lints section in the Manifest Format
 > chapter](manifest.md#the-lints-section) to configure lint levels for tools
-> such as `rustc` or `clippy`.
-
-> [!WARNING]
-> [Cargo's linting system is unstable](unstable.md#lintscargo) and can only be used on nightly
-> toolchains."
+> such as `rustc` or `clippy`."
     )?;
     writeln!(buf)?;
 

--- a/doc/book/src/guide/build-performance.md
+++ b/doc/book/src/guide/build-performance.md
@@ -151,16 +151,11 @@ Trade-offs:
 
 ### Removing unused dependencies
 
-Recommendation: periodically review unused dependencies for removal using:
-```console
-$ cargo +nightly check -Zcargo-lints --workspace --all-targets
-```
-This may have false positives from:
-- when a dependency's use is dynamically controlled by a `build.rs` or `RUSTFLAGS`
+The [`cargo::unused_dependencies`](../reference/lints.md#unused_dependencies) will identify most unused dependencies with few false positives.
 
-Also, periodically review hidden [`cargo::unused_dependencies`] results:
+For everything else, periodically review hidden [`cargo::unused_dependencies`] results:
 ```console
-$ CARGO_LOG=cargo::diagnostics::rules::unused_dependencies=debug cargo +nightly check -Zcargo-lints --workspace --all-targets
+$ CARGO_LOG=cargo::diagnostics::rules::unused_dependencies=debug cargo check --workspace --all-targets
 ```
 This will show potential unused dependencies for
 - registry and git dependencies
@@ -174,10 +169,8 @@ it can be easy to miss that a dependency is no longer used and can be removed.
 
 Trade-offs:
 - ✅ Faster full build and link times
-- ❌ **Requires using nightly Rust and an [unstable Cargo feature][cargo-lints] when reviewing unused dependencies**
 - ❌ It takes effort to identify unused dependencies from among the false positives
 
-[cargo-lints]: ../reference/unstable.md#lintscargo
 [`cargo::unused_dependencies`]: ../reference/lints.md#unused_dependencies
 [`package.rust-version`]: ../reference/rust-version.md
 

--- a/doc/book/src/reference/lints.md
+++ b/doc/book/src/reference/lints.md
@@ -7,10 +7,6 @@
 > chapter](manifest.md#the-lints-section) to configure lint levels for tools
 > such as `rustc` or `clippy`.
 
-> [!WARNING]
-> [Cargo's linting system is unstable](unstable.md#lintscargo) and can only be used on nightly
-> toolchains.
-
 
 
 | Group                | Description                                                                         | Default level |

--- a/doc/book/src/reference/unstable.md
+++ b/doc/book/src/reference/unstable.md
@@ -114,7 +114,6 @@ Each new feature described below should explain how to use it.
     * [per-package-target](#per-package-target) --- Sets the `--target` to use for each individual package.
     * [artifact dependencies](#artifact-dependencies) --- Allow build artifacts to be included into other build artifacts and build them for different targets.
     * [Profile `trim-paths` option](#profile-trim-paths-option) --- Control the sanitization of file paths in build outputs.
-    * [`[lints.cargo]`](#lintscargo) --- Allows configuring lints for Cargo.
     * [path bases](#path-bases) --- Named base directories for path dependencies.
     * [`unstable-editions`](#unstable-editions) --- Allows use of editions that are not yet stable.
 * Information and metadata
@@ -1758,27 +1757,6 @@ panic = "immediate-abort"
 
 Use fine grain locking instead of locking the entire build cache.
 
-## `[lints.cargo]`
-
-* Tracking Issue: [#12235](https://github.com/rust-lang/cargo/issues/12235)
-
-A new `lints` tool table for `cargo` that can be used to configure lints emitted
-by `cargo` itself when `-Zcargo-lints` is used
-```toml
-[lints.cargo]
-implicit-features = "warn"
-```
-
-This will work with
-[RFC 2906 `workspace-deduplicate`](https://rust-lang.github.io/rfcs/2906-cargo-workspace-deduplicate.html):
-```toml
-[workspace.lints.cargo]
-implicit-features = "warn"
-
-[lints]
-workspace = true
-```
-
 ## Path Bases
 
 * Tracking Issue: [#14355](https://github.com/rust-lang/cargo/issues/14355)
@@ -2482,3 +2460,9 @@ See <https://github.com/rust-lang/cargo/pull/17333> fopr the reason for its remo
 ## build-dir-new-layout
 
 The new build-dir filesystem layout was stabilized in the 1.100.0 release.
+
+## `[lints.cargo]`
+
+Cargo's linting system and the `[lints.cargo]` table have been stabilized in Rust 1.100.
+See the [lints chapter](lints.md) and [the lints section](manifest.md#the-lints-section)
+for information about configuring Cargo lints.

--- a/src/compiler/job_queue/mod.rs
+++ b/src/compiler/job_queue/mod.rs
@@ -841,15 +841,13 @@ impl<'gctx> DrainState<'gctx> {
         }
         self.progress.clear();
 
-        if build_runner.bcx.gctx.cli_unstable().cargo_lints {
-            let mut global_stats = GlobalDiagnosticStats::new();
-            drop(unused_dependencies::lint_build_results(
-                build_runner,
-                &mut global_stats,
-            ));
-            errors.count += global_stats.error_count();
-            build_runner.compilation.lint_warning_count += global_stats.lint_warning_count();
-        }
+        let mut global_stats = GlobalDiagnosticStats::new();
+        drop(unused_dependencies::lint_build_results(
+            build_runner,
+            &mut global_stats,
+        ));
+        errors.count += global_stats.error_count();
+        build_runner.compilation.lint_warning_count += global_stats.lint_warning_count();
 
         let profile_name = build_runner.bcx.build_config.requested_profile;
         // NOTE: this may be a bit inaccurate, since this may not display the

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -881,11 +881,9 @@ fn prepare_rustc(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> CargoResult
         base.env("CARGO_TARGET_TMPDIR", tmp.display().to_string());
     }
 
-    if build_runner.bcx.gctx.cli_unstable().cargo_lints {
-        // Added last to reduce the risk of RUSTFLAGS or `[lints]` from interfering with
-        // `unused_dependencies` tracking
-        base.arg("--force-warn=unused_crate_dependencies");
-    }
+    // Added last to reduce the risk of RUSTFLAGS or `[lints]` from interfering with
+    // `unused_dependencies` tracking
+    base.arg("--force-warn=unused_crate_dependencies");
 
     Ok(base)
 }
@@ -1273,10 +1271,9 @@ fn add_error_format_and_color(build_runner: &BuildRunner<'_, '_>, cmd: &mut Proc
 
     cmd.arg("--error-format=json");
 
-    let mut json = String::from("--json=diagnostic-rendered-ansi,artifacts,future-incompat");
-    if build_runner.bcx.gctx.cli_unstable().cargo_lints {
-        json.push_str(",unused-externs-silent");
-    }
+    let mut json = String::from(
+        "--json=diagnostic-rendered-ansi,artifacts,future-incompat,unused-externs-silent",
+    );
     if let MessageFormat::Short | MessageFormat::Json { short: true, .. } =
         build_runner.bcx.build_config.message_format
     {

--- a/src/diagnostics/passes.rs
+++ b/src/diagnostics/passes.rs
@@ -153,19 +153,17 @@ fn emit_parse_pkg_diagnostics(
                 rule(workspace, manifest, &path, &mut pkg_stats, workspace.gctx())?;
             }
             ParsePassRule::LintManifest { rule, lint } => {
-                if workspace.gctx().cli_unstable().cargo_lints {
-                    let manifest: ManifestFor<'_> = pkg.into();
-                    let level = manifest.lint_level(&cargo_lints, lint, workspace.gctx());
-                    if level.level != LintLevel::Allow {
-                        rule(
-                            workspace,
-                            manifest,
-                            &path,
-                            level,
-                            &mut pkg_stats,
-                            workspace.gctx(),
-                        )?;
-                    }
+                let manifest: ManifestFor<'_> = pkg.into();
+                let level = manifest.lint_level(&cargo_lints, lint, workspace.gctx());
+                if level.level != LintLevel::Allow {
+                    rule(
+                        workspace,
+                        manifest,
+                        &path,
+                        level,
+                        &mut pkg_stats,
+                        workspace.gctx(),
+                    )?;
                 }
             }
             ParsePassRule::DiagnosticWorkspace { .. } | ParsePassRule::LintWorkspace { .. } => {}
@@ -173,24 +171,22 @@ fn emit_parse_pkg_diagnostics(
                 rule(workspace, pkg, &path, &mut pkg_stats, workspace.gctx())?;
             }
             ParsePassRule::LintPackage { rule, lint } => {
-                if workspace.gctx().cli_unstable().cargo_lints {
-                    let level = lint.level(
-                        &cargo_lints,
-                        pkg.rust_version(),
-                        pkg.manifest().unstable_features(),
-                        workspace.gctx(),
-                    );
+                let level = lint.level(
+                    &cargo_lints,
+                    pkg.rust_version(),
+                    pkg.manifest().unstable_features(),
+                    workspace.gctx(),
+                );
 
-                    if level.level != LintLevel::Allow {
-                        rule(
-                            workspace,
-                            pkg,
-                            &path,
-                            level,
-                            &mut pkg_stats,
-                            workspace.gctx(),
-                        )?;
-                    }
+                if level.level != LintLevel::Allow {
+                    rule(
+                        workspace,
+                        pkg,
+                        &path,
+                        level,
+                        &mut pkg_stats,
+                        workspace.gctx(),
+                    )?;
                 }
             }
         }
@@ -242,19 +238,17 @@ fn emit_parse_ws_diagnostics(
                 )?;
             }
             ParsePassRule::LintManifest { rule, lint } => {
-                if workspace.gctx().cli_unstable().cargo_lints {
-                    let manifest: ManifestFor<'_> = (workspace, workspace.root_maybe()).into();
-                    let level = manifest.lint_level(&cargo_lints, lint, workspace.gctx());
-                    if level.level != LintLevel::Allow {
-                        rule(
-                            workspace,
-                            manifest,
-                            workspace.root_manifest(),
-                            level,
-                            &mut pkg_stats,
-                            workspace.gctx(),
-                        )?;
-                    }
+                let manifest: ManifestFor<'_> = (workspace, workspace.root_maybe()).into();
+                let level = manifest.lint_level(&cargo_lints, lint, workspace.gctx());
+                if level.level != LintLevel::Allow {
+                    rule(
+                        workspace,
+                        manifest,
+                        workspace.root_manifest(),
+                        level,
+                        &mut pkg_stats,
+                        workspace.gctx(),
+                    )?;
                 }
             }
             ParsePassRule::DiagnosticWorkspace { rule } => {
@@ -267,23 +261,21 @@ fn emit_parse_ws_diagnostics(
                 )?;
             }
             ParsePassRule::LintWorkspace { rule, lint } => {
-                if workspace.gctx().cli_unstable().cargo_lints {
-                    let level = lint.level(
-                        &cargo_lints,
-                        workspace.lowest_rust_version(),
-                        workspace.root_maybe().unstable_features(),
+                let level = lint.level(
+                    &cargo_lints,
+                    workspace.lowest_rust_version(),
+                    workspace.root_maybe().unstable_features(),
+                    workspace.gctx(),
+                );
+                if level.level != LintLevel::Allow {
+                    rule(
+                        workspace,
+                        workspace.root_maybe(),
+                        workspace.root_manifest(),
+                        level,
+                        &mut pkg_stats,
                         workspace.gctx(),
-                    );
-                    if level.level != LintLevel::Allow {
-                        rule(
-                            workspace,
-                            workspace.root_maybe(),
-                            workspace.root_manifest(),
-                            level,
-                            &mut pkg_stats,
-                            workspace.gctx(),
-                        )?;
-                    }
+                    )?;
                 }
             }
             ParsePassRule::DiagnosticPackage { .. } | ParsePassRule::LintPackage { .. } => {}

--- a/src/workspace/features.rs
+++ b/src/workspace/features.rs
@@ -886,7 +886,6 @@ unstable_cli_options!(
     build_std: Option<Vec<String>>  = ("Enable Cargo to compile the standard library itself as part of a crate graph compilation"),
     #[serde(deserialize_with = "deserialize_comma_separated_list")]
     build_std_features: Option<Vec<String>>  = ("Configure features enabled for the standard library itself when building the standard library"),
-    cargo_lints: bool = ("Enable the `[lints.cargo]` table"),
     checksum_freshness: bool = ("Use a checksum to determine if output is fresh rather than filesystem mtime"),
     codegen_backend: bool = ("Enable the `codegen-backend` option in profiles in .cargo/config.toml file"),
     direct_minimal_versions: bool = ("Resolve minimal dependency versions instead of maximum (direct dependencies only)"),
@@ -1002,6 +1001,8 @@ const STABILIZED_REGISTRY_AUTH: &str =
     "Authenticated registries are available if a credential provider is configured.";
 
 const STABILIZED_LINTS: &str = "The `[lints]` table is now always available.";
+
+const STABILIZED_CARGO_LINTS: &str = "The `[lints.cargo]` table is now always available.";
 
 const STABILIZED_CHECK_CFG: &str =
     "Compile-time checking of conditional (a.k.a. `-Zcheck-cfg`) is now always enabled.";
@@ -1422,6 +1423,7 @@ impl CliUnstable {
             "lockfile-path" => stabilized_warn(k, "1.97", STABILIZED_LOCKFILE_PATH),
             "warnings" => stabilized_warn(k, "1.97", STABILIZED_WARNINGS),
             "build-dir-new-layout" => stabilized_warn(k, "1.100", STABILIZED_BUILD_DIR_NEW_LAYOUT),
+            "cargo-lints" => stabilized_warn(k, "1.100", STABILIZED_CARGO_LINTS),
 
             // Unstable features
             // Sorted alphabetically:
@@ -1434,7 +1436,6 @@ impl CliUnstable {
             "build-analysis" => self.build_analysis = parse_empty(k, v)?,
             "build-std" => self.build_std = Some(parse_list(v)),
             "build-std-features" => self.build_std_features = Some(parse_list(v)),
-            "cargo-lints" => self.cargo_lints = parse_empty(k, v)?,
             "codegen-backend" => self.codegen_backend = parse_empty(k, v)?,
             "direct-minimal-versions" => self.direct_minimal_versions = parse_empty(k, v)?,
             "dual-proc-macros" => self.dual_proc_macros = parse_empty(k, v)?,

--- a/src/workspace/parser/mod.rs
+++ b/src/workspace/parser/mod.rs
@@ -85,7 +85,7 @@ pub fn read_manifest(
         let cargo_features = original_toml.cargo_features.as_ref().unwrap_or(&empty);
         let features = Features::new(cargo_features, gctx, &mut warnings, source_id.is_path())?;
         let workspace_config =
-            to_workspace_config(&original_toml, path, is_embedded, gctx, &mut warnings)?;
+            to_workspace_config(&original_toml, path, is_embedded, &mut warnings)?;
         if let WorkspaceConfig::Root(ws_root_config) = &workspace_config {
             let package_root = path.parent().unwrap();
             gctx.ws_roots()
@@ -233,7 +233,6 @@ fn to_workspace_config(
     original_toml: &manifest::TomlManifest,
     manifest_file: &Path,
     is_embedded: bool,
-    gctx: &GlobalContext,
     warnings: &mut Vec<String>,
 ) -> CargoResult<WorkspaceConfig> {
     if is_embedded {
@@ -245,7 +244,7 @@ fn to_workspace_config(
         original_toml.package().and_then(|p| p.workspace.as_ref()),
     ) {
         (Some(toml_config), None) => {
-            verify_lints(toml_config.lints.as_ref(), gctx, warnings)?;
+            verify_lints(toml_config.lints.as_ref(), warnings)?;
             if let Some(ws_deps) = &toml_config.dependencies {
                 for (name, dep) in ws_deps {
                     if dep.is_optional() {
@@ -1664,7 +1663,6 @@ pub fn to_real_manifest(
         normalized_toml
             .normalized_lints()
             .expect("previously normalized"),
-        gctx,
         warnings,
     )?;
     let default = manifest::TomlLints::default();
@@ -2676,7 +2674,6 @@ fn validate_profile_override(profile: &manifest::TomlProfile, which: &str) -> Ca
 
 fn verify_lints(
     lints: Option<&manifest::TomlLints>,
-    gctx: &GlobalContext,
     warnings: &mut Vec<String>,
 ) -> CargoResult<()> {
     let Some(lints) = lints else {
@@ -2693,9 +2690,6 @@ supported tools: {}",
             );
             warnings.push(message);
             continue;
-        }
-        if tool == "cargo" && !gctx.cli_unstable().cargo_lints {
-            warn_for_cargo_lint_feature(gctx, warnings);
         }
         let mut seen_normalized: HashMap<String, String> = HashMap::default();
         for (name, config) in lints {
@@ -2748,38 +2742,6 @@ static EXPECTED_LINT_CONFIG: &[(&str, &str, &str)] = &[
     // forwarded to rustc/rustdoc
     ("rust", "unexpected_cfgs", "check-cfg"),
 ];
-
-fn warn_for_cargo_lint_feature(gctx: &GlobalContext, warnings: &mut Vec<String>) {
-    use std::fmt::Write as _;
-
-    let key_name = "lints.cargo";
-    let feature_name = "cargo-lints";
-
-    let mut message = String::new();
-
-    let _ = write!(
-        message,
-        "unused manifest key `{key_name}` (may be supported in a future version)"
-    );
-    if gctx.nightly_features_allowed {
-        let _ = write!(
-            message,
-            "
-
-consider passing `-Z{feature_name}` to enable this feature."
-        );
-    } else {
-        let _ = write!(
-            message,
-            "
-
-this Cargo does not support nightly features, but if you
-switch to nightly channel you can pass
-`-Z{feature_name}` to enable this feature.",
-        );
-    }
-    warnings.push(message);
-}
 
 fn lints_to_rustflags(lints: &manifest::TomlLints) -> CargoResult<Vec<String>> {
     let mut rustflags = lints

--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -467,24 +467,16 @@ fn build_std_does_not_warn_about_implicit_std_deps() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    let output = p
-        .cargo("build")
-        .build_std()
-        .target_host()
-        .env("RUSTFLAGS", "-W unused-crate-dependencies")
-        .run();
+    let output = p.cargo("build").build_std().target_host().run();
     let stderr = String::from_utf8(output.stderr).unwrap();
     println!("{stderr}");
     let mut unused_warnings = stderr
         .lines()
-        .filter(|l| l.contains("is unused in crate"))
+        .filter(|l| l.contains("unused dependency"))
         .collect::<Vec<_>>();
     unused_warnings.sort();
     let unused_warnings = unused_warnings.join("\n");
-    assert_data_eq!(
-        unused_warnings,
-        str!["warning: extern crate `bar` is unused in crate `buildstd_test`"]
-    );
+    assert_data_eq!(unused_warnings, str!["warning: unused dependency `bar`"]);
 }
 
 #[cargo_test(build_std_real)]

--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -445,7 +445,7 @@ fn build_std_does_not_warn_about_implicit_std_deps() {
             "Cargo.toml",
             r#"
                 [package]
-                name = "buildstd_test"
+                name = "buildstd-test"
                 version = "0.1.0"
                 edition = "2021"
 
@@ -473,7 +473,7 @@ fn build_std_does_not_warn_about_implicit_std_deps() {
         .with_stderr_data(
             str![[r#"
 [WARNING] extern crate `bar` is unused in crate `buildstd_test`
-[WARNING] `buildstd_test` (bin "buildstd_test") generated 1 warning
+[WARNING] `buildstd-test` (bin "buildstd-test") generated 1 warning
 ...
 "#]]
             .unordered(),

--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -25,6 +25,7 @@ use cargo_test_support::basic_manifest;
 use cargo_test_support::paths;
 use cargo_test_support::project;
 use cargo_test_support::rustc_host;
+use cargo_test_support::snapbox::assert_data_eq;
 use cargo_test_support::str;
 use cargo_test_support::target_spec_json;
 use cargo_test_support::{Project, prelude::*};
@@ -466,19 +467,24 @@ fn build_std_does_not_warn_about_implicit_std_deps() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    let output = p
+        .cargo("build")
         .build_std()
         .target_host()
         .env("RUSTFLAGS", "-W unused-crate-dependencies")
-        .with_stderr_data(
-            str![[r#"
-[WARNING] extern crate `bar` is unused in crate `buildstd_test`
-[WARNING] `buildstd-test` (bin "buildstd-test") generated 1 warning
-...
-"#]]
-            .unordered(),
-        )
         .run();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    println!("{stderr}");
+    let mut unused_warnings = stderr
+        .lines()
+        .filter(|l| l.contains("is unused in crate"))
+        .collect::<Vec<_>>();
+    unused_warnings.sort();
+    let unused_warnings = unused_warnings.join("\n");
+    assert_data_eq!(
+        unused_warnings,
+        str!["warning: extern crate `bar` is unused in crate `buildstd_test`"]
+    );
 }
 
 #[cargo_test(build_std_real)]

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -26,6 +26,9 @@ fn depend_on_alt_registry() {
                 [dependencies.bar]
                 version = "0.0.1"
                 registry = "alternative"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -75,6 +78,9 @@ fn depend_on_alt_registry_depends_on_same_registry_no_index() {
                 [dependencies.bar]
                 version = "0.0.1"
                 registry = "alternative"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -121,6 +127,9 @@ fn depend_on_alt_registry_depends_on_same_registry() {
                 [dependencies.bar]
                 version = "0.0.1"
                 registry = "alternative"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -167,6 +176,9 @@ fn depend_on_alt_registry_depends_on_crates_io() {
                 [dependencies.bar]
                 version = "0.0.1"
                 registry = "alternative"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -215,6 +227,9 @@ fn registry_and_path_dep_works() {
                 [dependencies.bar]
                 path = "bar"
                 registry = "alternative"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -250,6 +265,9 @@ fn registry_and_git_dep_works() {
                 version = "0.0.1"
                 edition = "2015"
                 authors = []
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -270,6 +288,9 @@ fn registry_and_git_dep_works() {
                 version = "0.0.1"
                 registry = "alternative"
                 git="{}"
+
+                [lints.cargo]
+                default = "allow"
             "#,
                 bar.url(),
             ),
@@ -371,6 +392,9 @@ fn publish_with_registry_dependency() {
                 [dependencies.bar]
                 version = "0.0.1"
                 registry = "alternative"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -456,6 +480,9 @@ fn alt_registry_and_crates_io_deps() {
                 [dependencies.alt_reg_dep]
                 version = "0.1.0"
                 registry = "alternative"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -612,6 +639,9 @@ fn publish_with_crates_io_dep() {
 
                 [dependencies.bar]
                 version = "0.0.1"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -696,6 +726,9 @@ fn publish_with_git_and_registry_dep() {
                 version = "0.0.1"
                 edition = "2015"
                 authors = []
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -716,6 +749,9 @@ fn publish_with_git_and_registry_dep() {
                 version = "0.0.1"
                 registry = "alternative"
                 git="{}"
+
+                [lints.cargo]
+                default = "allow"
             "#,
                 bar.url(),
             ),
@@ -929,6 +965,9 @@ fn no_api() {
                 [dependencies.bar]
                 version = "0.0.1"
                 registry = "alternative"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -1784,6 +1823,9 @@ fn registries_index_relative_url() {
                 [dependencies.bar]
                 version = "0.0.1"
                 registry = "relative"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -1974,6 +1974,9 @@ fn show_no_lib_warning_with_artifact_dependencies_that_have_no_lib_but_lib_true(
 
                 [dependencies]
                 bar = { path = "bar/", artifact = "bin", lib = true }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -2854,6 +2857,9 @@ fn decouple_same_target_transitive_dep_from_artifact_dep() {
                 [dependencies]
                 a = {{ path = "a" }}
                 bar = {{ path = "bar", artifact = "bin", target = "{target}" }}
+
+                [lints.cargo]
+                default = "allow"
             "#
             ),
         )
@@ -2873,6 +2879,9 @@ fn decouple_same_target_transitive_dep_from_artifact_dep() {
 
                 [dependencies]
                 a = { path = "../a", features = ["feature"] }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file(
@@ -2895,6 +2904,9 @@ fn decouple_same_target_transitive_dep_from_artifact_dep() {
 
                 [features]
                 feature = ["c/feature"]
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file(
@@ -2917,6 +2929,9 @@ fn decouple_same_target_transitive_dep_from_artifact_dep() {
 
                 [dependencies]
                 c = { path = "../c" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file(
@@ -2939,6 +2954,9 @@ fn decouple_same_target_transitive_dep_from_artifact_dep() {
 
                 [features]
                 feature = []
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file(
@@ -2981,6 +2999,9 @@ fn decouple_same_target_transitive_dep_from_artifact_dep_lib() {
                 a = {{ path = "a" }}
                 b = {{ path = "b", features = ["feature"] }}
                 bar = {{ path = "bar", artifact = "bin", lib = true, target = "{target}" }}
+
+                [lints.cargo]
+                default = "allow"
             "#
             ),
         )
@@ -2996,6 +3017,9 @@ fn decouple_same_target_transitive_dep_from_artifact_dep_lib() {
                 [dependencies]
                 a = { path = "../a", features = ["b"] }
                 b = { path = "../b" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("bar/src/lib.rs", "")
@@ -3019,6 +3043,9 @@ fn decouple_same_target_transitive_dep_from_artifact_dep_lib() {
 
                 [dependencies]
                 b = { path = "../b", optional = true }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file(
@@ -3040,6 +3067,9 @@ fn decouple_same_target_transitive_dep_from_artifact_dep_lib() {
 
                 [features]
                 feature = []
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file(
@@ -3081,6 +3111,9 @@ fn decouple_same_target_transitive_dep_from_artifact_dep_and_proc_macro() {
                 [dependencies]
                 c = {{ path = "c" }}
                 bar = {{ path = "bar", artifact = "bin", target = "{target}" }}
+
+                [lints.cargo]
+                default = "allow"
             "#
             ),
         )
@@ -3095,6 +3128,9 @@ fn decouple_same_target_transitive_dep_from_artifact_dep_and_proc_macro() {
 
             [dependencies]
             b = { path = "../b" }
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file("bar/src/main.rs", "fn main() {}")
@@ -3111,6 +3147,9 @@ fn decouple_same_target_transitive_dep_from_artifact_dep_and_proc_macro() {
 
             [lib]
             proc-macro = true
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file("b/src/lib.rs", "")
@@ -3128,6 +3167,9 @@ fn decouple_same_target_transitive_dep_from_artifact_dep_and_proc_macro() {
 
             [lib]
             proc-macro = true
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file(
@@ -3150,6 +3192,9 @@ fn decouple_same_target_transitive_dep_from_artifact_dep_and_proc_macro() {
 
             [dependencies]
             d = { path = "../d" }
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file(
@@ -3172,6 +3217,9 @@ fn decouple_same_target_transitive_dep_from_artifact_dep_and_proc_macro() {
 
             [features]
             feature = []
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file("d/src/lib.rs", "pub struct D;")

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -1084,6 +1084,9 @@ fn build_dependencies2() {
 
                 [build_dependencies]
                 a = {path = "a"}
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -1094,6 +1097,9 @@ fn build_dependencies2() {
                 name = "a"
                 version = "0.0.1"
                 edition = "2015"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("a/src/lib.rs", "")
@@ -1164,6 +1170,9 @@ fn build_dependencies2_conflict() {
                 a = {path = "a"}
                 [build_dependencies]
                 a = {path = "a"}
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -1174,6 +1183,9 @@ fn build_dependencies2_conflict() {
                 name = "a"
                 version = "0.0.1"
                 edition = "2015"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("a/src/lib.rs", "")
@@ -1797,6 +1809,9 @@ fn default_features2() {
 
                 [dependencies]
                 a = { path = "a", features = ["f1"], default_features = false }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -1812,6 +1827,9 @@ fn default_features2() {
                 [features]
                 default = ["f1"]
                 f1 = []
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("a/src/lib.rs", "")
@@ -1890,6 +1908,9 @@ fn default_features2_conflict() {
 
                 [dependencies]
                 a = { path = "a", features = ["f1"], default-features = false, default_features = false }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -1905,6 +1926,9 @@ fn default_features2_conflict() {
                 [features]
                 default = ["f1"]
                 f1 = []
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("a/src/lib.rs", "")
@@ -1946,6 +1970,9 @@ fn workspace_default_features2() {
 
                 [dependencies]
                 dep_workspace_only.workspace = true
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("workspace_only/src/lib.rs", "")
@@ -1957,6 +1984,9 @@ fn workspace_default_features2() {
                 version = "0.1.0"
                 edition = "2015"
                 authors = []
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("dep_workspace_only/src/lib.rs", "")
@@ -1971,6 +2001,9 @@ fn workspace_default_features2() {
 
                 [dependencies]
                 dep_package_only = { workspace = true, default_features = true }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("package_only/src/lib.rs", "")
@@ -1982,6 +2015,9 @@ fn workspace_default_features2() {
                 version = "0.1.0"
                 edition = "2015"
                 authors = []
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("dep_package_only/src/lib.rs", "")
@@ -2987,6 +3023,9 @@ fn warn_semver_metadata() {
 
             [dependencies]
             bar = "1.0.0+1234"
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file("src/lib.rs", "")

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -645,7 +645,7 @@ fn cargo_compile_with_bin_and_crate_type() {
                 edition = "2015"
 
                 [[bin]]
-                name = "the_foo_bin"
+                name = "the-foo-bin"
                 path = "src/foo.rs"
                 crate-type = ["cdylib", "rlib"]
             "#,
@@ -656,7 +656,7 @@ fn cargo_compile_with_bin_and_crate_type() {
     p.cargo("build")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] Cargo.toml: the target `the_foo_bin` is a binary and can't have any crate-types set (currently "cdylib, rlib")
+[ERROR] Cargo.toml: the target `the-foo-bin` is a binary and can't have any crate-types set (currently "cdylib, rlib")
 [ERROR] could not parse `foo` (manifest) due to 1 previous error
 
 "#]])
@@ -731,7 +731,7 @@ fn cargo_compile_with_bin_and_proc() {
                 edition = "2015"
 
                 [[bin]]
-                name = "the_foo_bin"
+                name = "the-foo-bin"
                 path = "src/foo.rs"
                 proc-macro = true
             "#,
@@ -742,7 +742,7 @@ fn cargo_compile_with_bin_and_proc() {
     p.cargo("build")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] Cargo.toml: the target `the_foo_bin` is a binary and can't have `proc-macro` set `true`
+[ERROR] Cargo.toml: the target `the-foo-bin` is a binary and can't have `proc-macro` set `true`
 [ERROR] could not parse `foo` (manifest) due to 1 previous error
 
 "#]])

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -5924,7 +5924,7 @@ fn build_lib_only() {
     p.cargo("build --lib -v")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out`
+[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -1564,7 +1564,7 @@ fn cargo_default_env_metadata_env_var() {
                 path = "bar"
             "#,
         )
-        .file("src/lib.rs", "// hi")
+        .file("src/lib.rs", "extern crate bar;")
         .file(
             "bar/Cargo.toml",
             r#"
@@ -3866,6 +3866,9 @@ fn build_all_workspace() {
                 bar = { path = "bar" }
 
                 [workspace]
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -4347,6 +4350,9 @@ fn build_all_member_dependency_same_name() {
 
                 [dependencies]
                 a = "0.1.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("a/src/lib.rs", "pub fn a() {}")
@@ -4633,6 +4639,9 @@ fn rustc_wrapper_relative() {
 
                 [dependencies]
                 bar = "1.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -6594,7 +6603,7 @@ fn should_not_include_current_build_unit_path_in_rustc_args() {
         // Don't pass any `-L` args if there are no dependencies (including our own `out` dir)
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo [..] --out-dir [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out`
+[RUNNING] `rustc --crate-name foo [..] --out-dir [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out --force-warn=unused_crate_dependencies`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -6624,7 +6633,7 @@ fn should_not_include_build_script_out_dir_path_in_rustc_args() {
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]`
 [RUNNING] `[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/build_script_build`
-[RUNNING] `rustc --crate-name foo [..] --out-dir [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out`
+[RUNNING] `rustc --crate-name foo [..] --out-dir [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out --force-warn=unused_crate_dependencies`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -6769,6 +6778,9 @@ fn should_not_include_proc_macro_deps_paths_in_rustc_args() {
 
                 [dependencies]
                 my-proc-macro = { path = "my-proc-macro" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -6783,6 +6795,9 @@ fn should_not_include_proc_macro_deps_paths_in_rustc_args() {
 
                 [lib]
                 crate-type = ["dylib"]
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file(
@@ -6797,6 +6812,9 @@ fn should_not_include_proc_macro_deps_paths_in_rustc_args() {
                 version = "0.1.0"
                 edition = "2021"
                 authors = []
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file(
@@ -6818,6 +6836,9 @@ fn should_not_include_proc_macro_deps_paths_in_rustc_args() {
                 [dependencies]
                 my-dylib = { path = "../my-dylib" }
                 my-rlib = { path = "../my-rlib" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file(
@@ -6849,7 +6870,7 @@ fn should_not_include_proc_macro_deps_paths_in_rustc_args() {
 [COMPILING] my-proc-macro v0.1.0 ([ROOT]/foo/my-proc-macro)
 [RUNNING] `rustc --crate-name my_proc_macro [..]`
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo [..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/my-proc-macro/[HASH]/out --extern my_proc_macro=[ROOT]/foo/target/debug/build/my-proc-macro/[HASH]/out/[..]`
+[RUNNING] `rustc --crate-name foo [..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/my-proc-macro/[HASH]/out --extern my_proc_macro=[ROOT]/foo/target/debug/build/my-proc-macro/[HASH]/out/[..] --force-warn=unused_crate_dependencies`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]].unordered())

--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -45,6 +45,7 @@ fn binary_with_debug() {
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
 
@@ -97,6 +98,7 @@ fn binary_with_release() {
 [ROOT]/foo/build-dir/release/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/foo/build-dir/release/build/foo/[HASH]/fingerprint/dep-bin-foo
 [ROOT]/foo/build-dir/release/build/foo/[HASH]/fingerprint/invoked.timestamp
+[ROOT]/foo/build-dir/release/build/foo/[HASH]/fingerprint/output-bin-foo
 [ROOT]/foo/build-dir/release/build/foo/[HASH]/out/foo[..][EXE]
 [ROOT]/foo/build-dir/release/build/foo/[HASH]/out/foo[..].d
 
@@ -203,6 +205,7 @@ fn should_default_to_target() {
 [ROOT]/foo/target/debug/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/foo/target/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
 [ROOT]/foo/target/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
+[ROOT]/foo/target/debug/build/foo/[HASH]/fingerprint/output-bin-foo
 [ROOT]/foo/target/debug/build/foo/[HASH]/out/foo[..][EXE]
 [ROOT]/foo/target/debug/build/foo/[HASH]/out/foo[..].d
 [ROOT]/foo/target/debug/foo[EXE]
@@ -230,6 +233,7 @@ fn should_respect_env_var() {
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
 
@@ -287,6 +291,8 @@ fn build_script_should_output_to_build_dir() {
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/run/stdout
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/run/root-output
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/run/stderr
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-bin-foo
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-build-script-build-script-build
 
 "#]]);
 }
@@ -341,6 +347,9 @@ fn cargo_tmpdir_should_output_to_build_dir() {
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-bin-foo
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-test-integration-test-foo
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-test-bin-foo
 [ROOT]/foo/build-dir/tmp/foo.txt
 [ROOT]/foo/build-dir/.rustc_info.json
 
@@ -382,6 +391,7 @@ fn examples_should_output_to_build_dir_and_uplift_to_target_dir() {
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/example-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/example-foo.json
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-example-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
 
@@ -433,6 +443,8 @@ fn benches_should_output_to_build_dir() {
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-bin-foo
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-test-bench-foo
 [ROOT]/foo/build-dir/.rustc_info.json
 
 "#]]);
@@ -578,6 +590,7 @@ fn cargo_package_should_build_in_build_dir_and_output_to_target_dir() {
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
 [ROOT]/foo/build-dir/debug/foo[EXE]
@@ -654,6 +667,7 @@ fn cargo_clean_should_clean_the_target_dir_and_build_dir() {
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
 
@@ -721,12 +735,14 @@ fn cargo_clean_should_remove_correct_files() {
 [ROOT]/foo/build-dir/debug/build/bar/[HASH]/fingerprint/invoked.timestamp
 [ROOT]/foo/build-dir/debug/build/bar/[HASH]/fingerprint/lib-bar
 [ROOT]/foo/build-dir/debug/build/bar/[HASH]/fingerprint/lib-bar.json
-[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
-[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
+[ROOT]/foo/build-dir/debug/build/bar/[HASH]/fingerprint/output-lib-bar
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-bin-foo
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
 
 "#]]);
 
@@ -742,6 +758,7 @@ fn cargo_clean_should_remove_correct_files() {
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-bin-foo
 
 "#]]);
 }
@@ -866,6 +883,7 @@ fn template_workspace_root() {
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
 
@@ -911,6 +929,7 @@ fn template_cargo_cache_home() {
 [ROOT]/home/.cargo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/home/.cargo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
 [ROOT]/home/.cargo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
+[ROOT]/home/.cargo/build-dir/debug/build/foo/[HASH]/fingerprint/output-bin-foo
 [ROOT]/home/.cargo/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
 [ROOT]/home/.cargo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
 
@@ -970,6 +989,7 @@ fn template_workspace_path_hash() {
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
+[ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/output-bin-foo
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/out/foo[..].d
 
@@ -1035,6 +1055,7 @@ fn template_workspace_path_hash_should_handle_symlink() {
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/lib-foo
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/lib-foo.json
+[ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/output-lib-foo
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/out/foo-[HASH].d
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/out/libfoo-[HASH].rmeta
 
@@ -1070,6 +1091,7 @@ fn template_workspace_path_hash_should_handle_symlink() {
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/lib-foo
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/lib-foo.json
+[ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/output-lib-foo
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/out/foo-[HASH].d
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/out/libfoo-[HASH].rmeta
 
@@ -1207,6 +1229,8 @@ CARGO_BIN_FILE_BAR_bar=[ROOT]/foo/build-dir/debug/build/bar/[HASH]/artifact/bin/
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
+[ROOT]/foo/build-dir/debug/build/bar/[HASH]/fingerprint/output-bin-bar
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-bin-foo
 [ROOT]/foo/build-dir/debug/build/bar/[HASH]/artifact/bin/bar[..][EXE]
 [ROOT]/foo/build-dir/debug/build/bar/[HASH]/artifact/bin/bar[..].d
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
@@ -1389,6 +1413,7 @@ fn should_work_with_cargo_default_lib_metadata() {
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/run-build-script-build-script-build
@@ -1400,6 +1425,7 @@ fn should_work_with_cargo_default_lib_metadata() {
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/build-script-build-script-build
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/build-script-build-script-build.json
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-build-script-build-script-build
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-build-script-build-script-build
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/build_script_build[EXE]
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/build_script_build.d
@@ -1436,6 +1462,7 @@ fn new_layout_opt_out_nightly() {
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo.json
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/dep-bin-foo
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/invoked.timestamp
+[ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/output-bin-foo
 [ROOT]/foo/build-dir/debug/deps/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/deps/foo[..].d
 
@@ -1482,6 +1509,7 @@ fn new_layout_opt_out_stable() {
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo.json
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/dep-bin-foo
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/invoked.timestamp
+[ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/output-bin-foo
 [ROOT]/foo/build-dir/debug/deps/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/deps/foo[..].d
 

--- a/tests/testsuite/build_dir_fine_grain_locking.rs
+++ b/tests/testsuite/build_dir_fine_grain_locking.rs
@@ -47,6 +47,7 @@ fn binary_with_debug() {
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/.lock
@@ -103,6 +104,7 @@ fn binary_with_release() {
 [ROOT]/foo/build-dir/release/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/foo/build-dir/release/build/foo/[HASH]/fingerprint/dep-bin-foo
 [ROOT]/foo/build-dir/release/build/foo/[HASH]/fingerprint/invoked.timestamp
+[ROOT]/foo/build-dir/release/build/foo/[HASH]/fingerprint/output-bin-foo
 [ROOT]/foo/build-dir/release/build/foo/[HASH]/out/foo[..][EXE]
 [ROOT]/foo/build-dir/release/build/foo/[HASH]/out/foo[..].d
 [ROOT]/foo/build-dir/release/build/foo/[HASH]/.lock
@@ -216,6 +218,7 @@ fn should_default_to_target() {
 [ROOT]/foo/target/debug/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/foo/target/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
 [ROOT]/foo/target/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
+[ROOT]/foo/target/debug/build/foo/[HASH]/fingerprint/output-bin-foo
 [ROOT]/foo/target/debug/build/foo/[HASH]/out/foo[..][EXE]
 [ROOT]/foo/target/debug/build/foo/[HASH]/out/foo[..].d
 [ROOT]/foo/target/debug/foo[EXE]
@@ -248,6 +251,7 @@ fn should_respect_env_var() {
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/.lock
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-bin-foo
 
 "#]]);
 }
@@ -309,6 +313,8 @@ fn build_script_should_output_to_build_dir() {
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/.lock
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/.lock
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/.lock
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-bin-foo
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-build-script-build-script-build
 
 "#]]);
 }
@@ -371,6 +377,9 @@ fn cargo_tmpdir_should_output_to_build_dir() {
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/.lock
 [ROOT]/foo/build-dir/tmp/foo.txt
 [ROOT]/foo/build-dir/.rustc_info.json
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-bin-foo
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-test-integration-test-foo
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-test-bin-foo
 
 "#]]);
 
@@ -413,6 +422,7 @@ fn examples_should_output_to_build_dir_and_uplift_to_target_dir() {
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/example-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/example-foo.json
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-example-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/.lock
@@ -471,6 +481,8 @@ fn benches_should_output_to_build_dir() {
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/.lock
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/.lock
 [ROOT]/foo/build-dir/.rustc_info.json
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-bin-foo
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-test-bench-foo
 
 "#]]);
 
@@ -583,6 +595,7 @@ fn cargo_package_should_build_in_build_dir_and_output_to_target_dir() {
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/.lock
@@ -664,6 +677,7 @@ fn cargo_clean_should_clean_the_target_dir_and_build_dir() {
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/.lock
@@ -744,6 +758,8 @@ fn cargo_clean_should_remove_correct_files() {
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
+[ROOT]/foo/build-dir/debug/build/bar/[HASH]/fingerprint/output-lib-bar
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-bin-foo
 [ROOT]/foo/build-dir/debug/build/bar/[HASH]/.lock
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/.lock
 
@@ -765,6 +781,7 @@ fn cargo_clean_should_remove_correct_files() {
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/.lock
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-bin-foo
 
 "#]]);
 }
@@ -898,6 +915,7 @@ fn template_workspace_root() {
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/.lock
@@ -947,6 +965,7 @@ fn template_cargo_cache_home() {
 [ROOT]/home/.cargo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/home/.cargo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
 [ROOT]/home/.cargo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
+[ROOT]/home/.cargo/build-dir/debug/build/foo/[HASH]/fingerprint/output-bin-foo
 [ROOT]/home/.cargo/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
 [ROOT]/home/.cargo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
 [ROOT]/home/.cargo/build-dir/debug/build/foo/[HASH]/.lock
@@ -1010,6 +1029,7 @@ fn template_workspace_path_hash() {
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
+[ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/output-bin-foo
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/out/foo[..].d
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/.lock
@@ -1079,6 +1099,7 @@ fn template_workspace_path_hash_should_handle_symlink() {
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/lib-foo
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/lib-foo.json
+[ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/output-lib-foo
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/out/foo-[HASH].d
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/out/libfoo-[HASH].rmeta
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/.lock
@@ -1120,6 +1141,7 @@ fn template_workspace_path_hash_should_handle_symlink() {
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/lib-foo
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/lib-foo.json
+[ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/fingerprint/output-lib-foo
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/out/foo-[HASH].d
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/out/libfoo-[HASH].rmeta
 [ROOT]/foo/foo/[HASH]/build-dir/debug/build/foo/[HASH]/.lock
@@ -1259,6 +1281,8 @@ CARGO_BIN_FILE_BAR_bar=[ROOT]/foo/build-dir/debug/build/bar/[HASH]/artifact/bin/
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
+[ROOT]/foo/build-dir/debug/build/bar/[HASH]/fingerprint/output-bin-bar
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-bin-foo
 [ROOT]/foo/build-dir/debug/build/bar/[HASH]/artifact/bin/bar[..][EXE]
 [ROOT]/foo/build-dir/debug/build/bar/[HASH]/artifact/bin/bar[..].d
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
@@ -1313,6 +1337,7 @@ fn new_layout_opt_out() {
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/.lock
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/output-bin-foo
 
 "#]]);
 

--- a/tests/testsuite/build_dir_legacy.rs
+++ b/tests/testsuite/build_dir_legacy.rs
@@ -48,6 +48,7 @@ fn binary_with_debug() {
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo.json
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/dep-bin-foo
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/invoked.timestamp
+[ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/output-bin-foo
 [ROOT]/foo/build-dir/debug/deps/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/deps/foo[..].d
 
@@ -103,6 +104,7 @@ fn binary_with_release() {
 [ROOT]/foo/build-dir/release/.fingerprint/foo-[HASH]/bin-foo.json
 [ROOT]/foo/build-dir/release/.fingerprint/foo-[HASH]/dep-bin-foo
 [ROOT]/foo/build-dir/release/.fingerprint/foo-[HASH]/invoked.timestamp
+[ROOT]/foo/build-dir/release/.fingerprint/foo-[HASH]/output-bin-foo
 [ROOT]/foo/build-dir/release/deps/foo[..][EXE]
 [ROOT]/foo/build-dir/release/deps/foo[..].d
 
@@ -212,6 +214,7 @@ fn should_default_to_target() {
 [ROOT]/foo/target/debug/.fingerprint/foo-[HASH]/bin-foo.json
 [ROOT]/foo/target/debug/.fingerprint/foo-[HASH]/dep-bin-foo
 [ROOT]/foo/target/debug/.fingerprint/foo-[HASH]/invoked.timestamp
+[ROOT]/foo/target/debug/.fingerprint/foo-[HASH]/output-bin-foo
 [ROOT]/foo/target/debug/deps/foo[..][EXE]
 [ROOT]/foo/target/debug/deps/foo[..].d
 [ROOT]/foo/target/debug/foo[EXE]
@@ -240,6 +243,7 @@ fn should_respect_env_var() {
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo.json
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/dep-bin-foo
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/invoked.timestamp
+[ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/output-bin-foo
 [ROOT]/foo/build-dir/debug/deps/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/deps/foo[..].d
 
@@ -286,6 +290,7 @@ fn build_script_should_output_to_build_dir() {
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/dep-bin-foo
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo.json
+[ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/output-bin-foo
 [ROOT]/foo/build-dir/.rustc_info.json
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/run-build-script-build-script-build
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/run-build-script-build-script-build.json
@@ -293,6 +298,7 @@ fn build_script_should_output_to_build_dir() {
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/dep-build-script-build-script-build
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/build-script-build-script-build
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/build-script-build-script-build.json
+[ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/output-build-script-build-script-build
 [ROOT]/foo/build-dir/debug/build/foo-[HASH]/build_script_build[..].d
 [ROOT]/foo/build-dir/debug/build/foo-[HASH]/build_script_build[..][EXE]
 [ROOT]/foo/build-dir/debug/build/foo-[HASH]/build-script-build[EXE]
@@ -358,6 +364,9 @@ fn cargo_tmpdir_should_output_to_build_dir() {
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/dep-bin-foo
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo.json
+[ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/output-bin-foo
+[ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/output-test-integration-test-foo
+[ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/output-test-bin-foo
 [ROOT]/foo/build-dir/tmp/foo.txt
 [ROOT]/foo/build-dir/.rustc_info.json
 
@@ -402,6 +411,7 @@ fn examples_should_output_to_build_dir_and_uplift_to_target_dir() {
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/example-foo
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/example-foo.json
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/invoked.timestamp
+[ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/output-example-foo
 [ROOT]/foo/build-dir/debug/examples/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/examples/foo[..].d
 
@@ -454,6 +464,8 @@ fn benches_should_output_to_build_dir() {
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/dep-bin-foo
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo.json
+[ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/output-bin-foo
+[ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/output-test-bench-foo
 [ROOT]/foo/build-dir/.rustc_info.json
 
 "#]]);
@@ -607,6 +619,7 @@ fn cargo_package_should_build_in_build_dir_and_output_to_target_dir() {
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo.json
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/dep-bin-foo
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/invoked.timestamp
+[ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/output-bin-foo
 [ROOT]/foo/build-dir/debug/deps/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/deps/foo[..].d
 [ROOT]/foo/build-dir/debug/foo[EXE]
@@ -687,6 +700,7 @@ fn cargo_clean_should_clean_the_target_dir_and_build_dir() {
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo.json
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/dep-bin-foo
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/invoked.timestamp
+[ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/output-bin-foo
 [ROOT]/foo/build-dir/debug/deps/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/deps/foo[..].d
 
@@ -754,12 +768,14 @@ fn cargo_clean_should_remove_correct_files() {
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo.json
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/dep-bin-foo
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/invoked.timestamp
+[ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/output-bin-foo
 [ROOT]/foo/build-dir/debug/deps/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/deps/foo[..].d
 [ROOT]/foo/build-dir/debug/.fingerprint/bar-[HASH]/lib-bar
 [ROOT]/foo/build-dir/debug/.fingerprint/bar-[HASH]/lib-bar.json
 [ROOT]/foo/build-dir/debug/.fingerprint/bar-[HASH]/dep-lib-bar
 [ROOT]/foo/build-dir/debug/.fingerprint/bar-[HASH]/invoked.timestamp
+[ROOT]/foo/build-dir/debug/.fingerprint/bar-[HASH]/output-lib-bar
 [ROOT]/foo/build-dir/debug/deps/bar[..].d
 [ROOT]/foo/build-dir/debug/deps/libbar[..].rlib
 [ROOT]/foo/build-dir/debug/deps/libbar[..].rmeta
@@ -779,6 +795,7 @@ fn cargo_clean_should_remove_correct_files() {
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo.json
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/dep-bin-foo
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/invoked.timestamp
+[ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/output-bin-foo
 [ROOT]/foo/build-dir/debug/deps/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/deps/foo[..].d
 
@@ -914,6 +931,7 @@ fn template_workspace_root() {
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo.json
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/dep-bin-foo
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/invoked.timestamp
+[ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/output-bin-foo
 [ROOT]/foo/build-dir/debug/deps/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/deps/foo[..].d
 
@@ -962,6 +980,7 @@ fn template_cargo_cache_home() {
 [ROOT]/home/.cargo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo.json
 [ROOT]/home/.cargo/build-dir/debug/.fingerprint/foo-[HASH]/dep-bin-foo
 [ROOT]/home/.cargo/build-dir/debug/.fingerprint/foo-[HASH]/invoked.timestamp
+[ROOT]/home/.cargo/build-dir/debug/.fingerprint/foo-[HASH]/output-bin-foo
 [ROOT]/home/.cargo/build-dir/debug/deps/foo[..][EXE]
 [ROOT]/home/.cargo/build-dir/debug/deps/foo[..].d
 
@@ -1024,6 +1043,7 @@ fn template_workspace_path_hash() {
 [ROOT]/foo/foo/[HASH]/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo.json
 [ROOT]/foo/foo/[HASH]/build-dir/debug/.fingerprint/foo-[HASH]/dep-bin-foo
 [ROOT]/foo/foo/[HASH]/build-dir/debug/.fingerprint/foo-[HASH]/invoked.timestamp
+[ROOT]/foo/foo/[HASH]/build-dir/debug/.fingerprint/foo-[HASH]/output-bin-foo
 [ROOT]/foo/foo/[HASH]/build-dir/debug/deps/foo[..][EXE]
 [ROOT]/foo/foo/[HASH]/build-dir/debug/deps/foo[..].d
 
@@ -1092,6 +1112,7 @@ fn template_workspace_path_hash_should_handle_symlink() {
 [ROOT]/foo/foo/[HASH]/build-dir/debug/.fingerprint/foo-[HASH]/invoked.timestamp
 [ROOT]/foo/foo/[HASH]/build-dir/debug/.fingerprint/foo-[HASH]/lib-foo
 [ROOT]/foo/foo/[HASH]/build-dir/debug/.fingerprint/foo-[HASH]/lib-foo.json
+[ROOT]/foo/foo/[HASH]/build-dir/debug/.fingerprint/foo-[HASH]/output-lib-foo
 [ROOT]/foo/foo/[HASH]/build-dir/debug/deps/foo-[HASH].d
 [ROOT]/foo/foo/[HASH]/build-dir/debug/deps/libfoo-[HASH].rmeta
 
@@ -1131,6 +1152,7 @@ fn template_workspace_path_hash_should_handle_symlink() {
 [ROOT]/foo/foo/[HASH]/build-dir/debug/.fingerprint/foo-[HASH]/invoked.timestamp
 [ROOT]/foo/foo/[HASH]/build-dir/debug/.fingerprint/foo-[HASH]/lib-foo
 [ROOT]/foo/foo/[HASH]/build-dir/debug/.fingerprint/foo-[HASH]/lib-foo.json
+[ROOT]/foo/foo/[HASH]/build-dir/debug/.fingerprint/foo-[HASH]/output-lib-foo
 [ROOT]/foo/foo/[HASH]/build-dir/debug/deps/foo-[HASH].d
 [ROOT]/foo/foo/[HASH]/build-dir/debug/deps/libfoo-[HASH].rmeta
 
@@ -1269,6 +1291,8 @@ CARGO_BIN_FILE_BAR_bar=[ROOT]/foo/build-dir/debug/deps/artifact/bar-[HASH]/bin/b
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/bin-foo.json
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/dep-bin-foo
 [ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/invoked.timestamp
+[ROOT]/foo/build-dir/debug/.fingerprint/bar-[HASH]/output-bin-bar
+[ROOT]/foo/build-dir/debug/.fingerprint/foo-[HASH]/output-bin-foo
 [ROOT]/foo/build-dir/debug/deps/artifact/bar-[HASH]/bin/bar[..][EXE]
 [ROOT]/foo/build-dir/debug/deps/artifact/bar-[HASH]/bin/bar[..].d
 [ROOT]/foo/build-dir/debug/deps/foo[..][EXE]

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -2723,11 +2723,11 @@ fn build_cmd_with_a_build_cmd() {
 [COMPILING] a v0.5.0 ([ROOT]/foo/a)
 [RUNNING] `rustc --crate-name build_script_build [..] a/build.rs [..] --extern b=[ROOT]/foo/target/debug/build/b/[HASH]/out/libb-[HASH].rlib[..]`
 [RUNNING] `[ROOT]/foo/target/debug/build/a/[HASH]/out/build_script_build`
-[RUNNING] `rustc --crate-name a [..]a/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/build/a/[HASH]/out`
+[RUNNING] `rustc --crate-name a [..]a/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C metadata=[..]`
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin --emit=[..]link[..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out [..] --extern a=[ROOT]/foo/target/debug/build/a/[HASH]/out/liba-[HASH].rlib[..]`
+[RUNNING] `rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin --emit=[..]link[..]-C metadata=[..]`
 [RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
-[RUNNING] `rustc --crate-name foo [..]src/lib.rs [..]--crate-type lib --emit=[..]-C debuginfo=2 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out`
+[RUNNING] `rustc --crate-name foo [..]src/lib.rs [..]--crate-type lib --emit=[..]-C debuginfo=2 [..]-C metadata=[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]]).run();

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -1291,6 +1291,9 @@ fn custom_build_script_rustc_flags() {
 
                 [dependencies.foo]
                 path = "foo"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -1304,6 +1307,9 @@ fn custom_build_script_rustc_flags() {
                 edition = "2015"
                 authors = ["wycats@example.com"]
                 build = "build.rs"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("foo/src/lib.rs", "")
@@ -1351,6 +1357,9 @@ fn custom_build_script_rustc_flags_no_space() {
 
                 [dependencies.foo]
                 path = "foo"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -1364,6 +1373,9 @@ fn custom_build_script_rustc_flags_no_space() {
                 edition = "2015"
                 authors = ["wycats@example.com"]
                 build = "build.rs"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("foo/src/lib.rs", "")
@@ -1654,6 +1666,9 @@ fn overrides_and_links() {
 
                 [dependencies.a]
                 path = "a"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -1691,6 +1706,9 @@ fn overrides_and_links() {
                 authors = []
                 links = "foo"
                 build = "build.rs"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("a/src/lib.rs", "")
@@ -1845,6 +1863,9 @@ fn main() {
 name = "links"
 edition = "2024"
 links = "foo"
+
+[lints.cargo]
+default = "allow"
 "#,
         )
         .file("links/src/lib.rs", "")
@@ -1858,6 +1879,9 @@ edition = "2024"
 
 [dependencies]
 links.path = "../links"
+
+[lints.cargo]
+default = "allow"
 "#,
         )
         .file("n/src/lib.rs", "")
@@ -1871,6 +1895,9 @@ edition = "2024"
 
 [build-dependencies]
 links.path = "../links"
+
+[lints.cargo]
+default = "allow"
 "#,
         )
         .file("b/src/lib.rs", "")
@@ -1884,6 +1911,9 @@ edition = "2024"
 
 [dev-dependencies]
 links.path = "../links"
+
+[lints.cargo]
+default = "allow"
 "#,
         )
         .file("d/src/lib.rs", "")
@@ -2206,6 +2236,9 @@ fn with_patch() {
 
             [patch.crates-io]
             cxx = { path = "cxx" }
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -2218,6 +2251,9 @@ fn with_patch() {
             version = "1.0.0"
             edition = "2021"
             links = "cxx"
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file("cxx/src/lib.rs", "")
@@ -2434,6 +2470,9 @@ fn propagation_of_l_flags() {
                 authors = []
                 [dependencies.a]
                 path = "a"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -2450,6 +2489,9 @@ fn propagation_of_l_flags() {
 
                 [dependencies.b]
                 path = "../b"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("a/src/lib.rs", "")
@@ -2467,6 +2509,9 @@ fn propagation_of_l_flags() {
                 authors = []
                 links = "foo"
                 build = "build.rs"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("b/src/lib.rs", "")
@@ -2509,6 +2554,9 @@ fn propagation_of_l_flags_new() {
                 authors = []
                 [dependencies.a]
                 path = "a"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -2525,6 +2573,9 @@ fn propagation_of_l_flags_new() {
 
                 [dependencies.b]
                 path = "../b"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("a/src/lib.rs", "")
@@ -2546,6 +2597,9 @@ fn propagation_of_l_flags_new() {
                 authors = []
                 links = "foo"
                 build = "build.rs"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("b/src/lib.rs", "")
@@ -3939,6 +3993,9 @@ fn diamond_passes_args_only_once() {
                 [dependencies]
                 a = { path = "a" }
                 b = { path = "b" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -3954,6 +4011,9 @@ fn diamond_passes_args_only_once() {
                 [dependencies]
                 b = { path = "../b" }
                 c = { path = "../c" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("a/src/lib.rs", "")
@@ -3967,6 +4027,9 @@ fn diamond_passes_args_only_once() {
                 authors = []
                 [dependencies]
                 c = { path = "../c" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("b/src/lib.rs", "")
@@ -3979,6 +4042,9 @@ fn diamond_passes_args_only_once() {
                 edition = "2015"
                 authors = []
                 build = "build.rs"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file(
@@ -4841,6 +4907,9 @@ fn warnings_emitted_from_path_dep() {
 
                 [dependencies]
                 a = { path = "a" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -4853,6 +4922,9 @@ fn warnings_emitted_from_path_dep() {
                 edition = "2015"
                 authors = []
                 build = "build.rs"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("a/src/lib.rs", "")
@@ -5084,6 +5156,9 @@ fn warnings_hidden_for_upstream() {
                 edition = "2015"
                 authors = []
                 build = "build.rs"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -5101,6 +5176,9 @@ fn warnings_hidden_for_upstream() {
 
                 [dependencies]
                 bar = "*"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -5145,6 +5223,9 @@ fn warnings_printed_on_vv() {
                 edition = "2015"
                 authors = []
                 build = "build.rs"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -5162,6 +5243,9 @@ fn warnings_printed_on_vv() {
 
                 [dependencies]
                 bar = "*"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -6317,6 +6401,9 @@ fn rerun_if_published_directory() {
 
                 [dependencies]
                 mylib-sys = "1.0.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")

--- a/tests/testsuite/build_script_extra_link_arg.rs
+++ b/tests/testsuite/build_script_extra_link_arg.rs
@@ -266,6 +266,9 @@ fn link_arg_transitive_not_allowed() {
 
                 [dependencies]
                 bar = "1.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")

--- a/tests/testsuite/cache_messages.rs
+++ b/tests/testsuite/cache_messages.rs
@@ -230,6 +230,9 @@ fn very_verbose() {
 
             [dependencies]
             bar = "1.0"
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file("src/lib.rs", "")

--- a/tests/testsuite/cache_messages.rs
+++ b/tests/testsuite/cache_messages.rs
@@ -163,11 +163,6 @@ fn clears_cache_after_fix() {
 
 "#]])
         .run();
-    assert_eq!(
-        p.glob("target/debug/build/foo/*/fingerprint/output-*")
-            .count(),
-        0
-    );
 
     // And again, check the cache is correct.
     p.cargo("check")
@@ -275,54 +270,6 @@ fn very_verbose() {
 
 "#]])
         .run();
-}
-
-#[cargo_test]
-fn doesnt_create_extra_files() {
-    // Ensure it doesn't create `output` files when not needed.
-    Package::new("dep", "1.0.0")
-        .file("src/lib.rs", "fn unused() {}")
-        .publish();
-
-    let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-                [package]
-                name = "foo"
-                version = "0.1.0"
-                edition = "2015"
-
-                [dependencies]
-                dep = "1.0"
-            "#,
-        )
-        .file("src/lib.rs", "")
-        .file("src/main.rs", "fn main() {}")
-        .build();
-
-    p.cargo("check").run();
-
-    assert_eq!(
-        p.glob("target/debug/build/foo/*/fingerprint/output-*")
-            .count(),
-        0
-    );
-    assert_eq!(
-        p.glob("target/debug/build/foo/*/fingerprint/dep-*/output-*")
-            .count(),
-        0
-    );
-    if is_coarse_mtime() {
-        sleep_ms(1000);
-    }
-    p.change_file("src/lib.rs", "fn unused() {}");
-    p.cargo("check").run();
-    assert_eq!(
-        p.glob("target/debug/build/foo/*/fingerprint/output-*")
-            .count(),
-        1
-    );
 }
 
 #[cargo_test]

--- a/tests/testsuite/cargo/z_help/stdout.term.svg
+++ b/tests/testsuite/cargo/z_help/stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="1255px" height="1010px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1255px" height="992px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -42,89 +42,87 @@
 </tspan>
     <tspan x="10px" y="244px"><tspan>    -Z build-std-features          Configure features enabled for the standard library itself when building the standard library</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>    -Z cargo-lints                 Enable the `[lints.cargo]` table</tspan>
+    <tspan x="10px" y="262px"><tspan>    -Z checksum-freshness          Use a checksum to determine if output is fresh rather than filesystem mtime</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>    -Z checksum-freshness          Use a checksum to determine if output is fresh rather than filesystem mtime</tspan>
+    <tspan x="10px" y="280px"><tspan>    -Z codegen-backend             Enable the `codegen-backend` option in profiles in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>    -Z codegen-backend             Enable the `codegen-backend` option in profiles in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="298px"><tspan>    -Z direct-minimal-versions     Resolve minimal dependency versions instead of maximum (direct dependencies only)</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>    -Z direct-minimal-versions     Resolve minimal dependency versions instead of maximum (direct dependencies only)</tspan>
+    <tspan x="10px" y="316px"><tspan>    -Z dual-proc-macros            Build proc-macros for both the host and the target</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>    -Z dual-proc-macros            Build proc-macros for both the host and the target</tspan>
+    <tspan x="10px" y="334px"><tspan>    -Z feature-unification         Enable new feature unification modes in workspaces</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>    -Z feature-unification         Enable new feature unification modes in workspaces</tspan>
+    <tspan x="10px" y="352px"><tspan>    -Z fine-grain-locking          Use fine grain locking instead of locking the entire build cache</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>    -Z fine-grain-locking          Use fine grain locking instead of locking the entire build cache</tspan>
+    <tspan x="10px" y="370px"><tspan>    -Z fix-edition                 Permanently unstable edition migration helper</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>    -Z fix-edition                 Permanently unstable edition migration helper</tspan>
+    <tspan x="10px" y="388px"><tspan>    -Z gc                          Track cache usage and "garbage collect" unused files</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>    -Z gc                          Track cache usage and "garbage collect" unused files</tspan>
+    <tspan x="10px" y="406px"><tspan>    -Z git                         Enable support for shallow git fetch operations</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>    -Z git                         Enable support for shallow git fetch operations</tspan>
+    <tspan x="10px" y="424px"><tspan>    -Z gitoxide                    Use gitoxide for the given git interactions, or all of them if no argument is given</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>    -Z gitoxide                    Use gitoxide for the given git interactions, or all of them if no argument is given</tspan>
+    <tspan x="10px" y="442px"><tspan>    -Z hint-msrv                   Enable passing `package.rust-version` to rustc for lints</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>    -Z hint-msrv                   Enable passing `package.rust-version` to rustc for lints</tspan>
+    <tspan x="10px" y="460px"><tspan>    -Z host-config                 Enable the `[host]` section in the .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>    -Z host-config                 Enable the `[host]` section in the .cargo/config.toml file</tspan>
+    <tspan x="10px" y="478px"><tspan>    -Z json-target-spec            Enable `.json` target spec files</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>    -Z json-target-spec            Enable `.json` target spec files</tspan>
+    <tspan x="10px" y="496px"><tspan>    -Z min-publish-age             Enable the `min-publish-age` configuration for dependency version age filtering</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>    -Z min-publish-age             Enable the `min-publish-age` configuration for dependency version age filtering</tspan>
+    <tspan x="10px" y="514px"><tspan>    -Z minimal-versions            Resolve minimal dependency versions instead of maximum</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>    -Z minimal-versions            Resolve minimal dependency versions instead of maximum</tspan>
+    <tspan x="10px" y="532px"><tspan>    -Z msrv-policy                 Enable rust-version aware policy within cargo</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>    -Z msrv-policy                 Enable rust-version aware policy within cargo</tspan>
+    <tspan x="10px" y="550px"><tspan>    -Z mtime-on-use                Configure Cargo to update the mtime of used files</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>    -Z mtime-on-use                Configure Cargo to update the mtime of used files</tspan>
+    <tspan x="10px" y="568px"><tspan>    -Z no-index-update             Do not update the registry index even if the cache is outdated</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>    -Z no-index-update             Do not update the registry index even if the cache is outdated</tspan>
+    <tspan x="10px" y="586px"><tspan>    -Z panic-abort-tests           Enable support to run tests with -Cpanic=abort</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>    -Z panic-abort-tests           Enable support to run tests with -Cpanic=abort</tspan>
+    <tspan x="10px" y="604px"><tspan>    -Z panic-immediate-abort       Enable setting `panic = "immediate-abort"` in profiles</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>    -Z panic-immediate-abort       Enable setting `panic = "immediate-abort"` in profiles</tspan>
+    <tspan x="10px" y="622px"><tspan>    -Z profile-hint-mostly-unused  Enable the `hint-mostly-unused` setting in profiles to mark a crate as mostly unused.</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>    -Z profile-hint-mostly-unused  Enable the `hint-mostly-unused` setting in profiles to mark a crate as mostly unused.</tspan>
+    <tspan x="10px" y="640px"><tspan>    -Z profile-rustflags           Enable the `rustflags` option in profiles in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>    -Z profile-rustflags           Enable the `rustflags` option in profiles in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="658px"><tspan>    -Z public-dependency           Respect a dependency's `public` field in Cargo.toml to control public/private dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan>    -Z public-dependency           Respect a dependency's `public` field in Cargo.toml to control public/private dependencies</tspan>
+    <tspan x="10px" y="676px"><tspan>    -Z publish-timeout             Enable the `publish.timeout` key in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan>    -Z publish-timeout             Enable the `publish.timeout` key in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="694px"><tspan>    -Z root-dir                    Set the root directory relative to which paths are printed (defaults to workspace root)</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>    -Z root-dir                    Set the root directory relative to which paths are printed (defaults to workspace root)</tspan>
+    <tspan x="10px" y="712px"><tspan>    -Z rustc-unicode               Enable `rustc`'s unicode error format in Cargo's error messages</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>    -Z rustc-unicode               Enable `rustc`'s unicode error format in Cargo's error messages</tspan>
+    <tspan x="10px" y="730px"><tspan>    -Z rustdoc-depinfo             Use dep-info files in rustdoc rebuild detection</tspan>
 </tspan>
-    <tspan x="10px" y="748px"><tspan>    -Z rustdoc-depinfo             Use dep-info files in rustdoc rebuild detection</tspan>
+    <tspan x="10px" y="748px"><tspan>    -Z rustdoc-map                 Allow passing external documentation mappings to rustdoc</tspan>
 </tspan>
-    <tspan x="10px" y="766px"><tspan>    -Z rustdoc-map                 Allow passing external documentation mappings to rustdoc</tspan>
+    <tspan x="10px" y="766px"><tspan>    -Z rustdoc-mergeable-info      Use rustdoc mergeable cross-crate-info files</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan>    -Z rustdoc-mergeable-info      Use rustdoc mergeable cross-crate-info files</tspan>
+    <tspan x="10px" y="784px"><tspan>    -Z rustdoc-scrape-examples     Allows Rustdoc to scrape code examples from reverse-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan>    -Z rustdoc-scrape-examples     Allows Rustdoc to scrape code examples from reverse-dependencies</tspan>
+    <tspan x="10px" y="802px"><tspan>    -Z sbom                        Enable the `sbom` option in build config in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="820px"><tspan>    -Z sbom                        Enable the `sbom` option in build config in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="820px"><tspan>    -Z script                      Enable support for single-file, `.rs` packages</tspan>
 </tspan>
-    <tspan x="10px" y="838px"><tspan>    -Z script                      Enable support for single-file, `.rs` packages</tspan>
+    <tspan x="10px" y="838px"><tspan>    -Z section-timings             Enable support for extended compilation sections in --timings output</tspan>
 </tspan>
-    <tspan x="10px" y="856px"><tspan>    -Z section-timings             Enable support for extended compilation sections in --timings output</tspan>
+    <tspan x="10px" y="856px"><tspan>    -Z target-applies-to-host      Enable the `target-applies-to-host` key in the .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="874px"><tspan>    -Z target-applies-to-host      Enable the `target-applies-to-host` key in the .cargo/config.toml file</tspan>
+    <tspan x="10px" y="874px"><tspan>    -Z trim-paths                  Enable the `trim-paths` option in profiles</tspan>
 </tspan>
-    <tspan x="10px" y="892px"><tspan>    -Z trim-paths                  Enable the `trim-paths` option in profiles</tspan>
+    <tspan x="10px" y="892px"><tspan>    -Z unstable-options            Allow the usage of unstable options</tspan>
 </tspan>
-    <tspan x="10px" y="910px"><tspan>    -Z unstable-options            Allow the usage of unstable options</tspan>
+    <tspan x="10px" y="910px">
 </tspan>
-    <tspan x="10px" y="928px">
+    <tspan x="10px" y="928px"><tspan>Run with `cargo -Z [FLAG] [COMMAND]`</tspan>
 </tspan>
-    <tspan x="10px" y="946px"><tspan>Run with `cargo -Z [FLAG] [COMMAND]`</tspan>
+    <tspan x="10px" y="946px">
 </tspan>
-    <tspan x="10px" y="964px">
+    <tspan x="10px" y="964px"><tspan>See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html for more information about these flags.</tspan>
 </tspan>
-    <tspan x="10px" y="982px"><tspan>See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html for more information about these flags.</tspan>
-</tspan>
-    <tspan x="10px" y="1000px">
+    <tspan x="10px" y="982px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -528,6 +528,9 @@ fn nightly_feature_requires_nightly_in_dep() {
 
                 [dependencies]
                 a = { path = "a" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -542,6 +545,9 @@ fn nightly_feature_requires_nightly_in_dep() {
                 edition = "2015"
                 authors = []
                 im-a-teapot = true
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("a/src/lib.rs", "")

--- a/tests/testsuite/cfg.rs
+++ b/tests/testsuite/cfg.rs
@@ -529,6 +529,9 @@ fn cfg_raw_idents() {
 
                 [target.'cfg(any(r#true, r#all, r#target_os = "<>"))'.dependencies]
                 b = { path = "b/" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -618,6 +621,9 @@ fn cfg_keywords() {
 
                 [target.'cfg(any(async, fn, const, return, true))'.dependencies]
                 b = { path = "b/" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file(
@@ -659,6 +665,9 @@ fn cfg_booleans() {
 
                 [target.'cfg(false)'.dependencies]
                 c = { path = 'c' }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -724,6 +733,9 @@ fn cfg_booleans_not() {
 
                 [target.'cfg(not(false))'.dependencies]
                 b = { path = 'b' }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -756,6 +768,9 @@ fn cfg_booleans_combinators() {
 
                 [target.'cfg(all(any(true), not(false), true))'.dependencies]
                 b = { path = 'b' }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -791,6 +806,9 @@ fn cfg_booleans_rustflags_no_effect() {
 
                 [target.'cfg(false)'.dependencies]
                 c = { path = 'c' }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -1208,6 +1208,9 @@ fn git_manifest_package_and_project() {
             name = "bar"
             version = "0.0.1"
             edition = "2015"
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -1227,6 +1230,9 @@ fn git_manifest_package_and_project() {
                 version = "0.0.1"
                 git  = '{}'
 
+
+                [lints.cargo]
+                default = "allow"
             "#,
                 git_project.url()
             ),
@@ -1276,6 +1282,9 @@ fn git_manifest_with_project() {
                 version = "0.0.1"
                 git  = '{}'
 
+
+                [lints.cargo]
+                default = "allow"
             "#,
                 git_project.url()
             ),
@@ -1633,6 +1642,9 @@ fn check_unused_manifest_keys() {
 
             [target.bar.build-dependencies]
             foo = { version = "0.1.0", wxz = "wxz" }
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("src/main.rs", "fn main() {}")

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -230,6 +230,9 @@ fn clean_release() {
 
                 [dependencies]
                 a = { path = "a" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -827,6 +830,9 @@ fn clean_spec_reserved() {
 
                 [dependencies]
                 bar = "1.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")

--- a/tests/testsuite/clean_legacy_layout.rs
+++ b/tests/testsuite/clean_legacy_layout.rs
@@ -395,6 +395,9 @@ fn clean_release() {
 
                 [dependencies]
                 a = { path = "a" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -1095,6 +1098,9 @@ fn clean_spec_reserved() {
 
                 [dependencies]
                 bar = "1.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")

--- a/tests/testsuite/collisions.rs
+++ b/tests/testsuite/collisions.rs
@@ -352,6 +352,9 @@ fn collision_doc_profile_split() {
 
                 [profile.dev]
                 opt-level = 2
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -368,6 +371,9 @@ fn collision_doc_profile_split() {
 
                 [lib]
                 proc-macro = true
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("pm/src/lib.rs", "")

--- a/tests/testsuite/credential_process.rs
+++ b/tests/testsuite/credential_process.rs
@@ -661,6 +661,9 @@ fn basic_provider() {
                 [dependencies.bar]
                 version = "0.0.1"
                 registry = "alternative"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -721,6 +724,9 @@ fn basic_provider_crlf() {
                 [dependencies.bar]
                 version = "0.0.1"
                 registry = "alternative"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")

--- a/tests/testsuite/dep_info.rs
+++ b/tests/testsuite/dep_info.rs
@@ -205,6 +205,9 @@ fn relative_depinfo_paths_ws() {
             [build-dependencies]
             bdep = "0.1"
             bar = {path = "../bar"}
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file(
@@ -233,6 +236,9 @@ fn relative_depinfo_paths_ws() {
 
             [dependencies]
             pmdep = "0.1"
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file(
@@ -346,6 +352,9 @@ fn relative_depinfo_paths_no_ws() {
             [build-dependencies]
             bdep = "0.1"
             bar = {path = "bar"}
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file(
@@ -374,6 +383,9 @@ fn relative_depinfo_paths_no_ws() {
 
             [dependencies]
             pmdep = "0.1"
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file(

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -580,6 +580,9 @@ fn git_lock_file_doesnt_change() {
 
                     [dependencies]
                     git = {{ git = '{0}' }}
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 git.url()
             ),
@@ -696,6 +699,9 @@ fn workspace_different_locations() {
 
                 [dependencies]
                 baz = "*"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("foo/src/lib.rs", "")
@@ -712,6 +718,9 @@ fn workspace_different_locations() {
 
                 [dependencies]
                 baz = "*"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("bar/src/lib.rs", "")

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -290,6 +290,9 @@ fn doc_multiple_targets_same_name() {
                 [[bin]]
                 name = "foo_lib"
                 path = "src/foo_lib.rs"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("foo/src/foo_lib.rs", "")
@@ -302,6 +305,9 @@ fn doc_multiple_targets_same_name() {
                 edition = "2015"
                 [lib]
                 name = "foo_lib"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("bar/src/lib.rs", "")

--- a/tests/testsuite/feature_unification.rs
+++ b/tests/testsuite/feature_unification.rs
@@ -39,6 +39,9 @@ fn workspace_feature_unification() {
                 [features]
                 a = []
                 b = []
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file(
@@ -58,6 +61,9 @@ fn workspace_feature_unification() {
 
                 [dependencies]
                 common = { path = "../common", features = ["a"] }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("a/src/lib.rs", "")
@@ -71,6 +77,9 @@ fn workspace_feature_unification() {
 
                 [dependencies]
                 common = { path = "../common", features = ["b"] }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("b/src/lib.rs", "")
@@ -158,6 +167,9 @@ fn package_feature_unification() {
                 [features]
                 a = []
                 b = []
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file(
@@ -182,6 +194,9 @@ fn package_feature_unification() {
                 [dependencies]
                 common = { path = "../common", features = ["a"] }
                 outside = { version = "0.1.0", features = ["a"] }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("a/src/lib.rs", "pub use common::a;")
@@ -196,6 +211,9 @@ fn package_feature_unification() {
                 [dependencies]
                 common = { path = "../common", features = ["b"] }
                 outside = { version = "0.1.0", features = ["b"] }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("b/src/lib.rs", "pub use common::b;")
@@ -428,6 +446,9 @@ fn package_feature_unification_cli_features() {
                 [features]
                 a = []
                 b = []
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file(
@@ -455,6 +476,9 @@ fn package_feature_unification_cli_features() {
 
                 [features]
                 a = ["common/a", "outside/a"]
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("a/src/lib.rs", "pub use common::a;")
@@ -472,6 +496,9 @@ fn package_feature_unification_cli_features() {
 
                 [features]
                 b = ["common/b", "outside/b"]
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("b/src/lib.rs", "pub use common::b;")
@@ -855,6 +882,9 @@ fn cargo_install_ignores_config() {
 
                 [workspace]
                 members = ["common", "b"]
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -869,6 +899,9 @@ fn cargo_install_ignores_config() {
                 [features]
                 a = []
                 b = []
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file(
@@ -888,6 +921,9 @@ fn cargo_install_ignores_config() {
 
                 [dependencies]
                 common = { path = "../common", features = ["b"] }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("b/src/lib.rs", "")

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -1027,6 +1027,9 @@ fn many_features_no_rebuilds() {
                 [dependencies.a]
                 path = "a"
                 features = ["fall"]
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -1043,6 +1046,9 @@ fn many_features_no_rebuilds() {
                 ftest  = []
                 ftest2 = []
                 fall   = ["ftest", "ftest2"]
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("a/src/lib.rs", "")
@@ -1213,6 +1219,9 @@ fn no_rebuild_when_frobbing_default_feature() {
                 [dependencies]
                 a = { path = "a" }
                 b = { path = "b" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -1227,6 +1236,9 @@ fn no_rebuild_when_frobbing_default_feature() {
 
                 [dependencies]
                 a = { path = "../a", features = ["f1"], default-features = false }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("b/src/lib.rs", "")
@@ -1242,6 +1254,9 @@ fn no_rebuild_when_frobbing_default_feature() {
                 [features]
                 default = ["f1"]
                 f1 = []
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("a/src/lib.rs", "")
@@ -1277,6 +1292,9 @@ fn unions_work_with_no_default_features() {
                 [dependencies]
                 a = { path = "a" }
                 b = { path = "b" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "extern crate a; pub fn foo() { a::a(); }")
@@ -1291,6 +1309,9 @@ fn unions_work_with_no_default_features() {
 
                 [dependencies]
                 a = { path = "../a", features = [], default-features = false }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("b/src/lib.rs", "")
@@ -1306,6 +1327,9 @@ fn unions_work_with_no_default_features() {
                 [features]
                 default = ["f1"]
                 f1 = []
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("a/src/lib.rs", r#"#[cfg(feature = "f1")] pub fn a() {}"#)

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -1183,6 +1183,9 @@ fn proc_macro_ws() {
 
             [features]
             feat1 = []
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file("foo/src/lib.rs", "")
@@ -1199,6 +1202,9 @@ fn proc_macro_ws() {
 
             [dependencies]
             foo = { path = "../foo", features=["feat1"] }
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file("pm/src/lib.rs", "")
@@ -1649,6 +1655,9 @@ fn resolver_enables_new_features() {
 
             [target.'cfg(whatever)'.dependencies]
             common = {version = "1.0", features=["itarget"]}
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file(
@@ -1679,6 +1688,9 @@ fn resolver_enables_new_features() {
 
             [features]
             ping = []
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file(
@@ -2210,6 +2222,9 @@ fn minimal_download() {
                 [target.'cfg(whatever)'.build-dependencies]
                 itarget_build_dep = "1.0"
                 itarget_build_dep_pm = "1.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -2403,6 +2418,9 @@ fn pm_with_int_shared() {
                 [dependencies]
                 pm = { path = "../pm" }
                 shared = { path = "../shared", features = ["norm-feat"] }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file(
@@ -2425,6 +2443,9 @@ fn pm_with_int_shared() {
 
                 [dependencies]
                 shared = { path = "../shared", features = ["host-feat"] }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file(
@@ -2452,6 +2473,9 @@ fn pm_with_int_shared() {
                 [features]
                 norm-feat = []
                 host-feat = []
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file(
@@ -2722,6 +2746,9 @@ fn dep_with_optional_host_deps_activated() {
 
                 [dependencies]
                 serde = { path = "serde", features = ["derive", "build"] }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -2742,6 +2769,9 @@ fn dep_with_optional_host_deps_activated() {
                 [features]
                 derive = ["dep:serde_derive"]
                 build = ["dep:serde_build"]
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("serde/src/lib.rs", "")
@@ -2756,6 +2786,9 @@ fn dep_with_optional_host_deps_activated() {
 
                 [lib]
                 proc-macro = true
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("serde_derive/src/lib.rs", "")
@@ -2792,6 +2825,9 @@ fn dont_unify_proc_macro_example_from_dependency() {
 
                 [dependencies]
                 pm_helper = { path = "pm_helper" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -2805,6 +2841,9 @@ fn dont_unify_proc_macro_example_from_dependency() {
                 name = "pm"
                 proc-macro = true
                 crate-type = ["proc-macro"]
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("pm_helper/src/lib.rs", "")

--- a/tests/testsuite/features_namespaced.rs
+++ b/tests/testsuite/features_namespaced.rs
@@ -26,6 +26,9 @@ fn dependency_with_crate_syntax() {
 
                 [dependencies]
                 bar = {version="1.0", features=["feat"]}
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -169,6 +172,9 @@ fn namespaced_implicit_feature() {
 
                 [dependencies]
                 baz = { version = "0.1", optional = true }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -311,6 +317,9 @@ fn namespaced_same_name() {
 
                 [dependencies]
                 baz = { version = "0.1", optional = true }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file(
@@ -373,6 +382,9 @@ fn no_implicit_feature() {
 
                 [features]
                 regex = ["dep:regex", "dep:lazy_static"]
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file(
@@ -684,6 +696,9 @@ fn crate_feature_with_explicit() {
                 f1 = ["bar/bar_feat"]
                 bar = ["dep:bar", "f2"]
                 f2 = []
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file(

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -1319,6 +1319,9 @@ fn only_warn_for_relevant_crates() {
 
                 [dependencies]
                 a = { path = 'a' }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -1329,6 +1332,9 @@ fn only_warn_for_relevant_crates() {
                 name = "a"
                 version = "0.1.0"
                 edition = "2015"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file(
@@ -1562,6 +1568,9 @@ fn edition_v2_resolver_report() {
 
                 [dev-dependencies]
                 common = { version="1.0", features=["dev-feat"] }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -2668,6 +2677,12 @@ a = {path = "a", default_features = false}
 # After build_dependencies line
 a = {path = "a", default_features = false}
 # After build_dependencies table
+
+[lints.cargo]
+default = "allow"
+
+[workspace.lints.cargo]
+default = "allow"
 "#,
         )
         .file("src/lib.rs", "")
@@ -2684,6 +2699,9 @@ a = {path = "a", default_features = false}
                 name = "a"
                 version = "0.0.1"
                 edition = "2015"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("a/src/lib.rs", "")
@@ -2751,6 +2769,12 @@ a = {path = "a", default-features = false}
 a = {path = "a", default-features = false}
 # After build_dependencies table
 
+[lints.cargo]
+default = "allow"
+
+[workspace.lints.cargo]
+default = "allow"
+
 "#]],
     );
 }
@@ -2769,6 +2793,9 @@ resolver = "2"
 # Before default_features
 a = {path = "a", default_features = false}  # After default_features value
 # After default_features line
+
+[workspace.lints.cargo]
+default = "allow"
 "#,
         )
         .file(
@@ -2777,6 +2804,9 @@ a = {path = "a", default_features = false}  # After default_features value
 [package]
 name = "foo"
 edition = "2021"
+
+[lints.cargo]
+default = "allow"
 "#,
         )
         .file("foo/src/lib.rs", "")
@@ -2787,6 +2817,9 @@ edition = "2021"
                 name = "a"
                 version = "0.0.1"
                 edition = "2015"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("a/src/lib.rs", "")
@@ -2816,6 +2849,9 @@ resolver = "2"
 a = {path = "a", default-features = false}  # After default_features value
 # After default_features line
 
+[workspace.lints.cargo]
+default = "allow"
+
 "#]],
     );
     assert_e2e().eq(
@@ -2825,6 +2861,9 @@ a = {path = "a", default-features = false}  # After default_features value
 [package]
 name = "foo"
 edition = "2021"
+
+[lints.cargo]
+default = "allow"
 
 "#]],
     );
@@ -2856,6 +2895,9 @@ dep_df_false = { workspace = true }
 dep_simple = { workspace = true }
 dep_df_true = { workspace = true }
 dep_df_false = { workspace = true }
+
+[lints.cargo]
+default = "allow"
 "#;
     let pkg_df_true = r#"
 [package]
@@ -2877,6 +2919,9 @@ dep_df_false = { workspace = true, default-features = true }
 dep_simple = { workspace = true, default-features = true }
 dep_df_true = { workspace = true, default-features = true }
 dep_df_false = { workspace = true, default-features = true }
+
+[lints.cargo]
+default = "allow"
 "#;
     let pkg_df_false = r#"
 [package]
@@ -2898,6 +2943,9 @@ dep_df_false = { workspace = true, default-features = false }
 dep_simple = { workspace = true, default-features = false }
 dep_df_true = { workspace = true, default-features = false }
 dep_df_false = { workspace = true, default-features = false }
+
+[lints.cargo]
+default = "allow"
 "#;
     let p = project()
         .file(
@@ -2975,6 +3023,9 @@ dep_df_false = { workspace = true, default-features = false }
 dep_simple = { workspace = true}
 dep_df_true = { workspace = true}
 dep_df_false = { workspace = true, default-features = false }
+
+[lints.cargo]
+default = "allow"
 
 "#]],
     );

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -459,6 +459,9 @@ fn no_rebuild_transitive_target_deps() {
                 a = { path = "a" }
                 [dev-dependencies]
                 b = { path = "b" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -523,6 +526,9 @@ fn rerun_if_changed_in_dep() {
 
                 [dependencies]
                 a = { path = "a" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -571,6 +577,9 @@ fn same_build_dir_cached_packages() {
                 authors = []
                 [dependencies]
                 b = { path = "../b" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("a1/src/lib.rs", "")
@@ -584,6 +593,9 @@ fn same_build_dir_cached_packages() {
                 authors = []
                 [dependencies]
                 b = { path = "../b" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("a2/src/lib.rs", "")
@@ -732,6 +744,9 @@ fn unused_optional_dep() {
                 bar = { path = "bar" }
                 baz = { path = "baz" }
                 registry1 = "*"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -791,6 +806,9 @@ fn path_dev_dep_registry_updates() {
 
                 [dependencies]
                 bar = { path = "bar" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -890,6 +908,9 @@ fn dont_rebuild_based_on_plugins() {
 
                 [dependencies]
                 proc-macro-thing = { path = 'proc-macro-thing' }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -992,6 +1013,9 @@ fn reuse_shared_build_dep() {
 
                 [workspace]
                 members = ["shared", "bar"]
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -1120,6 +1144,9 @@ fn reuse_panic_build_dep_test() {
 
                 [profile.dev]
                 panic = "abort"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -1164,6 +1191,9 @@ fn reuse_panic_pm() {
 
                 [profile.dev]
                 panic = "abort"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "extern crate bar;")

--- a/tests/testsuite/freshness_checksum.rs
+++ b/tests/testsuite/freshness_checksum.rs
@@ -450,6 +450,9 @@ fn no_rebuild_if_build_artifacts_move_backwards_in_time() {
 
                 [dependencies]
                 a = { path = "a" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -491,6 +494,9 @@ fn no_rebuild_if_build_artifacts_move_forward_in_time() {
 
                 [dependencies]
                 a = { path = "a" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -535,6 +541,9 @@ fn no_rebuild_when_rename_dir() {
 
                 [dependencies]
                 foo = { path = "foo" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/_unused.rs", "")
@@ -584,6 +593,9 @@ fn update_dependency_mtime_does_not_rebuild() {
 
                 [dependencies]
                 bar = { path = "bar" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -678,6 +690,9 @@ fn fingerprint_cleaner_does_not_rebuild() {
 
                 [features]
                 a = []
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -762,6 +777,9 @@ fn bust_patched_dep() {
 
                 [patch.crates-io]
                 registry1 = { path = "reg1new" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -1401,6 +1419,9 @@ fn verify_source_before_recompile() {
 
                 [dependencies]
                 bar = "0.1.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")

--- a/tests/testsuite/freshness_mtime.rs
+++ b/tests/testsuite/freshness_mtime.rs
@@ -228,6 +228,9 @@ fn no_rebuild_if_build_artifacts_move_backwards_in_time() {
 
                 [dependencies]
                 a = { path = "a" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -262,6 +265,9 @@ fn rebuild_if_build_artifacts_move_forward_in_time() {
 
                 [dependencies]
                 a = { path = "a" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -301,6 +307,9 @@ fn no_rebuild_when_rename_dir() {
 
                 [dependencies]
                 foo = { path = "foo" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/_unused.rs", "")
@@ -344,6 +353,9 @@ fn update_dependency_mtime_does_not_rebuild() {
 
                 [dependencies]
                 bar = { path = "bar" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -432,6 +444,9 @@ fn fingerprint_cleaner_does_not_rebuild() {
 
                 [features]
                 a = []
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -506,6 +521,9 @@ fn bust_patched_dep() {
 
                 [patch.crates-io]
                 registry1 = { path = "reg1new" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -1090,6 +1108,9 @@ fn verify_source_before_recompile() {
 
                 [dependencies]
                 bar = "0.1.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")

--- a/tests/testsuite/future_incompat_report.rs
+++ b/tests/testsuite/future_incompat_report.rs
@@ -38,6 +38,9 @@ fn dependency_project() -> Project {
                 version = "1.0.0"
                 edition = "2015"
                 repository = "https://example.com/"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", FUTURE_EXAMPLE)
@@ -53,6 +56,9 @@ fn dependency_project() -> Project {
 
                 [dependencies]
                 bar = "1.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -545,6 +551,9 @@ fn suggestions_for_updates() {
                 with_updates = "1"
                 big_update = "1"
                 without_updates = "1"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -978,6 +978,9 @@ fn dep_with_relative_submodule() {
 
             [dependencies]
             deployment.path = "deployment"
+
+            [lints.cargo]
+            default = "allow"
         "#,
             )
             .file(
@@ -1011,6 +1014,9 @@ fn dep_with_relative_submodule() {
 
                     [dependencies.base]
                     git = '{}'
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 base.url()
             ),
@@ -1162,6 +1168,9 @@ fn dep_with_skipped_submodule() {
 
                     [dependencies.bar]
                     git = "{}"
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 bar.url()
             ),
@@ -1196,6 +1205,9 @@ fn ambiguous_published_deps() {
                     version = "0.5.0"
                     edition = "2015"
                     publish = true
+
+                    [lints.cargo]
+                    default = "allow"
                 "#
                 ),
             )
@@ -1209,6 +1221,9 @@ fn ambiguous_published_deps() {
                     version = "0.5.0"
                     edition = "2015"
                     publish = true
+
+                    [lints.cargo]
+                    default = "allow"
                 "#
                 ),
             )
@@ -1229,6 +1244,9 @@ fn ambiguous_published_deps() {
 
                     [dependencies.duplicate]
                     git = '{}'
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 git_project.url()
             ),
@@ -1270,6 +1288,9 @@ fn no_duplicate_package_warning_with_dotdot_cargo_home() {
 
                     [dependencies]
                     member = { path = "member" }
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
             )
             .file("src/lib.rs", "")
@@ -1280,6 +1301,9 @@ fn no_duplicate_package_warning_with_dotdot_cargo_home() {
                     name = "member"
                     version = "0.1.0"
                     edition = "2015"
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
             )
             .file("member/src/lib.rs", "")
@@ -1296,6 +1320,9 @@ fn no_duplicate_package_warning_with_dotdot_cargo_home() {
 
                     [dependencies]
                     dep = {{ git = '{}' }}
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 git_project.url()
             ),
@@ -1334,6 +1361,9 @@ fn unused_ambiguous_published_deps() {
                     version = "0.5.0"
                     edition = "2015"
                     publish = true
+
+                    [lints.cargo]
+                    default = "allow"
                 "#
                 ),
             )
@@ -1347,6 +1377,9 @@ fn unused_ambiguous_published_deps() {
                     version = "0.5.0"
                     edition = "2015"
                     publish = true
+
+                    [lints.cargo]
+                    default = "allow"
                 "#
                 ),
             )
@@ -1360,6 +1393,9 @@ fn unused_ambiguous_published_deps() {
                     version = "0.5.0"
                     edition = "2015"
                     publish = true
+
+                    [lints.cargo]
+                    default = "allow"
                 "#
                 ),
             )
@@ -1393,6 +1429,9 @@ fn unused_ambiguous_published_deps() {
 
                     [dependencies.unique]
                     git = '{}'
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 git_project.url()
             ),
@@ -1445,6 +1484,9 @@ fn two_deps_only_update_one() {
                     git = '{}'
                     [dependencies.dep2]
                     git = '{}'
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 git1.url(),
                 git2.url()
@@ -1915,6 +1957,9 @@ fn git_repo_changing_no_rebuild() {
                     build = 'build.rs'
                     [dependencies.bar]
                     git = '{}'
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 bar.url()
             ),
@@ -1954,6 +1999,9 @@ fn git_repo_changing_no_rebuild() {
                     authors = []
                     [dependencies.bar]
                     git = '{}'
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 bar.url()
             ),
@@ -2167,6 +2215,9 @@ fn warnings_in_git_dep() {
                     authors = []
                     [dependencies.bar]
                     git = '{}'
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 bar.url()
             ),
@@ -2317,6 +2368,9 @@ fn switch_deps_does_not_update_transitive() {
 
                         [dependencies.transitive]
                         git = '{}'
+
+                        [lints.cargo]
+                        default = "allow"
                     "#,
                     transitive.url()
                 ),
@@ -2337,6 +2391,9 @@ fn switch_deps_does_not_update_transitive() {
 
                         [dependencies.transitive]
                         git = '{}'
+
+                        [lints.cargo]
+                        default = "allow"
                     "#,
                     transitive.url()
                 ),
@@ -2356,6 +2413,9 @@ fn switch_deps_does_not_update_transitive() {
                     authors = []
                     [dependencies.dep]
                     git = '{}'
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 dep1.url()
             ),
@@ -2389,6 +2449,9 @@ fn switch_deps_does_not_update_transitive() {
                 authors = []
                 [dependencies.dep]
                 git = '{}'
+
+                [lints.cargo]
+                default = "allow"
             "#,
             dep2.url()
         ),
@@ -2492,6 +2555,9 @@ fn switch_sources() {
                 authors = []
                 [dependencies.b]
                 path = "b"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -2506,6 +2572,9 @@ fn switch_sources() {
                     authors = []
                     [dependencies.a]
                     git = '{}'
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 a1.url()
             ),
@@ -2536,6 +2605,9 @@ fn switch_sources() {
                 authors = []
                 [dependencies.a]
                 git = '{}'
+
+                [lints.cargo]
+                default = "allow"
             "#,
             a2.url()
         ),
@@ -2668,6 +2740,9 @@ fn lints_are_suppressed() {
 
                     [dependencies]
                     a = {{ git = '{}' }}
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 a.url()
             ),
@@ -2712,6 +2787,9 @@ fn denied_lints_are_allowed() {
 
                     [dependencies]
                     a = {{ git = '{}' }}
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 a.url()
             ),
@@ -3074,6 +3152,9 @@ fn use_the_cli() {
 
                     [dependencies]
                     dep1 = {{ git = '{}' }}
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 git_project.url()
             ),
@@ -3759,6 +3840,9 @@ fn historical_lockfile_works() {
 
                     [dependencies]
                     dep1 = {{ git = '{}', branch = 'master' }}
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 git_project.url()
             ),
@@ -3880,6 +3964,9 @@ fn two_dep_forms() {
                     [dependencies]
                     dep1 = {{ git = '{}', branch = 'master' }}
                     a = {{ path = 'a' }}
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 git_project.url()
             ),
@@ -3895,6 +3982,9 @@ fn two_dep_forms() {
                     edition = "2015"
                     [dependencies]
                     dep1 = {{ git = '{}' }}
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 git_project.url()
             ),
@@ -4421,6 +4511,9 @@ fn different_user_relative_submodules() {
 
                     [dependencies.dep1]
                     git = '{}'
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 user1_git_project.url()
             ),
@@ -4464,6 +4557,9 @@ fn git_worktree_with_original_repo_renamed() {
                     documentation = ""
                     repository = "https://example.org"
                     readme = "./README.md"
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
             )
             .file("src/lib.rs", "")
@@ -4627,6 +4723,9 @@ fn git_worktree_with_bare_original_repo() {
                     documentation = ""
                     repository = "https://example.org"
                     readme = "./README.md"
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
             )
             .file("src/lib.rs", "")
@@ -5041,6 +5140,9 @@ fn lockfile_with_multiple_revisions_change_code_content() {
 
                     [dependencies]
                     a = {{ git = "{}" }}
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 upstream.url()
             ),
@@ -5093,6 +5195,9 @@ rev1
 
                     [dependencies]
                     b = {{ git = "{}" }}
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 upstream.url()
             ),
@@ -5111,6 +5216,9 @@ rev1
                 [dependencies]
                 a = {{ git = "{}" }}
                 m2 = {{ git = "{}" }}
+
+                [lints.cargo]
+                default = "allow"
             "#,
             upstream.url(),
             m2.url()

--- a/tests/testsuite/global_cache_tracker.rs
+++ b/tests/testsuite/global_cache_tracker.rs
@@ -45,6 +45,9 @@ fn basic_foo_bar_project() -> Project {
 
                 [dependencies]
                 bar = "1.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -1217,6 +1220,9 @@ fn package_cache_lock_during_build() {
 
                 [dependencies]
                 bar = "1.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -1249,6 +1255,9 @@ fn package_cache_lock_during_build() {
 
                 [dependencies]
                 bar = "1.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")

--- a/tests/testsuite/hints.rs
+++ b/tests/testsuite/hints.rs
@@ -43,6 +43,9 @@ fn unknown_hints_warn() {
 
             [hints]
             this-is-an-unknown-hint = true
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -61,6 +64,9 @@ fn unknown_hints_warn() {
 
             [hints]
             this-is-an-unknown-hint = true
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -96,6 +102,9 @@ fn hint_unknown_type_warn() {
 
             [hints]
             mostly-unused = 1
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -114,6 +123,9 @@ fn hint_unknown_type_warn() {
 
             [hints]
             mostly-unused = "string"
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -149,6 +161,9 @@ fn hints_mostly_unused_warn_without_gate() {
 
             [hints]
             mostly-unused = true
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -167,6 +182,9 @@ fn hints_mostly_unused_warn_without_gate() {
 
             [hints]
             mostly-unused = true
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -202,6 +220,9 @@ fn hints_mostly_unused_nightly() {
 
             [hints]
             mostly-unused = true
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -217,6 +238,9 @@ fn hints_mostly_unused_nightly() {
 
             [dependencies]
             bar = "1.0"
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -254,6 +278,9 @@ fn mostly_unused_profile_overrides_hints_nightly() {
 
             [hints]
             mostly-unused = true
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -272,6 +299,9 @@ fn mostly_unused_profile_overrides_hints_nightly() {
 
             [profile.dev.package.bar]
             hint-mostly-unused = false
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")

--- a/tests/testsuite/inheritable_workspace_fields.rs
+++ b/tests/testsuite/inheritable_workspace_fields.rs
@@ -34,6 +34,9 @@ fn permit_additional_workspace_fields() {
 
             [workspace.dependencies]
             dep = "0.1"
+
+            [workspace.lints.cargo]
+            default = "allow"
         "#,
         )
         .file(
@@ -45,6 +48,9 @@ fn permit_additional_workspace_fields() {
               edition = "2015"
               authors = []
               workspace = ".."
+
+              [lints.cargo]
+              default = "allow"
               "#,
         )
         .file("bar/src/main.rs", "fn main() {}")
@@ -286,6 +292,9 @@ fn inherit_own_dependencies() {
             dep = "0.1"
             dep-build = "0.8"
             dep-dev = "0.5.2"
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -435,6 +444,9 @@ version = "0.5.2"
 [build-dependencies.dep-build]
 version = "0.8"
 
+[lints.cargo]
+default = "allow"
+
 "##]],
         )],
     );
@@ -461,6 +473,9 @@ fn inherit_own_detailed_dependencies() {
 
             [workspace.dependencies]
             dep = { version = "0.1.2", features = ["testing"] }
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -580,6 +595,9 @@ path = "src/main.rs"
 version = "0.1.2"
 features = ["testing"]
 
+[lints.cargo]
+default = "allow"
+
 "##]],
         )],
     );
@@ -653,6 +671,9 @@ fn inherited_dependencies_union_features() {
             members = []
             [workspace.dependencies]
             dep = { version = "0.1", features = ["fancy"] }
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -890,6 +911,9 @@ fn inherit_dependencies() {
             dep-build.workspace = true
             [dev-dependencies]
             dep-dev.workspace = true
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("bar/src/main.rs", "fn main() {}")
@@ -1040,6 +1064,9 @@ version = "0.5.2"
 [build-dependencies.dep-build]
 version = "0.8"
 
+[lints.cargo]
+default = "allow"
+
 "##]],
         )],
     );
@@ -1070,6 +1097,9 @@ fn inherit_target_dependencies() {
             dep.workspace = true
             [target.'cfg(windows)'.dependencies]
             dep.workspace = true
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("bar/src/main.rs", "fn main() {}")
@@ -1162,6 +1192,9 @@ fn inherit_dependency_features() {
             members = []
             [workspace.dependencies]
             dep = "0.1"
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -1235,6 +1268,9 @@ fn inherit_detailed_dependencies() {
             authors = []
             [dependencies]
             detailed.workspace = true
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("bar/src/main.rs", "fn main() {}")
@@ -1275,6 +1311,9 @@ fn inherit_path_dependencies() {
             authors = []
             [dependencies]
             dep.workspace = true
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("bar/src/main.rs", "fn main() {}")
@@ -1533,6 +1572,9 @@ fn warn_inherit_def_feat_true_member_def_feat_false() {
             members = []
             [workspace.dependencies]
             dep = { version = "0.1.0", default-features = true }
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -1580,6 +1622,9 @@ fn inherit_def_feat_true_member_def_feat_false_2024_edition() {
             members = []
             [workspace.dependencies]
             dep = { version = "0.1.0", default-features = true }
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -1625,6 +1670,9 @@ fn warn_inherit_simple_member_def_feat_false() {
             members = []
             [workspace.dependencies]
             dep = "0.1.0"
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -1672,6 +1720,9 @@ fn inherit_simple_member_def_feat_false_2024_edition() {
             members = []
             [workspace.dependencies]
             dep = "0.1.0"
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -1717,6 +1768,9 @@ fn inherit_def_feat_false_member_def_feat_true() {
             members = []
             [workspace.dependencies]
             dep = { version = "0.1.0", default-features = false }
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -1804,6 +1858,9 @@ fn warn_inherit_unused_manifest_key_dep() {
 
             [dependencies]
             dep = { workspace = true, wxz = "wxz" }
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -1842,6 +1899,12 @@ fn warn_unused_workspace_package_field() {
             [package]
             name = "foo"
             edition = "2015"
+
+            [workspace.lints.cargo]
+            default = "allow"
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("src/main.rs", "fn main() {}")

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -2785,6 +2785,9 @@ fn ambiguous_registry_vs_local_package() {
 
         [dependencies]
         foo = "0.0.1"
+
+        [lints.cargo]
+        default = "allow"
     "#,
         )
         .build();
@@ -3228,8 +3231,8 @@ im_a_teapot = "warn"
         )
         .file("src/main.rs", "fn main() { let unused = 10; }")
         .build();
-    p.cargo("install --path . -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints", "test-dummy-unstable"])
+    p.cargo("install --path .")
+        .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_stdout_data(str![])
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.0.1 ([ROOT]/foo)
@@ -3276,8 +3279,8 @@ im_a_teapot = "deny"
         .file("src/main.rs", "fn main() { let unused = 10; }")
         .publish();
 
-    cargo_process("install foo -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints", "test-dummy-unstable"])
+    cargo_process("install foo")
+        .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_stdout_data(str![])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index

--- a/tests/testsuite/lints/blanket_hint_mostly_unused.rs
+++ b/tests/testsuite/lints/blanket_hint_mostly_unused.rs
@@ -19,8 +19,8 @@ hint-mostly-unused = true
         )
         .file("src/main.rs", "fn main() {}")
         .build();
-    p.cargo("check -Zprofile-hint-mostly-unused -Zcargo-lints -Zcargo-lints -v")
-        .masquerade_as_nightly_cargo(&["profile-hint-mostly-unused", "cargo-lints"])
+    p.cargo("check -Zprofile-hint-mostly-unused -v")
+        .masquerade_as_nightly_cargo(&["profile-hint-mostly-unused"])
         .with_stderr_data(str![[r#"
 [WARNING] `hint-mostly-unused` is being blanket applied to all dependencies
  --> Cargo.toml:7:10
@@ -61,8 +61,8 @@ hint-mostly-unused = true
         )
         .file("src/main.rs", "fn main() {}")
         .build();
-    p.cargo("check -Zprofile-hint-mostly-unused -Zcargo-lints -v")
-        .masquerade_as_nightly_cargo(&["profile-hint-mostly-unused", "cargo-lints"])
+    p.cargo("check -Zprofile-hint-mostly-unused -v")
+        .masquerade_as_nightly_cargo(&["profile-hint-mostly-unused"])
         .with_stderr_data(str![[r#"
 [WARNING] `hint-mostly-unused` is being blanket applied to all dependencies
  --> Cargo.toml:7:22
@@ -100,8 +100,8 @@ hint-mostly-unused = true
         )
         .file("src/main.rs", "fn main() {}")
         .build();
-    p.cargo("check -Zprofile-hint-mostly-unused -Zcargo-lints -v")
-        .masquerade_as_nightly_cargo(&["profile-hint-mostly-unused", "cargo-lints"])
+    p.cargo("check -Zprofile-hint-mostly-unused -v")
+        .masquerade_as_nightly_cargo(&["profile-hint-mostly-unused"])
         .with_stderr_data(str![[r#"
 [WARNING] `hint-mostly-unused` is being blanket applied to all dependencies
  --> Cargo.toml:7:14
@@ -148,8 +148,8 @@ authors = []
         .file("foo/src/lib.rs", "")
         .build();
 
-    p.cargo("check -Zprofile-hint-mostly-unused -Zcargo-lints -v")
-        .masquerade_as_nightly_cargo(&["profile-hint-mostly-unused", "cargo-lints"])
+    p.cargo("check -Zprofile-hint-mostly-unused -v")
+        .masquerade_as_nightly_cargo(&["profile-hint-mostly-unused"])
         .with_stderr_data(str![[r#"
 [WARNING] `hint-mostly-unused` is being blanket applied to all dependencies
  --> Cargo.toml:5:22
@@ -191,8 +191,8 @@ blanket_hint_mostly_unused = "deny"
         )
         .file("src/main.rs", "fn main() {}")
         .build();
-    p.cargo("check -Zprofile-hint-mostly-unused -v -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["profile-hint-mostly-unused", "cargo-lints"])
+    p.cargo("check -Zprofile-hint-mostly-unused -v")
+        .masquerade_as_nightly_cargo(&["profile-hint-mostly-unused"])
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] `hint-mostly-unused` is being blanket applied to all dependencies
@@ -236,8 +236,5 @@ blanket_hint_mostly_unused = "warn"
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
-        .with_stderr_data(str![""])
-        .run();
+    p.cargo("fetch").with_stderr_data(str![""]).run();
 }

--- a/tests/testsuite/lints/error/mod.rs
+++ b/tests/testsuite/lints/error/mod.rs
@@ -25,10 +25,9 @@ im_a_teapot = "deny"
         .build();
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo(&["cargo-lints", "test-dummy-unstable"])
+        .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .current_dir(p.root())
         .arg("check")
-        .arg("-Zcargo-lints")
         .assert()
         .code(101)
         .stdout_eq(str![""])

--- a/tests/testsuite/lints/inherited/mod.rs
+++ b/tests/testsuite/lints/inherited/mod.rs
@@ -32,10 +32,8 @@ workspace = true
         .build();
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
         .current_dir(p.root())
         .arg("check")
-        .arg("-Zcargo-lints")
         .assert()
         .code(101)
         .stdout_eq(str![""])

--- a/tests/testsuite/lints/manual_readme.rs
+++ b/tests/testsuite/lints/manual_readme.rs
@@ -24,8 +24,7 @@ manual_readme = "warn"
         .file("README.md", "")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [WARNING] explicit `package.readme` can be inferred
  --> Cargo.toml:7:1
@@ -64,10 +63,7 @@ manual_readme = "warn"
         .file("README.txt", "")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
-        .with_stderr_data(str![""])
-        .run();
+    p.cargo("fetch").with_stderr_data(str![""]).run();
 }
 
 #[cargo_test]
@@ -92,8 +88,7 @@ manual_readme = "warn"
         .file("README.txt", "")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [WARNING] explicit `package.readme` can be inferred
  --> Cargo.toml:7:1
@@ -130,10 +125,7 @@ manual_readme = "warn"
         .file("README.md", "")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
-        .with_stderr_data(str![""])
-        .run();
+    p.cargo("fetch").with_stderr_data(str![""]).run();
 }
 
 #[cargo_test]
@@ -158,10 +150,7 @@ manual_readme = "warn"
         .file("FOO.md", "")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
-        .with_stderr_data(str![""])
-        .run();
+    p.cargo("fetch").with_stderr_data(str![""]).run();
 }
 
 #[cargo_test]
@@ -186,10 +175,7 @@ manual_readme = "warn"
         .file("src/README.md", "")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
-        .with_stderr_data(str![""])
-        .run();
+    p.cargo("fetch").with_stderr_data(str![""]).run();
 }
 
 #[cargo_test]
@@ -217,8 +203,5 @@ manual_readme = "warn"
         .file("README.md", "")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
-        .with_stderr_data(str![""])
-        .run();
+    p.cargo("fetch").with_stderr_data(str![""]).run();
 }

--- a/tests/testsuite/lints/missing_lints_inheritance.rs
+++ b/tests/testsuite/lints/missing_lints_inheritance.rs
@@ -25,10 +25,7 @@ edition = "2015"
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
-        .with_stderr_data(str![""])
-        .run();
+    p.cargo("fetch").with_stderr_data(str![""]).run();
 }
 
 #[cargo_test]
@@ -58,8 +55,7 @@ edition = "2015"
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [WARNING] missing `[lints]` to inherit `[workspace.lints]`
  --> bar/Cargo.toml
@@ -110,10 +106,7 @@ edition = "2015"
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
-        .with_stderr_data(str![""])
-        .run();
+    p.cargo("fetch").with_stderr_data(str![""]).run();
 }
 
 #[cargo_test]
@@ -146,8 +139,5 @@ workspace = true
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
-        .with_stderr_data(str![""])
-        .run();
+    p.cargo("fetch").with_stderr_data(str![""]).run();
 }

--- a/tests/testsuite/lints/mod.rs
+++ b/tests/testsuite/lints/mod.rs
@@ -43,8 +43,8 @@ im_a_teapot = "warn"
         .file("src/lib.rs", "")
         .build();
 
-    foo.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints", "test-dummy-unstable"])
+    foo.cargo("fetch")
+        .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_stderr_data(str![[r#"
 [WARNING] `im_a_teapot` is specified
  --> Cargo.toml:9:1
@@ -82,8 +82,8 @@ test_dummy_unstable = { level = "forbid", priority = -1 }
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints", "test-dummy-unstable"])
+    p.cargo("fetch")
+        .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] `im_a_teapot` is specified
@@ -125,8 +125,8 @@ workspace = true
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints", "test-dummy-unstable"])
+    p.cargo("fetch")
+        .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] `im_a_teapot` is specified
@@ -173,8 +173,8 @@ im-a-teapot = true
         .file("foo/src/lib.rs", "")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("fetch")
+        .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_stderr_data(str![[r#"
 [WARNING] missing `[lints]` to inherit `[workspace.lints]`
   --> foo/Cargo.toml
@@ -236,8 +236,8 @@ bar = "0.1.0"
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("fetch")
+        .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to highest compatible version
@@ -267,8 +267,7 @@ im_a_teapot = "warn"
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("fetch")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] use of unstable lint `im_a_teapot`
@@ -314,8 +313,7 @@ workspace = true
         .file("foo/src/lib.rs", "")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("fetch")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] use of unstable lint `im_a_teapot`
@@ -365,8 +363,7 @@ authors = []
         .file("foo/src/lib.rs", "")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("fetch")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] use of unstable lint `im_a_teapot`
@@ -426,8 +423,8 @@ im_a_teapot = { level = "warn", priority = 10 }
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("fetch -Zcargo-lints -Zrustc-unicode")
-        .masquerade_as_nightly_cargo(&["cargo-lints", "rustc-unicode", "test-dummy-unstable"])
+    p.cargo("fetch -Zrustc-unicode")
+        .masquerade_as_nightly_cargo(&["rustc-unicode", "test-dummy-unstable"])
         .with_stderr_data(str![[r#"
 [WARNING] `im_a_teapot` is specified
   ╭▸ Cargo.toml:9:1
@@ -468,8 +465,7 @@ fn explicit_lint_level_overrides_default() {
         )
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("fetch")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] `package.homepage` is redundant with `package.repository`

--- a/tests/testsuite/lints/non_kebab_case_bins.rs
+++ b/tests/testsuite/lints/non_kebab_case_bins.rs
@@ -26,8 +26,7 @@ non_kebab_case_bins = "warn"
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [WARNING] binary `foo_bar` should have a kebab-case name
   |
@@ -67,8 +66,7 @@ non_kebab_case_bins = "warn"
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [WARNING] binary `foo_bar` should have a kebab-case name
    |
@@ -116,8 +114,7 @@ non_kebab_case_bins = "warn"
         .file("src/bin/foo_bar.rs", "fn main() {}")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [WARNING] binary `foo_bar` should have a kebab-case name
   |
@@ -151,8 +148,8 @@ fn main() {}"#,
         )
         .build();
 
-    p.cargo("fetch -Zcargo-lints -Zscript --manifest-path foo_bar")
-        .masquerade_as_nightly_cargo(&["cargo-lints", "script"])
+    p.cargo("fetch -Zscript --manifest-path foo_bar")
+        .masquerade_as_nightly_cargo(&["script"])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
 [HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/foo_bar`

--- a/tests/testsuite/lints/non_kebab_case_features.rs
+++ b/tests/testsuite/lints/non_kebab_case_features.rs
@@ -26,8 +26,8 @@ non_kebab_case_features = "warn"
         .file("src/lib.rs", "")
         .build();
 
-    foo.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints", "test-dummy-unstable"])
+    foo.cargo("fetch")
+        .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_stderr_data(str![[r#"
 [WARNING] feature `foo_bar` should have a kebab-case name
  --> Cargo.toml:9:1
@@ -72,8 +72,8 @@ non_kebab_case_features = "warn"
         .file("src/lib.rs", "")
         .build();
 
-    foo.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints", "test-dummy-unstable"])
+    foo.cargo("fetch")
+        .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_stderr_data(str![[r#"
 [WARNING] feature `foo_bar` should have a kebab-case name
  --> Cargo.toml:9:1

--- a/tests/testsuite/lints/non_kebab_case_packages.rs
+++ b/tests/testsuite/lints/non_kebab_case_packages.rs
@@ -22,8 +22,8 @@ non_kebab_case_packages = "warn"
         .file("src/lib.rs", "")
         .build();
 
-    foo.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints", "test-dummy-unstable"])
+    foo.cargo("fetch")
+        .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_stderr_data(str![[r#"
 [WARNING] package `foo_bar` should have a kebab-case name
  --> Cargo.toml:3:8
@@ -58,8 +58,8 @@ fn main() {}"#,
         )
         .build();
 
-    p.cargo("fetch -Zcargo-lints -Zscript --manifest-path foo_bar")
-        .masquerade_as_nightly_cargo(&["cargo-lints", "script"])
+    p.cargo("fetch -Zscript --manifest-path foo_bar")
+        .masquerade_as_nightly_cargo(&["script"])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
 [HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/foo_bar`

--- a/tests/testsuite/lints/non_snake_case_features.rs
+++ b/tests/testsuite/lints/non_snake_case_features.rs
@@ -26,8 +26,8 @@ non_snake_case_features = "warn"
         .file("src/lib.rs", "")
         .build();
 
-    foo.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints", "test-dummy-unstable"])
+    foo.cargo("fetch")
+        .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_stderr_data(str![[r#"
 [WARNING] feature `foo-bar` should have a snake-case name
  --> Cargo.toml:9:1
@@ -72,8 +72,8 @@ non_snake_case_features = "warn"
         .file("src/lib.rs", "")
         .build();
 
-    foo.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints", "test-dummy-unstable"])
+    foo.cargo("fetch")
+        .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_stderr_data(str![[r#"
 [WARNING] feature `foo-bar` should have a snake-case name
  --> Cargo.toml:9:1

--- a/tests/testsuite/lints/non_snake_case_packages.rs
+++ b/tests/testsuite/lints/non_snake_case_packages.rs
@@ -22,8 +22,8 @@ non_snake_case_packages = "warn"
         .file("src/lib.rs", "")
         .build();
 
-    foo.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints", "test-dummy-unstable"])
+    foo.cargo("fetch")
+        .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_stderr_data(str![[r#"
 [WARNING] package `foo-bar` should have a snake-case name
  --> Cargo.toml:3:8
@@ -58,8 +58,8 @@ fn main() {}"#,
         )
         .build();
 
-    p.cargo("fetch -Zcargo-lints -Zscript --manifest-path foo-bar")
-        .masquerade_as_nightly_cargo(&["cargo-lints", "script"])
+    p.cargo("fetch -Zscript --manifest-path foo-bar")
+        .masquerade_as_nightly_cargo(&["script"])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
 [HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/foo-bar`

--- a/tests/testsuite/lints/redundant_homepage.rs
+++ b/tests/testsuite/lints/redundant_homepage.rs
@@ -24,8 +24,7 @@ redundant_homepage = "warn"
         .file("README.md", "")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [WARNING] `package.homepage` is redundant with `package.repository`
  --> Cargo.toml:7:12
@@ -65,8 +64,7 @@ redundant_homepage = "warn"
         .file("README.md", "")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [WARNING] `package.homepage` is redundant with `package.documentation`
  --> Cargo.toml:7:12
@@ -110,8 +108,7 @@ redundant_homepage = "warn"
         .file("README.md", "")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [WARNING] `package.homepage` is redundant with `package.documentation`
   --> Cargo.toml:11:1

--- a/tests/testsuite/lints/text_direction_codepoint.rs
+++ b/tests/testsuite/lints/text_direction_codepoint.rs
@@ -30,8 +30,7 @@ text_direction_codepoint_in_literal = \"allow\"
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [WARNING] unicode codepoint changing visible direction of text present in comment
  --> Cargo.toml:7:51
@@ -86,8 +85,7 @@ text_direction_codepoint_in_literal = \"warn\"
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [WARNING] unicode codepoint changing visible direction of text present in literal
  --> Cargo.toml:7:18
@@ -173,8 +171,7 @@ edition = \"2015\"
         .file("bar/src/lib.rs", "")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [WARNING] unicode codepoint changing visible direction of text present in comment
   --> Cargo.toml:10:51
@@ -298,8 +295,7 @@ workspace = true
         .file("bar/src/lib.rs", "")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [WARNING] unicode codepoint changing visible direction of text present in comment
  --> Cargo.toml:6:51

--- a/tests/testsuite/lints/unknown_lints.rs
+++ b/tests/testsuite/lints/unknown_lints.rs
@@ -23,8 +23,7 @@ this_lint_does_not_exist = "warn"
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [WARNING] unknown lint: `this_lint_does_not_exist`
   --> Cargo.toml:11:1
@@ -70,8 +69,7 @@ workspace = true
         .file("foo/src/lib.rs", "")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [WARNING] unknown lint: `this_lint_does_not_exist`
  --> Cargo.toml:8:1
@@ -114,8 +112,7 @@ authors = []
         .file("foo/src/lib.rs", "")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [WARNING] unknown lint: `this_lint_does_not_exist`
  --> Cargo.toml:8:1

--- a/tests/testsuite/lints/unused_dependencies.rs
+++ b/tests/testsuite/lints/unused_dependencies.rs
@@ -34,8 +34,7 @@ fn unused_dep_normal() {
         )
         .build();
 
-    p.cargo("check -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to highest compatible version
@@ -93,8 +92,7 @@ fn unused_dep_build() {
         )
         .build();
 
-    p.cargo("check -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to highest compatible version
@@ -146,8 +144,7 @@ fn unused_dep_build_no_build_rs() {
         )
         .build();
 
-    p.cargo("check -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check")
         .with_stderr_data(str![[r#"
 [WARNING] unused build dependency `unused`
  --> Cargo.toml:9:13
@@ -218,8 +215,7 @@ fn unused_dep_lib_bins() {
         )
         .build();
 
-    p.cargo("check -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check")
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
@@ -248,24 +244,21 @@ fn unused_dep_lib_bins() {
         )
         .run();
 
-    p.cargo("check -Zcargo-lints --lib")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check --lib")
         .with_stderr_data(str![[r#"
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
         .run();
 
-    p.cargo("check -Zcargo-lints --bins")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check --bins")
         .with_stderr_data(str![[r#"
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
         .run();
 
-    p.cargo("check -Zcargo-lints --bin foo")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check --bin foo")
         .with_stderr_data(str![[r#"
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -314,8 +307,7 @@ fn unused_dep_build_with_used_dep_normal() {
         )
         .build();
 
-    p.cargo("check -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to highest compatible version
@@ -376,8 +368,7 @@ fn unused_dep_normal_but_implicit_used_dep_dev() {
         )
         .build();
 
-    p.cargo("check -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to highest compatible version
@@ -399,8 +390,7 @@ fn unused_dep_normal_but_implicit_used_dep_dev() {
 "#]])
         .run();
 
-    p.cargo("check -Zcargo-lints --all-targets")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check --all-targets")
         .with_stderr_data(str![[r#"
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [WARNING] unused dependency `used_dev`
@@ -460,8 +450,7 @@ fn unused_dep_normal_but_explicit_used_dep_dev() {
         )
         .build();
 
-    p.cargo("check -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to highest compatible version
@@ -528,8 +517,7 @@ fn unused_dep_dev_but_explicit_used_dep_normal() {
 
     // No warning because the dependency is used at test time by the unit tests and the two
     // dependencies are indistinguishable
-    p.cargo("check -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to highest compatible version
@@ -578,8 +566,7 @@ fn optional_dependency() {
         )
         .build();
 
-    p.cargo("check -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to highest compatible versions
@@ -589,8 +576,7 @@ fn optional_dependency() {
 "#]])
         .run();
 
-    p.cargo("check -Zcargo-lints -F used,unused")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check -F used,unused")
         .with_stderr_data(
             str![[r#"
 [DOWNLOADING] crates ...
@@ -649,8 +635,7 @@ fn unused_dep_renamed() {
         )
         .build();
 
-    p.cargo("check -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check")
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
@@ -708,8 +693,7 @@ fn warning_replay() {
         )
         .build();
 
-    p.cargo("check -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to highest compatible version
@@ -731,8 +715,7 @@ fn warning_replay() {
 "#]])
         .run();
 
-    p.cargo("check -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check")
         .with_stderr_data(str![[r#"
 [WARNING] unused dependency `unused`
  --> Cargo.toml:9:13
@@ -785,8 +768,7 @@ fn unused_dep_target() {
         )
         .build();
 
-    p.cargo(&format!("check -Zcargo-lints --target {host}"))
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo(&format!("check --target {host}"))
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
@@ -883,8 +865,7 @@ fn unused_dev_deps() {
         .build();
 
     // doesn't check any tests, still no unused dev dep warnings
-    p.cargo("check -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 6 packages to highest compatible versions
@@ -895,8 +876,7 @@ fn unused_dev_deps() {
         .run();
 
     // doesn't check doctests, still no unused dev dep warnings
-    p.cargo("check -Zcargo-lints --all-targets")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check --all-targets")
         .with_stderr_data(
             str![[r#"
 [DOWNLOADING] crates ...
@@ -921,8 +901,7 @@ fn unused_dev_deps() {
         .run();
 
     // doesn't test doctests and benches and thus doesn't create unused dev dep warnings
-    p.cargo("test -Zcargo-lints --no-run")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("test --no-run")
         .with_stderr_data(
             str![[r#"
 [COMPILING] example_used v0.1.0
@@ -942,8 +921,7 @@ fn unused_dev_deps() {
         .run();
 
     // doesn't test doctests, still no unused dev dep warnings
-    p.cargo("test -Zcargo-lints --no-run --all-targets")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("test --no-run --all-targets")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -957,8 +935,7 @@ fn unused_dev_deps() {
 
     // tests everything including doctests, but not
     // the benches
-    p.cargo("test -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("test")
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
@@ -1064,8 +1041,7 @@ fn package_selection() {
         )
         .build();
 
-    p.cargo("check -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check")
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
@@ -1125,8 +1101,7 @@ fn package_selection() {
         )
         .run();
 
-    p.cargo("check -Zcargo-lints -p foo")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check -p foo")
         .with_stderr_data(
             str![[r#"
 [WARNING] unused dependency `bar`
@@ -1159,8 +1134,7 @@ fn package_selection() {
         )
         .run();
 
-    p.cargo("check -Zcargo-lints -p bar")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check -p bar")
         .with_stderr_data(
             str![[r#"
 [WARNING] unused dependency `unused_bar`
@@ -1222,8 +1196,7 @@ fn pinned_transitive_dep() {
         )
         .build();
 
-    p.cargo("check -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check")
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
@@ -1297,8 +1270,7 @@ pub fn fun() -> &'static str {
         )
         .build();
 
-    p.cargo("check -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check")
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
@@ -1347,9 +1319,8 @@ fn allow_rustflags() {
         )
         .build();
 
-    p.cargo("check -Zcargo-lints")
+    p.cargo("check")
         .env("RUSTFLAGS", "-Aunused_crate_dependencies")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to highest compatible version
@@ -1403,8 +1374,7 @@ fn allow_attribute() {
         )
         .build();
 
-    p.cargo("check -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to highest compatible version
@@ -1456,8 +1426,7 @@ fn deny_in_manifest() {
         )
         .build();
 
-    p.cargo("check -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
@@ -1510,9 +1479,8 @@ fn deny_rustflags() {
         )
         .build();
 
-    p.cargo("check -Zcargo-lints")
+    p.cargo("check")
         .env("RUSTFLAGS", "-Dunused_crate_dependencies")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to highest compatible version
@@ -1566,8 +1534,7 @@ fn deny_attribute() {
         )
         .build();
 
-    p.cargo("check -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to highest compatible version
@@ -1620,9 +1587,8 @@ fn forbid_rustflags() {
         )
         .build();
 
-    p.cargo("check -Zcargo-lints")
+    p.cargo("check")
         .env("RUSTFLAGS", "-Funused_crate_dependencies")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to highest compatible version
@@ -1676,8 +1642,7 @@ fn forbid_attribute() {
         )
         .build();
 
-    p.cargo("check -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to highest compatible version

--- a/tests/testsuite/lints/unused_workspace_dependencies.rs
+++ b/tests/testsuite/lints/unused_workspace_dependencies.rs
@@ -76,8 +76,7 @@ workspace = true
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [WARNING] unused workspace dependency `not-inherited`
   --> Cargo.toml:12:1

--- a/tests/testsuite/lints/unused_workspace_package_fields.rs
+++ b/tests/testsuite/lints/unused_workspace_package_fields.rs
@@ -48,8 +48,7 @@ workspace = true
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [WARNING] unused field `rust-version` in `workspace.package`
  --> Cargo.toml:8:1

--- a/tests/testsuite/lints/warning/mod.rs
+++ b/tests/testsuite/lints/warning/mod.rs
@@ -25,10 +25,9 @@ im_a_teapot = "warn"
         .build();
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo(&["cargo-lints", "test-dummy-unstable"])
+        .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .current_dir(p.root())
         .arg("check")
-        .arg("-Zcargo-lints")
         .assert()
         .success()
         .stdout_eq(str![""])

--- a/tests/testsuite/lints_table.rs
+++ b/tests/testsuite/lints_table.rs
@@ -19,6 +19,9 @@ fn dependency_warning_ignored() {
 
                 [dependencies]
                 bar.path = "../bar"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -37,6 +40,9 @@ fn dependency_warning_ignored() {
 
                 [lints.rust]
                 unsafe_code = "forbid"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -98,6 +104,9 @@ fn fail_on_invalid_tool() {
 
                 [workspace.lints.super-awesome-linter]
                 unsafe_code = "forbid"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -737,39 +746,6 @@ pub const Ĕ: i32 = 2;
 }
 
 #[cargo_test]
-fn cargo_lints_nightly_required() {
-    let foo = project()
-        .file(
-            "Cargo.toml",
-            r#"
-[package]
-name = "foo"
-version = "0.0.1"
-edition = "2015"
-authors = []
-
-[lints.cargo]
-            "#,
-        )
-        .file("src/lib.rs", "")
-        .build();
-
-    foo.cargo("check")
-        .with_stderr_data(str![[r#"
-[WARNING] Cargo.toml: unused manifest key `lints.cargo` (may be supported in a future version)
-
-this Cargo does not support nightly features, but if you
-switch to nightly channel you can pass
-`-Zcargo-lints` to enable this feature.
-[WARNING] `foo` (manifest) generated 1 warning
-[CHECKING] foo v0.0.1 ([ROOT]/foo)
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-
-"#]])
-        .run();
-}
-
-#[cargo_test]
 fn cargo_lints_no_z_flag() {
     let foo = project()
         .file(
@@ -791,12 +767,8 @@ im-a-teapot = true
         .build();
 
     foo.cargo("check")
-        .masquerade_as_nightly_cargo(&["cargo-lints", "test-dummy-unstable"])
+        .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_stderr_data(str![[r#"
-[WARNING] Cargo.toml: unused manifest key `lints.cargo` (may be supported in a future version)
-
-consider passing `-Zcargo-lints` to enable this feature.
-[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -826,8 +798,8 @@ im_a_teapot = "warn"
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("check -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints", "test-dummy-unstable"])
+    p.cargo("check")
+        .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_stderr_data(str![[r#"
 [WARNING] `im_a_teapot` is specified
  --> Cargo.toml:9:1

--- a/tests/testsuite/local_registry.rs
+++ b/tests/testsuite/local_registry.rs
@@ -125,6 +125,9 @@ fn depend_on_yanked() {
 
                 [dependencies]
                 bar = "0.0.1"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")

--- a/tests/testsuite/lockfile_compat.rs
+++ b/tests/testsuite/lockfile_compat.rs
@@ -998,6 +998,9 @@ dependencies = [
 
                     [dependencies]
                     dep1 = {{ git = '{url}', {ref_kind} = '{git_ref}' }}
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
             ),
         )
@@ -1093,6 +1096,9 @@ dependencies = [
 
                     [dependencies]
                     dep1 = {{ git = '{url}', {ref_kind} = '{git_ref}' }}
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
             ),
         )

--- a/tests/testsuite/lto.rs
+++ b/tests/testsuite/lto.rs
@@ -730,6 +730,9 @@ fn test_profile() {
 
                 [dependencies]
                 bar = "*"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file(
@@ -888,6 +891,9 @@ fn fresh_swapping_commands() {
 
                 [profile.release]
                 lto = true
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "pub fn foo() { println!(\"hi!\"); }")

--- a/tests/testsuite/message_format.rs
+++ b/tests/testsuite/message_format.rs
@@ -195,7 +195,7 @@ mod tests {
         .masquerade_as_nightly_cargo(&["rustc-unicode"])
         .with_stderr_data(str![[r#"
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc [..] --json=diagnostic-rendered-ansi,artifacts,future-incompat,diagnostic-unicode [..]`
+[RUNNING] `rustc [..] --json=diagnostic-rendered-ansi,artifacts,future-incompat,unused-externs-silent,diagnostic-unicode [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])

--- a/tests/testsuite/metabuild.rs
+++ b/tests/testsuite/metabuild.rs
@@ -267,6 +267,9 @@ fn metabuild_fresh() {
 
                 [build-dependencies]
                 mb = {path="mb"}
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")

--- a/tests/testsuite/min_publish_age.rs
+++ b/tests/testsuite/min_publish_age.rs
@@ -537,6 +537,9 @@ fn locked_versions_preserved() {
 
                 [dependencies]
                 bar = "1"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file(

--- a/tests/testsuite/offline.rs
+++ b/tests/testsuite/offline.rs
@@ -122,6 +122,9 @@ fn cargo_compile_with_downloaded_dependency_with_offline() {
 
             [dependencies]
             present_dep = "1.2.3"
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -140,6 +143,9 @@ fn cargo_compile_with_downloaded_dependency_with_offline() {
 
             [dependencies]
             present_dep = "1.2.3"
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file("src/lib.rs", "")

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1908,6 +1908,9 @@ fn package_should_use_build_cache() {
 
                 [dependencies]
                 other = "1.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -3417,6 +3420,9 @@ fn workspace_noconflict_readme() {
                 description = "bar"
                 readme = "../README.md"
                 workspace = ".."
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("bar/src/main.rs", "fn main() {}")
@@ -3459,6 +3465,9 @@ fn workspace_conflict_readme() {
                 description = "bar"
                 readme = "../README.md"
                 workspace = ".."
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("bar/src/main.rs", "fn main() {}")
@@ -5760,6 +5769,9 @@ fn workspace_with_local_deps_project() -> Project {
             [dependencies]
             # Let one dependency also specify features, for the added test coverage when generating package files.
             level2 = { workspace = true, features = ["foo"] }
+
+            [lints.cargo]
+            default = "allow"
         "#,
             )
             .file("level1/src/main.rs", "fn main() {}")
@@ -5780,6 +5792,9 @@ fn workspace_with_local_deps_project() -> Project {
 
             [dependencies]
             level3 = { path = "../level3", version = "0.0.1" }
+
+            [lints.cargo]
+            default = "allow"
         "#
             )
             .file("level2/src/lib.rs", "")
@@ -5794,6 +5809,9 @@ fn workspace_with_local_deps_project() -> Project {
             license = "MIT"
             description = "level3"
             repository = "bar"
+
+            [lints.cargo]
+            default = "allow"
         "#,
             )
             .file("level3/src/lib.rs", "")
@@ -5897,6 +5915,9 @@ path = "src/main.rs"
 [dependencies.level2]
 version = "0.0.1"
 features = ["foo"]
+
+[lints.cargo]
+default = "allow"
 
 "##]];
 
@@ -6144,6 +6165,9 @@ fn workspace_with_local_deps_packaging_one_with_needed_deps() {
 
             [dependencies]
             level2 = { path = "../level2", version = "0.0.1" }
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("level1/src/main.rs", "fn main() {}")
@@ -6161,6 +6185,9 @@ fn workspace_with_local_deps_packaging_one_with_needed_deps() {
 
             [dependencies]
             level3 = { path = "../level3", version = "0.0.1" }
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("level2/src/lib.rs", "")
@@ -6175,6 +6202,9 @@ fn workspace_with_local_deps_packaging_one_with_needed_deps() {
             license = "MIT"
             description = "level3"
             repository = "bar"
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("level3/src/lib.rs", "")
@@ -6363,6 +6393,9 @@ fn workspace_with_local_deps_alternative_index() {
 
             [dependencies]
             level2 = { path = "../level2", version = "0.0.1", registry = "alternative" }
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("level1/src/main.rs", "fn main() {}")
@@ -6377,6 +6410,9 @@ fn workspace_with_local_deps_alternative_index() {
             license = "MIT"
             description = "level2"
             repository = "bar"
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("level2/src/lib.rs", "")
@@ -6459,6 +6495,9 @@ fn workspace_with_local_dep_already_published_project() -> Project {
 
             [dependencies]
             dep = { path = "../dep", version = "0.1.0" }
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("main/src/main.rs", "fn main() {}")
@@ -6473,6 +6512,9 @@ fn workspace_with_local_dep_already_published_project() -> Project {
             license = "MIT"
             description = "dep"
             repository = "bar"
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("dep/src/lib.rs", "")
@@ -6537,6 +6579,9 @@ fn workspace_with_local_and_remote_deps() {
             [dependencies]
             dep = { path = "../dep", version = "0.1.0" }
             old_dep = { package = "dep", version = "0.0.1" }
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("main/src/main.rs", "fn main() {}")
@@ -6551,6 +6596,9 @@ fn workspace_with_local_and_remote_deps() {
             license = "MIT"
             description = "dep"
             repository = "bar"
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("dep/src/lib.rs", "")
@@ -6771,6 +6819,9 @@ fn workspace_with_dot_rs_dir() {
             repository = "bar"
 
             [dependencies]
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("crates/foo.rs/src/lib.rs", "pub fn foo() {}")
@@ -6788,6 +6839,9 @@ fn workspace_with_dot_rs_dir() {
 
             [dependencies]
             foo = { path = "../foo.rs", version = "0.16.2" }
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("crates/bar.rs/src/lib.rs", "pub fn foo() {}")
@@ -6889,6 +6943,9 @@ fn registry_inferred_from_unique_option() {
 
             [dependencies]
             dep = { path = "../dep", version = "0.1.0", registry = "alternative" }
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("main/src/main.rs", "fn main() {}")
@@ -6904,6 +6961,9 @@ fn registry_inferred_from_unique_option() {
             description = "dep"
             repository = "bar"
             publish = ["alternative"]
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("dep/src/lib.rs", "")
@@ -6961,6 +7021,9 @@ fn registry_not_inferred_because_of_conflict() {
 
             [dependencies]
             dep = { path = "../dep", version = "0.1.0", registry = "alternative" }
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("main/src/main.rs", "fn main() {}")
@@ -6976,6 +7039,9 @@ fn registry_not_inferred_because_of_conflict() {
             description = "dep"
             repository = "bar"
             publish = ["alternative2"]
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("dep/src/lib.rs", "")
@@ -7076,6 +7142,9 @@ fn registry_inference_ignores_unpublishable() {
 
             [dependencies]
             dep = { path = "../dep", version = "0.1.0", registry = "alternative" }
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("main/src/main.rs", "fn main() {}")
@@ -7091,6 +7160,9 @@ fn registry_inference_ignores_unpublishable() {
             description = "dep"
             repository = "bar"
             publish = ["alternative"]
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("dep/src/lib.rs", "")
@@ -7166,6 +7238,9 @@ fn registry_not_inferred_because_of_multiple_options() {
 
             [dependencies]
             dep = { path = "../dep", version = "0.1.0", registry = "alternative" }
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("main/src/main.rs", "fn main() {}")
@@ -7181,6 +7256,9 @@ fn registry_not_inferred_because_of_multiple_options() {
             description = "dep"
             repository = "bar"
             publish = ["alternative", "alternative2"]
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("dep/src/lib.rs", "")
@@ -7272,6 +7350,9 @@ fn registry_not_inferred_because_of_mismatch() {
 
             [dependencies]
             dep = { path = "../dep", version = "0.1.0", registry = "alternative" }
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("main/src/main.rs", "fn main() {}")
@@ -7288,6 +7369,9 @@ fn registry_not_inferred_because_of_mismatch() {
             license = "MIT"
             description = "dep"
             repository = "bar"
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("dep/src/lib.rs", "")

--- a/tests/testsuite/package_features.rs
+++ b/tests/testsuite/package_features.rs
@@ -888,6 +888,9 @@ fn non_member_feature() {
                 edition = "2015"
                 resolver = "{}"
 
+                [lints.cargo]
+                default = "allow"
+
                 [dependencies]
             "#,
             resolver

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -90,6 +90,9 @@ fn from_config() {
 
                 [dependencies]
                 bar = "0.1.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file(
@@ -132,6 +135,9 @@ fn from_config_relative() {
 
                 [dependencies]
                 bar = "0.1.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file(
@@ -177,6 +183,9 @@ fn from_config_precedence() {
 
                 [patch.crates-io]
                 bar = { path = 'no-such-path' }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file(
@@ -433,6 +442,9 @@ fn unused() {
 
                 [patch.crates-io]
                 bar = { path = "bar" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -504,6 +516,9 @@ fn unused_with_mismatch_source_being_patched() {
 
                 [patch.crates-io]
                 bar = { path = "baz" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -556,6 +571,9 @@ fn prefer_patch_version() {
 
                 [patch.crates-io]
                 bar = { path = "bar" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -602,6 +620,9 @@ fn unused_from_config() {
 
                 [dependencies]
                 bar = "0.1.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file(
@@ -682,6 +703,9 @@ fn unused_git() {
 
                     [patch.crates-io]
                     bar = {{ git = '{}' }}
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 foo.url()
             ),
@@ -737,6 +761,9 @@ fn add_patch() {
 
                 [dependencies]
                 bar = "0.1.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -777,6 +804,9 @@ fn add_patch() {
 
             [patch.crates-io]
             bar = { path = 'bar' }
+
+            [lints.cargo]
+            default = "allow"
         "#,
     );
 
@@ -814,6 +844,9 @@ fn add_patch_from_config() {
 
                 [dependencies]
                 bar = "0.1.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -882,6 +915,9 @@ fn add_ignored_patch() {
 
                 [dependencies]
                 bar = "0.1.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -922,6 +958,9 @@ fn add_ignored_patch() {
 
             [patch.crates-io]
             bar = { path = 'bar' }
+
+            [lints.cargo]
+            default = "allow"
         "#,
     );
 
@@ -978,6 +1017,9 @@ fn add_patch_with_features() {
 
             [patch.crates-io]
             bar = { path = 'bar', features = ["some_feature"] }
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("src/lib.rs", "")
@@ -1028,6 +1070,9 @@ fn add_patch_with_setting_default_features() {
 
             [patch.crates-io]
             bar = { path = 'bar', default-features = false, features = ["none_default_feature"] }
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("src/lib.rs", "")
@@ -1123,6 +1168,9 @@ fn new_minor() {
 
                 [patch.crates-io]
                 bar = { path = 'bar' }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -1161,6 +1209,9 @@ fn transitive_new_minor() {
 
                 [patch.crates-io]
                 baz = { path = 'baz' }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -1175,6 +1226,9 @@ fn transitive_new_minor() {
 
                 [dependencies]
                 baz = '0.1.0'
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("bar/src/lib.rs", r#""#)
@@ -1214,6 +1268,9 @@ fn new_major() {
 
                 [patch.crates-io]
                 bar = { path = 'bar' }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -1252,6 +1309,9 @@ fn new_major() {
 
             [dependencies]
             bar = "0.2.0"
+
+            [lints.cargo]
+            default = "allow"
         "#,
     );
     p.cargo("check")
@@ -1288,6 +1348,9 @@ fn transitive_new_major() {
 
                 [patch.crates-io]
                 baz = { path = 'baz' }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -1302,6 +1365,9 @@ fn transitive_new_major() {
 
                 [dependencies]
                 baz = '0.2.0'
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("bar/src/lib.rs", r#""#)
@@ -1347,6 +1413,9 @@ fn shared_by_transitive() {
 
                     [patch.crates-io]
                     baz = {{ git = "{}", version = "0.1" }}
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 baz.url(),
             ),
@@ -1362,6 +1431,9 @@ fn shared_by_transitive() {
 
                 [dependencies]
                 baz = "0.1.1"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("bar/src/lib.rs", "")
@@ -1545,6 +1617,9 @@ fn patch_in_virtual() {
 
                 [dependencies]
                 bar = "0.1"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("foo/src/lib.rs", r#""#)
@@ -1596,6 +1671,9 @@ fn patch_depends_on_another_patch() {
                 [patch.crates-io]
                 bar = { path = "bar" }
                 baz = { path = "baz" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -1612,6 +1690,9 @@ fn patch_depends_on_another_patch() {
 
                 [dependencies]
                 bar = "0.1"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("baz/src/lib.rs", r#""#)
@@ -1695,6 +1776,9 @@ fn patch_older() {
 
                 [patch.crates-io]
                 baz = { path = "./baz" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -1709,6 +1793,9 @@ fn patch_older() {
 
                 [dependencies]
                 baz = "1.0.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("bar/src/lib.rs", "")
@@ -1720,6 +1807,9 @@ fn patch_older() {
                 version = "1.0.1"
                 edition = "2015"
                 authors = []
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("baz/src/lib.rs", "")
@@ -2162,6 +2252,9 @@ fn update_unused_new_version() {
 
                 [patch.crates-io]
                 bar = { path = "../bar" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -2507,6 +2600,9 @@ fn patch_from_env_config_is_ignored() {
 
                  [dependencies]
                  bar = "1.0.0"
+
+                 [lints.cargo]
+                 default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -2550,6 +2646,9 @@ fn patch_walks_backwards() {
 
             [patch.crates-io]
             bar = {path="bar"}
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -2604,6 +2703,9 @@ fn patch_walks_backwards_restricted() {
 
             [patch.crates-io]
             bar = {path="bar", version="0.1.1"}
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -2659,6 +2761,9 @@ fn patched_dep_new_version() {
 
             [patch.crates-io]
             bar = {path="bar"}
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -2672,6 +2777,9 @@ fn patched_dep_new_version() {
 
             [dependencies]
             baz = "0.1"
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file("bar/src/lib.rs", "")
@@ -2713,6 +2821,9 @@ fn patched_dep_new_version() {
 
             [dependencies]
             baz = "0.1.1"
+
+            [lints.cargo]
+            default = "allow"
         "#,
     );
 
@@ -2756,6 +2867,9 @@ fn patch_update_doesnt_update_other_sources() {
 
             [patch.crates-io]
             bar = { path = "bar" }
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -2832,6 +2946,9 @@ fn can_update_with_alt_reg() {
 
                 [patch.crates-io]
                 bar = { version = "=0.1.1", registry = "alternative" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -2886,6 +3003,9 @@ fn can_update_with_alt_reg() {
 
             [patch.crates-io]
             bar = { version = "=0.1.2", registry = "alternative" }
+
+            [lints.cargo]
+            default = "allow"
         "#,
     );
 

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -516,6 +516,9 @@ fn nested_deps_recompile() {
 
                 version = "0.5.0"
                 path = "src/bar"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", &main_file(r#""{}", bar::gimme()"#, &["bar"]))
@@ -1474,6 +1477,9 @@ fn custom_target_no_rebuild() {
                 a = { path = "a" }
                 [workspace]
                 members = ["a", "b"]
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -1489,6 +1495,9 @@ fn custom_target_no_rebuild() {
                 authors = []
                 [dependencies]
                 a = { path = "../a" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("b/src/lib.rs", "")
@@ -1530,6 +1539,9 @@ fn override_and_depend() {
                 authors = []
                 [dependencies]
                 a2 = { path = "../a2" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("a/a1/src/lib.rs", "")
@@ -1546,6 +1558,9 @@ fn override_and_depend() {
                 [dependencies]
                 a1 = { path = "../a/a1" }
                 a2 = { path = "../a/a2" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("b/src/lib.rs", "")

--- a/tests/testsuite/paths.rs
+++ b/tests/testsuite/paths.rs
@@ -22,6 +22,9 @@ fn broken_path_override_warns() {
 
                 [dependencies]
                 a = { path = "a1" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -36,6 +39,9 @@ fn broken_path_override_warns() {
 
                 [dependencies]
                 bar = "0.1"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("a1/src/lib.rs", "")
@@ -50,6 +56,9 @@ fn broken_path_override_warns() {
 
                 [dependencies]
                 bar = "0.2"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("a2/src/lib.rs", "")
@@ -142,6 +151,9 @@ fn paths_ok_with_optional() {
 
                 [dependencies]
                 bar = { path = "bar" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -156,6 +168,9 @@ fn paths_ok_with_optional() {
 
                 [dependencies]
                 baz = { version = "0.1", optional = true }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("bar/src/lib.rs", "")
@@ -170,6 +185,9 @@ fn paths_ok_with_optional() {
 
                 [dependencies]
                 baz = { version = "0.1", optional = true }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("bar2/src/lib.rs", "")
@@ -203,6 +221,9 @@ fn paths_add_optional_bad() {
 
                 [dependencies]
                 bar = { path = "bar" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -219,6 +240,9 @@ fn paths_add_optional_bad() {
 
                 [dependencies]
                 baz = { version = "0.1", optional = true }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("bar2/src/lib.rs", "")
@@ -269,6 +293,9 @@ fn env_paths_overrides_not_supported() {
                 file = "0.1.0"
                 cli = "0.1.0"
                 env = "0.1.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")

--- a/tests/testsuite/pgo.rs
+++ b/tests/testsuite/pgo.rs
@@ -104,7 +104,7 @@ fn pgo_works() {
         )
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustc [..]-Cprofile-use=[ROOT]/foo/target/merged.profdata -Cllvm-args=-pgo-warn-missing-function`
+[RUNNING] `rustc [..]-Cprofile-use=[ROOT]/foo/target/merged.profdata -Cllvm-args=-pgo-warn-missing-function[..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 
 "#]])

--- a/tests/testsuite/proc_macro.rs
+++ b/tests/testsuite/proc_macro.rs
@@ -519,6 +519,9 @@ fn proc_macro_built_once() {
 
                 [build-dependencies]
                 the-macro = { path = '../the-macro' }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("a/build.rs", "fn main() {}")
@@ -533,6 +536,9 @@ fn proc_macro_built_once() {
 
                 [dependencies]
                 the-macro = { path = '../the-macro', features = ['a'] }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("b/src/main.rs", "fn main() {}")
@@ -549,6 +555,9 @@ fn proc_macro_built_once() {
 
                 [features]
                 a = []
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("the-macro/src/lib.rs", "")

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -288,6 +288,9 @@ fn profile_config_override_precedence() {
 
                 [profile.dev.package.bar]
                 opt-level = 3
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")

--- a/tests/testsuite/profile_custom.rs
+++ b/tests/testsuite/profile_custom.rs
@@ -312,6 +312,9 @@ fn overrides_with_custom() {
 
                 [profile.other.package.yyy]
                 codegen-units = 6
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")

--- a/tests/testsuite/profile_overrides.rs
+++ b/tests/testsuite/profile_overrides.rs
@@ -24,6 +24,9 @@ fn profile_override_basic() {
 
                 [profile.dev.package.bar]
                 opt-level = 3
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -66,6 +69,9 @@ fn profile_override_warnings() {
 
                 [profile.dev.package."bar:1.2.3"]
                 opt-level = 3
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")

--- a/tests/testsuite/profile_settings.rs
+++ b/tests/testsuite/profile_settings.rs
@@ -159,6 +159,9 @@ fn top_level_overrides_deps() {
 
                 [dependencies.foo]
                 path = "foo"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -179,6 +182,9 @@ fn top_level_overrides_deps() {
                 [lib]
                 name = "foo"
                 crate-type = ["dylib", "rlib"]
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("foo/src/lib.rs", "")
@@ -195,7 +201,7 @@ fn top_level_overrides_deps() {
         -C opt-level=1[..]\
         -C debuginfo=2 [..]\
         -C metadata=[..] \
-        --out-dir [ROOT]/foo/target/release/build/foo/[HASH]/out`
+        --out-dir [ROOT]/foo/target/release/build/foo/[HASH]/out[..]`
 [COMPILING] test v0.0.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name test --edition=2015 src/lib.rs [..]--crate-type lib \
         --emit=[..]link[..] \
@@ -892,6 +898,9 @@ fn profile_hint_mostly_unused_warn_without_gate() {
 
             [profile.dev.package.bar]
             hint-mostly-unused = true
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -931,6 +940,9 @@ fn profile_hint_mostly_unused_nightly() {
 
             [profile.dev.package.bar]
             hint-mostly-unused = true
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")

--- a/tests/testsuite/profile_settings.rs
+++ b/tests/testsuite/profile_settings.rs
@@ -29,7 +29,7 @@ fn profile_overrides() {
         .build();
     p.cargo("build -v").with_stderr_data(str![[r#"
 [COMPILING] test v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name test --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..] -C opt-level=1[..] -C debug-assertions=on[..] -C metadata=[..] -C rpath --out-dir [ROOT]/foo/target/debug/build/test/[HASH]/out [..]`
+[RUNNING] `rustc --crate-name test --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..] -C opt-level=1[..] -C debug-assertions=on[..] -C metadata=[..] -C rpath --out-dir [..]`
 [FINISHED] `dev` profile [optimized] target(s) in [ELAPSED]s
 
 "#]]).run();
@@ -56,7 +56,7 @@ fn opt_level_override_0() {
         .build();
     p.cargo("build -v").with_stderr_data(str![[r#"
 [COMPILING] test v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name test --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=2 [..] -C metadata=[..] --out-dir [ROOT]/foo/target/debug/build/test/[HASH]/out`
+[RUNNING] `rustc --crate-name test --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=2 [..] -C metadata=[..] --out-dir [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]]).run();
@@ -82,7 +82,7 @@ fn debug_override_1() {
         .build();
     p.cargo("build -v").with_stderr_data(str![[r#"
 [COMPILING] test v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name test --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=1 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/build/test/[HASH]/out`
+[RUNNING] `rustc --crate-name test --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=1 [..]-C metadata=[..] --out-dir [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]]).run();

--- a/tests/testsuite/pub_priv.rs
+++ b/tests/testsuite/pub_priv.rs
@@ -133,6 +133,9 @@ fn requires_feature() {
 
                 [dependencies]
                 pub_dep = { version = "0.1.0", public = true }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -597,6 +597,9 @@ fn publish_clean() {
                 documentation = "foo"
                 homepage = "foo"
                 repository = "foo"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -645,6 +648,9 @@ fn publish_in_sub_repo() {
                 documentation = "foo"
                 homepage = "foo"
                 repository = "foo"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("bar/src/main.rs", "fn main() {}")
@@ -694,6 +700,9 @@ fn publish_when_ignored() {
                 documentation = "foo"
                 homepage = "foo"
                 repository = "foo"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -744,6 +753,9 @@ fn ignore_when_crate_ignored() {
                 documentation = "foo"
                 homepage = "foo"
                 repository = "foo"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .nocommit_file("bar/src/main.rs", "fn main() {}");
@@ -933,6 +945,9 @@ fn publish_allowed_registry() {
                 homepage = "foo"
                 repository = "foo"
                 publish = ["alternative"]
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -993,6 +1008,9 @@ fn publish_implicitly_to_only_allowed_registry() {
                 homepage = "foo"
                 repository = "foo"
                 publish = ["alternative"]
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -1054,6 +1072,9 @@ fn publish_when_both_publish_and_index_specified() {
                 homepage = "foo"
                 repository = "foo"
                 publish = ["registry"]
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -3914,6 +3935,9 @@ fn workspace_with_local_deps_project() -> Project {
             [dependencies]
             # Let one dependency also specify features, for the added test coverage when generating package files.
             level2 = { workspace = true, features = ["foo"] }
+
+            [lints.cargo]
+            default = "allow"
         "#,
             )
             .file("level1/src/main.rs", "fn main() {}")
@@ -3934,6 +3958,9 @@ fn workspace_with_local_deps_project() -> Project {
 
             [dependencies]
             level3 = { path = "../level3", version = "0.0.1" }
+
+            [lints.cargo]
+            default = "allow"
         "#
             )
             .file("level2/src/lib.rs", "")
@@ -3948,6 +3975,9 @@ fn workspace_with_local_deps_project() -> Project {
             license = "MIT"
             description = "level3"
             repository = "bar"
+
+            [lints.cargo]
+            default = "allow"
         "#,
             )
             .file("level3/src/lib.rs", "")
@@ -4028,6 +4058,9 @@ fn workspace_parallel() {
             license = "MIT"
             description = "a"
             repository = "bar"
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("a/src/lib.rs", "")
@@ -4042,6 +4075,9 @@ fn workspace_parallel() {
             license = "MIT"
             description = "b"
             repository = "bar"
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("b/src/lib.rs", "")
@@ -4060,6 +4096,9 @@ fn workspace_parallel() {
             [dependencies]
             a = { path = "../a", version = "0.0.1" }
             b = { path = "../b", version = "0.0.1" }
+
+            [lints.cargo]
+            default = "allow"
         "#,
         )
         .file("c/src/lib.rs", "")
@@ -4595,6 +4634,9 @@ fn checksum_changed() {
                 [dependencies]
                 dep = { path = "./dep", version = "1.0.0" }
                 transitive = "1.0.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -4605,6 +4647,9 @@ fn checksum_changed() {
                 name = "dep"
                 version = "1.0.0"
                 edition = "2015"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("dep/src/lib.rs", "")

--- a/tests/testsuite/publish_lockfile.rs
+++ b/tests/testsuite/publish_lockfile.rs
@@ -24,6 +24,9 @@ fn pl_manifest(name: &str, version: &str, extra: &str) -> String {
         repository = "foo"
 
         {}
+
+        [lints.cargo]
+        default = "allow"
         "#,
         name, version, extra
     )
@@ -562,6 +565,9 @@ fn use_workspace_root_lockfile() {
 
                 [workspace]
                 members = ["bar"]
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -579,6 +585,9 @@ fn use_workspace_root_lockfile() {
 
                 [dependencies]
                 serde = "0.2"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("bar/src/main.rs", "fn main() {}")

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -86,6 +86,9 @@ fn simple(pre_clean_expected: impl IntoData, post_clean_expected: impl IntoData)
 
                 [dependencies]
                 bar = ">= 0.0.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -149,6 +152,9 @@ fn deps(expected: impl IntoData) {
 
                 [dependencies]
                 bar = ">= 0.0.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -524,6 +530,9 @@ fn update_registry(pre_publish_expected: impl IntoData, post_publish_expected: i
 
                 [dependencies]
                 notyet = ">= 0.0.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -622,6 +631,9 @@ fn package_with_path_deps(
                 [dependencies.notyet]
                 version = "0.0.1"
                 path = "notyet"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -695,6 +707,9 @@ fn lockfile_locks(pre_publish_expected: impl IntoData, post_publish_expected: im
 
                 [dependencies]
                 bar = "*"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -775,6 +790,9 @@ fn lockfile_locks_transitively(
 
                 [dependencies]
                 bar = "*"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -842,6 +860,9 @@ fn yanks_are_not_used(expected: impl IntoData) {
 
                 [dependencies]
                 bar = "*"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -963,6 +984,9 @@ fn yanks_in_lockfiles_are_ok(expected_check: impl IntoData, expected_update: imp
 
                 [dependencies]
                 bar = "*"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -1051,6 +1075,9 @@ fn yanks_in_lockfiles_are_ok_for_other_update(
                 [dependencies]
                 bar = "*"
                 baz = "*"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -1124,6 +1151,9 @@ fn yanks_in_lockfiles_are_ok_with_new_dep(expected: impl IntoData) {
 
                 [dependencies]
                 bar = "*"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -1150,6 +1180,9 @@ fn yanks_in_lockfiles_are_ok_with_new_dep(expected: impl IntoData) {
             [dependencies]
             bar = "*"
             baz = "*"
+
+            [lints.cargo]
+            default = "allow"
         "#,
     );
 
@@ -1192,6 +1225,9 @@ fn update_with_lockfile_if_packages_missing(expected: impl IntoData) {
 
                 [dependencies]
                 bar = "*"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -1320,6 +1356,9 @@ fn update_lockfile(
 
                 [dependencies]
                 bar = "*"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -1406,6 +1445,9 @@ fn dev_dependency_not_used(expected: impl IntoData) {
 
                 [dependencies]
                 bar = "*"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -1540,6 +1582,9 @@ fn updating_a_dep(pre_update_expected: impl IntoData, post_update_expected: impl
 
                 [dependencies.a]
                 path = "a"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -1554,6 +1599,9 @@ fn updating_a_dep(pre_update_expected: impl IntoData, post_update_expected: impl
 
                 [dependencies]
                 bar = "*"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("a/src/lib.rs", "")
@@ -1581,6 +1629,9 @@ fn updating_a_dep(pre_update_expected: impl IntoData, post_update_expected: impl
 
         [dependencies]
         bar = "0.1.0"
+
+        [lints.cargo]
+        default = "allow"
         "#,
     );
     Package::new("bar", "0.1.0").publish();
@@ -1654,6 +1705,9 @@ fn git_and_registry_dep(pre_move_expected: impl IntoData, post_move_expected: im
 
                 [dependencies]
                 a = "0.0.1"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -1674,6 +1728,9 @@ fn git_and_registry_dep(pre_move_expected: impl IntoData, post_move_expected: im
 
                     [dependencies.b]
                     git = '{}'
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 b.url()
             ),
@@ -1733,6 +1790,9 @@ fn update_publish_then_update(expected: impl IntoData) {
 
                 [dependencies]
                 a = "0.1.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -1762,6 +1822,9 @@ fn update_publish_then_update(expected: impl IntoData) {
 
                 [dependencies]
                 a = "0.1.1"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -1882,6 +1945,9 @@ fn update_transitive_dependency(expected_update: impl IntoData, expected_check: 
 
                 [dependencies]
                 a = "0.1.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -2047,6 +2113,9 @@ fn update_multiple_packages(
                 a = "*"
                 b = "*"
                 c = "*"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -2316,6 +2385,9 @@ fn only_download_relevant(expected: impl IntoData) {
                 bar = "*"
                 [dependencies]
                 baz = "*"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -2507,6 +2579,9 @@ fn add_dep_dont_update_registry(expected: impl IntoData) {
 
                 [dependencies]
                 baz = { path = "baz" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -2521,6 +2596,9 @@ fn add_dep_dont_update_registry(expected: impl IntoData) {
 
                 [dependencies]
                 remote = "0.3"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("baz/src/lib.rs", "")
@@ -2542,6 +2620,9 @@ fn add_dep_dont_update_registry(expected: impl IntoData) {
         [dependencies]
         baz = { path = "baz" }
         remote = "0.3"
+
+        [lints.cargo]
+        default = "allow"
         "#,
     );
 
@@ -2580,6 +2661,9 @@ fn bump_version_dont_update_registry(expected: impl IntoData) {
 
                 [dependencies]
                 baz = { path = "baz" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -2594,6 +2678,9 @@ fn bump_version_dont_update_registry(expected: impl IntoData) {
 
                 [dependencies]
                 remote = "0.3"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("baz/src/lib.rs", "")
@@ -2614,6 +2701,9 @@ fn bump_version_dont_update_registry(expected: impl IntoData) {
 
         [dependencies]
         baz = { path = "baz" }
+
+        [lints.cargo]
+        default = "allow"
         "#,
     );
 
@@ -3105,6 +3195,9 @@ fn inaccessible_registry_cache_still_works() {
                 [dependencies]
                 foo = '0.1.0'
                 fo2 = '0.1.0'
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -3487,6 +3580,9 @@ fn reach_max_unpack_size() {
 
                 [dependencies]
                 bar = ">= 0.0.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -3632,6 +3728,9 @@ fn sparse_retry_single() {
 
                 [dependencies]
                 bar = ">= 0.0.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -3927,6 +4026,9 @@ fn retry_too_many_requests() {
 
                 [dependencies]
                 bar = ">= 0.0.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -4519,6 +4621,9 @@ fn differ_only_by_metadata() {
 
                 [dependencies]
                 baz = "=0.0.1"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -4567,6 +4672,9 @@ fn differ_only_by_metadata_with_lockfile() {
 
                 [dependencies]
                 baz = "=0.0.1"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")

--- a/tests/testsuite/registry_auth.rs
+++ b/tests/testsuite/registry_auth.rs
@@ -31,6 +31,9 @@ fn make_project() -> Project {
                 [dependencies.bar]
                 version = "0.0.1"
                 registry = "alternative"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")

--- a/tests/testsuite/registry_overlay.rs
+++ b/tests/testsuite/registry_overlay.rs
@@ -64,6 +64,9 @@ fn registry_version_wins() {
 
                 [dependencies]
                 baz = "0.1.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -106,6 +109,9 @@ fn overlay_version_wins() {
 
                 [dependencies]
                 baz = "0.1.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -147,6 +153,9 @@ fn version_precedence() {
 
                 [dependencies]
                 baz = "0.1.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -222,6 +231,9 @@ fn registry_dep_depends_on_new_local_package() {
                 [dependencies]
                 registry-package = "0.1.0"
                 workspace-package = "0.0.1"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")

--- a/tests/testsuite/rename_deps.rs
+++ b/tests/testsuite/rename_deps.rs
@@ -183,6 +183,9 @@ fn rename_twice() {
                 bar = { version = "0.1", package = "foo" }
                 [build-dependencies]
                 foo = { version = "0.1" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")

--- a/tests/testsuite/replace.rs
+++ b/tests/testsuite/replace.rs
@@ -284,6 +284,9 @@ fn transitive() {
 
                     [replace]
                     "bar:0.1.0" = {{ git = '{}' }}
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 foo.url()
             ),
@@ -507,6 +510,9 @@ fn override_adds_some_deps() {
 
                 [dependencies]
                 baz = "0.1"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -528,6 +534,9 @@ fn override_adds_some_deps() {
 
                     [replace]
                     "bar:0.1.0" = {{ git = '{}' }}
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 foo.url()
             ),
@@ -604,6 +613,9 @@ fn locked_means_locked_yes_no_seriously_i_mean_locked() {
 
                 [dependencies]
                 baz = "*"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -626,6 +638,9 @@ fn locked_means_locked_yes_no_seriously_i_mean_locked() {
 
                     [replace]
                     "bar:0.1.0" = {{ git = '{}' }}
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 foo.url()
             ),
@@ -1098,6 +1113,9 @@ fn overriding_nonexistent_no_spurious() {
 
                 [dependencies]
                 baz = { path = "baz" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "pub fn bar() {}")
@@ -1122,6 +1140,9 @@ fn overriding_nonexistent_no_spurious() {
                     [replace]
                     "bar:0.1.0" = {{ git = '{url}' }}
                     "baz:0.1.0" = {{ git = '{url}' }}
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 url = bar.url()
             ),
@@ -1166,6 +1187,9 @@ fn no_warnings_when_replace_is_used_in_another_workspace_member() {
 
                 [dependencies]
                 bar = "0.1.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("first_crate/src/lib.rs", "")
@@ -1535,6 +1559,9 @@ fn yanked_candidates_are_skipped() {
 
                 [replace]
                 "bar:1.0.0" = { path = "../bar" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")

--- a/tests/testsuite/required_features.rs
+++ b/tests/testsuite/required_features.rs
@@ -861,6 +861,9 @@ fn install_multiple_required_features() {
                 name = "foo_4"
                 path = "src/foo_4.rs"
                 required-features = ["a"]
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/foo_1.rs", "fn main() {}")
@@ -1286,6 +1289,9 @@ fn test_skips_compiling_bin_with_missing_required_features() {
                 name = "bin_foo"
                 path = "src/bin/foo.rs"
                 required-features = ["a"]
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/bin/foo.rs", "extern crate bar; fn main() {}")

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -1105,9 +1105,9 @@ fn example_with_release_flag() {
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
-[RUNNING] `rustc --crate-name bar --edition=2015 bar/src/bar.rs [..]--crate-type lib --emit=[..]link[..] -C opt-level=3[..] -C metadata=[..] --out-dir [ROOT]/foo/target/release/build/bar/[HASH]/out -C strip=debuginfo`
+[RUNNING] `rustc --crate-name bar --edition=2015 bar/src/bar.rs [..]--crate-type lib --emit=[..]link[..] -C opt-level=3[..] -C metadata=[..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name a --edition=2015 examples/a.rs [..]--crate-type bin --emit=[..]link[..] -C opt-level=3[..] -C metadata=[..] --out-dir [ROOT]/foo/target/release/build/foo/[HASH]/out -C strip=debuginfo -L dependency=[ROOT]/foo/target/release/build/bar/[HASH]/out --extern bar=[ROOT]/foo/target/release/build/bar/[HASH]/out/libbar-[HASH].rlib[..]`
+[RUNNING] `rustc --crate-name a --edition=2015 examples/a.rs [..]--crate-type bin --emit=[..]link[..] -C opt-level=3[..] -C metadata=[..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 [RUNNING] `target/release/examples/a[EXE]`
 
@@ -1122,9 +1122,9 @@ fast2
     p.cargo("run -v --example a")
         .with_stderr_data(str![[r#"
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
-[RUNNING] `rustc --crate-name bar --edition=2015 bar/src/bar.rs [..]--crate-type lib --emit=[..]link [..]-C debuginfo=2 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/build/bar/[HASH]/out`
+[RUNNING] `rustc --crate-name bar --edition=2015 bar/src/bar.rs [..]--crate-type lib --emit=[..]link [..]-C debuginfo=2 [..]-C metadata=[..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name a --edition=2015 examples/a.rs [..]--crate-type bin --emit=[..]link [..]-C debuginfo=2 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/bar/[HASH]/out --extern bar=[ROOT]/foo/target/debug/build/bar/[HASH]/out/libbar-[HASH].rlib[..]`
+[RUNNING] `rustc --crate-name a --edition=2015 examples/a.rs [..]--crate-type bin --emit=[..]link [..]-C debuginfo=2 [..]-C metadata=[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `target/debug/examples/a[EXE]`
 

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -17,7 +17,7 @@ fn build_lib_for_foo() {
 
     p.cargo("rustc --lib -v").with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=2 [..]-C metadata=[..] [..]--out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out`
+[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=2 [..]-C metadata=[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]]).run();
@@ -33,7 +33,7 @@ fn lib() {
     p.cargo("rustc --lib -v -- -C debug-assertions=off")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=2 [..]-C metadata=[..] [..]--out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out[..]-C debug-assertions=off[..]`
+[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=2 [..]-C metadata=[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -50,8 +50,8 @@ fn build_main_and_allow_unstable_options() {
     p.cargo("rustc -v --bin foo -- -C debug-assertions")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=2 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out`
-[RUNNING] `rustc --crate-name foo --edition=2015 src/main.rs [..]--crate-type bin --emit=[..]link[..]-C debuginfo=2 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/foo/[HASH]/out --extern foo=[ROOT]/foo/target/debug/build/foo/[HASH]/out/libfoo-[HASH].rlib[..]-C debug-assertions[..]`
+[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=2 [..]-C metadata=[..]`
+[RUNNING] `rustc --crate-name foo --edition=2015 src/main.rs [..]--crate-type bin --emit=[..]link[..]-C debuginfo=2 [..]-C metadata=[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -870,7 +870,7 @@ fn precedence() {
         .env("RUSTFLAGS", "--cfg from_rustflags")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustc [..]-C strip=debuginfo [..]--cfg cargo_rustc -C strip=symbols --cfg from_rustflags`
+[RUNNING] `rustc [..]-C strip=debuginfo [..]--cfg cargo_rustc -C strip=symbols --cfg from_rustflags[..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 
 "#]])

--- a/tests/testsuite/rustdocflags.rs
+++ b/tests/testsuite/rustdocflags.rs
@@ -178,7 +178,7 @@ fn not_affected_by_target_rustflags() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 ...
-[RUNNING] `rustc [..] -D missing-docs`
+[RUNNING] `rustc [..] -D missing-docs[..]`
 ...
 "#]])
         .run();

--- a/tests/testsuite/rustflags.rs
+++ b/tests/testsuite/rustflags.rs
@@ -1166,7 +1166,7 @@ fn cfg_rustflags_normal_source() {
     p.cargo("build --lib -v")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo [..] --cfg bar`
+[RUNNING] `rustc --crate-name foo [..] --cfg bar[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -1175,7 +1175,7 @@ fn cfg_rustflags_normal_source() {
     p.cargo("build --bin=a -v")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name a [..] --cfg bar`
+[RUNNING] `rustc --crate-name a [..] --cfg bar[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -1184,7 +1184,7 @@ fn cfg_rustflags_normal_source() {
     p.cargo("build --example=b -v")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name b [..] --cfg bar`
+[RUNNING] `rustc --crate-name b [..] --cfg bar[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -1193,9 +1193,9 @@ fn cfg_rustflags_normal_source() {
     p.cargo("test --no-run -v")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc [..] --cfg bar`
-[RUNNING] `rustc [..] --cfg bar`
-[RUNNING] `rustc [..] --cfg bar`
+[RUNNING] `rustc [..] --cfg bar[..]`
+[RUNNING] `rustc [..] --cfg bar[..]`
+[RUNNING] `rustc [..] --cfg bar[..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
 [EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/a-[HASH][EXE]`
@@ -1207,9 +1207,9 @@ fn cfg_rustflags_normal_source() {
     p.cargo("bench --no-run -v")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc [..] --cfg bar`
-[RUNNING] `rustc [..] --cfg bar`
-[RUNNING] `rustc [..] --cfg bar`
+[RUNNING] `rustc [..] --cfg bar[..]`
+[RUNNING] `rustc [..] --cfg bar[..]`
+[RUNNING] `rustc [..] --cfg bar[..]`
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
 [EXECUTABLE] `[ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE]`
 [EXECUTABLE] `[ROOT]/foo/target/release/build/foo/[HASH]/out/a-[HASH][EXE]`
@@ -1248,7 +1248,7 @@ fn cfg_rustflags_precedence() {
     p.cargo("build --lib -v")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo [..] --cfg bar`
+[RUNNING] `rustc --crate-name foo [..] --cfg bar[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -1257,7 +1257,7 @@ fn cfg_rustflags_precedence() {
     p.cargo("build --bin=a -v")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name a [..] --cfg bar`
+[RUNNING] `rustc --crate-name a [..] --cfg bar[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -1266,7 +1266,7 @@ fn cfg_rustflags_precedence() {
     p.cargo("build --example=b -v")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name b [..] --cfg bar`
+[RUNNING] `rustc --crate-name b [..] --cfg bar[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -1275,9 +1275,9 @@ fn cfg_rustflags_precedence() {
     p.cargo("test --no-run -v")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc [..] --cfg bar`
-[RUNNING] `rustc [..] --cfg bar`
-[RUNNING] `rustc [..] --cfg bar`
+[RUNNING] `rustc [..] --cfg bar[..]`
+[RUNNING] `rustc [..] --cfg bar[..]`
+[RUNNING] `rustc [..] --cfg bar[..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
 [EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/a-[HASH][EXE]`
@@ -1289,9 +1289,9 @@ fn cfg_rustflags_precedence() {
     p.cargo("bench --no-run -v")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc [..] --cfg bar`
-[RUNNING] `rustc [..] --cfg bar`
-[RUNNING] `rustc [..] --cfg bar`
+[RUNNING] `rustc [..] --cfg bar[..]`
+[RUNNING] `rustc [..] --cfg bar[..]`
+[RUNNING] `rustc [..] --cfg bar[..]`
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
 [EXECUTABLE] `[ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE]`
 [EXECUTABLE] `[ROOT]/foo/target/release/build/foo/[HASH]/out/a-[HASH][EXE]`
@@ -1316,7 +1316,7 @@ fn target_rustflags_string_and_array_form1() {
     p1.cargo("check -v")
         .with_stderr_data(str![[r#"
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo [..] --cfg foo`
+[RUNNING] `rustc --crate-name foo [..] --cfg foo[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -1336,7 +1336,7 @@ fn target_rustflags_string_and_array_form1() {
     p2.cargo("check -v")
         .with_stderr_data(str![[r#"
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo [..] --cfg foo`
+[RUNNING] `rustc --crate-name foo [..] --cfg foo[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -1362,7 +1362,7 @@ fn target_rustflags_string_and_array_form2() {
     p1.cargo("check -v")
         .with_stderr_data(str![[r#"
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo [..] --cfg foo`
+[RUNNING] `rustc --crate-name foo [..] --cfg foo[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -1385,7 +1385,7 @@ fn target_rustflags_string_and_array_form2() {
     p2.cargo("check -v")
         .with_stderr_data(str![[r#"
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo [..] --cfg foo`
+[RUNNING] `rustc --crate-name foo [..] --cfg foo[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])

--- a/tests/testsuite/rustflags.rs
+++ b/tests/testsuite/rustflags.rs
@@ -1750,6 +1750,9 @@ fn host_config_shared_build_dep() {
 
             [profile.dev]
             debug = 0
+
+            [lints.cargo]
+            default = "allow"
             "#,
         )
         .file("src/lib.rs", "")

--- a/tests/testsuite/script/cargo.rs
+++ b/tests/testsuite/script/cargo.rs
@@ -613,6 +613,7 @@ args: []
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
 [HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/s-h.w§c!.rs`
+...
 [COMPILING] s-h-w-c- v0.0.0 ([ROOT]/foo/s-h.w§c!.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `[ROOT]/home/.cargo/build/[HASH]/target/debug/s-h-w-c-[EXE]`
@@ -927,6 +928,9 @@ fn test_name_same_as_dependency() {
 ---
 [dependencies]
 script = "1.0.0"
+
+[lints.cargo]
+default = "allow"
 ---
 
 fn main() {
@@ -964,6 +968,9 @@ fn test_path_dep() {
 ---
 [dependencies]
 bar.path = "./bar"
+
+[lints.cargo]
+default = "allow"
 ---
 
 fn main() {

--- a/tests/testsuite/source_replacement.rs
+++ b/tests/testsuite/source_replacement.rs
@@ -197,6 +197,9 @@ fn publish_with_replacement() {
 
                 [dependencies]
                 bar = "1.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -277,6 +280,9 @@ fn source_replacement_with_registry_url() {
                 edition = "2015"
                 [dependencies.bar]
                 version = "0.0.1"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -584,6 +584,9 @@ fn test_with_deep_lib_dep() {
 
                 [dependencies.bar]
                 path = "../bar"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file(

--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -1393,6 +1393,9 @@ fn git_complex() {
 
                 [dependencies]
                 dep_b = { path = 'dep_b' }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -1413,6 +1416,9 @@ fn git_complex() {
                     [dependencies]
                     b = {{ git = '{}' }}
                     dep_a = {{ path = 'dep_a' }}
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 git_b.url()
             ),
@@ -1434,6 +1440,9 @@ fn git_complex() {
 
                     [dependencies]
                     a = {{ git = '{}' }}
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 git_a.url()
             ),
@@ -1749,6 +1758,9 @@ fn config_instructions_works() {
                 dep = "0.1"
                 altdep = {{version="0.1", registry="alternative"}}
                 gitdep = {{git='{}'}}
+
+                [lints.cargo]
+                default = "allow"
                 "#,
                 git_project.url()
             ),
@@ -1908,6 +1920,9 @@ fn vendor_crate_with_ws_inherit() {
                 name = "bar"
                 version.workspace = true
                 edition = "2021"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("bar/src/lib.rs", "")
@@ -1925,6 +1940,9 @@ fn vendor_crate_with_ws_inherit() {
 
                     [dependencies]
                     bar = {{ git = '{}' }}
+
+                    [lints.cargo]
+                    default = "allow"
                 "#,
                 git.url()
             ),

--- a/tests/testsuite/warn_on_failure.rs
+++ b/tests/testsuite/warn_on_failure.rs
@@ -18,6 +18,9 @@ fn make_lib(lib_src: &str) {
                 version = "0.0.1"
                 edition = "2015"
                 build = "build.rs"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file(
@@ -52,6 +55,9 @@ fn make_upstream(main_src: &str) -> Project {
 
                 [dependencies]
                 bar = "*"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", &format!("fn main() {{ {} }}", main_src))

--- a/tests/testsuite/warning_override.rs
+++ b/tests/testsuite/warning_override.rs
@@ -255,8 +255,7 @@ fn lint_parse_pass() {
         .build();
 
     // Verify the lints fire
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [WARNING] `package.homepage` is redundant with `package.repository`
  --> Cargo.toml:8:24
@@ -272,8 +271,7 @@ fn lint_parse_pass() {
 
 "#]])
         .run();
-    p.cargo("check -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check")
         .with_stderr_data(str![[r#"
 [WARNING] `package.homepage` is redundant with `package.repository`
  --> Cargo.toml:8:24
@@ -292,14 +290,12 @@ fn lint_parse_pass() {
 "#]])
         .run();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("fetch")
         .arg("--config")
         .arg("build.warnings='allow'")
         .with_stderr_data(str![""])
         .run();
-    p.cargo("check -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check")
         .arg("--config")
         .arg("build.warnings='allow'")
         .with_stderr_data(str![[r#"
@@ -308,8 +304,7 @@ fn lint_parse_pass() {
 "#]])
         .run();
 
-    p.cargo("fetch -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("fetch")
         .arg("--config")
         .arg("build.warnings='deny'")
         .with_status(101)
@@ -329,8 +324,7 @@ fn lint_parse_pass() {
 
 "#]])
         .run();
-    p.cargo("check -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check")
         .arg("--config")
         .arg("build.warnings='deny'")
         .with_status(101)
@@ -384,8 +378,7 @@ fn lint_build_result_pass() {
         .build();
 
     // Verify the lints fire
-    p.cargo("check --all-targets -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check --all-targets")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to highest compatible version
@@ -407,8 +400,7 @@ fn lint_build_result_pass() {
 "#]])
         .run();
 
-    p.cargo("check --all-targets -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check --all-targets")
         .arg("--config")
         .arg("build.warnings='allow'")
         .with_stderr_data(str![[r#"
@@ -417,8 +409,7 @@ fn lint_build_result_pass() {
 "#]])
         .run();
 
-    p.cargo("check --all-targets -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["cargo-lints"])
+    p.cargo("check --all-targets")
         .arg("--config")
         .arg("build.warnings='deny'")
         .with_status(101)
@@ -620,6 +611,9 @@ fn cap_lints_deny() {
 
                 [dependencies]
                 has_warning = "1"
+
+                [lints.cargo]
+                default = "allow"
             "#
             ),
         )
@@ -695,6 +689,9 @@ fn cap_lints_allow() {
 
                 [dependencies]
                 has_warning = "1"
+
+                [lints.cargo]
+                default = "allow"
             "#
             ),
         )

--- a/tests/testsuite/weak_dep_features.rs
+++ b/tests/testsuite/weak_dep_features.rs
@@ -44,6 +44,9 @@ fn simple() {
 
                 [features]
                 f1 = ["bar?/feat"]
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", &require(&["f1"], &[]))
@@ -100,6 +103,9 @@ fn deferred() {
                 [dependencies]
                 dep = { version = "1.0", features = ["feat"] }
                 bar_activator = "1.0"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -182,6 +188,9 @@ fn optional_cli_syntax() {
 
                 [dependencies]
                 bar = { version = "1.0", optional = true }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", "")
@@ -397,6 +406,9 @@ fn weak_namespaced() {
                 [features]
                 f1 = ["bar?/feat"]
                 f2 = ["dep:bar"]
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/lib.rs", &require(&["f1"], &["f2", "bar"]))

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -674,6 +674,9 @@ fn share_dependencies() {
 
                 [workspace]
                 members = ["bar"]
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -688,6 +691,9 @@ fn share_dependencies() {
 
                 [dependencies]
                 dep1 = "< 0.1.5"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("bar/src/main.rs", "fn main() {}");
@@ -774,6 +780,9 @@ fn lock_works_for_everyone() {
 
                 [workspace]
                 members = ["bar"]
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -788,6 +797,9 @@ fn lock_works_for_everyone() {
 
                 [dependencies]
                 dep1 = "0.1"
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("bar/src/main.rs", "fn main() {}");
@@ -2020,6 +2032,9 @@ fn dep_used_with_separate_features() {
 
                 [features]
                 myfeature = []
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("feat_lib/src/lib.rs", "")
@@ -2034,6 +2049,9 @@ fn dep_used_with_separate_features() {
 
                 [dependencies]
                 feat_lib = { path = "../feat_lib" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("caller1/src/main.rs", "fn main() {}")
@@ -2050,6 +2068,9 @@ fn dep_used_with_separate_features() {
                 [dependencies]
                 feat_lib = { path = "../feat_lib", features = ["myfeature"] }
                 caller1 = { path = "../caller1" }
+
+                [lints.cargo]
+                default = "allow"
             "#,
         )
         .file("caller2/src/main.rs", "fn main() {}")


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/cargo/pull/17298)*

### What does this PR try to resolve?

Fixes #12235

Unstable feature docs: https://doc.rust-lang.org/stable/cargo/reference/unstable.html#lintscargo

We are adding a linting system to workspaces and packages controlled by `[lints.cargo]`.

As the presence of `[lints.cargo]` was a hard error before 1.79, by-default warn/deny lints are ignored when `package.rust-version` is set below that.

Workspace lints are controlled by `[workspace.lints]` if present, otherwise `[lints]`. This was inspired by `workspace.resolver`.
The rust-version used for the workspace is the lowest among the workspace members.

In vetting the design, we have a fully general parse-pass that runs during build operations as well as `cargo fetxh` (matching deferred warnings and errors from manifest parsing). We also have a one-off lint that runs against the completed build units.

The initial batch of lints being stabilized is documented at https://doc.rust-lang.org/nightly/cargo/reference/lints.html

For more on the behavior of these lints, see https://github.com/rust-lang/cargo/tree/master/tests/testsuite/lints

Relevant docs:
- [lint naming rules](https://rustc-dev-guide.rust-lang.org/diagnostics.html#lint-naming)
- [lint group (and by extension, level)](https://doc.rust-lang.org/clippy/)
- [diagnostic structure](https://rustc-dev-guide.rust-lang.org/diagnostics.html#lint-naming)
- https://doc.rust-lang.org/clippy/development/adding_lints.html#pr-checklist

### How to test and review this PR?

At [#t-cargo > Last items for linting system: &#96;unused_dependencies&#96;](https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/Last.20items.20for.20linting.20system.3A.20.60unused_dependencies.60/with/613764963), I raised concern over `unused_dependencies` name in case we want to add other kinds of unused dependencies (like artifacts) as separate lints. No one expressed interest in that, so I kept it as a general lint name. I didn't add `package` to the name since our existing dept tables don't have that and the intent is likely clear.