### PR TITLE
fix(diag): Remove complexity, perf, and nursery lint groups

### DIFF
--- a/doc/book/src/reference/lints.md
+++ b/doc/book/src/reference/lints.md
@@ -17,11 +17,8 @@
 |----------------------|-------------------------------------------------------------------------------------|---------------|
 | `cargo::default`     | all lints that are on by default (correctness, suspicious, style, complexity, perf) | warn/deny     |
 | `cargo::correctness` | code that is outright wrong or useless                                              | deny          |
-| `cargo::complexity`  | code that does something simple but in a complex way                                | warn          |
-| `cargo::perf`        | code that can be written to run faster                                              | warn          |
 | `cargo::style`       | code that should be written in a more idiomatic way                                 | warn          |
 | `cargo::suspicious`  | code that is most likely wrong or useless                                           | warn          |
-| `cargo::nursery`     | new lints that are still under development                                          | allow         |
 | `cargo::pedantic`    | lints which are rather strict or have occasional false positives                    | allow         |
 | `cargo::restriction` | lints which prevent the use of Cargo features                                       | allow         |
 

--- a/src/diagnostics/rules/mod.rs
+++ b/src/diagnostics/rules/mod.rs
@@ -126,11 +126,8 @@ static CARGO_LINTS_MSRV: cargo_util_schemas::manifest::RustVersion =
 pub static LINT_GROUPS: &[LintGroup] = &[
     DEFAULT,
     CORRECTNESS,
-    COMPLEXITY,
-    PERF,
     STYLE,
     SUSPICIOUS,
-    NURSERY,
     PEDANTIC,
     RESTRICTION,
     TEST_DUMMY_UNSTABLE,
@@ -144,14 +141,6 @@ const DEFAULT: LintGroup = LintGroup {
     hidden: false,
 };
 
-const COMPLEXITY: LintGroup = LintGroup {
-    name: "complexity",
-    desc: "code that does something simple but in a complex way",
-    default_level: LintLevel::Warn,
-    feature_gate: None,
-    hidden: false,
-};
-
 const CORRECTNESS: LintGroup = LintGroup {
     name: "correctness",
     desc: "code that is outright wrong or useless",
@@ -160,26 +149,10 @@ const CORRECTNESS: LintGroup = LintGroup {
     hidden: false,
 };
 
-const NURSERY: LintGroup = LintGroup {
-    name: "nursery",
-    desc: "new lints that are still under development",
-    default_level: LintLevel::Allow,
-    feature_gate: None,
-    hidden: false,
-};
-
 const PEDANTIC: LintGroup = LintGroup {
     name: "pedantic",
     desc: "lints which are rather strict or have occasional false positives",
     default_level: LintLevel::Allow,
-    feature_gate: None,
-    hidden: false,
-};
-
-const PERF: LintGroup = LintGroup {
-    name: "perf",
-    desc: "code that can be written to run faster",
-    default_level: LintLevel::Warn,
     feature_gate: None,
     hidden: false,
 };


### PR DESCRIPTION
### What does this PR try to resolve?

These are currently unused and have less chanced of being used in Cargo as compared to Clippy.

Pedantic is also unused but only because we removed a lint that used it. It is likely to be used again and having it makes it more likely for people to use it.

This was brought up during stabilization.


### How to test and review this PR?

