### PR TITLE
fix(diag): Gate blanket_hint_mostly_unused with -Zprofile-hint-mostly-unused

### DIFF
--- a/src/diagnostics/rules/blanket_hint_mostly_unused.rs
+++ b/src/diagnostics/rules/blanket_hint_mostly_unused.rs
@@ -7,7 +7,7 @@ use cargo_util_terminal::report::Level;
 use cargo_util_terminal::report::Origin;
 use cargo_util_terminal::report::Patch;
 use cargo_util_terminal::report::Snippet;
-use tracing::instrument;
+use tracing::{instrument, trace};
 
 use super::SUSPICIOUS;
 use crate::CargoResult;
@@ -63,6 +63,11 @@ pub(crate) fn lint_workspace(
     pkg_stats: &mut ScopedDiagnosticStats<'_>,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
+    if !gctx.cli_unstable().profile_hint_mostly_unused {
+        trace!("ignoring `blanket_hint_mostly_unused` without `-Zprofile-hint-mostly-unused`");
+        return Ok(());
+    }
+
     let LintLevelProduct {
         level: lint_level,
         source,

--- a/tests/testsuite/lints/blanket_hint_mostly_unused.rs
+++ b/tests/testsuite/lints/blanket_hint_mostly_unused.rs
@@ -213,3 +213,47 @@ blanket_hint_mostly_unused = "deny"
 "#]])
         .run();
 }
+
+#[cargo_test]
+fn disabled_without_profile_hint_mostly_unused() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+[package]
+name = "foo"
+version = "0.0.1"
+edition = "2015"
+
+[profile.dev]
+hint-mostly-unused = true
+
+[lints.cargo]
+default = { level = "allow", priority = -1 }
+blanket_hint_mostly_unused = "warn"
+"#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("fetch -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr_data(str![[r#"
+[WARNING] `hint-mostly-unused` is being blanket applied to all dependencies
+ --> Cargo.toml:7:10
+  |
+7 | [profile.dev]
+  |          ^^^
+8 | hint-mostly-unused = true
+  | -------------------------
+  |
+  = [NOTE] `cargo::blanket_hint_mostly_unused` is set to `warn` in `[lints]`
+[HELP] scope `hint-mostly-unused` to specific packages with a lot of unused object code
+  |
+7 | [profile.dev.package.<pkg_name>]
+  |             +++++++++++++++++++
+[WARNING] workspace (manifest) generated 1 warning
+
+"#]])
+        .run();
+}

--- a/tests/testsuite/lints/blanket_hint_mostly_unused.rs
+++ b/tests/testsuite/lints/blanket_hint_mostly_unused.rs
@@ -238,22 +238,6 @@ blanket_hint_mostly_unused = "warn"
 
     p.cargo("fetch -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
-        .with_stderr_data(str![[r#"
-[WARNING] `hint-mostly-unused` is being blanket applied to all dependencies
- --> Cargo.toml:7:10
-  |
-7 | [profile.dev]
-  |          ^^^
-8 | hint-mostly-unused = true
-  | -------------------------
-  |
-  = [NOTE] `cargo::blanket_hint_mostly_unused` is set to `warn` in `[lints]`
-[HELP] scope `hint-mostly-unused` to specific packages with a lot of unused object code
-  |
-7 | [profile.dev.package.<pkg_name>]
-  |             +++++++++++++++++++
-[WARNING] workspace (manifest) generated 1 warning
-
-"#]])
+        .with_stderr_data(str![""])
         .run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?

This way we can stabilize cargo-lints without stabilizing this lint.

### How to test and review this PR?

It won't get marked as unused but I worry that that could get annoying
with `CARGO_BUILD_WARNINGS=deny` and the intention of this feature
being usable without an MSRV bump or even while its nightly-only.