### PR TITLE
Add a suggestion when adding `[lints]` to a workspace to use `[workspace.lints]` instead

### DIFF
--- a/src/workspace/parser/mod.rs
+++ b/src/workspace/parser/mod.rs
@@ -582,7 +582,14 @@ fn normalize_toml(
         normalized_toml.badges = original_toml.badges.clone();
     } else {
         if let Some(field) = original_toml.requires_package().next() {
-            bail!("this virtual manifest specifies a `{field}` section, which is not allowed");
+            let suggestion = if field == "lints" {
+                "\nhelp: a similar field exists: `[workspace.lints]`"
+            } else {
+                ""
+            };
+            bail!(
+                "this virtual manifest specifies a `{field}` section, which is not allowed{suggestion}"
+            );
         }
     }
 

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -2345,7 +2345,6 @@ fn ws_err_unused() {
         "[features]",
         "[target]",
         "[badges]",
-        "[lints]",
     ] {
         let key = table.trim_start_matches('[').trim_end_matches(']');
         let p = project()
@@ -2379,7 +2378,20 @@ Caused by:
 
 #[cargo_test]
 fn ws_err_unused_similar_suggest() {
-    let cases: &[(&str, &str)] = &[];
+    let cases: &[(&str, &str)] = &[
+        (
+            "[lints]",
+            "[HELP] a similar field exists: `[workspace.lints]`",
+        ),
+        (
+            "[lints.rust]",
+            "[HELP] a similar field exists: `[workspace.lints]`",
+        ),
+        (
+            "[lints.clippy]",
+            "[HELP] a similar field exists: `[workspace.lints]`",
+        ),
+    ];
     for (table, suggestion) in cases {
         let key = table.trim_start_matches('[').trim_end_matches(']');
         let key = key.split_once('.').map(|p| p.0).unwrap_or(key);

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -2378,6 +2378,42 @@ Caused by:
 }
 
 #[cargo_test]
+fn ws_err_unused_similar_suggest() {
+    let cases: &[(&str, &str)] = &[];
+    for (table, suggestion) in cases {
+        let key = table.trim_start_matches('[').trim_end_matches(']');
+        let key = key.split_once('.').map(|p| p.0).unwrap_or(key);
+        let p = project()
+            .file(
+                "Cargo.toml",
+                &format!(
+                    r#"
+                    [workspace]
+                    members = ["a"]
+
+                    {table}
+                    "#,
+                ),
+            )
+            .file("a/Cargo.toml", &basic_lib_manifest("a"))
+            .file("a/src/lib.rs", "")
+            .build();
+        p.cargo("check")
+            .with_status(101)
+            .with_stderr_data(&format!(
+                "\
+[ERROR] failed to parse manifest at `[..]/foo/Cargo.toml`
+
+Caused by:
+  this virtual manifest specifies a `{key}` section, which is not allowed
+  {suggestion}
+",
+            ))
+            .run();
+    }
+}
+
+#[cargo_test]
 fn ws_warn_unused() {
     for (key, name) in &[
         ("[profile.dev]\nopt-level = 1", "profiles"),


### PR DESCRIPTION
### What does this PR try to resolve?

A minor nitpick involving lints. If you add a `[lints.<something>]` table to a workspace's Cargo.toml, cargo will reject it outright when `[workspace.lints.<something>]` would have worked as the user (me :sweat_smile:) probably expected.

### How to test and review this PR?

I added a test case (also generalized for any future similar changes, I hope cargo's multi-project functionality gets better over time \:3) and updated the previous test case to exclude this specific change.

in short, `cargo test ws_err_similar_suggest,ws_err_unused` should pass.