### PR TITLE
docs: remove stray `directory` metavar from `cargo update --breaking` option

### DIFF
--- a/doc/book/src/commands/cargo-update.md
+++ b/doc/book/src/commands/cargo-update.md
@@ -50,7 +50,7 @@ requirement in <code>Cargo.toml</code> doesn’t contain any pre-release identif
 </dd>
 
 
-<dt class="option-term" id="option-cargo-update---breaking"><a class="option-anchor" href="#option-cargo-update---breaking"><code>--breaking</code> <em>directory</em></a></dt>
+<dt class="option-term" id="option-cargo-update---breaking"><a class="option-anchor" href="#option-cargo-update---breaking"><code>--breaking</code></a></dt>
 <dd class="option-desc"><p>Update <em>spec</em> to highest SemVer-breaking version.</p>
 <p>Version requirements will be modified to allow this update.</p>
 <p>This only applies to dependencies when</p>

--- a/doc/man/cargo-update.md
+++ b/doc/man/cargo-update.md
@@ -51,7 +51,7 @@ A compatible `pre-release` version can also be specified even when the version
 requirement in `Cargo.toml` doesn't contain any pre-release identifier (nightly only).
 {{/option}}
 
-{{#option "`--breaking` _directory_" }}
+{{#option "`--breaking`" }}
 Update _spec_ to highest SemVer-breaking version.
 
 Version requirements will be modified to allow this update.

--- a/doc/man/generated_txt/cargo-update.txt
+++ b/doc/man/generated_txt/cargo-update.txt
@@ -43,7 +43,7 @@ OPTIONS
            version requirement in Cargo.toml doesn’t contain any pre-release
            identifier (nightly only).
 
-       --breaking directory
+       --breaking
            Update spec to highest SemVer-breaking version.
 
            Version requirements will be modified to allow this update.

--- a/etc/man/cargo-update.1
+++ b/etc/man/cargo-update.1
@@ -48,7 +48,7 @@ A compatible \fBpre\-release\fR version can also be specified even when the vers
 requirement in \fBCargo.toml\fR doesn\[cq]t contain any pre\-release identifier (nightly only).
 .RE
 .sp
-\fB\-\-breaking\fR \fIdirectory\fR
+\fB\-\-breaking\fR
 .RS 4
 Update \fIspec\fR to highest SemVer\-breaking version.
 .sp


### PR DESCRIPTION
### What does this PR try to resolve?

The `--breaking` option in `cargo update` is documented as taking a `directory` argument:

    --breaking directory
        Update spec to latest SemVer-breaking version.

This is incorrect — `--breaking` is a plain boolean flag with no argument. It's defined via the `flag(...)` helper in `src/bin/cargo/commands/update.rs` and checked with `args.flag("breaking")`, the same pattern used by `--recursive`/`--dry-run`, which correctly show no metavar. Running `cargo update --help` confirms this:

    -b, --breaking  Update [SPEC] to latest SemVer-breaking version (unstable)

The stray `_directory_` appears to be a copy-paste artifact from other flags that legitimately take a directory value (e.g. `--artifact-dir`, `--target-dir`), most likely introduced when `--breaking` was added in #13979.

This PR removes the incorrect metavar from the doc/man source (`doc/man/cargo-update.md`) and regenerates the derived outputs (`doc/man/generated_txt/cargo-update.txt`, `etc/man/cargo-update.1`, `doc/book/src/commands/cargo-update.md`) via `cargo build-man`, per the [documentation contributor guide](https://rust-lang.github.io/cargo/contrib/documentation/index.html#building-the-man-pages).

### How to test and review this PR?

Compare the rendered `--breaking` entry before/after in `doc/man/generated_txt/cargo-update.txt` or `doc/book/src/commands/cargo-update.md` — it should no longer show `directory` after `--breaking`. This is a docs-only change; no behavior is affected.

Fixes #17318
