### PR TITLE
refactor: Remove unnecessary mut in sources

### DIFF
--- a/src/ops/cargo_add/mod.rs
+++ b/src/ops/cargo_add/mod.rs
@@ -380,7 +380,7 @@ fn resolve_dependency(
             }
             selected
         } else {
-            let mut source = crate::sources::GitSource::new(src.source_id()?, gctx)?;
+            let source = crate::sources::GitSource::new(src.source_id()?, gctx)?;
             let packages = source.read_packages()?;
             let package = infer_package_for_git_source(packages, &src)?;
             Dependency::from(package.summary())
@@ -417,7 +417,7 @@ fn resolve_dependency(
             }
             selected
         } else {
-            let mut source = crate::sources::PathSource::new(&src.path, src.source_id()?, gctx);
+            let source = crate::sources::PathSource::new(&src.path, src.source_id()?, gctx);
             let package = source.root_package()?;
             let mut selected = Dependency::from(package.summary());
             if let Some(Source::Path(selected_src)) = &mut selected.source {

--- a/src/ops/cargo_package/verify.rs
+++ b/src/ops/cargo_package/verify.rs
@@ -62,7 +62,7 @@ pub fn run_verify(
     // Manufacture an ephemeral workspace to ensure that even if the top-level
     // package has a workspace we can still build our new crate.
     let id = SourceId::for_path(&dst)?;
-    let mut src = PathSource::new(&dst, id, ws.gctx());
+    let src = PathSource::new(&dst, id, ws.gctx());
     let new_pkg = src.root_package()?;
     let pkg_fingerprint = hash_all(&dst)?;
 

--- a/src/resolver/errors.rs
+++ b/src/resolver/errors.rs
@@ -611,7 +611,7 @@ fn alt_paths(
         return None;
     }
     let source_id = dep.source_id();
-    let mut source = RecursivePathSource::new(&path, source_id, gctx);
+    let source = RecursivePathSource::new(&path, source_id, gctx);
     let packages = source.read_packages().ok()?;
     if packages.is_empty() {
         None

--- a/src/sources/directory.rs
+++ b/src/sources/directory.rs
@@ -133,7 +133,7 @@ impl<'gctx> DirectorySource<'gctx> {
                 continue;
             }
 
-            let mut src = PathSource::new(&path, self.source_id, self.gctx);
+            let src = PathSource::new(&path, self.source_id, self.gctx);
             src.load()?;
             let mut pkg = src.root_package()?;
 

--- a/src/sources/git/source.rs
+++ b/src/sources/git/source.rs
@@ -158,16 +158,12 @@ impl<'gctx> GitSource<'gctx> {
     /// Returns the packages discovered by this source. It may fetch the Git
     /// repository as well as walk the filesystem if package information
     /// haven't yet updated.
-    pub fn read_packages(&mut self) -> CargoResult<Vec<Package>> {
+    pub fn read_packages(&self) -> CargoResult<Vec<Package>> {
         if self.path_source.borrow().is_none() {
             self.invalidate_cache();
             self.update()?;
         }
-        self.path_source
-            .borrow_mut()
-            .as_mut()
-            .unwrap()
-            .read_packages()
+        self.path_source.borrow().as_ref().unwrap().read_packages()
     }
 
     fn mark_used(&self) -> CargoResult<()> {

--- a/src/sources/git/utils.rs
+++ b/src/sources/git/utils.rs
@@ -1144,7 +1144,7 @@ fn has_shallow_lock_file(err: &crate::sources::git::fetch::Error) -> bool {
 /// [1]: https://doc.rust-lang.org/nightly/cargo/reference/config.html#netgit-fetch-with-cli
 #[tracing::instrument(skip(repo, gctx))]
 fn fetch_with_cli(
-    repo: &mut git2::Repository,
+    repo: &git2::Repository,
     url: &str,
     refspecs: &[String],
     tags: bool,
@@ -1581,7 +1581,7 @@ enum FastPathRev {
 /// [^1]: <https://developer.github.com/v3/repos/commits/#get-the-sha-1-of-a-commit-reference>
 #[tracing::instrument(skip(repo, gctx))]
 fn github_fast_path(
-    repo: &mut git2::Repository,
+    repo: &git2::Repository,
     url: &str,
     reference: &GitReference,
     gctx: &GlobalContext,
@@ -1744,14 +1744,14 @@ mod tests {
     #[test]
     fn github_fast_path_full_hash_returns_needs_fetch() {
         let temp_dir = tempfile::TempDir::new().unwrap();
-        let mut repo = git2::Repository::init_bare(temp_dir.path()).unwrap();
+        let repo = git2::Repository::init_bare(temp_dir.path()).unwrap();
         let full_hash = "c9040898c9183ddbb9402dcbf749ed06d6ea90ad";
         let reference = GitReference::Rev(full_hash.to_string());
         let gctx = GlobalContext::default().unwrap();
         let expected_oid = rev_to_oid(full_hash).unwrap();
 
         let result =
-            github_fast_path(&mut repo, "https://github.com/user/repo", &reference, &gctx).unwrap();
+            github_fast_path(&repo, "https://github.com/user/repo", &reference, &gctx).unwrap();
 
         assert!(matches!(result, FastPathRev::NeedsFetch(oid) if oid == expected_oid));
     }

--- a/src/sources/path.rs
+++ b/src/sources/path.rs
@@ -69,7 +69,7 @@ impl<'gctx> PathSource<'gctx> {
     }
 
     /// Returns the root package, or an error if it is missing or failed to load.
-    pub fn root_package(&mut self) -> CargoResult<Package> {
+    pub fn root_package(&self) -> CargoResult<Package> {
         trace!("root_package; source={:?}", self);
 
         self.load()?;
@@ -258,7 +258,7 @@ impl<'gctx> RecursivePathSource<'gctx> {
 
     /// Returns the packages discovered by this source. It may walk the
     /// filesystem if package information haven't yet loaded.
-    pub fn read_packages(&mut self) -> CargoResult<Vec<Package>> {
+    pub fn read_packages(&self) -> CargoResult<Vec<Package>> {
         self.load()?;
         Ok(self
             .packages


### PR DESCRIPTION
### What does this PR try to resolve?

This PR is split out from a WIP PR - I found that many of the methods in `src/sources/` take a mutable reference, which is unnecessary as they often use interior mutability.

### How to test and review this PR?

There should be no behavioural changes with this PR, and the normal test suite is enough to verify that it's safe.
