### PR TITLE
Avoid parsing unchanged lockfiles

### DIFF
--- a/src/ops/lockfile.rs
+++ b/src/ops/lockfile.rs
@@ -208,6 +208,11 @@ fn serialize_resolve(resolve: &Resolve, orig: Option<&str>) -> String {
 
 #[tracing::instrument(skip_all)]
 fn are_equal_lockfiles(orig: &str, current: &str, ws: &Workspace<'_>) -> bool {
+    // Avoid deserializing lockfiles when their contents already match.
+    if orig.lines().eq(current.lines()) {
+        return true;
+    }
+
     // If we want to try and avoid updating the lock file, parse both and
     // compare them; since this is somewhat expensive, don't do it in the
     // common case where we can update lock files.
@@ -222,7 +227,7 @@ fn are_equal_lockfiles(orig: &str, current: &str, ws: &Workspace<'_>) -> bool {
         }
     }
 
-    orig.lines().eq(current.lines())
+    false
 }
 
 fn emit_package(dep: &toml::Table, out: &mut String) {


### PR DESCRIPTION
### What does this PR try to resolve?

Previously, checking an unchanged lockfile with `--locked` or `--frozen` deserialized both lockfiles and rebuilt their resolution graphs before checking whether their contents already matched. For large workspaces, this repeats expensive work on the common unchanged-lockfile path.

This PR moves the existing line-by-line equality check ahead of the semantic comparison. The existing line-ending behavior is preserved, and differing lockfiles still fall back to the full deserialization and resolution comparison.

On my M4, with 15 interleaved runs of `cargo metadata --offline --locked --format-version 1` per workspace:

| Workspace | Before | After | Improvement |
| --------- | -----: | ----: | ----------: |
| Cargo     | 157.209 ms | 152.477 ms | 3.01% |
| Ruff      | 161.157 ms | 156.841 ms | 2.68% |
| uv        | 208.884 ms | 201.747 ms | 3.42% |
| Codex     | 458.177 ms | 442.278 ms | 3.47% |

### How to test and review this PR?

The change only reorders the existing equality checks. All 24 lockfile compatibility integration tests pass, including coverage for frozen lockfile preservation and `--locked` errors.
