### PR TITLE
Remove redundant else in matches_prerelease

### DIFF
--- a/src/util/semver_ext.rs
+++ b/src/util/semver_ext.rs
@@ -134,9 +134,8 @@ impl OptVersionReq {
     pub fn matches_prerelease(&self, version: &Version) -> bool {
         if let OptVersionReq::Req(req) = self {
             return req.matches_prerelease(version);
-        } else {
-            return self.matches(version);
         }
+        self.matches(version)
     }
 
     pub fn matches(&self, version: &Version) -> bool {


### PR DESCRIPTION
## What does this PR try to resolve?

Remove the redundant `else` block

This addresses `clippy::redundant_else` and `clippy::needless_return`.

## How should we test and review this PR?

The control flow remains the same. No behavior change.