### PR TITLE
fix(lock): Use more accurate 'highest, rather than 'latest'

### DIFF
--- a/doc/book/src/commands/cargo-update.md
+++ b/doc/book/src/commands/cargo-update.md
@@ -51,7 +51,7 @@ requirement in <code>Cargo.toml</code> doesn’t contain any pre-release identif
 
 
 <dt class="option-term" id="option-cargo-update---breaking"><a class="option-anchor" href="#option-cargo-update---breaking"><code>--breaking</code> <em>directory</em></a></dt>
-<dd class="option-desc"><p>Update <em>spec</em> to latest SemVer-breaking version.</p>
+<dd class="option-desc"><p>Update <em>spec</em> to highest SemVer-breaking version.</p>
 <p>Version requirements will be modified to allow this update.</p>
 <p>This only applies to dependencies when</p>
 <ul>

--- a/doc/man/cargo-update.md
+++ b/doc/man/cargo-update.md
@@ -52,7 +52,7 @@ requirement in `Cargo.toml` doesn't contain any pre-release identifier (nightly 
 {{/option}}
 
 {{#option "`--breaking` _directory_" }}
-Update _spec_ to latest SemVer-breaking version.
+Update _spec_ to highest SemVer-breaking version.
 
 Version requirements will be modified to allow this update.
 

--- a/doc/man/generated_txt/cargo-update.txt
+++ b/doc/man/generated_txt/cargo-update.txt
@@ -44,7 +44,7 @@ OPTIONS
            identifier (nightly only).
 
        --breaking directory
-           Update spec to latest SemVer-breaking version.
+           Update spec to highest SemVer-breaking version.
 
            Version requirements will be modified to allow this update.
 

--- a/etc/man/cargo-update.1
+++ b/etc/man/cargo-update.1
@@ -50,7 +50,7 @@ requirement in \fBCargo.toml\fR doesn\[cq]t contain any pre\-release identifier 
 .sp
 \fB\-\-breaking\fR \fIdirectory\fR
 .RS 4
-Update \fIspec\fR to latest SemVer\-breaking version.
+Update \fIspec\fR to highest SemVer\-breaking version.
 .sp
 Version requirements will be modified to allow this update.
 .sp

--- a/src/bin/cargo/commands/update.rs
+++ b/src/bin/cargo/commands/update.rs
@@ -41,7 +41,7 @@ pub fn cli() -> Command {
         .arg(
             flag(
                 "breaking",
-                "Update [SPEC] to latest SemVer-breaking version (unstable)",
+                "Update [SPEC] to highest SemVer-breaking version (unstable)",
             )
             .short('b'),
         )

--- a/src/ops/cargo_update.rs
+++ b/src/ops/cargo_update.rs
@@ -768,9 +768,9 @@ fn status_locking(ws: &Workspace<'_>, num_pkgs: usize) -> CargoResult<()> {
     if !ws.gctx().cli_unstable().direct_minimal_versions {
         write!(&mut cfg, " to")?;
         if ws.gctx().cli_unstable().minimal_versions {
-            write!(&mut cfg, " earliest")?;
+            write!(&mut cfg, " lowest")?;
         } else {
-            write!(&mut cfg, " latest")?;
+            write!(&mut cfg, " highest")?;
         }
 
         if let Some(rust_version) = required_rust_version(ws) {

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -36,7 +36,7 @@ fn depend_on_alt_registry() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
 [CHECKING] bar v0.0.1 (registry `alternative`)
@@ -90,7 +90,7 @@ fn depend_on_alt_registry_depends_on_same_registry_no_index() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
 [DOWNLOADED] baz v0.0.1 (registry `alternative`)
@@ -136,7 +136,7 @@ fn depend_on_alt_registry_depends_on_same_registry() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
 [DOWNLOADED] baz v0.0.1 (registry `alternative`)
@@ -183,7 +183,7 @@ fn depend_on_alt_registry_depends_on_crates_io() {
             str![[r#"
 [UPDATING] `alternative` index
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.0.1 (registry `dummy-registry`)
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
@@ -224,7 +224,7 @@ fn registry_and_path_dep_works() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.0.1 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -282,7 +282,7 @@ fn registry_and_git_dep_works() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.0.1 ([ROOTURL]/bar#[..])
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -471,7 +471,7 @@ fn alt_registry_and_crates_io_deps() {
             str![[r#"
 [UPDATING] `alternative` index
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] crates_io_dep v0.0.1 (registry `dummy-registry`)
 [DOWNLOADED] alt_reg_dep v0.1.0 (registry `alternative`)
@@ -847,7 +847,7 @@ fn patch_alt_reg() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -937,7 +937,7 @@ fn no_api() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
 [CHECKING] bar v0.0.1 (registry `alternative`)
@@ -1794,7 +1794,7 @@ fn registries_index_relative_url() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `relative` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `relative`)
 [CHECKING] bar v0.0.1 (registry `relative`)

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -221,7 +221,7 @@ fn disallow_artifact_and_no_artifact_dep_to_same_package_within_the_same_dep_cat
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [WARNING] foo v0.0.0 ([ROOT]/foo) ignoring invalid dependency `bar_stable` which is missing a lib target
 [ERROR] the crate `foo v0.0.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
 
@@ -331,7 +331,7 @@ fn features_are_unified_among_lib_and_bin_dep_of_same_target() {
     p.cargo("build -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] d2 v0.0.1 ([ROOT]/foo/d2)
 [COMPILING] d1 v0.0.1 ([ROOT]/foo/d1)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -442,7 +442,7 @@ fn features_are_not_unified_among_lib_and_bin_dep_of_different_target() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] d2 v0.0.1 ([ROOT]/foo/d2)
 [COMPILING] d1 v0.0.1 ([ROOT]/foo/d1)
 error[E0425]: cannot find function `f2` in crate `d2`
@@ -604,7 +604,7 @@ fn build_script_with_bin_artifacts() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(
             str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
@@ -796,7 +796,7 @@ fn build_script_with_selected_dashed_bin_artifact_and_lib_true() {
     p.cargo("build -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar-baz v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -888,7 +888,7 @@ fn lib_with_selected_dashed_bin_artifact_and_lib_true() {
     p.cargo("build -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar-baz v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -939,7 +939,7 @@ fn allow_artifact_and_no_artifact_dep_to_same_package_within_different_dep_categ
     p.cargo("test -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1014,7 +1014,7 @@ fn disallow_using_example_binaries_as_artifacts() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ERROR] dependency `bar` in package `foo` requires a `bin:one-example` artifact to be present.
 
 "#]])
@@ -1067,7 +1067,7 @@ fn allow_artifact_and_non_artifact_dependency_to_same_crate() {
     p.cargo("check -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1186,7 +1186,7 @@ fn build_script_deps_adopt_do_not_allow_multiple_targets_under_different_name_an
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ERROR] the crate `foo v0.0.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
 
 "#]])
@@ -1288,7 +1288,7 @@ fn cross_doctests_works_with_artifacts() {
         .arg(&target)
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1414,7 +1414,7 @@ fn profile_override_basic() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(
             str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [RUNNING] `rustc --crate-name build_script_build [..] -C opt-level=1 [..]`
 [RUNNING] `rustc --crate-name bar --edition=2015 bar/src/main.rs [..] -C opt-level=3 [..]`
@@ -1526,7 +1526,7 @@ fn artifact_dep_target_specified() {
     p.cargo("check -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bindep v0.0.0 ([ROOT]/foo/bindep)
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1603,7 +1603,7 @@ fn dep_of_artifact_dep_same_target_specified() {
     p.cargo("check -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] baz v0.1.0 ([ROOT]/foo/baz)
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
@@ -1722,7 +1722,7 @@ foo v0.1.0 ([ROOT]/foo)
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [ADDING] artifact v1.0.0
 [UPDATING] bar v1.0.0 -> v1.0.1
 
@@ -1796,7 +1796,7 @@ fn proc_macro_in_artifact_dep() {
         .with_stderr_data(str![[r#"
 ...
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 ...
 [ERROR] failed to download from `[ROOTURL]/dl/pm/1.0.0/download`
@@ -1849,7 +1849,7 @@ fn allow_dep_renames_with_multiple_versions() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [COMPILING] bar v1.0.0
@@ -1911,7 +1911,7 @@ fn allow_artifact_and_non_artifact_dependency_to_same_crate_if_these_are_not_the
     p.cargo("build -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1947,7 +1947,7 @@ fn prevent_no_lib_warning_with_artifact_dependencies() {
     p.cargo("check -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1984,7 +1984,7 @@ fn show_no_lib_warning_with_artifact_dependencies_that_have_no_lib_but_lib_true(
     p.cargo("check -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [WARNING] foo v0.0.0 ([ROOT]/foo) ignoring invalid dependency `bar` which is missing a lib target
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
@@ -2052,7 +2052,7 @@ fn check_missing_crate_type_in_package_fails() {
             .masquerade_as_nightly_cargo(&["bindeps"])
             .with_status(101)
             .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ERROR] dependency `bar` in package `foo` requires a [..] artifact to be present.
 
 "#]])
@@ -2203,7 +2203,7 @@ fn env_vars_and_build_products_for_various_build_targets() {
     p.cargo("test -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2400,7 +2400,7 @@ fn doc_lib_true() {
     p.cargo("doc -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [DOCUMENTING] bar v0.0.1 ([ROOT]/foo/bar)
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
@@ -2482,7 +2482,7 @@ fn rustdoc_works_on_libs_with_artifacts_and_lib_false() {
     p.cargo("doc -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2689,7 +2689,7 @@ fn calc_bin_artifact_fingerprint() {
     p.cargo("check -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2768,7 +2768,7 @@ fn with_target_and_optional() {
     p.cargo("check -Z bindeps -F d1 -v")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] d1 v0.0.1 ([ROOT]/foo/d1)
 [RUNNING] `rustc --crate-name d1 [..]--crate-type bin[..]
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -2818,7 +2818,7 @@ fn with_assumed_host_target_and_optional_build_dep() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(
             str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] d1 v0.0.1 ([ROOT]/foo/d1)
 [RUNNING] `rustc --crate-name build_script_build --edition=2021 [..]--crate-type bin[..]
 [RUNNING] `rustc --crate-name d1 --edition=2021 [..]--crate-type bin[..]
@@ -2947,7 +2947,7 @@ fn decouple_same_target_transitive_dep_from_artifact_dep() {
     p.cargo("build -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 4 packages to highest compatible versions
 [COMPILING] c v0.1.0 ([ROOT]/foo/c)
 [COMPILING] b v0.1.0 ([ROOT]/foo/b)
 [COMPILING] a v0.1.0 ([ROOT]/foo/a)
@@ -3050,7 +3050,7 @@ fn decouple_same_target_transitive_dep_from_artifact_dep_lib() {
     p.cargo("build -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [COMPILING] b v0.1.0 ([ROOT]/foo/b)
 [COMPILING] a v0.1.0 ([ROOT]/foo/a)
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
@@ -3177,7 +3177,7 @@ fn decouple_same_target_transitive_dep_from_artifact_dep_and_proc_macro() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(
             str![[r#"
-[LOCKING] 5 packages to latest compatible versions
+[LOCKING] 5 packages to highest compatible versions
 [COMPILING] d v0.1.0 ([ROOT]/foo/d)
 [COMPILING] a v0.1.0 ([ROOT]/foo/a)
 [COMPILING] b v0.1.0 ([ROOT]/foo/b)
@@ -3244,7 +3244,7 @@ fn same_target_artifact_dep_sharing() {
     p.cargo(&format!("build -Z bindeps --target {target}"))
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] a v0.1.0 ([ROOT]/foo/a)
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
@@ -3300,7 +3300,7 @@ fn check_transitive_artifact_dependency_with_different_target() {
     p.cargo("check -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [ERROR] failed to determine target information for target `custom-target`.
   Artifact dependency `baz` in package `bar v0.0.0 ([ROOT]/foo/bar)` requires building for `custom-target`
 
@@ -3632,7 +3632,7 @@ fn artifact_dep_target_does_not_propagate_to_deps_of_build_script() {
         .build();
     p.cargo("test -Z bindeps")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [COMPILING] arch v0.0.1 ([ROOT]/foo/arch)
 [COMPILING] builder v0.0.1 ([ROOT]/foo/builder)
 [COMPILING] artifact v0.0.1 ([ROOT]/foo/artifact)
@@ -3724,7 +3724,7 @@ fn artifact_dep_target_does_not_propagate_to_proc_macro() {
         .build();
     p.cargo("test -Z bindeps")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [COMPILING] arch v0.0.1 ([ROOT]/foo/arch)
 [COMPILING] macro v0.0.1 ([ROOT]/foo/macro)
 [COMPILING] artifact v0.0.1 ([ROOT]/foo/artifact)

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -985,7 +985,7 @@ fn dev_dependencies2() {
 [WARNING] Cargo.toml: `dev_dependencies` is deprecated in favor of `dev-dependencies` and will not work in the 2024 edition
 (in the `foo` package)
 [WARNING] `foo` (manifest) generated 1 warning
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1064,7 +1064,7 @@ fn dev_dependencies2_conflict() {
     p.cargo("check").with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `dev_dependencies` is redundant with `dev-dependencies`, preferring `dev-dependencies` in the `foo` package
 [WARNING] `foo` (manifest) generated 1 warning
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1102,7 +1102,7 @@ fn build_dependencies2() {
 [WARNING] Cargo.toml: `build_dependencies` is deprecated in favor of `build-dependencies` and will not work in the 2024 edition
 (in the `foo` package)
 [WARNING] `foo` (manifest) generated 1 warning
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1181,7 +1181,7 @@ fn build_dependencies2_conflict() {
     p.cargo("check").with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `build_dependencies` is redundant with `build-dependencies`, preferring `build-dependencies` in the `foo` package
 [WARNING] `foo` (manifest) generated 1 warning
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1557,7 +1557,7 @@ fn cargo_platform_build_dependencies2() {
 [WARNING] Cargo.toml: `build_dependencies` is deprecated in favor of `build-dependencies` and will not work in the 2024 edition
 (in the `[HOST_TARGET]` platform target)
 [WARNING] `foo` (manifest) generated 1 warning
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] build v0.5.0 ([ROOT]/foo/build)
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1646,7 +1646,7 @@ fn cargo_platform_build_dependencies2_conflict() {
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `build_dependencies` is redundant with `build-dependencies`, preferring `build-dependencies` in the `[HOST_TARGET]` platform target
 [WARNING] `foo` (manifest) generated 1 warning
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] build v0.5.0 ([ROOT]/foo/build)
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1690,7 +1690,7 @@ fn cargo_platform_dev_dependencies2() {
 [WARNING] Cargo.toml: `dev_dependencies` is deprecated in favor of `dev-dependencies` and will not work in the 2024 edition
 (in the `[HOST_TARGET]` platform target)
 [WARNING] `foo` (manifest) generated 1 warning
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1775,7 +1775,7 @@ fn cargo_platform_dev_dependencies2_conflict() {
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `dev_dependencies` is redundant with `dev-dependencies`, preferring `dev-dependencies` in the `[HOST_TARGET]` platform target
 [WARNING] `foo` (manifest) generated 1 warning
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1821,7 +1821,7 @@ fn default_features2() {
 [WARNING] Cargo.toml: `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition
 (in the `a` dependency)
 [WARNING] `foo` (manifest) generated 1 warning
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] a v0.1.0 ([ROOT]/foo/a)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1913,7 +1913,7 @@ fn default_features2_conflict() {
     p.cargo("check").with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `default_features` is redundant with `default-features`, preferring `default-features` in the `a` dependency
 [WARNING] `foo` (manifest) generated 1 warning
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] a v0.1.0 ([ROOT]/foo/a)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2995,7 +2995,7 @@ fn warn_semver_metadata() {
 [WARNING] Cargo.toml: version requirement `1.0.0+1234` for dependency `bar` includes semver metadata which will be ignored, removing the metadata is recommended to avoid confusion
 [WARNING] `foo` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [CHECKING] bar v1.0.0

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -522,7 +522,7 @@ fn bench_with_deep_lib_dep() {
 
     p.cargo("bench")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [COMPILING] bar v0.0.1 ([ROOT]/bar)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
@@ -1074,7 +1074,7 @@ fn bench_dylib() {
 
     p.cargo("bench -v")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] [..] -C opt-level=3 [..]
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -1552,7 +1552,7 @@ fn test_bench_multiple_packages() {
 "#]])
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] bar v0.1.0 ([ROOT]/bar)
 [COMPILING] baz v0.1.0 ([ROOT]/baz)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -962,7 +962,7 @@ fn cargo_compile_with_warnings_in_a_dep_package() {
 
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [WARNING] [..]dead[..]
 ...
@@ -2844,7 +2844,7 @@ fn bad_platform_specific_dependency() {
     p.cargo("build")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 error[E0463]: can't find crate for `bar`
 ...
@@ -3074,7 +3074,7 @@ fn transitive_dependencies_not_available() {
     p.cargo("build -v")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] bbbbb v0.0.1 ([ROOT]/foo/b)
 [RUNNING] `rustc [..]
 [COMPILING] aaaaa v0.0.1 ([ROOT]/foo/a)
@@ -3486,7 +3486,7 @@ fn invalid_spec() {
     p.cargo("build -p notAValidDep")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ERROR] package ID specification `notAValidDep` did not match any packages
 
 "#]])
@@ -4354,7 +4354,7 @@ fn build_all_member_dependency_same_name() {
     p.cargo("build --workspace")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] a v0.1.0 (registry `dummy-registry`)
 [COMPILING] a v0.1.0
@@ -4642,7 +4642,7 @@ fn rustc_wrapper_relative() {
         .env("RUSTC_WRAPPER", &relative_path)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [COMPILING] bar v1.0.0
@@ -5175,7 +5175,7 @@ fn building_a_dependent_crate_without_bin_should_fail() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] testless v0.1.0 (registry `dummy-registry`)
 [ERROR] failed to download replaced source registry `crates-io`
@@ -5418,7 +5418,7 @@ fn no_linkable_target() {
         .build();
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [WARNING] the package `the_lib` provides no linkable target
   |
   = [NOTE] this might cause `foo` to fail compilation
@@ -5698,7 +5698,7 @@ fn signal_display() {
 
     foo.cargo("build")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] pm v0.1.0 ([ROOT]/foo/pm)
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [ERROR] could not compile `foo` (lib)
@@ -5756,7 +5756,7 @@ fn pipelining_works() {
     foo.cargo("build")
         .with_stdout_data(str![])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -5887,7 +5887,7 @@ b
 
 "#]])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 c
@@ -6542,7 +6542,7 @@ fn embed_metadata_no_invalidate() {
     p.cargo("build -Z embed-metadata=no")
         .masquerade_as_nightly_cargo(&["-Z embed-metadata"])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -6829,7 +6829,7 @@ fn should_not_include_proc_macro_deps_paths_in_rustc_args() {
         // Verify that the proc-macro dependencies (my-rlib and my-dylib) are not added to the rustc
         // invocation for the `foo` crate as `-L` args.
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [COMPILING] my-dylib v0.1.0 ([ROOT]/foo/my-dylib)
 [RUNNING] `rustc --crate-name my_dylib [..]`
 [COMPILING] my-rlib v0.1.0 ([ROOT]/foo/my-rlib)

--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -1189,7 +1189,7 @@ fn artifact_deps() {
         .masquerade_as_nightly_cargo(&["bindeps", "build-dir-new-layout"])
         .enable_mac_dsym()
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1322,7 +1322,7 @@ fn dylib_deps_output_overwrite() {
         .enable_mac_dsym()
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [COMPILING] baz v0.1.0 ([ROOT]/foo/baz)
 [COMPILING] main v0.0.0 ([ROOT]/foo)

--- a/tests/testsuite/build_dir_fine_grain_locking.rs
+++ b/tests/testsuite/build_dir_fine_grain_locking.rs
@@ -1233,7 +1233,7 @@ fn artifact_deps() {
         .masquerade_as_nightly_cargo(&["bindeps", "build-dir-new-layout"])
         .enable_mac_dsym()
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/build_dir_legacy.rs
+++ b/tests/testsuite/build_dir_legacy.rs
@@ -1243,7 +1243,7 @@ fn artifact_deps() {
         .env("__CARGO_TEMPORARY_BUILD_DIR_NEW_LAYOUT_OPT_OUT", "1")
         .enable_mac_dsym()
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1375,7 +1375,7 @@ fn dylib_deps_output() {
         .enable_mac_dsym()
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [COMPILING] baz v0.1.0 ([ROOT]/foo/baz)
 [COMPILING] foo v0.0.0 ([ROOT]/foo)

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -1322,7 +1322,7 @@ fn custom_build_script_rustc_flags() {
 
     p.cargo("build --verbose")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] foo v0.5.0 ([ROOT]/foo/foo)
 [RUNNING] `rustc --crate-name build_script_build --edition=2015 foo/build.rs [..]`
 [RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
@@ -1381,7 +1381,7 @@ fn custom_build_script_rustc_flags_no_space() {
     p.root().join("dummy-path2").mkdir_p();
 
     p.cargo("build --verbose").with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] foo v0.5.0 ([ROOT]/foo/foo)
 [RUNNING] `rustc --crate-name build_script_build --edition=2015 foo/build.rs [..]`
 [RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
@@ -1546,7 +1546,7 @@ fn links_duplicates_old_registry() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [ERROR] multiple packages link to native library `a`, but a native library can be linked only once
@@ -1698,7 +1698,7 @@ fn overrides_and_links() {
     p.cargo("build -v")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] a v0.5.0 ([ROOT]/foo/a)
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]`
@@ -2225,7 +2225,7 @@ fn with_patch() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] cxx v1.0.0 ([ROOT]/foo/cxx)
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2602,7 +2602,7 @@ fn build_deps_simple() {
         .build();
 
     p.cargo("check -v").with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] a v0.5.0 ([ROOT]/foo/a)
 [RUNNING] `rustc --crate-name a [..]`
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
@@ -2715,7 +2715,7 @@ fn build_cmd_with_a_build_cmd() {
         .build();
 
     p.cargo("check -v").with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] b v0.5.0 ([ROOT]/foo/b)
 [RUNNING] `rustc --crate-name b [..]`
 [COMPILING] a v0.5.0 ([ROOT]/foo/a)
@@ -3875,7 +3875,7 @@ fn flags_go_into_tests() {
 
     p.cargo("test -v --test=foo")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] a v0.5.0 ([ROOT]/foo/a)
 [RUNNING] `rustc [..] a/build.rs [..]`
 [RUNNING] `[ROOT]/foo/target/debug/build/a-[HASH]/build-script-build`
@@ -3989,7 +3989,7 @@ fn diamond_passes_args_only_once() {
 
     p.cargo("build -v")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [COMPILING] c v0.5.0 ([ROOT]/foo/c)
 [RUNNING] `rustc --crate-name build_script_build [..]`
 [RUNNING] `[ROOT]/foo/target/debug/build/c-[HASH]/build-script-build`
@@ -4864,7 +4864,7 @@ fn warnings_emitted_from_path_dep() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] a v0.5.0 ([ROOT]/foo/a)
 [WARNING] a@0.5.0: foo
 [WARNING] a@0.5.0: bar
@@ -4973,7 +4973,7 @@ fn warnings_emitted_when_dependency_panics() {
     .with_status(101)
     .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] published v0.1.0 (registry `dummy-registry`)
 [COMPILING] published v0.1.0
@@ -5044,7 +5044,7 @@ fn log_messages_emitted_when_dependency_logs_errors() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] published v0.1.0 (registry `dummy-registry`)
 [COMPILING] published v0.1.0
@@ -5104,7 +5104,7 @@ fn warnings_hidden_for_upstream() {
     p.cargo("check -v")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [COMPILING] bar v0.1.0
@@ -5165,7 +5165,7 @@ fn warnings_printed_on_vv() {
     p.cargo("check -vv")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [COMPILING] bar v0.1.0
@@ -5947,7 +5947,7 @@ fn optional_build_dep_and_required_normal_dep() {
 
 "#]])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/build_script_extra_link_arg.rs
+++ b/tests/testsuite/build_script_extra_link_arg.rs
@@ -274,7 +274,7 @@ fn link_arg_transitive_not_allowed() {
     p.cargo("build -v")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [COMPILING] bar v1.0.0

--- a/tests/testsuite/build_scripts_multiple.rs
+++ b/tests/testsuite/build_scripts_multiple.rs
@@ -352,7 +352,7 @@ fn verify_vendor_multiple_build_scripts() {
         .with_status(0)
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep`
-[LOCKING] 1 package to latest [..] compatible version
+[LOCKING] 1 package to highest [..] compatible version
    Vendoring dep v0.1.0 ([ROOTURL]/dep#[..]) ([ROOT]/home/.cargo/git/checkouts/dep-[HASH]/[..]) to vendor/dep
 [WARNING] ignoring `package.build` entry `build2.rs` as it is not included in the published package
 To use vendored sources, add this to your .cargo/config.toml for this project:

--- a/tests/testsuite/cache_messages.rs
+++ b/tests/testsuite/cache_messages.rs
@@ -241,7 +241,7 @@ fn very_verbose() {
     p.cargo("check -vv")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [CHECKING] bar v1.0.0

--- a/tests/testsuite/cargo_add/add_basic/stderr.term.svg
+++ b/tests/testsuite/cargo_add/add_basic/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/add_multiple/stderr.term.svg
+++ b/tests/testsuite/cargo_add/add_multiple/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to highest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/add_no_vendored_package_with_alter_registry/stderr.term.svg
+++ b/tests/testsuite/cargo_add/add_no_vendored_package_with_alter_registry/stderr.term.svg
@@ -42,7 +42,7 @@
 </tspan>
     <tspan x="10px" y="208px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> serde_test</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="226px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="244px">
 </tspan>

--- a/tests/testsuite/cargo_add/build/stderr.term.svg
+++ b/tests/testsuite/cargo_add/build/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-build-package2 v99999.0.0 to build-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to highest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/build_prefer_existing_version/stderr.term.svg
+++ b/tests/testsuite/cargo_add/build_prefer_existing_version/stderr.term.svg
@@ -27,7 +27,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> two</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/change_rename_target/stderr.term.svg
+++ b/tests/testsuite/cargo_add/change_rename_target/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> feature `some-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/cyclic_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/cyclic_features/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> feature-two</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_add/default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/default_features/stderr.term.svg
@@ -25,7 +25,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v0.4.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to highest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/dev/stderr.term.svg
+++ b/tests/testsuite/cargo_add/dev/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-dev-package2 v99999.0.0 to dev-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to highest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/dev_existing_path_base/stderr.term.svg
+++ b/tests/testsuite/cargo_add/dev_existing_path_base/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dev-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/dev_prefer_existing_version/stderr.term.svg
+++ b/tests/testsuite/cargo_add/dev_prefer_existing_version/stderr.term.svg
@@ -27,7 +27,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> two</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_activated_over_limit/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_activated_over_limit/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan>             100 deactivated features</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_deactivated_over_limit/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_deactivated_over_limit/stderr.term.svg
@@ -86,7 +86,7 @@
 </tspan>
     <tspan x="10px" y="622px"><tspan>             170 deactivated features</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="640px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="658px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_empty/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_empty/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_multiple_occurrences/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_multiple_occurrences/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_preserve/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_preserve/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_spaced_values/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_spaced_values/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/git/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_branch/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_branch/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_dev/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_dev/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_inferred_name/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_inferred_name/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_multiple_names/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_multiple_names/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to highest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_multiple_packages_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_multiple_packages_features/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_registry/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_registry/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/versioned-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_rev/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_rev/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_tag/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_tag/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/infer_prerelease/stderr.term.svg
+++ b/tests/testsuite/cargo_add/infer_prerelease/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> prerelease_only v0.2.0-alpha.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/list_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/list_features/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/list_features_path/stderr.term.svg
+++ b/tests/testsuite/cargo_add/list_features_path/stderr.term.svg
@@ -34,7 +34,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/list_features_path_no_default/stderr.term.svg
+++ b/tests/testsuite/cargo_add/list_features_path_no_default/stderr.term.svg
@@ -34,7 +34,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/lockfile_updated/stderr.term.svg
+++ b/tests/testsuite/cargo_add/lockfile_updated/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0+my-package</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/namever/stderr.term.svg
+++ b/tests/testsuite/cargo_add/namever/stderr.term.svg
@@ -27,7 +27,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 3 packages to highest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v0.2.3+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/no_default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/no_default_features/stderr.term.svg
@@ -25,7 +25,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v0.4.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to highest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/no_optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/no_optional/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/no_public/stderr.term.svg
+++ b/tests/testsuite/cargo_add/no_public/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/normalize_name_registry/stderr.term.svg
+++ b/tests/testsuite/cargo_add/normalize_name_registry/stderr.term.svg
@@ -56,7 +56,7 @@
 </tspan>
     <tspan x="10px" y="334px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> unstable</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="352px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to highest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="370px">
 </tspan>

--- a/tests/testsuite/cargo_add/normalize_name_registry_existing/stderr.term.svg
+++ b/tests/testsuite/cargo_add/normalize_name_registry_existing/stderr.term.svg
@@ -36,7 +36,7 @@
 </tspan>
     <tspan x="10px" y="154px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>

--- a/tests/testsuite/cargo_add/normalize_name_registry_yanked/stderr.term.svg
+++ b/tests/testsuite/cargo_add/normalize_name_registry_yanked/stderr.term.svg
@@ -25,7 +25,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> linked-hash-map v0.5.4 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/normalize_name_workspace_dep/stderr.term.svg
+++ b/tests/testsuite/cargo_add/normalize_name_workspace_dep/stderr.term.svg
@@ -25,7 +25,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> fuzzy_dependency (workspace) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/optional/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> feature `my-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_default_features/stderr.term.svg
@@ -25,7 +25,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v0.4.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to highest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_default_features_with_no_default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_default_features_with_no_default_features/stderr.term.svg
@@ -25,7 +25,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v0.4.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to highest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_features/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_git_with_path/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_git_with_path/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> feature `cargo-list-test-fixture-dependency`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_inline_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_inline_features/stderr.term.svg
@@ -34,7 +34,7 @@
 </tspan>
     <tspan x="10px" y="154px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to highest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_name_dev_noop/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_name_dev_noop/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_name_noop/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_name_noop/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> feature `your-face`</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_no_default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_no_default_features/stderr.term.svg
@@ -25,7 +25,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v0.4.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to highest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_no_default_features_with_default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_no_default_features_with_default_features/stderr.term.svg
@@ -25,7 +25,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v0.4.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to highest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_no_optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_no_optional/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_no_optional_with_optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_no_optional_with_optional/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> feature `my-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_no_public/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_no_public/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_no_public_with_public/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_no_public_with_public/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.0 to public dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_optional/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> feature `my-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_optional_with_no_optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_optional_with_no_optional/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_optional_with_optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_optional_with_optional/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package1 v99999.0.0 to optional dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_path_base_with_version/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_path_base_with_version/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> feature `cargo-list-test-fixture-dependency`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_path_noop/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_path_noop/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> feature `your-face`</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_path_with_version/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_path_with_version/stderr.term.svg
@@ -25,7 +25,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> feature `cargo-list-test-fixture-dependency`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency v20.0.0+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_preserves_inline_table/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_preserves_inline_table/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_public/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_public/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.0 to public dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_public_with_no_public/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_public_with_no_public/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_rename_with_no_rename/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_rename_with_no_rename/stderr.term.svg
@@ -23,7 +23,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> versioned-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to highest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_rename_with_rename/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_rename_with_rename/stderr.term.svg
@@ -23,7 +23,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> versioned-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to highest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_rename_with_rename_noop/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_rename_with_rename_noop/stderr.term.svg
@@ -25,7 +25,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> feature `a1`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_version_with_git/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_version_with_git/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/versioned-package`</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_version_with_path/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_version_with_path/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> feature `cargo-list-test-fixture-dependency`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_with_rename/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_with_rename/stderr.term.svg
@@ -23,7 +23,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> versioned-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to highest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/path/stderr.term.svg
+++ b/tests/testsuite/cargo_add/path/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/path_base/stderr.term.svg
+++ b/tests/testsuite/cargo_add/path_base/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/path_base_inferred_name/stderr.term.svg
+++ b/tests/testsuite/cargo_add/path_base_inferred_name/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/path_dev/stderr.term.svg
+++ b/tests/testsuite/cargo_add/path_dev/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dev-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/path_inferred_name/stderr.term.svg
+++ b/tests/testsuite/cargo_add/path_inferred_name/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/preserve_dep_std_table/stderr.term.svg
+++ b/tests/testsuite/cargo_add/preserve_dep_std_table/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/preserve_features_sorted/stderr.term.svg
+++ b/tests/testsuite/cargo_add/preserve_features_sorted/stderr.term.svg
@@ -34,7 +34,7 @@
 </tspan>
     <tspan x="10px" y="154px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> e</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>

--- a/tests/testsuite/cargo_add/preserve_features_table/stderr.term.svg
+++ b/tests/testsuite/cargo_add/preserve_features_table/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/preserve_features_unsorted/stderr.term.svg
+++ b/tests/testsuite/cargo_add/preserve_features_unsorted/stderr.term.svg
@@ -34,7 +34,7 @@
 </tspan>
     <tspan x="10px" y="154px"><tspan>             </tspan><tspan class="fg-bright-green bold">+</tspan><tspan> e</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>

--- a/tests/testsuite/cargo_add/preserve_sorted/stderr.term.svg
+++ b/tests/testsuite/cargo_add/preserve_sorted/stderr.term.svg
@@ -23,7 +23,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> toml v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 3 packages to highest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/preserve_unsorted/stderr.term.svg
+++ b/tests/testsuite/cargo_add/preserve_unsorted/stderr.term.svg
@@ -23,7 +23,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> toml v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 3 packages to highest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/public/stderr.term.svg
+++ b/tests/testsuite/cargo_add/public/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.0 to public dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/public_common_version/stderr.term.svg
+++ b/tests/testsuite/cargo_add/public_common_version/stderr.term.svg
@@ -21,13 +21,13 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to highest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.0 </tspan><tspan class="fg-yellow bold">(available: v0.2.0)</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package-dep ^0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to highest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.1.0 </tspan><tspan class="fg-yellow bold">(available: v0.2.0)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/registry/stderr.term.svg
+++ b/tests/testsuite/cargo_add/registry/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to highest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/rename/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rename/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/require_weak/stderr.term.svg
+++ b/tests/testsuite/cargo_add/require_weak/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-bright-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/rust_version_ignore/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rust_version_ignore/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> rust-version-user v0.2.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/rust_version_latest/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rust_version_latest/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> rust-version-user v0.2.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest Rust 1.72 compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest Rust 1.72 compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/rust_version_older/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rust_version_older/stderr.term.svg
@@ -25,7 +25,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> rust-version-user v0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest Rust 1.70 compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest Rust 1.70 compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> rust-version-user v0.1.0 (available: v0.2.1, requires Rust 1.72)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/rustc_ignore/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rustc_ignore/stderr.term.svg
@@ -23,7 +23,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> rust-version-user v0.2.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> rust-version-user v0.2.1 </tspan><tspan class="fg-bright-red bold">(requires Rust 1.2345)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/rustc_latest/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rustc_latest/stderr.term.svg
@@ -25,7 +25,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> rust-version-user v0.1.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest Rust [..] compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> rust-version-user v0.1.1 (available: v0.2.1, requires Rust 1.2345)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/rustc_older/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rustc_older/stderr.term.svg
@@ -25,7 +25,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> rust-version-user v0.1.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest Rust [..] compatible version</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> rust-version-user v0.1.1 (available: v0.2.1, requires Rust 1.2345)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/script_bare/stderr.term.svg
+++ b/tests/testsuite/cargo_add/script_bare/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest Rust [..] compatible version</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/script_escape/stderr.term.svg
+++ b/tests/testsuite/cargo_add/script_escape/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/script_frontmatter/stderr.term.svg
+++ b/tests/testsuite/cargo_add/script_frontmatter/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/script_frontmatter_empty/stderr.term.svg
+++ b/tests/testsuite/cargo_add/script_frontmatter_empty/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest Rust [..] compatible version</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/script_shebang/stderr.term.svg
+++ b/tests/testsuite/cargo_add/script_shebang/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest Rust [..] compatible version</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest Rust [..] compatible version</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/sorted_table_with_dotted_item/stderr.term.svg
+++ b/tests/testsuite/cargo_add/sorted_table_with_dotted_item/stderr.term.svg
@@ -23,7 +23,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> unrelateed-crate v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 4 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 4 packages to highest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-build-package1 v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(available: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/target/stderr.term.svg
+++ b/tests/testsuite/cargo_add/target/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v99999.0.0 to dependencies for target `wasm32-unknown-unknown`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to highest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/target_cfg/stderr.term.svg
+++ b/tests/testsuite/cargo_add/target_cfg/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package2 v99999.0.0 to dependencies for target `cfg(target_os="linux")`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 2 packages to highest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/vers/stderr.term.svg
+++ b/tests/testsuite/cargo_add/vers/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package &gt;=0.1.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/yanked/stderr.term.svg
+++ b/tests/testsuite/cargo_add/yanked/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> linked-hash-map v0.5.4 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -100,7 +100,7 @@ fn feature_required_dependency() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [ERROR] failed to download replaced source registry `crates-io`
@@ -549,7 +549,7 @@ fn nightly_feature_requires_nightly_in_dep() {
     p.cargo("check")
         .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] a v0.0.1 ([ROOT]/foo/a)
 [CHECKING] b v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/cargo_info/within_ws_without_lockfile/stderr.term.svg
+++ b/tests/testsuite/cargo_info/within_ws_without_lockfile/stderr.term.svg
@@ -22,7 +22,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 1 package to highest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">      Adding</tspan><tspan> my-package v0.2.3+my-package </tspan><tspan class="fg-yellow bold">(available: v0.4.1+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_tree/deps.rs
+++ b/tests/testsuite/cargo_tree/deps.rs
@@ -1680,7 +1680,7 @@ fn ambiguous_name() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [ADDING] dep v1.0.0 (available: v2.0.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)

--- a/tests/testsuite/cargo_tree/dupe/stderr.term.svg
+++ b/tests/testsuite/cargo_tree/dupe/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 3 packages to highest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold"> Downloading</tspan><tspan> crates ...</tspan>
 </tspan>

--- a/tests/testsuite/cargo_tree/edge_kind/stderr.term.svg
+++ b/tests/testsuite/cargo_tree/edge_kind/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 18 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">     Locking</tspan><tspan> 18 packages to highest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-bright-green bold"> Downloading</tspan><tspan> crates ...</tspan>
 </tspan>

--- a/tests/testsuite/cargo_update/help/stdout.term.svg
+++ b/tests/testsuite/cargo_update/help/stdout.term.svg
@@ -36,7 +36,7 @@
 </tspan>
     <tspan x="10px" y="154px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--precise</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PRECISE&gt;</tspan><tspan>        Update [SPEC] to exactly PRECISE</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-b</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--breaking</tspan><tspan>                 Update [SPEC] to latest SemVer-breaking version (unstable)</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-b</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--breaking</tspan><tspan>                 Update [SPEC] to highest SemVer-breaking version (unstable)</tspan>
 </tspan>
     <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan class="fg-cyan">...</tspan><tspan>               Use verbose output (-vv very verbose/build.rs output)</tspan>
 </tspan>

--- a/tests/testsuite/cfg.rs
+++ b/tests/testsuite/cfg.rs
@@ -56,7 +56,7 @@ fn dont_include() {
         .build();
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] a v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -96,7 +96,7 @@ fn works_through_the_registry() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [DOWNLOADED] baz v0.1.0 (registry `dummy-registry`)
@@ -147,7 +147,7 @@ fn ignore_version_from_other_platform() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [ADDING] bar v0.1.0 (available: v0.2.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
@@ -538,7 +538,7 @@ fn cfg_raw_idents() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] b v0.0.1 ([ROOT]/foo/b)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -633,7 +633,7 @@ fn cfg_keywords() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] b v0.0.1 ([ROOT]/foo/b)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -670,7 +670,7 @@ fn cfg_booleans() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [CHECKING] b v0.0.1 ([ROOT]/foo/b)
 [CHECKING] a v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -733,7 +733,7 @@ fn cfg_booleans_not() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] b v0.0.1 ([ROOT]/foo/b)
 [CHECKING] a v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -765,7 +765,7 @@ fn cfg_booleans_combinators() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] b v0.0.1 ([ROOT]/foo/b)
 [CHECKING] a v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -803,7 +803,7 @@ fn cfg_booleans_rustflags_no_effect() {
     p.cargo("check")
         .env("RUSTFLAGS", "--cfg r#false")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [CHECKING] b v0.0.1 ([ROOT]/foo/b)
 [CHECKING] a v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -355,7 +355,7 @@ fn rustc_check_err() {
     foo.cargo("rustc --profile check -- --emit=metadata")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.1.0 ([ROOT]/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 error[E0425]: [..]
@@ -1203,7 +1203,7 @@ fn git_manifest_package_and_project() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.0.1 ([ROOTURL]/bar#[..])
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1252,7 +1252,7 @@ fn git_manifest_with_project() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.0.1 ([ROOTURL]/bar#[..])
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1616,7 +1616,7 @@ fn check_unused_manifest_keys() {
 [WARNING] Cargo.toml: unused manifest key: target.wasm32-wasip1.dev-dependencies.foo.wxz
 [WARNING] `bar` (manifest) generated 7 warnings
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.1.0 (registry `dummy-registry`)
 [DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)

--- a/tests/testsuite/collisions.rs
+++ b/tests/testsuite/collisions.rs
@@ -202,7 +202,7 @@ fn collision_doc_multiple_versions() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [ADDING] bar v1.0.0 (available: v2.0.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v2.0.0 (registry `dummy-registry`)
@@ -380,7 +380,7 @@ fn collision_doc_profile_split() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] common v1.0.0 (registry `dummy-registry`)
 [COMPILING] common v1.0.0
@@ -441,7 +441,7 @@ fn collision_doc_sources() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [WARNING] output filename collision at [ROOT]/foo/target/doc/bar/index.html
@@ -496,7 +496,7 @@ fn collision_doc_target() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [ADDING] bar v1.0.0 (available: v2.0.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] orphaned v1.0.0 (registry `dummy-registry`)
@@ -566,7 +566,7 @@ fn collision_with_root() {
     p.cargo("doc -j=1")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo-macro v1.0.0 (registry `dummy-registry`)
 [WARNING] output filename collision at [ROOT]/foo/target/doc/foo_macro/index.html

--- a/tests/testsuite/compile_time_deps.rs
+++ b/tests/testsuite/compile_time_deps.rs
@@ -56,7 +56,7 @@ fn non_comp_time_dep() {
     p.cargo("-Zunstable-options check --compile-time-deps")
         .masquerade_as_nightly_cargo(&["compile-time-deps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -241,7 +241,7 @@ fn build_dep() {
     p.cargo("-Zunstable-options check --compile-time-deps")
         .masquerade_as_nightly_cargo(&["compile-time-deps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] baz v0.0.1 ([ROOT]/foo/bar/baz)
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -315,7 +315,7 @@ fn indirect_comp_time_dep() {
     p.cargo("-Zunstable-options check --compile-time-deps")
         .masquerade_as_nightly_cargo(&["compile-time-deps"])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] baz v0.0.1 ([ROOT]/foo/bar/baz)
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -379,7 +379,7 @@ fn tests_target() {
 
     p.cargo("-Zunstable-options check --tests --compile-time-deps")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/credential_process.rs
+++ b/tests/testsuite/credential_process.rs
@@ -670,7 +670,7 @@ fn basic_provider() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 CARGO=Some([..])
 CARGO_REGISTRY_NAME_OPT=Some("alternative")
 CARGO_REGISTRY_INDEX_URL=Some("[ROOTURL]/alternative-registry")
@@ -730,7 +730,7 @@ fn basic_provider_crlf() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
 [CHECKING] bar v0.0.1 (registry `alternative`)

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -767,7 +767,7 @@ fn build_script_needed_for_host_and_target() {
     p.cargo("build -v --target")
         .arg(&target)
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] d1 v0.0.0 ([ROOT]/foo/d1)
 [RUNNING] `rustc [..] d1/build.rs [..] --out-dir [ROOT]/foo/target/debug/build/d1-[HASH] [..]
 [RUNNING] `[ROOT]/foo/target/debug/build/d1-[HASH]/build-script-build`
@@ -943,7 +943,7 @@ fn build_script_with_platform_specific_dependencies() {
     p.cargo("build -v --target")
         .arg(&target)
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] d2 v0.0.0 ([ROOT]/foo/d2)
 [RUNNING] `rustc [..] d2/src/lib.rs [..]`
 [COMPILING] d1 v0.0.0 ([ROOT]/foo/d1)
@@ -1194,7 +1194,7 @@ fn cross_test_dylib() {
     p.cargo("test --target")
         .arg(&target)
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -108,7 +108,7 @@ fn simple() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.1.0
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -148,7 +148,7 @@ fn simple_install() {
     cargo_process("install bar")
         .with_stderr_data(str![[r#"
 [INSTALLING] bar v0.1.0
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] foo v0.0.1
 [COMPILING] bar v0.1.0
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
@@ -241,7 +241,7 @@ fn install_without_feature_dep() {
     cargo_process("install bar")
         .with_stderr_data(str![[r#"
 [INSTALLING] bar v0.1.0
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] foo v0.0.1
 [COMPILING] bar v0.1.0
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
@@ -328,7 +328,7 @@ fn multiple() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] bar v0.1.0 (available: v0.2.0)
 [CHECKING] bar v0.1.0
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
@@ -367,7 +367,7 @@ fn crates_io_then_directory() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [CHECKING] bar v0.1.0
@@ -476,7 +476,7 @@ fn bad_file_checksum() {
     p.cargo("check")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ERROR] the listed checksum of `[ROOT]/index/bar/src/lib.rs` has changed:
 expected: [..]
 actual:   [..]
@@ -734,7 +734,7 @@ fn workspace_different_locations() {
     p.cargo("check")
         .cwd("bar")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -119,7 +119,7 @@ fn doc_deps() {
     p.cargo("doc")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOCUMENTING] bar v0.0.1 ([ROOT]/foo/bar)
 [CHECKING] bar v0.0.1 ([ROOT]/foo/bar)
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
@@ -176,7 +176,7 @@ fn doc_no_deps() {
 
     p.cargo("doc --no-deps")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.0.1 ([ROOT]/foo/bar)
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -729,7 +729,7 @@ fn doc_dash_p() {
     p.cargo("doc -p a")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOCUMENTING] b v0.0.1 ([ROOT]/foo/b)
 [CHECKING] b v0.0.1 ([ROOT]/foo/b)
 [DOCUMENTING] a v0.0.1 ([ROOT]/foo/a)
@@ -1070,7 +1070,7 @@ fn features() {
     p.cargo("doc --features foo")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.0.1 ([ROOT]/foo/bar)
 [DOCUMENTING] bar v0.0.1 ([ROOT]/foo/bar)
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
@@ -1408,7 +1408,7 @@ fn doc_all_member_dependency_same_name() {
     p.cargo("doc --workspace")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [WARNING] output filename collision at [ROOT]/foo/target/doc/bar/index.html
@@ -1845,7 +1845,7 @@ fn doc_cap_lints() {
     p.cargo("doc")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] git repository `[..]`
 [DOCUMENTING] a v0.5.0 ([..])
 [CHECKING] a v0.5.0 ([..])
@@ -2212,7 +2212,7 @@ fn bin_private_items_deps() {
     p.cargo("doc")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOCUMENTING] bar v0.0.1 ([ROOT]/foo/bar)
 [CHECKING] bar v0.0.1 ([ROOT]/foo/bar)
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
@@ -2788,7 +2788,7 @@ fn doc_lib_false() {
 
     p.cargo("doc")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [DOCUMENTING] foo v0.1.0 ([ROOT]/foo)
@@ -2838,7 +2838,7 @@ fn doc_lib_false_dep() {
 
     p.cargo("doc")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [DOCUMENTING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -3119,7 +3119,7 @@ fn rebuild_tracks_env_in_dep() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [CHECKING] bar v0.1.0
@@ -3246,7 +3246,7 @@ fn mergeable_info_with_deps() {
         .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info"])
         .with_stderr_data(
             str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOCUMENTING] dep v0.0.0 ([ROOT]/foo/dep)
 [CHECKING] dep v0.0.0 ([ROOT]/foo/dep)
 [RUNNING] `rustdoc [..]--crate-name dep [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/out [..]`
@@ -3332,7 +3332,7 @@ fn mergeable_info_no_deps() {
         .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info"])
         .with_stderr_data(
             str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] dep v0.0.0 ([ROOT]/foo/dep)
 [RUNNING] `rustc --crate-name dep --edition=2015 [..]`
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo)
@@ -3974,7 +3974,7 @@ fn mergeable_info_dep_collision() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [ADDING] dep v0.1.0 (available: v0.2.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)
@@ -4134,7 +4134,7 @@ fn doc_output_format_json_no_deps() {
     p.cargo("doc --no-deps -Z unstable-options --output-format json -v")
         .masquerade_as_nightly_cargo(&["rustdoc-output-format"])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [RUNNING] `rustc [..]--crate-name bar [..]`
 [DOCUMENTING] foo v0.1.0 ([ROOT]/foo)
@@ -4185,7 +4185,7 @@ fn doc_output_format_json_with_deps() {
         .masquerade_as_nightly_cargo(&["rustdoc-output-format"])
         .with_stderr_data(
             str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [RUNNING] `rustc [..]--crate-name bar [..]`
 [DOCUMENTING] bar v0.1.0 ([ROOT]/foo/bar)

--- a/tests/testsuite/docscrape.rs
+++ b/tests/testsuite/docscrape.rs
@@ -116,7 +116,7 @@ impl Foo {
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .with_stderr_data(
             str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] a v0.0.1 ([ROOT]/foo/crates/a)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [SCRAPING] foo v0.0.1 ([ROOT]/foo)
@@ -612,7 +612,7 @@ fn no_scrape_with_dev_deps() {
     p.cargo("doc -Zunstable-options -Z rustdoc-scrape-examples")
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [WARNING] Rustdoc did not scrape the following examples because they require dev-dependencies: ex
     If you want Rustdoc to scrape these examples, then add `doc-scrape-examples = true`
     to the [[example]] target configuration of at least one example.
@@ -682,7 +682,7 @@ fn use_dev_deps_if_explicitly_enabled() {
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .with_stderr_data(
             str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] a v0.0.1 ([ROOT]/foo/a)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [SCRAPING] foo v0.0.1 ([ROOT]/foo)

--- a/tests/testsuite/feature_unification.rs
+++ b/tests/testsuite/feature_unification.rs
@@ -206,7 +206,7 @@ fn package_feature_unification() {
         .masquerade_as_nightly_cargo(&["feature-unification"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] common v0.1.0 ([ROOT]/foo/common)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -485,7 +485,7 @@ fn package_feature_unification_cli_features() {
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [CHECKING] common v0.1.0 ([ROOT]/foo/common)
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] outside v0.1.0 (registry `dummy-registry`)
 [CHECKING] outside v0.1.0
@@ -1059,7 +1059,7 @@ fn edition_v2_resolver_report() {
             str![[r#"
 [MIGRATING] Cargo.toml from 2018 edition to 2021
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] common v1.0.0 (registry `dummy-registry`)
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -133,7 +133,7 @@ fn same_name() {
     p.cargo("tree -f")
         .arg("{p} [{f}]")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -496,7 +496,7 @@ fn cli_activates_required_dependency() {
 
     p.cargo("check --features bar")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ERROR] package `foo v0.0.1 ([ROOT]/foo)` does not have feature `bar`
 
 [HELP] a dependency with that name exists but it is required dependency and only optional dependencies can be used as features.
@@ -666,7 +666,7 @@ fn no_feature_doesnt_build() {
 
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -742,7 +742,7 @@ fn default_feature_pulled_in() {
 
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -885,7 +885,7 @@ fn groups_on_groups_on_groups() {
     p.cargo("check")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [CHECKING] bar v0.0.1 ([ROOT]/foo/bar)
 [CHECKING] baz v0.0.1 ([ROOT]/foo/baz)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -938,7 +938,7 @@ fn many_cli_features() {
         .arg("bar baz")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [CHECKING] bar v0.0.1 ([ROOT]/foo/bar)
 [CHECKING] baz v0.0.1 ([ROOT]/foo/baz)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -1026,7 +1026,7 @@ fn union_features() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [CHECKING] d2 v0.0.1 ([ROOT]/foo/d2)
 [CHECKING] d1 v0.0.1 ([ROOT]/foo/d1)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -1074,7 +1074,7 @@ fn many_features_no_rebuilds() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] a v0.1.0 ([ROOT]/foo/a)
 [CHECKING] b v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1375,7 +1375,7 @@ fn optional_and_dev_dep() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] test v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1663,7 +1663,7 @@ fn many_cli_features_comma_delimited() {
     p.cargo("check --features bar,baz")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [CHECKING] bar v0.0.1 ([ROOT]/foo/bar)
 [CHECKING] baz v0.0.1 ([ROOT]/foo/baz)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -1732,7 +1732,7 @@ fn many_cli_features_comma_and_space_delimited() {
         .arg("bar,baz bam bap")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 4 packages to highest compatible versions
 [CHECKING] bam v0.0.1 ([ROOT]/foo/bam)
 [CHECKING] bap v0.0.1 ([ROOT]/foo/bap)
 [CHECKING] bar v0.0.1 ([ROOT]/foo/bar)
@@ -1907,7 +1907,7 @@ fn warn_if_default_features() {
 [WARNING] Cargo.toml: `[features]` defines a feature named `default-features`
 [NOTE] only a feature named `default` will be enabled by default
 [WARNING] `foo` (manifest) generated 1 warning
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2267,7 +2267,7 @@ fn registry_summary_order_doesnt_matter() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -910,7 +910,7 @@ fn required_features_host_dep() {
     p.cargo("run")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ERROR] target `x` in package `foo` requires the features: `bdep/f1`
 Consider enabling them by passing, e.g., `--features="bdep/f1"`
 
@@ -1028,7 +1028,7 @@ fn required_features_inactive_dep() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -1283,7 +1283,7 @@ fn has_dev_dep_for_test() {
 
     p.cargo("check -v")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1698,7 +1698,7 @@ fn resolver_enables_new_features() {
         .env("EXPECTED_FEATS", "1")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] common v1.0.0 (registry `dummy-registry`)
 [COMPILING] common v1.0.0
@@ -2112,7 +2112,7 @@ fn doc_optional() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] spin v1.0.0 (registry `dummy-registry`)
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
@@ -2229,7 +2229,7 @@ fn minimal_download() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 14 packages to latest compatible versions
+[LOCKING] 14 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] normal_pm v1.0.0 (registry `dummy-registry`)
 [DOWNLOADED] normal v1.0.0 (registry `dummy-registry`)
@@ -2678,7 +2678,7 @@ fn all_features_merges_with_features() {
     p.cargo("run --example ex --all-features --features dep/feat1")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)
 [COMPILING] dep v0.1.0
@@ -2768,7 +2768,7 @@ fn dep_with_optional_host_deps_activated() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [COMPILING] serde_build v0.1.0 ([ROOT]/foo/serde_build)
 [COMPILING] serde_derive v0.1.0 ([ROOT]/foo/serde_derive)
 [COMPILING] serde v0.1.0 ([ROOT]/foo/serde)
@@ -2813,7 +2813,7 @@ fn dont_unify_proc_macro_example_from_dependency() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] pm_helper v0.0.0 ([ROOT]/foo/pm_helper)
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/features_namespaced.rs
+++ b/tests/testsuite/features_namespaced.rs
@@ -35,7 +35,7 @@ fn dependency_with_crate_syntax() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [DOWNLOADED] baz v1.0.0 (registry `dummy-registry`)
@@ -177,7 +177,7 @@ fn namespaced_implicit_feature() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -326,7 +326,7 @@ fn namespaced_same_name() {
     p.cargo("run")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `target/debug/foo[EXE]`
@@ -390,7 +390,7 @@ fn no_implicit_feature() {
     p.cargo("run")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `target/debug/foo[EXE]`
@@ -571,7 +571,7 @@ fn crate_required_features() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ERROR] invalid feature `dep:bar` in required-features of target `foo`: `dep:` prefixed feature values are not allowed in required-features
 
 "#]])
@@ -701,7 +701,7 @@ fn crate_feature_with_explicit() {
     p.cargo("check --features f1")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [CHECKING] bar v1.0.0
@@ -1339,7 +1339,7 @@ foo v0.1.0 ([ROOT]/foo) features=
 
 "#]])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]])
         .run();

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -1346,7 +1346,7 @@ fn only_warn_for_relevant_crates() {
     p.cargo("fix --allow-no-vcs --edition")
         .with_stderr_data(str![[r#"
 [MIGRATING] Cargo.toml from 2015 edition to 2018
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] a v0.1.0 ([ROOT]/foo/a)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [MIGRATING] src/lib.rs from 2015 edition to 2018
@@ -1571,7 +1571,7 @@ fn edition_v2_resolver_report() {
         .with_stderr_data(str![[r#"
 [MIGRATING] Cargo.toml from 2018 edition to 2021
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] common v1.0.0 (registry `dummy-registry`)
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
@@ -1780,7 +1780,7 @@ fn abnormal_exit() {
         )
         // "signal: 6, SIGABRT: process abort signal" on some platforms
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] pm v0.1.0 ([ROOT]/foo/pm)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [ERROR] errors present after applying fixes to crate `foo`
@@ -2929,7 +2929,7 @@ dep_df_false = { version = "0.1.0", default-features = false }
 [MIGRATING] pkg_df_false/Cargo.toml from 2021 edition to 2024
 [FIXED] pkg_df_false/Cargo.toml (6 fixes)
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep_simple v0.1.0 (registry `dummy-registry`)
 [DOWNLOADED] dep_df_true v0.1.0 (registry `dummy-registry`)

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -146,7 +146,7 @@ fn rebuild_sub_package_then_while_package() {
 
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] b v0.0.1 ([ROOT]/foo/b)
 [COMPILING] a v0.0.1 ([ROOT]/foo/a)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -400,7 +400,7 @@ ftest off
 
 "#]])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] dep_crate v0.0.1 ([ROOT]/foo/dep_crate)
 [COMPILING] a v0.0.1 ([ROOT]/foo/a)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -431,7 +431,7 @@ ftest on
 
 "#]])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] dep_crate v0.0.1 ([ROOT]/foo/dep_crate)
 [COMPILING] b v0.0.1 ([ROOT]/foo/b)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -807,7 +807,7 @@ fn same_build_dir_cached_packages() {
     p.cargo("build")
         .cwd("a1")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [COMPILING] d v0.0.1 ([ROOT]/foo/d)
 [COMPILING] c v0.0.1 ([ROOT]/foo/c)
 [COMPILING] b v0.0.1 ([ROOT]/foo/b)
@@ -819,7 +819,7 @@ fn same_build_dir_cached_packages() {
     p.cargo("build")
         .cwd("a2")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [COMPILING] a2 v0.0.1 ([ROOT]/foo/a2)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1422,7 +1422,7 @@ fn update_dependency_mtime_does_not_rebuild() {
         .masquerade_as_nightly_cargo(&["mtime-on-use"])
         .env("RUSTFLAGS", "-C linker=cc")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1580,7 +1580,7 @@ fn reuse_panic_build_dep_test() {
     // Check that `bar` is not built twice. It is only needed once (without `panic`).
     p.cargo("test --lib --no-run -v")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `rustc --crate-name bar [..]
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -1641,7 +1641,7 @@ fn reuse_panic_pm() {
     p.cargo("build -v")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `rustc --crate-name bar [..] -C panic=abort [..]
 [RUNNING] `rustc --crate-name bar [..]
@@ -3296,7 +3296,7 @@ fn symlink_to_package() {
         .build();
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v1.0.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/freshness_checksum.rs
+++ b/tests/testsuite/freshness_checksum.rs
@@ -291,7 +291,7 @@ fn rebuild_sub_package_then_while_package() {
     p.cargo("build -Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] b v0.0.1 ([ROOT]/foo/b)
 [COMPILING] a v0.0.1 ([ROOT]/foo/a)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -555,7 +555,7 @@ ftest off
 
 "#]])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] dep_crate v0.0.1 ([ROOT]/foo/dep_crate)
 [COMPILING] a v0.0.1 ([ROOT]/foo/a)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -588,7 +588,7 @@ ftest on
 
 "#]])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] dep_crate v0.0.1 ([ROOT]/foo/dep_crate)
 [COMPILING] b v0.0.1 ([ROOT]/foo/b)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -984,7 +984,7 @@ fn same_build_dir_cached_packages() {
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .cwd("a1")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [COMPILING] d v0.0.1 ([ROOT]/foo/d)
 [COMPILING] c v0.0.1 ([ROOT]/foo/c)
 [COMPILING] b v0.0.1 ([ROOT]/foo/b)
@@ -997,7 +997,7 @@ fn same_build_dir_cached_packages() {
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .cwd("a2")
         .with_stderr_data(str![[r#"
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [COMPILING] a2 v0.0.1 ([ROOT]/foo/a2)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1607,7 +1607,7 @@ fn reuse_panic_build_dep_test() {
     p.cargo("test -Zchecksum-freshness --lib --no-run -v")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `rustc --crate-name bar [..]
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -1669,7 +1669,7 @@ fn reuse_panic_pm() {
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `rustc --crate-name bar [..] -C panic=abort [..]
 [RUNNING] `rustc --crate-name bar [..]

--- a/tests/testsuite/future_incompat_report.rs
+++ b/tests/testsuite/future_incompat_report.rs
@@ -129,7 +129,7 @@ fn incompat_in_dependency() {
         .env("RUSTFLAGS", "-Zfuture-incompat-test")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [CHECKING] bar v1.0.0
@@ -678,7 +678,7 @@ fn correct_report_id_when_cached() {
         .env("RUSTFLAGS", "-Zfuture-incompat-test")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [CHECKING] bar v1.0.0

--- a/tests/testsuite/generate_lockfile.rs
+++ b/tests/testsuite/generate_lockfile.rs
@@ -65,11 +65,11 @@ fn no_index_update_sparse() {
     no_index_update(
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]],
         str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]],
     );
@@ -80,11 +80,11 @@ fn no_index_update_git() {
     no_index_update(
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]],
         str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]],
     );
@@ -273,14 +273,14 @@ fn generate_lockfile_holds_lock_and_offline() {
     p.cargo("generate-lockfile")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]])
         .run();
 
     p.cargo("generate-lockfile --offline")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]])
         .run();
@@ -342,7 +342,7 @@ fn publish_time() {
         .masquerade_as_nightly_cargo(&["publish-time"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions as of 2025-03-01T06:00:00Z
+[LOCKING] 2 packages to highest compatible versions as of 2025-03-01T06:00:00Z
 [ADDING] has_time v2025.1.1 (available: v2025.6.1)
 
 "#]])

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -61,7 +61,7 @@ fn cargo_compile_simple_git_dep() {
         .cargo("build")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep1`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] dep1 v0.5.0 ([ROOTURL]/dep1#[..])
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -133,7 +133,7 @@ fn cargo_compile_git_dep_branch() {
         .cargo("build")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep1`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] dep1 v0.5.0 ([ROOTURL]/dep1?branch=branchy#[..])
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -210,7 +210,7 @@ fn cargo_compile_git_dep_tag() {
         .cargo("build")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep1`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] dep1 v0.5.0 ([ROOTURL]/dep1?tag=v0.1.0#[..])
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -291,7 +291,7 @@ fn cargo_compile_git_dep_pull_request() {
         .cargo("build")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep1`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] dep1 v0.5.0 ([ROOTURL]/dep1?rev=refs%2Fpull%2F330%2Fhead#[..])
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -636,7 +636,7 @@ fn recompilation() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.5.0 ([ROOTURL]/bar#[..])
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -665,7 +665,7 @@ fn recompilation() {
     p.cargo("update")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 0 packages to latest compatible versions
+[LOCKING] 0 packages to highest compatible versions
 
 "#]])
         .run();
@@ -696,7 +696,7 @@ fn recompilation() {
     p.cargo("update")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] bar v0.5.0 ([ROOTURL]/bar#[..]) -> #[..]
 
 "#]])
@@ -804,7 +804,7 @@ fn update_with_shared_deps() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [CHECKING] bar v0.5.0 ([ROOTURL]/bar#[..])
 [CHECKING] dep1 v0.5.0 ([ROOT]/foo/dep1)
 [CHECKING] dep2 v0.5.0 ([ROOT]/foo/dep2)
@@ -830,7 +830,7 @@ fn update_with_shared_deps() {
     p.cargo("update dep1")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] bar v0.5.0 ([ROOTURL]/bar#[..]) -> #[..]
 
 "#]])
@@ -873,7 +873,7 @@ Caused by:
     p.cargo("update dep1 --recursive")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] bar v0.5.0 ([ROOTURL]/bar#[..]) -> #[..]
 
 "#]])
@@ -899,7 +899,7 @@ Caused by:
     p.cargo("update bar")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 0 packages to latest compatible versions
+[LOCKING] 0 packages to highest compatible versions
 
 "#]])
         .run();
@@ -948,7 +948,7 @@ fn dep_with_submodule() {
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep1`
 [UPDATING] git submodule `[ROOTURL]/dep2`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] dep1 v0.5.0 ([ROOTURL]/dep1#[..])
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1023,7 +1023,7 @@ fn dep_with_relative_submodule() {
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/base`
 [UPDATING] git submodule `[ROOTURL]/deployment`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [CHECKING] deployment v0.5.0 ([ROOTURL]/base#[..])
 [CHECKING] base v0.5.0 ([ROOTURL]/base#[..])
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
@@ -1173,7 +1173,7 @@ fn dep_with_skipped_submodule() {
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
 [SKIPPING] git submodule `[ROOTURL]/qux` due to update strategy in .gitmodules
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.0.0 ([ROOTURL]/bar#[..])
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1310,7 +1310,7 @@ fn no_duplicate_package_warning_with_dotdot_cargo_home() {
         .env("CARGO_HOME", &cargo_home)
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [CHECKING] member v0.1.0 ([ROOTURL]/dep#[..])
 [CHECKING] dep v0.1.0 ([ROOTURL]/dep#[..])
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
@@ -1470,7 +1470,7 @@ fn two_deps_only_update_one() {
             str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep1`
 [UPDATING] git repository `[ROOTURL]/dep2`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [CHECKING] dep1 v0.5.0 ([ROOTURL]/dep1#[..])
 [CHECKING] dep2 v0.5.0 ([ROOTURL]/dep2#[..])
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
@@ -1490,7 +1490,7 @@ fn two_deps_only_update_one() {
     p.cargo("update dep1")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep1`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] dep1 v0.5.0 ([ROOTURL]/dep1#[..]) -> #[..]
 
 "#]])
@@ -1631,7 +1631,7 @@ fn dep_with_changed_submodule() {
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep1`
 [UPDATING] git submodule `[ROOTURL]/dep2`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] dep1 v0.5.0 ([ROOTURL]/dep1#[..])
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1686,7 +1686,7 @@ project2
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep1`
 [UPDATING] git submodule `[ROOTURL]/dep3`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] dep1 v0.5.0 ([ROOTURL]/dep1#[..]) -> #[..]
 
 "#]])
@@ -1765,7 +1765,7 @@ fn dev_deps_with_testing() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1884,7 +1884,7 @@ fn git_name_not_always_needed() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1926,7 +1926,7 @@ fn git_repo_changing_no_rebuild() {
     p1.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] p1 v0.5.0 ([ROOT]/p1)
 [CHECKING] bar v0.5.0 ([ROOTURL]/bar#[..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1963,7 +1963,7 @@ fn git_repo_changing_no_rebuild() {
     p2.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.5.0 ([ROOTURL]/bar#[..])
 [CHECKING] p2 v0.5.0 ([ROOT]/p2)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2092,7 +2092,7 @@ fn fetch_downloads() {
     p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]])
         .run();
@@ -2138,7 +2138,7 @@ fn fetch_downloads_with_git2_first_then_with_gitoxide_and_vice_versa() {
         .masquerade_as_nightly_cargo(&["unstable features must be available for -Z gitoxide"])
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]])
         .run();
@@ -2177,7 +2177,7 @@ fn warnings_in_git_dep() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.5.0 ([ROOTURL]/bar#[..])
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2290,7 +2290,7 @@ fn update_one_dep_in_repo_with_many_deps() {
     p.cargo("update bar")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 0 packages to latest compatible versions
+[LOCKING] 0 packages to highest compatible versions
 
 "#]])
         .run();
@@ -2367,7 +2367,7 @@ fn switch_deps_does_not_update_transitive() {
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep1`
 [UPDATING] git repository `[ROOTURL]/transitive`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [CHECKING] transitive v0.5.0 ([ROOTURL]/transitive#[..])
 [CHECKING] dep v0.5.0 ([ROOTURL]/dep1#[..])
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
@@ -2397,7 +2397,7 @@ fn switch_deps_does_not_update_transitive() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep2`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] dep v0.5.0 ([ROOTURL]/dep2#[..])
 [CHECKING] dep v0.5.0 ([ROOTURL]/dep2#[..])
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
@@ -2516,7 +2516,7 @@ fn switch_sources() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/a1`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [CHECKING] a v0.5.0 ([ROOTURL]/a1#[..])
 [CHECKING] b v0.5.0 ([ROOT]/foo/b)
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
@@ -2544,7 +2544,7 @@ fn switch_sources() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/a2`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] a v0.5.1 ([ROOTURL]/a2#[..])
 [CHECKING] a v0.5.1 ([ROOTURL]/a2#[..])
 [CHECKING] b v0.5.0 ([ROOT]/foo/b)
@@ -2678,7 +2678,7 @@ fn lints_are_suppressed() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/a`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] a v0.5.0 ([ROOTURL]/a#[..])
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2722,7 +2722,7 @@ fn denied_lints_are_allowed() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/a`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] a v0.5.0 ([ROOTURL]/a#[..])
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -3093,7 +3093,7 @@ fn use_the_cli() {
 [RUNNING] `git -c core.fsmonitor=false fetch --no-tags --verbose --force --update-head-ok [..][ROOTURL]/dep1[..] [..]+HEAD:refs/remotes/origin/HEAD[..]`
 From [ROOTURL]/dep1
  * [new ref] [..] -> origin/HEAD[..]
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] dep1 v0.5.0 ([ROOTURL]/dep1#[..])
 [RUNNING] `rustc --crate-name dep1 [..]`
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
@@ -3727,7 +3727,7 @@ fn default_not_master() {
         .cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep1`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] dep1 v0.5.0 ([ROOTURL]/dep1#[..])
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -3791,7 +3791,7 @@ dependencies = [
     project
         .cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] dep1 v0.5.0 ([ROOTURL]/dep1?branch=master#[..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -3911,7 +3911,7 @@ fn two_dep_forms() {
             str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep1`
 [UPDATING] git repository `[ROOTURL]/dep1`
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [CHECKING] dep1 v0.5.0 ([ROOTURL]/dep1#[..])
 [CHECKING] dep1 v0.5.0 ([ROOTURL]/dep1?branch=master#[..])
 [CHECKING] a v0.5.0 ([ROOT]/foo/a)
@@ -4434,7 +4434,7 @@ fn different_user_relative_submodules() {
 [UPDATING] git repository `[ROOTURL]/user1/dep1`
 [UPDATING] git submodule `[ROOTURL]/user2/dep1`
 [UPDATING] git submodule `[ROOTURL]/user2/dep2`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] dep1 v0.5.0 ([ROOTURL]/user1/dep1#[..])
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -4774,7 +4774,7 @@ fn dep_with_cached_submodule() {
 [UPDATING] git repository `[ROOTURL]/dep1`
 [UPDATING] git submodule `[ROOTURL]/dep3`
 [UPDATING] git repository `[ROOTURL]/dep2`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [CHECKING] dep[..] v0.5.0 ([ROOTURL]/dep[..]#[..])
 [CHECKING] dep[..] v0.5.0 ([ROOTURL]/dep[..]#[..])
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
@@ -4963,7 +4963,7 @@ fn lockfile_with_multiple_revisions_bump_pkg_version() {
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/m2`
 [UPDATING] git repository `[ROOTURL]/upstream`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [ADDING] b v0.1.0 ([ROOTURL]/upstream#[..])
 [ADDING] m2 v0.1.0 ([ROOTURL]/m2#[..])
 [ERROR] failed to download `a v0.1.0 ([ROOTURL]/upstream#[..])`
@@ -5124,7 +5124,7 @@ rev1
             str![[r#"
 [UPDATING] git repository `[ROOTURL]/m2`
 [UPDATING] git repository `[ROOTURL]/upstream`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [ADDING] b v0.1.0 ([ROOTURL]/upstream#[..])
 [ADDING] m2 v0.1.0 ([ROOTURL]/m2#[..])
 [COMPILING] a v0.1.0 ([ROOTURL]/upstream#[..])

--- a/tests/testsuite/global_cache_tracker.rs
+++ b/tests/testsuite/global_cache_tracker.rs
@@ -1276,7 +1276,7 @@ fn package_cache_lock_during_build() {
         .env("CARGO_LOG", "gc=debug")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
    [..]s DEBUG gc: unable to acquire mutate lock, auto gc disabled
 [CHECKING] bar v1.0.0
 [CHECKING] foo2 v0.1.0 ([ROOT]/foo2)
@@ -1547,7 +1547,7 @@ fn clean_max_git_age() {
         .env("__CARGO_TEST_LAST_USE_NOW", days_ago_unix(2))
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/git_a`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] git_a v1.0.0 ([ROOTURL]/git_a#[..]) -> #[..]
 
 "#]])
@@ -1623,7 +1623,7 @@ fn clean_max_src_crate_age() {
         .env("__CARGO_TEST_LAST_USE_NOW", days_ago_unix(2))
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] bar v1.0.0 -> v1.0.1
 
 "#]])

--- a/tests/testsuite/hints.rs
+++ b/tests/testsuite/hints.rs
@@ -70,7 +70,7 @@ fn unknown_hints_warn() {
 [WARNING] Cargo.toml: unused manifest key: hints.this-is-an-unknown-hint
 [WARNING] `foo` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [CHECKING] bar v1.0.0
@@ -121,7 +121,7 @@ fn hint_unknown_type_warn() {
     p.cargo("check -v")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [WARNING] foo@0.0.1: ignoring unsupported value type (string) for 'hints.mostly-unused', which expects a boolean
@@ -174,7 +174,7 @@ fn hints_mostly_unused_warn_without_gate() {
     p.cargo("check -v")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [WARNING] foo@0.0.1: ignoring 'hints.mostly-unused', pass `-Zprofile-hint-mostly-unused` to enable it
@@ -225,7 +225,7 @@ fn hints_mostly_unused_nightly() {
         .masquerade_as_nightly_cargo(&["profile-hint-mostly-unused"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [CHECKING] bar v1.0.0
@@ -280,7 +280,7 @@ fn mostly_unused_profile_overrides_hints_nightly() {
         .masquerade_as_nightly_cargo(&["profile-hint-mostly-unused"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [CHECKING] bar v1.0.0

--- a/tests/testsuite/https.rs
+++ b/tests/testsuite/https.rs
@@ -132,7 +132,7 @@ fn self_signed_with_cacert() {
     p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `https://127.0.0.1:[..]/repos/bar.git`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]])
         .run();
@@ -159,7 +159,7 @@ fn github_works() {
     p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `https://github.com/rust-lang/bitflags.git`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]])
         .run();
@@ -173,7 +173,7 @@ fn github_works_cargo_install() {
 [INSTALLING] bitflags-smoke-test [..]
 [WARNING] Cargo.toml: unused manifest key: dependencies.bitflags.all-features
 [WARNING] `bitflags-smoke-test` (manifest) generated 1 warning
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 ...
 [INSTALLED] package [..]
 ...

--- a/tests/testsuite/inheritable_workspace_fields.rs
+++ b/tests/testsuite/inheritable_workspace_fields.rs
@@ -300,7 +300,7 @@ fn inherit_own_dependencies() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v0.1.2 (registry `dummy-registry`)
 [DOWNLOADED] dep-build v0.8.2 (registry `dummy-registry`)
@@ -473,7 +473,7 @@ fn inherit_own_detailed_dependencies() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v0.1.2 (registry `dummy-registry`)
 [CHECKING] dep v0.1.2
@@ -662,7 +662,7 @@ fn inherited_dependencies_union_features() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] fancy_dep v0.2.4 (registry `dummy-registry`)
 [DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)
@@ -904,7 +904,7 @@ fn inherit_dependencies() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v0.1.2 (registry `dummy-registry`)
 [DOWNLOADED] dep-build v0.8.2 (registry `dummy-registry`)
@@ -1080,7 +1080,7 @@ fn inherit_target_dependencies() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v0.1.2 (registry `dummy-registry`)
 [CHECKING] dep v0.1.2
@@ -1127,7 +1127,7 @@ fn inherit_dependency_override_optional() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.2.0 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1171,7 +1171,7 @@ fn inherit_dependency_features() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)
 [DOWNLOADED] fancy_dep v0.2.4 (registry `dummy-registry`)
@@ -1243,7 +1243,7 @@ fn inherit_detailed_dependencies() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/detailed`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] detailed v0.5.0 ([ROOTURL]/detailed?branch=branchy#[..])
 [CHECKING] bar v0.2.0 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1542,7 +1542,7 @@ fn warn_inherit_def_feat_true_member_def_feat_false() {
 [WARNING] Cargo.toml: `default-features` is ignored for dep, since `default-features` was true for `workspace.dependencies.dep`, this could become a hard error in the future
 [WARNING] `bar` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)
 [DOWNLOADED] fancy_dep v0.2.4 (registry `dummy-registry`)
@@ -1635,7 +1635,7 @@ fn warn_inherit_simple_member_def_feat_false() {
 [WARNING] Cargo.toml: `default-features` is ignored for dep, since `default-features` was not specified for `workspace.dependencies.dep`, this could become a hard error in the future
 [WARNING] `bar` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)
 [DOWNLOADED] fancy_dep v0.2.4 (registry `dummy-registry`)
@@ -1728,7 +1728,7 @@ fn inherit_def_feat_false_member_def_feat_true() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)
 [DOWNLOADED] fancy_dep v0.2.4 (registry `dummy-registry`)
@@ -1817,7 +1817,7 @@ fn warn_inherit_unused_manifest_key_dep() {
 [WARNING] Cargo.toml: unused manifest key: dependencies.dep.wxz
 [WARNING] `bar` (manifest) generated 2 warnings
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)
 [CHECKING] dep v0.1.0

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -2749,7 +2749,7 @@ fn self_referential() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.2 (registry `dummy-registry`)
 [INSTALLING] foo v0.0.2
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] foo v0.0.1 (available: v0.0.2)
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
@@ -2794,7 +2794,7 @@ fn ambiguous_registry_vs_local_package() {
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.1.0 ([ROOT]/foo)
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
 [COMPILING] foo v0.0.1
@@ -3068,7 +3068,7 @@ fn dry_run_incompatible_package_dependency() {
 [INSTALLING] foo v0.1.0 ([ROOT]/foo)
 [WARNING] Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
 [WARNING] `foo` (manifest) generated 1 warning
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ERROR] failed to compile `foo v0.1.0 ([ROOT]/foo)`, intermediate artifacts can be found at `[ROOT]/foo/target`.
 To reuse those artifacts with a future compilation, set the environment variable `CARGO_BUILD_BUILD_DIR` to that path.
 

--- a/tests/testsuite/lints/mod.rs
+++ b/tests/testsuite/lints/mod.rs
@@ -240,7 +240,7 @@ bar = "0.1.0"
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 ...
 

--- a/tests/testsuite/lints/non_kebab_case_features.rs
+++ b/tests/testsuite/lints/non_kebab_case_features.rs
@@ -85,7 +85,7 @@ non_kebab_case_features = "warn"
   = [NOTE] `cargo::non_kebab_case_features` is set to `warn` in `[lints]`
 [WARNING] `foo` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 ...
 

--- a/tests/testsuite/lints/non_snake_case_features.rs
+++ b/tests/testsuite/lints/non_snake_case_features.rs
@@ -85,7 +85,7 @@ non_snake_case_features = "warn"
   = [NOTE] `cargo::non_snake_case_features` is set to `warn` in `[lints]`
 [WARNING] `foo` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 ...
 

--- a/tests/testsuite/lints/unused_dependencies.rs
+++ b/tests/testsuite/lints/unused_dependencies.rs
@@ -38,7 +38,7 @@ fn unused_dep_normal() {
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
 [CHECKING] unused v0.1.0
@@ -97,7 +97,7 @@ fn unused_dep_build() {
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
 [COMPILING] unused v0.1.0
@@ -159,7 +159,7 @@ fn unused_dep_build_no_build_rs() {
 [HELP] consider removing the dependency on `unused`
 [WARNING] `foo` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
@@ -223,7 +223,7 @@ fn unused_dep_lib_bins() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
 [DOWNLOADED] lib_used v0.1.0 (registry `dummy-registry`)
@@ -318,7 +318,7 @@ fn unused_dep_build_with_used_dep_normal() {
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] unused_build v0.1.0 (registry `dummy-registry`)
 [COMPILING] unused_build v0.1.0
@@ -380,7 +380,7 @@ fn unused_dep_normal_but_implicit_used_dep_dev() {
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] used_dev v0.1.0 (registry `dummy-registry`)
 [CHECKING] used_dev v0.1.0
@@ -464,7 +464,7 @@ fn unused_dep_normal_but_explicit_used_dep_dev() {
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] used_once v0.1.0 (registry `dummy-registry`)
 [CHECKING] used_once v0.1.0
@@ -532,7 +532,7 @@ fn unused_dep_dev_but_explicit_used_dep_normal() {
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] used_once v0.1.0 (registry `dummy-registry`)
 [CHECKING] used_once v0.1.0
@@ -582,7 +582,7 @@ fn optional_dependency() {
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -654,7 +654,7 @@ fn unused_dep_renamed() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.2.0 (registry `dummy-registry`)
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
@@ -712,7 +712,7 @@ fn warning_replay() {
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
 [CHECKING] unused v0.1.0
@@ -790,7 +790,7 @@ fn unused_dep_target() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] used v0.1.0 (registry `dummy-registry`)
 [DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
@@ -887,7 +887,7 @@ fn unused_dev_deps() {
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 6 packages to latest compatible versions
+[LOCKING] 6 packages to highest compatible versions
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1069,7 +1069,7 @@ fn package_selection() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 7 packages to latest compatible versions
+[LOCKING] 7 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] unused_bar v0.1.0 (registry `dummy-registry`)
 [DOWNLOADED] unused_external v0.1.0 (registry `dummy-registry`)
@@ -1227,7 +1227,7 @@ fn pinned_transitive_dep() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] intermediate v0.1.0 (registry `dummy-registry`)
 [DOWNLOADED] transitive v0.1.1 (registry `dummy-registry`)
@@ -1302,7 +1302,7 @@ pub fn fun() -> &'static str {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] intermediate v0.1.0 (registry `dummy-registry`)
 [DOWNLOADED] transitive v0.1.1 (registry `dummy-registry`)
@@ -1352,7 +1352,7 @@ fn allow_rustflags() {
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
 [CHECKING] unused v0.1.0
@@ -1407,7 +1407,7 @@ fn allow_attribute() {
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
 [CHECKING] unused v0.1.0
@@ -1461,7 +1461,7 @@ fn deny_in_manifest() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
 [CHECKING] unused v0.1.0
@@ -1515,7 +1515,7 @@ fn deny_rustflags() {
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
 [CHECKING] unused v0.1.0
@@ -1570,7 +1570,7 @@ fn deny_attribute() {
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
 [CHECKING] unused v0.1.0
@@ -1625,7 +1625,7 @@ fn forbid_rustflags() {
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
 [CHECKING] unused v0.1.0
@@ -1680,7 +1680,7 @@ fn forbid_attribute() {
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
 [CHECKING] unused v0.1.0

--- a/tests/testsuite/lints/unused_workspace_dependencies.rs
+++ b/tests/testsuite/lints/unused_workspace_dependencies.rs
@@ -96,7 +96,7 @@ workspace = true
 [HELP] consider removing the workspace dependency `unused`
 [WARNING] workspace (manifest) generated 2 warnings
 [UPDATING] `dummy-registry` index
-[LOCKING] 6 packages to latest compatible versions
+[LOCKING] 6 packages to highest compatible versions
 [DOWNLOADING] crates ...
 ...
 

--- a/tests/testsuite/lints_table.rs
+++ b/tests/testsuite/lints_table.rs
@@ -44,7 +44,7 @@ fn dependency_warning_ignored() {
 
     foo.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.0.1 ([ROOT]/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/local_registry.rs
+++ b/tests/testsuite/local_registry.rs
@@ -53,7 +53,7 @@ fn simple() {
 
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UNPACKING] bar v0.0.1 (registry `[ROOT]/registry`)
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -178,7 +178,7 @@ fn multiple_versions() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UNPACKING] bar v0.1.0 (registry `[ROOT]/registry`)
 [CHECKING] bar v0.1.0
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -194,7 +194,7 @@ fn multiple_versions() {
 
     p.cargo("update")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] bar v0.1.0 -> v0.2.0
 
 "#]])
@@ -244,7 +244,7 @@ fn multiple_names() {
     p.cargo("check")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [UNPACKING] bar v0.0.1 (registry `[ROOT]/registry`)
 [UNPACKING] baz v0.1.0 (registry `[ROOT]/registry`)
 [CHECKING] bar v0.0.1
@@ -302,7 +302,7 @@ fn interdependent() {
     p.cargo("check")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [UNPACKING] bar v0.0.1 (registry `[ROOT]/registry`)
 [UNPACKING] baz v0.1.0 (registry `[ROOT]/registry`)
 [CHECKING] bar v0.0.1
@@ -375,7 +375,7 @@ fn path_dep_rewritten() {
     p.cargo("check")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [UNPACKING] bar v0.0.1 (registry `[ROOT]/registry`)
 [UNPACKING] baz v0.1.0 (registry `[ROOT]/registry`)
 [CHECKING] bar v0.0.1
@@ -542,7 +542,7 @@ fn crates_io_registry_url_is_optional() {
 
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UNPACKING] bar v0.0.1 (registry `[ROOT]/registry`)
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 ([ROOT]/foo)

--- a/tests/testsuite/lockfile_compat.rs
+++ b/tests/testsuite/lockfile_compat.rs
@@ -1009,7 +1009,7 @@ dependencies = [
         .with_stderr_data(format!(
             "\
 [UPDATING] git repository `[ROOTURL]/dep1`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] dep1 v0.5.0 ([ROOTURL]/dep1?{ref_kind}={encoded_ref}#[..])
 [CHECKING] dep1 v0.5.0 ([ROOTURL]/dep1?{ref_kind}={encoded_ref}#[..])
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -1104,7 +1104,7 @@ dependencies = [
         .with_stderr_data(format!(
             "\
 [UPDATING] git repository `[ROOTURL]/dep1`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] dep1 v0.5.0 ([ROOTURL]/dep1?{ref_kind}={encoded_ref}#[..])
 [CHECKING] dep1 v0.5.0 ([ROOTURL]/dep1?{ref_kind}={encoded_ref}#[..])
 [CHECKING] foo v0.0.1 ([ROOT]/foo)

--- a/tests/testsuite/lto.rs
+++ b/tests/testsuite/lto.rs
@@ -29,7 +29,7 @@ fn with_deps() {
     p.cargo("build -v --release")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [COMPILING] bar v0.0.1
@@ -72,7 +72,7 @@ fn shared_deps() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [COMPILING] bar v0.0.1
@@ -116,7 +116,7 @@ fn build_dep_not_ltod() {
     p.cargo("build -v --release")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [COMPILING] bar v0.0.1
@@ -297,7 +297,7 @@ fn off_in_manifest_works() {
     p.cargo("build -v --release")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [COMPILING] bar v0.0.1
@@ -749,7 +749,7 @@ fn test_profile() {
         // unordered because the two `foo` builds start in parallel
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [COMPILING] bar v0.0.1
@@ -807,7 +807,7 @@ fn doctest() {
     p.cargo("test --doc --release -v")
         // embed-bitcode should be harmless here
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [RUNNING] `rustc --crate-name bar [..]--crate-type lib [..]-C linker-plugin-lto [..]`
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
@@ -898,7 +898,7 @@ fn fresh_swapping_commands() {
     p.cargo("build --release -v")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [COMPILING] bar v1.0.0

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -2122,7 +2122,7 @@ fn cargo_metadata_with_invalid_artifact_deps() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [WARNING] please specify `--format-version` flag explicitly to avoid compatibility problems
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ERROR] dependency `artifact` in package `foo` requires a `bin:notfound` artifact to be present.
 
 "#]])
@@ -2153,7 +2153,7 @@ fn cargo_metadata_with_invalid_duplicate_renamed_deps() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [WARNING] please specify `--format-version` flag explicitly to avoid compatibility problems
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ERROR] the crate `foo v0.5.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
 
 "#]])
@@ -3512,7 +3512,7 @@ fn filter_platform() {
             str![[r#"
 [WARNING] please specify `--format-version` flag explicitly to avoid compatibility problems
 [UPDATING] `dummy-registry` index
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 4 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] normal-dep v0.0.1 (registry `dummy-registry`)
 [DOWNLOADED] host-dep v0.0.1 (registry `dummy-registry`)

--- a/tests/testsuite/min_publish_age.rs
+++ b/tests/testsuite/min_publish_age.rs
@@ -57,7 +57,7 @@ fn feature_gated() {
         .with_stderr_data(str![[r#"
 [WARNING] ignoring `registry.global-min-publish-age` without `-Zmin-publish-age`
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]])
         .run();
@@ -112,7 +112,7 @@ fn feature_gated_env() {
         .with_stderr_data(str![[r#"
 [WARNING] ignoring `registry.global-min-publish-age` without `-Zmin-publish-age`
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]])
         .run();
@@ -171,7 +171,7 @@ fn warns_on_resolver_config_without_flag() {
         .with_stderr_data(str![[r#"
 [WARNING] ignoring `resolver.incompatible-publish-age` without `-Zmin-publish-age`
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]])
         .run();
@@ -208,7 +208,7 @@ fn filters_too_new_versions() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] bar v1.0.0 (available: v1.1.0, published 2 days ago)
 
 "#]])
@@ -272,7 +272,7 @@ fn incompatible_publish_age_allow() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] bar v1.1.0 (published 2 days ago, minimum age 7 days)
 
 "#]])
@@ -336,7 +336,7 @@ fn incompatible_publish_age_deny() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] bar v1.0.0 (available: v1.1.0, published 2 days ago)
 
 "#]])
@@ -464,7 +464,7 @@ fn report_unchanged_too_new_version() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 0 packages to latest compatible versions
+[LOCKING] 0 packages to highest compatible versions
 [UNCHANGED] bar v1.1.0 (published 2 days ago, minimum age 7 days)
 [NOTE] to see how you depend on a package, run `cargo tree --invert <dep>@<ver>`
 
@@ -516,7 +516,7 @@ fn report_rust_version_note_over_too_new_note() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] bar v1.1.0 (requires Rust 1.65535.0)
 
 "#]])
@@ -652,7 +652,7 @@ fn patched_versions_preserved() {
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] bar v1.1.0 (registry `alternative`) (published 2 days ago, minimum age 7 days)
 
 "#]])
@@ -714,7 +714,7 @@ fn versions_without_pubtime_unaffected() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]])
         .run();
@@ -799,7 +799,7 @@ fn cargo_install_allows_too_new_deps() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v1.0.0 (registry `dummy-registry`)
 [INSTALLING] foo v1.0.0
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.1.0 (registry `dummy-registry`)
 [COMPILING] bar v1.1.0
@@ -847,7 +847,7 @@ fn cargo_install_path_allows_too_new_deps() {
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.0.0 ([ROOT]/foo)
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] bar v1.0.0 (available: v1.1.0, published 2 days ago)
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
@@ -945,7 +945,7 @@ fn update_precise_to_too_new() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] bar v1.0.0 (available: v1.1.0, published 2 days ago)
 
 "#]])
@@ -1048,7 +1048,7 @@ fn update_precise_with_allow() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] bar v1.0.0 (available: v1.2.0, published 24 hours ago)
 
 "#]])
@@ -1143,7 +1143,7 @@ fn publish_age_zero() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]])
         .run();
@@ -1240,7 +1240,7 @@ fn registry_default() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] bar v1.0.0 (available: v1.1.0, published 2 days ago)
 
 "#]])
@@ -1302,7 +1302,7 @@ fn registry_default_overrides_global() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] bar v1.0.0 (available: v1.1.0, published 2 days ago)
 
 "#]])
@@ -1364,7 +1364,7 @@ fn registry_default_zero_overrides_global() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]])
         .run();
@@ -1424,7 +1424,7 @@ fn registries_crates_io() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] bar v1.0.0 (available: v1.1.0, published 2 days ago)
 
 "#]])
@@ -1488,7 +1488,7 @@ fn registries_crates_io_overrides_registry_default() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]])
         .run();
@@ -1556,7 +1556,7 @@ fn registries_alt() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] bar v1.0.0 (registry `alternative`) (available: v1.1.0, published 2 days ago)
 
 "#]])
@@ -1628,7 +1628,7 @@ fn registries_alt_overrides_global() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]])
         .run();
@@ -1696,7 +1696,7 @@ fn registries_alt_respects_global() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] bar v1.0.0 (registry `alternative`) (available: v1.1.0, published 2 days ago)
 
 "#]])
@@ -1765,7 +1765,7 @@ fn registries_alt_ignores_registry_default() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]])
         .run();
@@ -1838,7 +1838,7 @@ fn registry_alt_ignores_min_publish_age() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]])
         .run();
@@ -1916,7 +1916,7 @@ fn resolve_with_backtracking() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [ADDING] dep v1.0.0 (available: v1.1.0)
 
 "#]])
@@ -1984,7 +1984,7 @@ fn cargo_add_skips_too_new() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [ADDING] bar v1.0.0 to dependencies
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] bar v1.0.0 (available: v1.1.0, published 2 days ago)
 
 "#]])

--- a/tests/testsuite/minimal_versions.rs
+++ b/tests/testsuite/minimal_versions.rs
@@ -34,7 +34,7 @@ fn minimal_version_cli() {
         .masquerade_as_nightly_cargo(&["minimal-versions"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to earliest compatible version
+[LOCKING] 1 package to lowest compatible version
 [ADDING] dep v1.0.0 (available: v1.1.0)
 
 "#]])

--- a/tests/testsuite/offline.rs
+++ b/tests/testsuite/offline.rs
@@ -147,7 +147,7 @@ fn cargo_compile_with_downloaded_dependency_with_offline() {
 
     p2.cargo("check --offline")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] present_dep v1.2.3
 [CHECKING] bar v0.1.0 ([ROOT]/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -265,7 +265,7 @@ fn main(){
 
     p2.cargo("run --offline")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] present_dep v1.2.3
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -521,7 +521,7 @@ fn compile_offline_with_cached_git_dep(shallow: bool) {
     let mut cargo = p.cargo("build --offline");
     cargo.with_stderr_data(format!(
         "\
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] dep1 v0.5.0 ([ROOTURL]/dep1#[..])
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -702,7 +702,7 @@ fn main(){
 
     p2.cargo("build --offline")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] present_dep v1.2.9
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -743,7 +743,7 @@ fn main(){
     p2.cargo("update --offline")
         .with_status(0)
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] present_dep v1.2.3 -> v1.2.9
 
 "#]])

--- a/tests/testsuite/old_cargos.rs
+++ b/tests/testsuite/old_cargos.rs
@@ -657,7 +657,7 @@ fn index_cache_rebuild() {
         .with_stderr_data(str![[r#"
 [WARNING] no edition set: defaulting to the 2015 edition while the latest is [..]
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.1 (registry `dummy-registry`)
 [CHECKING] bar v1.0.1

--- a/tests/testsuite/open_namespaces.rs
+++ b/tests/testsuite/open_namespaces.rs
@@ -381,7 +381,7 @@ fn update_spec_accepts_namespaced_name() {
         .masquerade_as_nightly_cargo(&["open-namespaces"])
         .with_stdout_data(str![""])
         .with_stderr_data(str![[r#"
-[LOCKING] 0 packages to latest compatible versions
+[LOCKING] 0 packages to highest compatible versions
 
 "#]])
         .run();
@@ -411,7 +411,7 @@ fn update_spec_accepts_namespaced_pkgid() {
         .masquerade_as_nightly_cargo(&["open-namespaces"])
         .with_stdout_data(str![""])
         .with_stderr_data(str![[r#"
-[LOCKING] 0 packages to latest compatible versions
+[LOCKING] 0 packages to highest compatible versions
 
 "#]])
         .run();

--- a/tests/testsuite/package_features.rs
+++ b/tests/testsuite/package_features.rs
@@ -62,7 +62,7 @@ fn virtual_no_default_features() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] a v0.1.0 ([ROOT]/foo/a)
 [CHECKING] b v0.1.0 ([ROOT]/foo/b)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -457,7 +457,7 @@ fn command_line_optional_dep() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ERROR] package `a v0.1.0 ([ROOT]/foo)` does not have feature `bar`
 
 [HELP] an optional dependency with that name exists, but the `features` table includes it with the "dep:" syntax so it does not have an implicit feature with that name
@@ -497,7 +497,7 @@ fn command_line_optional_dep_three_options() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ERROR] package `a v0.1.0 ([ROOT]/foo)` does not have feature `bar`
 
 [HELP] an optional dependency with that name exists, but the `features` table includes it with the "dep:" syntax so it does not have an implicit feature with that name
@@ -540,7 +540,7 @@ fn command_line_optional_dep_many_options() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ERROR] package `a v0.1.0 ([ROOT]/foo)` does not have feature `bar`
 
 [HELP] an optional dependency with that name exists, but the `features` table includes it with the "dep:" syntax so it does not have an implicit feature with that name
@@ -588,7 +588,7 @@ fn command_line_optional_dep_many_paths() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ERROR] package `a v0.1.0 ([ROOT]/foo)` does not have feature `bar`
 
 [HELP] an optional dependency with that name exists, but the `features` table includes it with the "dep:" syntax so it does not have an implicit feature with that name
@@ -775,7 +775,7 @@ fn non_member() {
     p.cargo("check -p dep")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v1.0.0 (registry `dummy-registry`)
 [CHECKING] dep v1.0.0

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -55,7 +55,7 @@ fn replace() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.1.0 (registry `dummy-registry`)
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
@@ -107,7 +107,7 @@ fn from_config() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.1.1 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -149,7 +149,7 @@ fn from_config_relative() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.1.1 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -194,7 +194,7 @@ fn from_config_precedence() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.1.1 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -235,7 +235,7 @@ fn nonexistent() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -288,7 +288,7 @@ fn patch_git() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/override`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -342,7 +342,7 @@ fn patch_to_git() {
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/override`
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.1.0 ([ROOTURL]/override#[..])
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -448,7 +448,7 @@ fn unused() {
       with the dependency requirements. If the patch has a different version from
       what is locked in the Cargo.lock file, run `cargo update` to use the new
       version. This may also occur with an optional dependency that is not enabled.
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] bar v0.1.0 (available: v0.2.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
@@ -525,7 +525,7 @@ fn unused_with_mismatch_source_being_patched() {
       with the dependency requirements. If the patch has a different version from
       what is locked in the Cargo.lock file, run `cargo update` to use the new
       version. This may also occur with an optional dependency that is not enabled.
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] bar v0.1.0 (available: v0.3.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
@@ -566,7 +566,7 @@ fn prefer_patch_version() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.1.1 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -624,7 +624,7 @@ fn unused_from_config() {
       with the dependency requirements. If the patch has a different version from
       what is locked in the Cargo.lock file, run `cargo update` to use the new
       version. This may also occur with an optional dependency that is not enabled.
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] bar v0.1.0 (available: v0.2.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
@@ -698,7 +698,7 @@ fn unused_git() {
       with the dependency requirements. If the patch has a different version from
       what is locked in the Cargo.lock file, run `cargo update` to use the new
       version. This may also occur with an optional dependency that is not enabled.
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] bar v0.1.0 (available: v0.2.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
@@ -747,7 +747,7 @@ fn add_patch() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [CHECKING] bar v0.1.0
@@ -782,7 +782,7 @@ fn add_patch() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] bar v0.1.0 ([ROOT]/foo/bar)
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -824,7 +824,7 @@ fn add_patch_from_config() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [CHECKING] bar v0.1.0
@@ -850,7 +850,7 @@ fn add_patch_from_config() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] bar v0.1.0 ([ROOT]/foo/bar)
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -892,7 +892,7 @@ fn add_ignored_patch() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [CHECKING] bar v0.1.0
@@ -991,7 +991,7 @@ fn add_patch_with_features() {
   |
   = [HELP] configure `features` in the `dependencies` entry
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1041,7 +1041,7 @@ fn add_patch_with_setting_default_features() {
   |
   = [HELP] configure `features`, `default-features` in the `dependencies` entry
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1133,7 +1133,7 @@ fn new_minor() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.1.1 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1185,7 +1185,7 @@ fn transitive_new_minor() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [CHECKING] baz v0.1.1 ([ROOT]/foo/baz)
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -1224,7 +1224,7 @@ fn new_major() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.2.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1257,7 +1257,7 @@ fn new_major() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] bar v0.2.0
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.2.0 (registry `dummy-registry`)
@@ -1312,7 +1312,7 @@ fn transitive_new_major() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [CHECKING] baz v0.2.0 ([ROOT]/foo/baz)
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -1371,7 +1371,7 @@ fn shared_by_transitive() {
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/override`
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [CHECKING] baz v0.1.2 ([ROOTURL]/override#[..])
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
@@ -1553,7 +1553,7 @@ fn patch_in_virtual() {
     p.cargo("check -p foo")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.1.0 ([ROOT]/foo/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1728,7 +1728,7 @@ fn patch_older() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [CHECKING] baz v1.0.1 ([ROOT]/foo/baz)
 [CHECKING] bar v0.5.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
@@ -2201,7 +2201,7 @@ fn update_unused_new_version() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] bar v0.1.6 ([ROOT]/bar)
 [CHECKING] bar v0.1.6 ([ROOT]/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -2225,7 +2225,7 @@ fn update_unused_new_version() {
     p.cargo("update bar")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] bar v0.1.6 ([ROOT]/bar)
 [REMOVING] bar v0.1.5
 
@@ -2237,7 +2237,7 @@ fn update_unused_new_version() {
     p.cargo("update")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] bar v0.1.6 ([ROOT]/bar)
 [REMOVING] bar v0.1.5
 
@@ -2520,7 +2520,7 @@ fn patch_from_env_config_is_ignored() {
         .with_status(0)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [CHECKING] bar v1.0.0
@@ -2560,7 +2560,7 @@ fn patch_walks_backwards() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.1.1 ([ROOT]/foo/bar)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2574,7 +2574,7 @@ fn patch_walks_backwards() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNGRADING] bar v0.1.1 ([ROOT]/foo/bar) -> v0.1.0
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
@@ -2614,7 +2614,7 @@ fn patch_walks_backwards_restricted() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.1.1 ([ROOT]/foo/bar)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2681,7 +2681,7 @@ fn patched_dep_new_version() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.1.0 (registry `dummy-registry`)
 [CHECKING] baz v0.1.0
@@ -2720,7 +2720,7 @@ fn patched_dep_new_version() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] baz v0.1.0 -> v0.1.1
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.1.1 (registry `dummy-registry`)
@@ -2768,7 +2768,7 @@ fn patch_update_doesnt_update_other_sources() {
             str![[r#"
 [UPDATING] `dummy-registry` index
 [UPDATING] `alternative` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `alternative`)
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
@@ -2800,7 +2800,7 @@ fn patch_update_doesnt_update_other_sources() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] bar v0.1.0 ([ROOT]/foo/bar) -> v0.1.1
 [CHECKING] bar v0.1.1 ([ROOT]/foo/bar)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
@@ -2841,7 +2841,7 @@ fn can_update_with_alt_reg() {
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.1 (registry `alternative`)
 [CHECKING] bar v0.1.1 (registry `alternative`)
@@ -2866,7 +2866,7 @@ fn can_update_with_alt_reg() {
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
 [UPDATING] `dummy-registry` index
-[LOCKING] 0 packages to latest compatible versions
+[LOCKING] 0 packages to highest compatible versions
 [NOTE] pass `--verbose` to see 1 unchanged dependencies behind latest
 
 "#]])
@@ -2893,7 +2893,7 @@ fn can_update_with_alt_reg() {
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] bar v0.1.1 (registry `alternative`) -> v0.1.2
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.2 (registry `alternative`)
@@ -2983,7 +2983,7 @@ dependencies = [
         .with_stderr_data(
             "\
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] bar v1.0.0 ([ROOTURL]/bar?branch=master#[..])
 ",
         )

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -75,7 +75,7 @@ fn cargo_compile_with_nested_deps_shorthand() {
 
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] baz v0.5.0 ([ROOT]/foo/bar/baz)
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
@@ -160,7 +160,7 @@ fn cargo_compile_with_root_dev_deps() {
     p.cargo("check")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 error[E0463]: can't find crate for `bar`
 ...
@@ -207,7 +207,7 @@ fn cargo_compile_with_root_dev_deps_with_testing() {
 
     p.cargo("test")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/bar)
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -276,7 +276,7 @@ fn cargo_compile_with_transitive_dev_deps() {
 
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -318,7 +318,7 @@ fn no_rebuild_dependency() {
     // First time around we should compile both foo and bar
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.5.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -387,7 +387,7 @@ fn deep_dependencies_trigger_rebuild() {
         .build();
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [CHECKING] baz v0.5.0 ([ROOT]/foo/baz)
 [CHECKING] bar v0.5.0 ([ROOT]/foo/bar)
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
@@ -481,7 +481,7 @@ fn no_rebuild_two_deps() {
         .build();
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] baz v0.5.0 ([ROOT]/foo/baz)
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
@@ -525,7 +525,7 @@ fn nested_deps_recompile() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.5.0 ([ROOT]/foo/src/bar)
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1363,7 +1363,7 @@ fn path_dep_build_cmd() {
 
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1433,7 +1433,7 @@ fn dev_deps_no_rebuild_lib() {
     p.cargo("build")
         .env("FOO", "bar")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1554,7 +1554,7 @@ fn override_and_depend() {
     p.cargo("check")
         .cwd("b")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [CHECKING] a2 v0.5.0 ([ROOT]/foo/a)
 [CHECKING] a1 v0.5.0 ([ROOT]/foo/a)
 [CHECKING] b v0.5.0 ([ROOT]/foo/b)
@@ -1855,7 +1855,7 @@ fn same_name_version_changed() {
 
     p.cargo("tree")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1876,7 +1876,7 @@ foo v1.0.0 ([ROOT]/foo)
     );
     p.cargo("tree")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] foo v2.0.1 ([ROOT]/foo/foo2)
 
 "#]])

--- a/tests/testsuite/paths.rs
+++ b/tests/testsuite/paths.rs
@@ -59,7 +59,7 @@ fn broken_path_override_warns() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [WARNING] path override for crate `a` has altered the original list of
 dependencies; the dependency on `bar` was either added or
 modified to not match the previously resolved version
@@ -178,7 +178,7 @@ fn paths_ok_with_optional() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.1.0 ([ROOT]/foo/bar2)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -227,7 +227,7 @@ fn paths_add_optional_bad() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [WARNING] path override for crate `bar` has altered the original list of
 dependencies; the dependency on `baz` was either added or
 modified to not match the previously resolved version
@@ -289,7 +289,7 @@ fn env_paths_overrides_not_supported() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] env v0.1.0 (registry `dummy-registry`)
 [CHECKING] file v0.2.0 ([ROOT]/foo/file)

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -227,7 +227,7 @@ fn profile_config_override_spec_multiple() {
     p.cargo("build -v")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ERROR] multiple package overrides in profile `dev` match package `bar v0.5.0 ([ROOT]/foo/bar)`
 found package specs: bar, bar@0.5.0
 
@@ -304,7 +304,7 @@ fn profile_config_override_precedence() {
 
     p.cargo("build -v")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [RUNNING] `rustc --crate-name bar [..] -C opt-level=2[..]-C codegen-units=2 [..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)

--- a/tests/testsuite/profile_custom.rs
+++ b/tests/testsuite/profile_custom.rs
@@ -326,7 +326,7 @@ fn overrides_with_custom() {
     p.cargo("build -v")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] xxx v0.5.0 ([ROOT]/foo/xxx)
 [COMPILING] yyy v0.5.0 ([ROOT]/foo/yyy)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -727,7 +727,7 @@ fn test_inherits_dev() {
     p.cargo("test --lib --no-run -v")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] somedep v1.0.0 (registry `dummy-registry`)
 [COMPILING] somedep v1.0.0

--- a/tests/testsuite/profile_overrides.rs
+++ b/tests/testsuite/profile_overrides.rs
@@ -33,7 +33,7 @@ fn profile_override_basic() {
 
     p.cargo("check -v")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.5.0 ([ROOT]/foo/bar)
 [RUNNING] `rustc --crate-name bar [..] -C opt-level=3 [..]`
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -226,7 +226,7 @@ fn profile_override_hierarchy() {
 
     p.cargo("build -v")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] m3 v0.5.0 ([ROOT]/foo/m3)
 [COMPILING] dep v0.5.0 ([ROOT]/dep)
 [RUNNING] `rustc --crate-name m3 --edition=2015 m3/src/lib.rs [..] --crate-type lib --emit=[..]link[..]-C codegen-units=4 [..]`

--- a/tests/testsuite/profile_settings.rs
+++ b/tests/testsuite/profile_settings.rs
@@ -187,7 +187,7 @@ fn top_level_overrides_deps() {
     p.cargo("build -v --release")
         .with_stderr_data(&format!(
             "\
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] foo v0.0.0 ([ROOT]/foo/foo)
 [RUNNING] `rustc --crate-name foo --edition=2015 foo/src/lib.rs [..]\
         --crate-type dylib --crate-type rlib \
@@ -902,7 +902,7 @@ fn profile_hint_mostly_unused_warn_without_gate() {
     p.cargo("check -v")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [WARNING] bar@1.0.0: ignoring 'hint-mostly-unused' profile option, pass `-Zprofile-hint-mostly-unused` to enable it
@@ -942,7 +942,7 @@ fn profile_hint_mostly_unused_nightly() {
         .masquerade_as_nightly_cargo(&["profile-hint-mostly-unused"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [CHECKING] bar v1.0.0

--- a/tests/testsuite/profile_targets.rs
+++ b/tests/testsuite/profile_targets.rs
@@ -89,7 +89,7 @@ fn profile_selection_build() {
     //   are built with debuginfo=0.
     p.cargo("build -vv")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]
@@ -127,7 +127,7 @@ fn profile_selection_build_release() {
     // `build --release`
     p.cargo("build --release -vv")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3 -C panic=abort[..]-C codegen-units=2 [..]
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=6 [..]
@@ -192,7 +192,7 @@ fn profile_selection_build_all_targets() {
     //   example  dev        build
     p.cargo("build --all-targets -vv")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C embed-bitcode=[..]-C codegen-units=1 -C debuginfo=2 [..]`
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort -C embed-bitcode=[..]-C codegen-units=1 -C debuginfo=2 [..]`
@@ -265,7 +265,7 @@ fn profile_selection_build_all_targets_release() {
     //   example  release        build
     p.cargo("build --all-targets --release -vv")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3 -C embed-bitcode=[..]-C codegen-units=2 [..]`
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3 -C panic=abort -C embed-bitcode=[..]-C codegen-units=2 [..]`
@@ -328,7 +328,7 @@ fn profile_selection_test() {
     //
     p.cargo("test -vv")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C embed-bitcode=[..]-C codegen-units=3 -C debuginfo=2 [..]`
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C embed-bitcode=[..]-C codegen-units=5 [..]`
@@ -401,7 +401,7 @@ fn profile_selection_test_release() {
     //
     p.cargo("test --release -vv")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=6 [..]`
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3 -C panic=abort[..]-C codegen-units=2 [..]`
@@ -473,7 +473,7 @@ fn profile_selection_bench() {
     //
     p.cargo("bench -vv")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3 -C embed-bitcode=[..]-C codegen-units=4 [..]`
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3 -C panic=abort -C embed-bitcode=[..]-C codegen-units=4 [..]`
@@ -544,7 +544,7 @@ fn profile_selection_check_all_targets() {
     //
     p.cargo("check --all-targets -vv")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C embed-bitcode=[..]-C codegen-units=5 [..]`
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]metadata -C embed-bitcode=[..]-C codegen-units=1 -C debuginfo=2 [..]`
@@ -595,7 +595,7 @@ fn profile_selection_check_all_targets_release() {
     // `dev` for all targets.
     p.cargo("check --all-targets --release -vv")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=6 [..]
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]metadata -C opt-level=3 -C panic=abort[..]-C codegen-units=2 [..]
@@ -660,7 +660,7 @@ fn profile_selection_check_all_targets_test() {
     //
     p.cargo("check --all-targets --profile=test -vv")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]`
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]metadata[..]-C codegen-units=3 -C debuginfo=2 [..]`
@@ -711,7 +711,7 @@ fn profile_selection_doc() {
     //   `*` = wants panic, but it is cleared when args are built.
     p.cargo("doc -vv")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [DOCUMENTING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]`

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -233,7 +233,7 @@ fn registry_dependency() {
 "#]]) // Omit the hash of Source URL
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [COMPILING] bar v0.0.1
@@ -335,7 +335,7 @@ fn registry_dependency_with_build_script_codegen() {
 "#]]) // Omit the hash of Source URL
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [COMPILING] bar v0.0.1
@@ -394,7 +394,7 @@ fn git_dependency() {
 "#]]) // Omit the hash of Source URL and commit
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/bar`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.0.1 ([ROOTURL]/bar#[..])
 [RUNNING] `rustc [..]--remap-path-scope=object --remap-path-prefix=[ROOT]/home/.cargo/git/checkouts/bar-[..]=/cargo/git/[..] --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -471,7 +471,7 @@ cocktail-bar/src/lib.rs
 
 "#]])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/foo/cocktail-bar)
 [RUNNING] `rustc [..]--remap-path-scope=object --remap-path-prefix=[ROOT]/foo=. --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -545,7 +545,7 @@ fn path_dependency_outside_workspace() {
 
 "#]])
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/bar)
 [RUNNING] `rustc [..]--remap-path-scope=object --remap-path-prefix=[ROOT]/bar=/cargo/path/bar-0.0.1 --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)

--- a/tests/testsuite/pub_priv.rs
+++ b/tests/testsuite/pub_priv.rs
@@ -79,7 +79,7 @@ fn exported_pub_dep() {
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] pub_dep v0.1.0 (registry `dummy-registry`)
 [CHECKING] pub_dep v0.1.0
@@ -144,7 +144,7 @@ fn requires_feature() {
 [WARNING] Cargo.toml: ignoring `public` on dependency pub_dep, pass `-Zpublic-dependency` to enable support for it
 [WARNING] `foo` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] pub_dep v0.1.0 (registry `dummy-registry`)
 [CHECKING] pub_dep v0.1.0
@@ -231,7 +231,7 @@ fn pub_dev_dependency_without_feature() {
 [WARNING] Cargo.toml: 'public' specifier can only be used on regular dependencies, not dev-dependencies
 [WARNING] `foo` (manifest) generated 1 warning
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -330,7 +330,7 @@ fn allow_priv_in_tests() {
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] priv_dep v0.1.0 (registry `dummy-registry`)
 [CHECKING] priv_dep v0.1.0
@@ -375,7 +375,7 @@ fn allow_priv_in_benches() {
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] priv_dep v0.1.0 (registry `dummy-registry`)
 [CHECKING] priv_dep v0.1.0
@@ -421,7 +421,7 @@ fn allow_priv_in_bins() {
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] priv_dep v0.1.0 (registry `dummy-registry`)
 [CHECKING] priv_dep v0.1.0
@@ -467,7 +467,7 @@ fn allow_priv_in_examples() {
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] priv_dep v0.1.0 (registry `dummy-registry`)
 [CHECKING] priv_dep v0.1.0
@@ -514,7 +514,7 @@ fn allow_priv_in_custom_build() {
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] priv_dep v0.1.0 (registry `dummy-registry`)
 [COMPILING] priv_dep v0.1.0
@@ -569,7 +569,7 @@ fn publish_package_with_public_dependency() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [DOWNLOADED] pub_bar v0.1.0 (registry `dummy-registry`)

--- a/tests/testsuite/publish_lockfile.rs
+++ b/tests/testsuite/publish_lockfile.rs
@@ -406,7 +406,7 @@ dependencies = [
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [INSTALLING] foo v0.1.0
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.1 (registry `dummy-registry`)
 [COMPILING] bar v0.1.1

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -34,7 +34,7 @@ fn simple_http() {
     simple(
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [CHECKING] bar v0.0.1
@@ -56,7 +56,7 @@ fn simple_git() {
     simple(
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [CHECKING] bar v0.0.1
@@ -108,7 +108,7 @@ fn deps_http() {
     let _server = setup_http();
     deps(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] ba[..] v0.0.1 (registry `dummy-registry`)
 [DOWNLOADED] ba[..] v0.0.1 (registry `dummy-registry`)
@@ -124,7 +124,7 @@ fn deps_http() {
 fn deps_git() {
     deps(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] ba[..] v0.0.1 (registry `dummy-registry`)
 [DOWNLOADED] ba[..] v0.0.1 (registry `dummy-registry`)
@@ -408,7 +408,7 @@ fn bad_cksum_http() {
     let _server = setup_http();
     bad_cksum(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bad-cksum v0.0.1 (registry `dummy-registry`)
 [ERROR] failed to download replaced source registry `crates-io`
@@ -423,7 +423,7 @@ Caused by:
 fn bad_cksum_git() {
     bad_cksum(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bad-cksum v0.0.1 (registry `dummy-registry`)
 [ERROR] failed to download replaced source registry `crates-io`
@@ -475,7 +475,7 @@ required by package `foo v0.0.1 ([ROOT]/foo)`
 "#]],
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] notyet v0.0.1 (registry `dummy-registry`)
 [CHECKING] notyet v0.0.1
@@ -498,7 +498,7 @@ required by package `foo v0.0.1 ([ROOT]/foo)`
 "#]],
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] notyet v0.0.1 (registry `dummy-registry`)
 [CHECKING] notyet v0.0.1
@@ -647,7 +647,7 @@ fn lockfile_locks_http() {
     lockfile_locks(
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [CHECKING] bar v0.0.1
@@ -667,7 +667,7 @@ fn lockfile_locks_git() {
     lockfile_locks(
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [CHECKING] bar v0.0.1
@@ -720,7 +720,7 @@ fn lockfile_locks_transitively_http() {
     lockfile_locks_transitively(
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] ba[..] v0.0.1 (registry `dummy-registry`)
 [DOWNLOADED] ba[..] v0.0.1 (registry `dummy-registry`)
@@ -742,7 +742,7 @@ fn lockfile_locks_transitively_git() {
     lockfile_locks_transitively(
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] ba[..] v0.0.1 (registry `dummy-registry`)
 [DOWNLOADED] ba[..] v0.0.1 (registry `dummy-registry`)
@@ -801,7 +801,7 @@ fn yanks_are_not_used_http() {
     let _server = setup_http();
     yanks_are_not_used(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] ba[..] v0.0.1 (registry `dummy-registry`)
 [DOWNLOADED] ba[..] v0.0.1 (registry `dummy-registry`)
@@ -817,7 +817,7 @@ fn yanks_are_not_used_http() {
 fn yanks_are_not_used_git() {
     yanks_are_not_used(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] ba[..] v0.0.1 (registry `dummy-registry`)
 [DOWNLOADED] ba[..] v0.0.1 (registry `dummy-registry`)
@@ -1002,7 +1002,7 @@ required by package `foo v0.0.1 ([ROOT]/foo)`
 "#]],
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] baz v0.0.1 -> v0.0.2
 
 "#]],
@@ -1026,7 +1026,7 @@ required by package `foo v0.0.1 ([ROOT]/foo)`
 "#]],
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] baz v0.0.1 -> v0.0.2
 
 "#]],
@@ -1085,7 +1085,7 @@ fn yanks_in_lockfiles_are_ok_with_new_dep_http() {
     let _server = setup_http();
     yanks_in_lockfiles_are_ok_with_new_dep(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] baz v0.0.1
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.0.1 (registry `dummy-registry`)
@@ -1100,7 +1100,7 @@ fn yanks_in_lockfiles_are_ok_with_new_dep_http() {
 fn yanks_in_lockfiles_are_ok_with_new_dep_git() {
     yanks_in_lockfiles_are_ok_with_new_dep(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] baz v0.0.1
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.0.1 (registry `dummy-registry`)
@@ -1224,7 +1224,7 @@ fn update_lockfile_http() {
 "#]],
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] bar v0.0.2 -> v0.0.3
 
 "#]],
@@ -1238,14 +1238,14 @@ fn update_lockfile_http() {
 "#]],
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [UPDATING] bar v0.0.3 -> v0.0.4
 [ADDING] spam v0.2.5
 
 "#]],
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] bar v0.0.4 -> v0.0.5
 [REMOVING] spam v0.2.5
 
@@ -1271,7 +1271,7 @@ fn update_lockfile_git() {
 "#]],
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] bar v0.0.2 -> v0.0.3
 
 "#]],
@@ -1285,14 +1285,14 @@ fn update_lockfile_git() {
 "#]],
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [UPDATING] bar v0.0.3 -> v0.0.4
 [ADDING] spam v0.2.5
 
 "#]],
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] bar v0.0.4 -> v0.0.5
 [REMOVING] spam v0.2.5
 
@@ -1369,7 +1369,7 @@ fn dev_dependency_not_used_http() {
     let _server = setup_http();
     dev_dependency_not_used(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [CHECKING] bar v0.0.1
@@ -1383,7 +1383,7 @@ fn dev_dependency_not_used_http() {
 fn dev_dependency_not_used_git() {
     dev_dependency_not_used(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [CHECKING] bar v0.0.1
@@ -1474,7 +1474,7 @@ fn updating_a_dep_http() {
     updating_a_dep(
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [CHECKING] bar v0.0.1
@@ -1485,7 +1485,7 @@ fn updating_a_dep_http() {
 "#]],
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] bar v0.0.1 -> v0.1.0
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
@@ -1503,7 +1503,7 @@ fn updating_a_dep_git() {
     updating_a_dep(
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [CHECKING] bar v0.0.1
@@ -1514,7 +1514,7 @@ fn updating_a_dep_git() {
 "#]],
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] bar v0.0.1 -> v0.1.0
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
@@ -1603,7 +1603,7 @@ fn git_and_registry_dep_http() {
         str![[r#"
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[ROOTURL]/b`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] a v0.0.1 (registry `dummy-registry`)
 [CHECKING] a v0.0.1
@@ -1625,7 +1625,7 @@ fn git_and_registry_dep_git() {
         str![[r#"
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[ROOTURL]/b`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] a v0.0.1 (registry `dummy-registry`)
 [CHECKING] a v0.0.1
@@ -1785,7 +1785,7 @@ fn fetch_downloads_http() {
     let _server = setup_http();
     fetch_downloads(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] a v0.1.0 (registry `dummy-registry`)
 
@@ -1796,7 +1796,7 @@ fn fetch_downloads_http() {
 fn fetch_downloads_git() {
     fetch_downloads(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] a v0.1.0 (registry `dummy-registry`)
 
@@ -1832,7 +1832,7 @@ fn update_transitive_dependency_http() {
     update_transitive_dependency(
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] b v0.1.0 -> v0.1.1
 
 "#]],
@@ -1853,7 +1853,7 @@ fn update_transitive_dependency_git() {
     update_transitive_dependency(
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] b v0.1.0 -> v0.1.1
 
 "#]],
@@ -1904,7 +1904,7 @@ fn update_backtracking_ok_http() {
     let _server = setup_http();
     update_backtracking_ok(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [UPDATING] hyper v0.6.5 -> v0.6.6
 [UPDATING] openssl v0.1.0 -> v0.1.1
 
@@ -1915,7 +1915,7 @@ fn update_backtracking_ok_http() {
 fn update_backtracking_ok_git() {
     update_backtracking_ok(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [UPDATING] hyper v0.6.5 -> v0.6.6
 [UPDATING] openssl v0.1.0 -> v0.1.1
 
@@ -1969,7 +1969,7 @@ fn update_multiple_packages_http() {
     update_multiple_packages(
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [UPDATING] a v0.1.0 -> v0.1.1
 [UPDATING] b v0.1.0 -> v0.1.1
 [NOTE] pass `--verbose` to see 1 unchanged dependencies behind latest
@@ -1977,7 +1977,7 @@ fn update_multiple_packages_http() {
 "#]],
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] c v0.1.0 -> v0.1.1
 
 "#]],
@@ -2001,7 +2001,7 @@ fn update_multiple_packages_git() {
     update_multiple_packages(
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [UPDATING] a v0.1.0 -> v0.1.1
 [UPDATING] b v0.1.0 -> v0.1.1
 [NOTE] pass `--verbose` to see 1 unchanged dependencies behind latest
@@ -2009,7 +2009,7 @@ fn update_multiple_packages_git() {
 "#]],
         str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] c v0.1.0 -> v0.1.1
 
 "#]],
@@ -2275,7 +2275,7 @@ fn only_download_relevant_http() {
     let _server = setup_http();
     only_download_relevant(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.1.0 (registry `dummy-registry`)
 [CHECKING] baz v0.1.0
@@ -2289,7 +2289,7 @@ fn only_download_relevant_http() {
 fn only_download_relevant_git() {
     only_download_relevant(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.1.0 (registry `dummy-registry`)
 [CHECKING] baz v0.1.0
@@ -2715,7 +2715,7 @@ fn bad_and_or_malicious_packages_rejected_http() {
     let _server = setup_http();
     bad_and_or_malicious_packages_rejected(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.2.0 (registry `dummy-registry`)
 [ERROR] failed to download replaced source registry `crates-io`
@@ -2733,7 +2733,7 @@ Caused by:
 fn bad_and_or_malicious_packages_rejected_git() {
     bad_and_or_malicious_packages_rejected(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.2.0 (registry `dummy-registry`)
 [ERROR] failed to download replaced source registry `crates-io`
@@ -3303,7 +3303,7 @@ fn package_lock_as_a_symlink_inside_package_is_invalid() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [ERROR] failed to download replaced source registry `crates-io`
@@ -3501,7 +3501,7 @@ fn reach_max_unpack_size() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [ERROR] failed to download replaced source registry `crates-io`
@@ -3586,7 +3586,7 @@ internal server error
    [..] DEBUG network::fetch: url="[..]/index/[..]"
    [..] DEBUG cargo::resolver::restarting: pending=[..]
    [..] DEBUG cargo::resolver::restarting: pending=0
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 ...
 [DOWNLOADING] crates ...
    [..] DEBUG network::fetch: url="[..]/dl/bar/0.0.1/download"
@@ -3647,7 +3647,7 @@ internal server error
 [WARNING] spurious network error (2 tries remaining): failed to get successful HTTP response from `http://127.0.0.1:[..]/index/3/b/bar` (127.0.0.1), got 500
 body:
 internal server error
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [CHECKING] bar v0.0.1
@@ -3733,7 +3733,7 @@ fn sparse_retry_multiple() {
     write!(
         &mut expected,
         "\
-[LOCKING] 93 packages to latest compatible versions
+[LOCKING] 93 packages to highest compatible versions
 "
     )
     .unwrap();
@@ -3786,7 +3786,7 @@ fn dl_retry_single() {
         .build();
     p.cargo("fetch").with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [WARNING] spurious network error (3 tries remaining): failed to get successful HTTP response from `http://127.0.0.1:[..]/dl/bar/1.0.0/download` (127.0.0.1), got 500
 body:
@@ -3883,7 +3883,7 @@ fn dl_retry_multiple() {
     }
     write!(
         &mut expected,
-        "[LOCKING] 93 packages to latest compatible versions\n"
+        "[LOCKING] 93 packages to highest compatible versions\n"
     )
     .unwrap();
     let _server = builder.build();
@@ -3940,7 +3940,7 @@ fn retry_too_many_requests() {
 [WARNING] spurious network error (3 tries remaining): failed to get successful HTTP response from `[..]/index/3/b/bar` ([..]), got 429
 body:
 too many requests, try again in 1 seconds
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [CHECKING] bar v0.0.1
@@ -3980,7 +3980,7 @@ fn deleted_entry() {
     p.cargo("tree")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.1 (registry `dummy-registry`)
 
@@ -4016,7 +4016,7 @@ foo v0.1.0 ([ROOT]/foo)
     p.cargo("tree")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 
@@ -4083,7 +4083,7 @@ fn corrupted_ok_overwritten() {
     p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 
@@ -4351,7 +4351,7 @@ fn debug_header_message_dl() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [WARNING] spurious network error (3 tries remaining): failed to get successful HTTP response from `http://127.0.0.1:[..]/dl/bar/1.0.0/download` (127.0.0.1), got 503
 body:
@@ -4406,7 +4406,7 @@ fn set_mask_during_unpacking() {
     p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 
@@ -4456,7 +4456,7 @@ fn unpack_again_when_cargo_ok_is_unrecognized() {
     p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 
@@ -4530,7 +4530,7 @@ fn differ_only_by_metadata() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.0.1+b (registry `dummy-registry`)
 [CHECKING] baz v0.0.1+b
@@ -4627,7 +4627,7 @@ fn builtin_source_replacement() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] crates.io index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bad-cksum v0.0.1
 [ERROR] failed to verify the checksum of `bad-cksum v0.0.1`
@@ -4762,7 +4762,7 @@ fn symlink_and_directory() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [ERROR] failed to download replaced source registry `crates-io`

--- a/tests/testsuite/registry_auth.rs
+++ b/tests/testsuite/registry_auth.rs
@@ -52,7 +52,7 @@ fn requires_credential_provider() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ERROR] failed to download `bar v0.0.1 (registry `alternative`)`
 
 Caused by:
@@ -78,7 +78,7 @@ fn simple() {
     cargo(&p, "build")
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
 [COMPILING] bar v0.0.1 (registry `alternative`)
@@ -102,7 +102,7 @@ fn simple_with_asymmetric() {
     cargo(&p, "build")
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
 [COMPILING] bar v0.0.1 (registry `alternative`)
@@ -131,7 +131,7 @@ fn environment_config() {
         .env("CARGO_REGISTRIES_ALTERNATIVE_TOKEN", registry.token())
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
 [COMPILING] bar v0.0.1 (registry `alternative`)
@@ -156,7 +156,7 @@ fn environment_token() {
         .env("CARGO_REGISTRIES_ALTERNATIVE_TOKEN", registry.token())
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
 [COMPILING] bar v0.0.1 (registry `alternative`)
@@ -186,7 +186,7 @@ fn environment_token_with_asymmetric() {
         .env("CARGO_REGISTRIES_ALTERNATIVE_SECRET_KEY", registry.key())
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
 [COMPILING] bar v0.0.1 (registry `alternative`)
@@ -373,7 +373,7 @@ fn missing_token_git() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ERROR] failed to download `bar v0.0.1 (registry `alternative`)`
 
 Caused by:
@@ -439,7 +439,7 @@ fn incorrect_token_git() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [ERROR] failed to download from `http://127.0.0.1:[..]/dl/bar/0.0.1/download`
 
@@ -567,7 +567,7 @@ fn duplicate_index() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ERROR] failed to download `bar v0.0.1 (registry `alternative`)`
 
 Caused by:

--- a/tests/testsuite/registry_overlay.rs
+++ b/tests/testsuite/registry_overlay.rs
@@ -80,7 +80,7 @@ fn registry_version_wins() {
         .overlay_registry(&reg.index_url(), &alt_path)
         .with_stderr_data(str![[r#"
 [UPDATING] `sparse+http://127.0.0.1:[..]/index/` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.1.1 (registry `sparse+http://127.0.0.1:[..]/index/`)
 [CHECKING] baz v0.1.1
@@ -122,7 +122,7 @@ fn overlay_version_wins() {
         .overlay_registry(&reg.index_url(), &alt_path)
         .with_stderr_data(str![[r#"
 [UPDATING] `sparse+http://127.0.0.1:[..]/index/` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UNPACKING] baz v0.1.1 (registry `[ROOT]/alternative-registry`)
 [CHECKING] baz v0.1.1
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -163,7 +163,7 @@ fn version_precedence() {
         .overlay_registry(&reg.index_url(), &alt_path)
         .with_stderr_data(str![[r#"
 [UPDATING] `sparse+http://127.0.0.1:[..]/index/` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UNPACKING] baz v0.1.1 (registry `[ROOT]/alternative-registry`)
 [CHECKING] baz v0.1.1
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -246,7 +246,7 @@ fn registry_dep_depends_on_new_local_package() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `sparse+http://127.0.0.1:[..]/index/` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [ADDING] workspace-package v0.0.1 (available: v0.1.1)
 [DOWNLOADING] crates ...
 [UNPACKING] workspace-package v0.1.1 (registry `[ROOT]/alternative-registry`)

--- a/tests/testsuite/rename_deps.rs
+++ b/tests/testsuite/rename_deps.rs
@@ -192,7 +192,7 @@ fn rename_twice() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.1.0 (registry `dummy-registry`)
 [ERROR] the crate `test v0.1.0 ([ROOT]/foo)` depends on crate `foo v0.1.0` multiple times with different names

--- a/tests/testsuite/replace.rs
+++ b/tests/testsuite/replace.rs
@@ -45,7 +45,7 @@ fn override_simple() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[ROOTURL]/override`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [CHECKING] bar v0.1.0 ([ROOTURL]/override#[..])
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -93,7 +93,7 @@ fn override_with_features() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[ROOTURL]/override`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [WARNING] unused field in replacement for `bar`: `features`
   |
   = [NOTE] configure `features` in the `dependencies` entry
@@ -144,7 +144,7 @@ fn override_with_setting_default_features() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[ROOTURL]/override`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [WARNING] unused field in replacement for `bar`: `features`, `default-features`
   |
   = [NOTE] configure `features`, `default-features` in the `dependencies` entry
@@ -295,7 +295,7 @@ fn transitive() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[ROOTURL]/override`
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.2.0 (registry `dummy-registry`)
 [CHECKING] bar v0.1.0 ([ROOTURL]/override#[..])
@@ -353,7 +353,7 @@ fn persists_across_rebuilds() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[ROOTURL]/override`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [CHECKING] bar v0.1.0 ([ROOTURL]/override#[..])
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -405,7 +405,7 @@ fn replace_registry_with_path() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [CHECKING] bar v0.1.0 ([ROOT]/bar)
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -473,7 +473,7 @@ fn use_a_spec_to_select() {
             str![[r#"
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[ROOTURL]/override`
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 4 packages to highest compatible versions
 [ADDING] baz v0.1.1 (available: v0.2.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.1.1 (registry `dummy-registry`)
@@ -539,7 +539,7 @@ fn override_adds_some_deps() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[ROOTURL]/override`
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.1.1 (registry `dummy-registry`)
 [CHECKING] baz v0.1.1
@@ -563,7 +563,7 @@ fn override_adds_some_deps() {
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/override`
 [UPDATING] `dummy-registry` index
-[LOCKING] 0 packages to latest compatible versions
+[LOCKING] 0 packages to highest compatible versions
 [NOTE] pass `--verbose` to see 1 unchanged dependencies behind latest
 
 "#]])
@@ -571,7 +571,7 @@ fn override_adds_some_deps() {
     p.cargo("update  https://github.com/rust-lang/crates.io-index#bar")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 0 packages to latest compatible versions
+[LOCKING] 0 packages to highest compatible versions
 [NOTE] pass `--verbose` to see 1 unchanged dependencies behind latest
 
 "#]])
@@ -867,7 +867,7 @@ fn test_override_dep() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[ROOTURL]/override`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [ERROR] specification `bar` is ambiguous
 [HELP] re-run this command with one of the following specifications
   registry+https://github.com/rust-lang/crates.io-index#bar@0.1.0
@@ -914,7 +914,7 @@ fn update() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[ROOTURL]/override`
-[LOCKING] 0 packages to latest compatible versions
+[LOCKING] 0 packages to highest compatible versions
 
 "#]])
         .run();
@@ -1183,7 +1183,7 @@ fn no_warnings_when_replace_is_used_in_another_workspace_member() {
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [CHECKING] bar v0.1.0 ([ROOT]/foo/local_bar)
 [CHECKING] first_crate v0.1.0 ([ROOT]/foo/first_crate)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1449,7 +1449,7 @@ fn override_respects_spec_metadata() {
 
     p.cargo("check").with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [WARNING] package replacement is not used: https://github.com/rust-lang/crates.io-index#bar@0.1.0+notTheBuild
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0+a (registry `dummy-registry`)
@@ -1501,7 +1501,7 @@ fn override_spec_metadata_is_optional() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[ROOTURL]/override`
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [CHECKING] bar v0.1.0+a ([ROOTURL]/override#[..])
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1543,7 +1543,7 @@ fn yanked_candidates_are_skipped() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [WARNING] package replacement is not used: https://github.com/rust-lang/crates.io-index#bar@1.0.0
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.1.0 (registry `dummy-registry`)

--- a/tests/testsuite/required_features.rs
+++ b/tests/testsuite/required_features.rs
@@ -1153,7 +1153,7 @@ fn dep_feature_in_cmd_line() {
     // This is a no-op
     p.cargo("build")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -1251,7 +1251,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured; 0 filtered out; fini
     p.cargo("install --path .")
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.0.1 ([ROOT]/foo)
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 [WARNING] none of the package's binaries are available for install using the selected features
   bin "foo" requires the features: `bar/a`
@@ -1511,7 +1511,7 @@ fn renamed_required_features() {
     p.cargo("run")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [ERROR] target `x` in package `foo` requires the features: `a1/f1`
 Consider enabling them by passing, e.g., `--features="a1/f1"`
 

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -1103,7 +1103,7 @@ fn example_with_release_flag() {
 
     p.cargo("run -v --release --example a")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [RUNNING] `rustc --crate-name bar --edition=2015 bar/src/bar.rs [..]--crate-type lib --emit=[..]link -C opt-level=3[..] -C metadata=[..] --out-dir [ROOT]/foo/target/release/deps -C strip=debuginfo -L dependency=[ROOT]/foo/target/release/deps`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -1210,7 +1210,7 @@ fn run_with_bin_dep() {
 
     p.cargo("run")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [WARNING] foo v0.0.1 ([ROOT]/foo) ignoring invalid dependency `bar` which is missing a lib target
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1274,7 +1274,7 @@ fn run_with_bin_deps() {
 
     p.cargo("run")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [WARNING] foo v0.0.1 ([ROOT]/foo) ignoring invalid dependency `bar1` which is missing a lib target
 [WARNING] foo v0.0.1 ([ROOT]/foo) ignoring invalid dependency `bar2` which is missing a lib target
 [COMPILING] foo v0.0.1 ([ROOT]/foo)

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -159,7 +159,7 @@ fn lint_dep_incompatible_with_rust_version() {
     p.cargo("generate-lockfile")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [ADDING] too_new_child v0.0.1 (requires Rust 1.2345.0)
 [ADDING] too_new_parent v0.0.1 (requires Rust 1.2345.0)
 
@@ -226,7 +226,7 @@ fn resolve_with_rust_version() {
         .env("CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS", "fallback")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 
 "#]])
         .run();
@@ -243,7 +243,7 @@ foo v0.0.1 ([ROOT]/foo)
         .env("CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS", "fallback")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest Rust 1.60.0 compatible versions
+[LOCKING] 2 packages to highest Rust 1.60.0 compatible versions
 [ADDING] newer-and-older v1.5.0 (available: v1.6.0, requires Rust 1.65.0)
 [ADDING] only-newer v1.6.0 (requires Rust 1.65.0)
 
@@ -297,7 +297,7 @@ fn resolve_with_rustc() {
         .env("CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS", "fallback")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [ADDING] newer-and-older v1.6.0 (requires Rust 1.2345)
 [ADDING] only-newer v1.6.0 (requires Rust 1.2345)
 
@@ -316,7 +316,7 @@ foo v0.0.1 ([ROOT]/foo)
         .env("CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS", "fallback")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest Rust 1.60.0 compatible versions
+[LOCKING] 2 packages to highest Rust 1.60.0 compatible versions
 [ADDING] newer-and-older v1.5.0 (available: v1.6.0, requires Rust 1.2345)
 [ADDING] only-newer v1.6.0 (requires Rust 1.2345)
 
@@ -368,7 +368,7 @@ fn resolve_with_backtracking() {
         .env("CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS", "fallback")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 
 "#]])
         .run();
@@ -386,7 +386,7 @@ foo v0.0.1 ([ROOT]/foo)
         .env("CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS", "fallback")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest Rust 1.60.0 compatible versions
+[LOCKING] 2 packages to highest Rust 1.60.0 compatible versions
 [ADDING] has-rust-version v1.6.0 (requires Rust 1.65.0)
 
 "#]])
@@ -480,7 +480,7 @@ fn resolve_with_multiple_rust_versions() {
         .env("CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS", "fallback")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 6 packages to latest compatible versions
+[LOCKING] 6 packages to highest compatible versions
 
 "#]])
         .run();
@@ -499,7 +499,7 @@ higher v0.0.1 ([ROOT]/foo)
         .env("CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS", "fallback")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 6 packages to latest Rust 1.50.0 compatible versions
+[LOCKING] 6 packages to highest Rust 1.50.0 compatible versions
 [ADDING] higher-newer-and-older v1.55.0 (available: v1.65.0, requires Rust 1.65.0)
 [ADDING] higher-only-newer v1.65.0 (requires Rust 1.65.0)
 [ADDING] lower-newer-and-older v1.45.0 (available: v1.55.0, requires Rust 1.55.0)
@@ -559,7 +559,7 @@ fn resolve_edition2024() {
     p.cargo("generate-lockfile")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest Rust 1.85.0 compatible versions
+[LOCKING] 2 packages to highest Rust 1.85.0 compatible versions
 [ADDING] newer-and-older v1.5.0 (available: v1.6.0, requires Rust 1.999.0)
 [ADDING] only-newer v1.6.0 (requires Rust 1.999.0)
 
@@ -578,7 +578,7 @@ foo v0.0.1 ([ROOT]/foo)
     p.cargo("generate-lockfile --ignore-rust-version")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [ADDING] newer-and-older v1.6.0 (requires Rust 1.999.0)
 [ADDING] only-newer v1.6.0 (requires Rust 1.999.0)
 
@@ -598,7 +598,7 @@ foo v0.0.1 ([ROOT]/foo)
         .env("CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS", "allow")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [ADDING] newer-and-older v1.6.0 (requires Rust 1.999.0)
 [ADDING] only-newer v1.6.0 (requires Rust 1.999.0)
 
@@ -653,7 +653,7 @@ fn resolve_v3() {
     p.cargo("generate-lockfile")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest Rust 1.85.0 compatible versions
+[LOCKING] 2 packages to highest Rust 1.85.0 compatible versions
 [ADDING] newer-and-older v1.5.0 (available: v1.6.0, requires Rust 1.999.0)
 [ADDING] only-newer v1.6.0 (requires Rust 1.999.0)
 
@@ -672,7 +672,7 @@ foo v0.0.1 ([ROOT]/foo)
     p.cargo("generate-lockfile --ignore-rust-version")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [ADDING] newer-and-older v1.6.0 (requires Rust 1.999.0)
 [ADDING] only-newer v1.6.0 (requires Rust 1.999.0)
 
@@ -692,7 +692,7 @@ foo v0.0.1 ([ROOT]/foo)
         .env("CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS", "allow")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [ADDING] newer-and-older v1.6.0 (requires Rust 1.999.0)
 [ADDING] only-newer v1.6.0 (requires Rust 1.999.0)
 
@@ -740,7 +740,7 @@ fn update_msrv_resolve() {
         .env("CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS", "fallback")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest Rust 1.60.0 compatible version
+[LOCKING] 1 package to highest Rust 1.60.0 compatible version
 [ADDING] bar v1.5.0 (available: v1.6.0, requires Rust 1.65.0)
 
 "#]])
@@ -749,7 +749,7 @@ fn update_msrv_resolve() {
         .env("CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS", "fallback")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] bar v1.5.0 -> v1.6.0
 
 "#]])
@@ -788,7 +788,7 @@ fn update_precise_overrides_msrv_resolver() {
         .env("CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS", "fallback")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest Rust 1.60.0 compatible version
+[LOCKING] 1 package to highest Rust 1.60.0 compatible version
 [ADDING] bar v1.5.0 (available: v1.6.0, requires Rust 1.65.0)
 
 "#]])
@@ -842,7 +842,7 @@ fn check_msrv_resolve() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] only-newer v1.6.0 (registry `dummy-registry`)
 [DOWNLOADED] newer-and-older v1.6.0 (registry `dummy-registry`)
@@ -869,7 +869,7 @@ foo v0.0.1 ([ROOT]/foo)
         .env("CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS", "fallback")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest Rust 1.60.0 compatible versions
+[LOCKING] 2 packages to highest Rust 1.60.0 compatible versions
 [ADDING] newer-and-older v1.5.0 (available: v1.6.0, requires Rust 1.65.0)
 [ADDING] only-newer v1.6.0 (requires Rust 1.65.0)
 [DOWNLOADING] crates ...
@@ -916,7 +916,7 @@ fn cargo_install_ignores_msrv_config() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
 [INSTALLING] foo v0.0.1
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v1.1.0 (registry `dummy-registry`)
 [COMPILING] dep v1.1.0
@@ -953,7 +953,7 @@ fn cargo_install_ignores_resolver_v3_msrv_change() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
 [INSTALLING] foo v0.0.1
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v1.1.0 (registry `dummy-registry`)
 [COMPILING] dep v1.1.0
@@ -1001,7 +1001,7 @@ fn cargo_install_path_honors_msrv_config() {
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.0.0 ([ROOT]/foo)
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest Rust 1.60 compatible version
+[LOCKING] 1 package to highest Rust 1.60 compatible version
 [ADDING] dep v1.0.0 (available: v1.1.0, requires Rust 1.70)
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v1.0.0 (registry `dummy-registry`)
@@ -1118,7 +1118,7 @@ fn report_rust_versions() {
         .env("CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS", "fallback")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 9 packages to latest Rust 1.60.0 compatible versions
+[LOCKING] 9 packages to highest Rust 1.60.0 compatible versions
 [ADDING] dep-only-high-incompatible v1.75.0 (requires Rust 1.75.0)
 [ADDING] dep-only-low-incompatible v1.75.0 (requires Rust 1.75.0)
 [ADDING] dep-only-unset-incompatible v1.2345.0 (requires Rust 1.2345.0)

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -225,7 +225,7 @@ fn build_with_crate_type_for_foo_with_deps() {
 
     p.cargo("rustc -v --crate-type cdylib")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] a v0.1.0 ([ROOT]/foo/a)
 [RUNNING] `rustc --crate-name a --edition=2015 a/src/lib.rs [..]--crate-type lib [..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -396,7 +396,7 @@ fn build_foo_with_bar_dependency() {
 
     foo.cargo("rustc -v -- -C debug-assertions")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.1.0 ([ROOT]/bar)
 [RUNNING] `rustc --crate-name bar [..] -C debuginfo=2[..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -433,7 +433,7 @@ fn build_only_bar_dependency() {
 
     foo.cargo("rustc -v -p bar -- -C debug-assertions")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.1.0 ([ROOT]/bar)
 [RUNNING] `rustc --crate-name bar [..]--crate-type lib [..] -C debug-assertions[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/rustdoc.rs
+++ b/tests/testsuite/rustdoc.rs
@@ -176,7 +176,7 @@ fn rustdoc_foo_with_bar_dependency() {
 
     foo.cargo("rustdoc -v -- --cfg=foo")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [CHECKING] bar v0.0.1 ([ROOT]/bar)
 [RUNNING] `rustc [..] [ROOT]/bar/src/lib.rs [..]`
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
@@ -214,7 +214,7 @@ fn rustdoc_only_bar_dependency() {
 
     foo.cargo("rustdoc -v -p bar -- --cfg=foo")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOCUMENTING] bar v0.0.1 ([ROOT]/bar)
 [RUNNING] `rustdoc [..] --crate-name bar [ROOT]/bar/src/lib.rs -o [ROOT]/foo/target/doc [..]-C metadata=[..] -L dependency=[ROOT]/foo/target/debug/deps [..]--cfg=foo[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -393,7 +393,7 @@ fn rustdoc_json_same_crate_different_version() {
         .cargo("rustdoc -v -Z unstable-options --output-format json -p dep@1.0.0")
         .masquerade_as_nightly_cargo(&["rustdoc-output-format"])
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [DOCUMENTING] dep v1.0.0 ([ROOT]/dep_v1)
 [RUNNING] `rustdoc [..] --crate-name dep [ROOT]/dep_v1/src/lib.rs [..] --output-format=json[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/rustflags.rs
+++ b/tests/testsuite/rustflags.rs
@@ -1775,7 +1775,7 @@ fn host_config_shared_build_dep() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] cc v1.0.0 (registry `dummy-registry`)
 [COMPILING] cc v1.0.0

--- a/tests/testsuite/script/cargo.rs
+++ b/tests/testsuite/script/cargo.rs
@@ -946,7 +946,7 @@ Hello world!
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
 [HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest Rust [..] compatible version
+[LOCKING] 1 package to highest Rust [..] compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] script v1.0.0 (registry `dummy-registry`)
 [COMPILING] script v1.0.0
@@ -985,7 +985,7 @@ Hello world!
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)
 [HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
-[LOCKING] 1 package to latest Rust [..] compatible version
+[LOCKING] 1 package to highest Rust [..] compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [COMPILING] script v0.0.0 ([ROOT]/foo/script.rs)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/source_replacement.rs
+++ b/tests/testsuite/source_replacement.rs
@@ -286,7 +286,7 @@ fn source_replacement_with_registry_url() {
         .replace_crates_io(crates_io.index_url())
         .with_stderr_data(str![[r#"
 [UPDATING] `using-registry-url` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `using-registry-url`)
 [CHECKING] bar v0.0.1

--- a/tests/testsuite/ssh.rs
+++ b/tests/testsuite/ssh.rs
@@ -203,7 +203,7 @@ fn known_host_works() {
         .env("SSH_AUTH_SOCK", &agent.sock)
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `ssh://testuser@127.0.0.1:[..]/repos/bar.git`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]])
         .run();
@@ -275,7 +275,7 @@ fn known_host_without_port() {
         .env("SSH_AUTH_SOCK", &agent.sock)
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `ssh://testuser@127.0.0.1:[..]/repos/bar.git`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]])
         .run();
@@ -312,7 +312,7 @@ fn hostname_case_insensitive() {
         .with_stderr_data(&format!(
             "\
 [UPDATING] git repository `ssh://testuser@{hostname}:{port}/repos/bar.git`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 "
         ))
         .run();
@@ -383,7 +383,7 @@ Caused by:
         .env("SSH_AUTH_SOCK", &agent.sock)
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `ssh://testuser@127.0.0.1:[..]/repos/bar.git`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]])
         .run();
@@ -628,7 +628,7 @@ fn ssh_key_in_config() {
         .env("SSH_AUTH_SOCK", &agent.sock)
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `ssh://testuser@127.0.0.1:[..]/repos/bar.git`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]])
         .run();

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -101,7 +101,7 @@ fn cargo_test_release() {
 
     p.cargo("test -v --release")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [RUNNING] `rustc [..]-C opt-level=3 [..]`
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
@@ -611,7 +611,7 @@ fn test_with_deep_lib_dep() {
 
     p.cargo("test")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1456,7 +1456,7 @@ fn test_dylib() {
 
     p.cargo("test")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2077,7 +2077,7 @@ fn selective_testing() {
     println!("d1");
     p.cargo("test -p d1")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [COMPILING] d1 v0.0.1 ([ROOT]/foo/d1)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] unittests src/lib.rs (target/debug/deps/d1-[HASH][EXE])
@@ -2307,7 +2307,7 @@ fn selective_testing_with_docs() {
 
     p.cargo("test -p d1")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] d1 v0.0.1 ([ROOT]/foo/d1)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] unittests d1.rs (target/debug/deps/d1-[HASH][EXE])
@@ -2416,7 +2416,7 @@ fn example_with_dev_dep() {
     p.cargo("test -v")
         .with_stderr_data(
             str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [COMPILING] a v0.0.1 ([ROOT]/foo/a)
 [RUNNING] `rustc --crate-name foo [..]`
@@ -2791,7 +2791,7 @@ fn cyclic_dev_dep_doc_test() {
         .build();
     p.cargo("test")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -3070,7 +3070,7 @@ fn selective_test_optional_dep() {
 
     p.cargo("test -v --no-run --features a -p a")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [COMPILING] a v0.0.1 ([ROOT]/foo/a)
 [RUNNING] `rustc [..] a/src/lib.rs [..]`
 [RUNNING] `rustc [..] a/src/lib.rs [..]`
@@ -4846,7 +4846,7 @@ fn test_dep_with_dev() {
     p.cargo("test -p bar")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ERROR] package `bar` cannot be tested because it requires dev-dependencies and is not a member of the workspace
 
 "#]])

--- a/tests/testsuite/timings.rs
+++ b/tests/testsuite/timings.rs
@@ -32,7 +32,7 @@ fn timings_works() {
     p.cargo("build --all-targets --timings")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)
 [COMPILING] dep v0.1.0

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -116,7 +116,7 @@ fn transitive_minor_update() {
     p.cargo("update serde")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 0 packages to latest compatible versions
+[LOCKING] 0 packages to highest compatible versions
 [NOTE] pass `--verbose` to see 2 unchanged dependencies behind latest
 
 "#]])
@@ -169,7 +169,7 @@ fn conservative() {
     p.cargo("update serde")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] serde v0.1.0 -> v0.1.1
 [NOTE] pass `--verbose` to see 1 unchanged dependencies behind latest
 
@@ -574,7 +574,7 @@ fn update_recursive() {
     p.cargo("update serde:0.2.1 --recursive")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [UPDATING] log v0.1.0 -> v0.1.1
 [UPDATING] serde v0.2.1 -> v0.2.2
 
@@ -612,7 +612,7 @@ fn update_aggressive_alias_for_recursive() {
     p.cargo("update serde:0.2.1 --aggressive")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [UPDATING] log v0.1.0 -> v0.1.1
 [UPDATING] serde v0.2.1 -> v0.2.2
 
@@ -922,7 +922,7 @@ fn dry_run_update() {
     p.cargo("update serde --dry-run")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] serde v0.1.0 -> v0.1.1
 [NOTE] pass `--verbose` to see 1 unchanged dependencies behind latest
 [WARNING] not updating lockfile due to dry run
@@ -1100,7 +1100,7 @@ rustdns.workspace = true
     p.cargo("generate-lockfile")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/rustdns`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]])
         .run();
@@ -1115,7 +1115,7 @@ rustdns.workspace = true
 
     p.cargo("update -p rootcrate")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [UPDATING] rootcrate v2.29.8 ([ROOT]/foo/rootcrate) -> v2.29.81
 [UPDATING] subcrate v2.29.8 ([ROOT]/foo/subcrate) -> v2.29.81
 
@@ -1190,7 +1190,7 @@ rustdns.workspace = true
     p.cargo("generate-lockfile")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/rustdns`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]])
         .run();
@@ -1205,7 +1205,7 @@ rustdns.workspace = true
 
     p.cargo("update -p crate2")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [UPDATING] crate1 v2.29.8 ([ROOT]/foo/crate1) -> v2.29.81
 [UPDATING] crate2 v2.29.8 ([ROOT]/foo/crate2) -> v2.29.81
 
@@ -1280,7 +1280,7 @@ rustdns.workspace = true
     p.cargo("generate-lockfile")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/rustdns`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]])
         .run();
@@ -1295,7 +1295,7 @@ rustdns.workspace = true
 
     p.cargo("update --workspace")
         .with_stderr_data(str![[r#"
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [UPDATING] crate1 v2.29.8 ([ROOT]/foo/crate1) -> v2.29.81
 [UPDATING] crate2 v2.29.8 ([ROOT]/foo/crate2) -> v2.29.81
 
@@ -1340,7 +1340,7 @@ fn update_precise_git_revisions() {
     p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/git`
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 
 "#]])
         .run();
@@ -1980,7 +1980,7 @@ fn report_behind() {
     p.cargo("update --dry-run")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] breaking v0.1.0 -> v0.1.1 (available: v0.2.0)
 [NOTE] pass `--verbose` to see 2 unchanged dependencies behind latest
 [WARNING] not updating lockfile due to dry run
@@ -1991,7 +1991,7 @@ fn report_behind() {
     p.cargo("update --dry-run --verbose")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] breaking v0.1.0 -> v0.1.1 (available: v0.2.0)
 [UNCHANGED] pre v1.0.0-alpha.0 (available: v1.0.0-alpha.1)
 [UNCHANGED] two-ver v0.1.0 (available: v0.2.0)
@@ -2006,7 +2006,7 @@ fn report_behind() {
     p.cargo("update --dry-run")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 0 packages to latest compatible versions
+[LOCKING] 0 packages to highest compatible versions
 [NOTE] pass `--verbose` to see 3 unchanged dependencies behind latest
 [WARNING] not updating lockfile due to dry run
 
@@ -2016,7 +2016,7 @@ fn report_behind() {
     p.cargo("update --dry-run --verbose")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 0 packages to latest compatible versions
+[LOCKING] 0 packages to highest compatible versions
 [UNCHANGED] breaking v0.1.1 (available: v0.2.0)
 [UNCHANGED] pre v1.0.0-alpha.0 (available: v1.0.0-alpha.1)
 [UNCHANGED] two-ver v0.1.0 (available: v0.2.0)
@@ -2056,7 +2056,7 @@ fn update_with_missing_feature() {
     p.cargo("update")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 0 packages to latest compatible versions
+[LOCKING] 0 packages to highest compatible versions
 [NOTE] pass `--verbose` to see 1 unchanged dependencies behind latest
 
 "#]])
@@ -2067,7 +2067,7 @@ fn update_with_missing_feature() {
     p.cargo("update")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] bar v0.1.0 -> v0.1.2
 
 "#]])
@@ -2151,7 +2151,7 @@ fn update_breaking_dry_run() {
 [UPDATING] `dummy-registry` index
 [UPGRADING] incompatible ^1.0 -> ^2.0
 [UPGRADING] ws ^1.0 -> ^2.0
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [UPDATING] incompatible v1.0.0 -> v2.0.0
 [UPDATING] ws v1.0.0 -> v2.0.0
 [WARNING] aborting update due to dry run
@@ -2362,7 +2362,7 @@ fn update_breaking() {
 [UPGRADING] dev ^1.0 -> ^2.0
 [UPGRADING] build ^1.0 -> ^2.0
 [UPGRADING] platform-specific ^1.0 -> ^2.0
-[LOCKING] 12 packages to latest compatible versions
+[LOCKING] 12 packages to highest compatible versions
 [UPDATING] alternative-1 v1.0.0 (registry `alternative`) -> v2.0.0
 [UPDATING] alternative-2 v1.0.0 (registry `alternative`) -> v2.0.0
 [UPDATING] build v1.0.0 -> v2.0.0
@@ -2464,7 +2464,7 @@ fn update_breaking() {
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
 [UPDATING] `dummy-registry` index
-[LOCKING] 4 packages to latest compatible versions
+[LOCKING] 4 packages to highest compatible versions
 [UPDATING] compatible v1.0.0 -> v1.0.1
 [UPDATING] less-than v1.0.0 -> v2.0.0
 [UPDATING] pinned v1.0.0 -> v1.0.1 (available: v2.0.0)
@@ -2561,7 +2561,7 @@ fn update_breaking_specific_packages() {
 [UPGRADING] shared ^1.0 -> ^2.0
 [UPGRADING] ws ^1.0 -> ^2.0
 [UPGRADING] just-foo ^1.0 -> ^2.0
-[LOCKING] 5 packages to latest compatible versions
+[LOCKING] 5 packages to highest compatible versions
 [UPDATING] just-foo v1.0.0 -> v2.0.0
 [UPDATING] shared v1.0.0 -> v2.0.0
 [UPDATING] transitive-compatible v1.0.0 -> v1.0.1
@@ -2657,7 +2657,7 @@ fn update_breaking_specific_packages_that_wont_update() {
     )
     .with_stderr_data(str![[r#"
 [UPDATING] `[..]` index
-[LOCKING] 5 packages to latest compatible versions
+[LOCKING] 5 packages to highest compatible versions
 [UPDATING] compatible v1.0.0 -> v1.0.1
 [UPDATING] non-semver v1.0.0 -> v1.0.1 (available: v2.0.0)
 [UPDATING] renamed-from v1.0.0 -> v1.0.1 (available: v2.0.0)
@@ -2701,7 +2701,7 @@ fn update_breaking_without_lock_file() {
         .with_stderr_data(str![[r#"
 [UPDATING] `[..]` index
 [UPGRADING] incompatible ^1.0 -> ^2.0
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 
 "#]])
         .run();
@@ -2778,7 +2778,7 @@ Caused by:
         .with_stderr_data(str![[r#"
 [UPDATING] `[..]` index
 [UPGRADING] incompatible ^1.0 -> ^2.0
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] incompatible v1.0.0 -> v2.0.0
 
 "#]])
@@ -2791,7 +2791,7 @@ Caused by:
         .with_stderr_data(str![[r#"
 [UPDATING] `[..]` index
 [UPGRADING] incompatible ^2.0 -> ^3.0
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] incompatible v2.0.0 -> v3.0.0
 
 "#]])
@@ -2879,7 +2879,7 @@ fn update_breaking_spec_version_transitive() {
         .with_stderr_data(str![[r#"
 [UPDATING] `[..]` index
 [UPGRADING] dep ^1.0 -> ^2.0
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] dep v2.0.0
 
 "#]])
@@ -2901,7 +2901,7 @@ fn update_breaking_spec_version_transitive() {
     p.cargo("update dep@1.1")
         .with_stderr_data(str![[r#"
 [UPDATING] `[..]` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] dep v1.1.0 -> v1.1.1
 
 "#]])
@@ -2960,7 +2960,7 @@ fn update_breaking_mixed_compatibility() {
         .with_stderr_data(str![[r#"
 [UPDATING] `[..]` index
 [UPGRADING] mixed-compatibility ^1.0 -> ^2.0
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] mixed-compatibility v2.0.1
 
 "#]])
@@ -3048,7 +3048,7 @@ fn update_breaking_mixed_pinning_renaming() {
 [UPGRADING] mixed-pinned ^1.0 -> ^2.0
 [UPGRADING] mixed-ws-pinned ^1.0 -> ^2.0
 [UPGRADING] renamed-from ^1.0 -> ^2.0
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [ADDING] mixed-pinned v2.0.0
 [ADDING] mixed-ws-pinned v2.0.0
 [ADDING] renamed-from v2.0.0
@@ -3218,7 +3218,7 @@ fn update_breaking_pre_release_upgrade() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [UPGRADING] bar ^2.0.0-beta.21 -> ^3.0.0
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UPDATING] bar v2.0.0-beta.21 -> v3.0.0
 
 "#]])
@@ -3321,7 +3321,7 @@ fn update_breaking_missing_package_error() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [UPGRADING] bar ^1.0 -> ^2.0
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 [UPDATING] bar v1.0.0 -> v2.0.0
 [ADDING] transitive v1.0.0
 

--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -1364,7 +1364,7 @@ fn git_duplicate() {
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/a`
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] b v0.5.0 (registry `dummy-registry`)
 [ERROR] failed to sync
@@ -1881,7 +1881,7 @@ fn no_remote_dependency_no_vendor() {
 
     p.cargo("vendor")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 There is no dependency to vendor in this project.
 
 "#]])
@@ -2162,7 +2162,7 @@ fn vendor_local_registry() {
 
     p.cargo("vendor --respect-source-config")
         .with_stderr_data(str![[r#"
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [UNPACKING] bar v0.0.0 (registry `[ROOT]/registry`)
    Vendoring bar v0.0.0 ([ROOT]/home/.cargo/registry/src/-[HASH]/bar-0.0.0) to vendor/bar
 To use vendored sources, add this to your .cargo/config.toml for this project:

--- a/tests/testsuite/warn_on_failure.rs
+++ b/tests/testsuite/warn_on_failure.rs
@@ -66,7 +66,7 @@ fn no_warning_on_success() {
         .cargo("build")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [COMPILING] bar v0.0.1
@@ -87,7 +87,7 @@ fn no_warning_on_bin_failure() {
         .with_stdout_does_not_contain("hidden stdout")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [COMPILING] bar v0.0.1
@@ -110,7 +110,7 @@ fn warning_on_lib_failure() {
         .with_stdout_does_not_contain("hidden stdout")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [COMPILING] bar v0.0.1

--- a/tests/testsuite/warning_override.rs
+++ b/tests/testsuite/warning_override.rs
@@ -388,7 +388,7 @@ fn lint_build_result_pass() {
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] unused v0.1.0 (registry `dummy-registry`)
 [CHECKING] unused v0.1.0
@@ -630,7 +630,7 @@ fn cap_lints_deny() {
     p.cargo("check -vv")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] has_warning v1.0.0 (registry `dummy-registry`)
 [CHECKING] has_warning v1.0.0
@@ -705,7 +705,7 @@ fn cap_lints_allow() {
     p.cargo("check -vv")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] has_warning v1.0.0 (registry `dummy-registry`)
 [CHECKING] has_warning v1.0.0

--- a/tests/testsuite/weak_dep_features.rs
+++ b/tests/testsuite/weak_dep_features.rs
@@ -54,7 +54,7 @@ fn simple() {
     p.cargo("check --features f1")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
@@ -109,7 +109,7 @@ fn deferred() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [DOWNLOADED] bar_activator v1.0.0 (registry `dummy-registry`)
@@ -191,7 +191,7 @@ fn optional_cli_syntax() {
     p.cargo("check --features bar?/feat")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)
@@ -262,7 +262,7 @@ fn required_features() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ERROR] invalid feature `bar?/feat` in required-features of target `foo`: optional dependency with `?` is not allowed in required-features
 
 "#]])
@@ -357,7 +357,7 @@ fn weak_with_host_decouple() {
         .with_stderr_data(
             str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
+[LOCKING] 3 packages to highest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [DOWNLOADED] bar_activator v1.0.0 (registry `dummy-registry`)
@@ -405,7 +405,7 @@ fn weak_namespaced() {
     p.cargo("check --features f1")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [CHECKING] foo v0.1.0 ([ROOT]/foo)

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -699,7 +699,7 @@ fn share_dependencies() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [ADDING] dep1 v0.1.3 (available: v0.1.8)
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep1 v0.1.3 (registry `dummy-registry`)
@@ -749,7 +749,7 @@ fn fetch_fetches_all() {
     p.cargo("fetch")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
+[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep1 v0.1.3 (registry `dummy-registry`)
 
@@ -799,7 +799,7 @@ fn lock_works_for_everyone() {
     p.cargo("generate-lockfile")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to latest compatible versions
+[LOCKING] 2 packages to highest compatible versions
 
 "#]])
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

Using "latest" is already inaccurate because patches for previous versions can be released. With min-publish-age adding a time dimension, using "latest" becomes a non-starter.

So instead use "highest". We could have used "maximum" but "highest" felt nicer to me for some reason.

This is part of #17009

### How to test and review this PR?

