### PR TITLE
fix(git): Avoid use of git's core.fsmonitor

### DIFF
--- a/src/sources/git/utils.rs
+++ b/src/sources/git/utils.rs
@@ -1154,6 +1154,9 @@ fn fetch_with_cli(
     debug!(target: "git-fetch", backend = "git-cli");
 
     let mut cmd = ProcessBuilder::new("git");
+    // Avoid potential for unused work that may also hang (#15775)
+    cmd.arg("-c").arg("core.fsmonitor=false");
+
     cmd.arg("fetch");
     if tags {
         cmd.arg("--tags");

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -3090,7 +3090,7 @@ fn use_the_cli() {
 
     let stderr = str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep1`
-[RUNNING] `git fetch --no-tags --verbose --force --update-head-ok [..][ROOTURL]/dep1[..] [..]+HEAD:refs/remotes/origin/HEAD[..]`
+[RUNNING] `git -c core.fsmonitor=false fetch --no-tags --verbose --force --update-head-ok [..][ROOTURL]/dep1[..] [..]+HEAD:refs/remotes/origin/HEAD[..]`
 From [ROOTURL]/dep1
  * [new ref] [..] -> origin/HEAD[..]
 [LOCKING] 1 package to latest compatible version
@@ -3374,7 +3374,7 @@ Caused by:
   failed to clone into: [ROOT]/home/.cargo/git/db/missing-[HASH]
 
 Caused by:
-  process didn't exit successfully: `git fetch [..]` ([EXIT_STATUS]: 128)
+  process didn't exit successfully: `git -c core.fsmonitor=false fetch [..]` ([EXIT_STATUS]: 128)
 
   [HELP] re-try with `net.git-fetch-with-cli = false` to see if it resolves the problem
   https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
@@ -3531,17 +3531,17 @@ fn git_cli_arg_injection_via_branch() {
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep1`
 fatal: couldn't find remote ref refs/heads/-u./payload
-[WARNING] spurious network error (3 tries remaining): process didn't exit successfully: `git fetch [..]` ([EXIT_STATUS]: 128)
+[WARNING] spurious network error (3 tries remaining): process didn't exit successfully: `git -c core.fsmonitor=false fetch [..]` ([EXIT_STATUS]: 128)
 
 [HELP] re-try with `net.git-fetch-with-cli = false` to see if it resolves the problem
 https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
 fatal: couldn't find remote ref refs/heads/-u./payload
-[WARNING] spurious network error (2 tries remaining): process didn't exit successfully: `git fetch [..]` ([EXIT_STATUS]: 128)
+[WARNING] spurious network error (2 tries remaining): process didn't exit successfully: `git -c core.fsmonitor=false fetch [..]` ([EXIT_STATUS]: 128)
 
 [HELP] re-try with `net.git-fetch-with-cli = false` to see if it resolves the problem
 https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
 fatal: couldn't find remote ref refs/heads/-u./payload
-[WARNING] spurious network error (1 try remaining): process didn't exit successfully: `git fetch [..]` ([EXIT_STATUS]: 128)
+[WARNING] spurious network error (1 try remaining): process didn't exit successfully: `git -c core.fsmonitor=false fetch [..]` ([EXIT_STATUS]: 128)
 
 [HELP] re-try with `net.git-fetch-with-cli = false` to see if it resolves the problem
 https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
@@ -3558,7 +3558,7 @@ Caused by:
   failed to clone into: [ROOT]/home/.cargo/git/db/dep1-[HASH]
 
 Caused by:
-  process didn't exit successfully: `git fetch [..]` ([EXIT_STATUS]: 128)
+  process didn't exit successfully: `git -c core.fsmonitor=false fetch [..]` ([EXIT_STATUS]: 128)
 
   [HELP] re-try with `net.git-fetch-with-cli = false` to see if it resolves the problem
   https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
@@ -4529,17 +4529,17 @@ fn github_fastpath_error_message() {
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `https://github.com/rust-lang/bitflags.git`
 fatal: remote [ERROR] upload-pack: not our ref 11111b376b93484341c68fbca3ca110ae5cd2790
-[WARNING] spurious network error (3 tries remaining): process didn't exit successfully: `git fetch --no-tags --quiet --force --update-head-ok [..]
+[WARNING] spurious network error (3 tries remaining): process didn't exit successfully: `git -c core.fsmonitor=false fetch --no-tags --quiet --force --update-head-ok [..]
 
 [HELP] re-try with `net.git-fetch-with-cli = false` to see if it resolves the problem
 https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
 fatal: remote [ERROR] upload-pack: not our ref 11111b376b93484341c68fbca3ca110ae5cd2790
-[WARNING] spurious network error (2 tries remaining): process didn't exit successfully: `git fetch --no-tags --quiet --force --update-head-ok [..]
+[WARNING] spurious network error (2 tries remaining): process didn't exit successfully: `git -c core.fsmonitor=false fetch --no-tags --quiet --force --update-head-ok [..]
 
 [HELP] re-try with `net.git-fetch-with-cli = false` to see if it resolves the problem
 https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
 fatal: remote [ERROR] upload-pack: not our ref 11111b376b93484341c68fbca3ca110ae5cd2790
-[WARNING] spurious network error (1 try remaining): process didn't exit successfully: `git fetch --no-tags --quiet --force --update-head-ok [..]
+[WARNING] spurious network error (1 try remaining): process didn't exit successfully: `git -c core.fsmonitor=false fetch --no-tags --quiet --force --update-head-ok [..]
 
 [HELP] re-try with `net.git-fetch-with-cli = false` to see if it resolves the problem
 https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
@@ -4559,7 +4559,7 @@ Caused by:
   revision 11111b376b93484341c68fbca3ca110ae5cd2790 not found
 
 Caused by:
-  process didn't exit successfully: `git fetch --no-tags --quiet --force --update-head-ok [..]
+  process didn't exit successfully: `git -c core.fsmonitor=false fetch --no-tags --quiet --force --update-head-ok [..]
 
   [HELP] re-try with `net.git-fetch-with-cli = false` to see if it resolves the problem
   https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli


### PR DESCRIPTION
### What does this PR try to resolve?

This is a shot in the dark to fix the hang at #15775. I'm on a Mac and haven't reproduced this (I tried with a test). However, having `core.fsmonitor` enabled is throwaway work for any of the git repos we manage, so this seems relatively safe.

### How to test and review this PR?

