### PR TITLE
fix(add): error on duplicate crate name specified in a single invocation

### DIFF
--- a/src/ops/cargo_add/mod.rs
+++ b/src/ops/cargo_add/mod.rs
@@ -114,6 +114,18 @@ pub fn add(workspace: &Workspace<'_>, options: &AddOptions<'_>) -> CargoResult<(
             .collect::<CargoResult<Vec<_>>>()?
     };
 
+    {
+        let mut seen = BTreeSet::new();
+        for dep in &deps {
+            let toml_key = dep.toml_key();
+            if !seen.insert(toml_key) {
+                anyhow::bail!(
+                    "dependency `{toml_key}` specified multiple times in the same `cargo add` invocation"
+                );
+            }
+        }
+    }
+
     let was_sorted = manifest
         .get_table(&dep_table)
         .map(TomlItem::as_table)

--- a/tests/testsuite/cargo_add/add_duplicate/in
+++ b/tests/testsuite/cargo_add/add_duplicate/in
@@ -1,0 +1,1 @@
+../add-basic.in

--- a/tests/testsuite/cargo_add/add_duplicate/in
+++ b/tests/testsuite/cargo_add/add_duplicate/in
@@ -1,1 +1,0 @@
-../add-basic.in

--- a/tests/testsuite/cargo_add/add_duplicate/in/Cargo.toml
+++ b/tests/testsuite/cargo_add/add_duplicate/in/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+
+[package]
+name = "cargo-list-test-fixture"
+version = "0.0.0"
+edition = "2015"

--- a/tests/testsuite/cargo_add/add_duplicate/mod.rs
+++ b/tests/testsuite/cargo_add/add_duplicate/mod.rs
@@ -1,0 +1,28 @@
+use crate::prelude::*;
+use cargo_test_support::Project;
+use cargo_test_support::compare::assert_ui;
+use cargo_test_support::current_dir;
+use cargo_test_support::file;
+use cargo_test_support::str;
+
+#[cargo_test]
+fn case() {
+    cargo_test_support::registry::init();
+    cargo_test_support::registry::Package::new("my-package1", "0.1.1+my-package").publish();
+    cargo_test_support::registry::Package::new("my-package1", "0.2.0+my-package").publish();
+
+    let project = Project::from_template(current_dir!().join("in"));
+    let project_root = project.root();
+    let cwd = &project_root;
+
+    snapbox::cmd::Command::cargo_ui()
+        .arg("add")
+        .arg_line("my-package1@0.1.1 my-package1@0.2.0")
+        .current_dir(cwd)
+        .assert()
+        .failure()
+        .stdout_eq(str![""])
+        .stderr_eq(file!["stderr.term.svg"]);
+
+    assert_ui().subset_matches(current_dir!().join("out"), &project_root);
+}

--- a/tests/testsuite/cargo_add/add_duplicate/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/add_duplicate/out/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+
+[package]
+name = "cargo-list-test-fixture"
+version = "0.0.0"
+edition = "2015"

--- a/tests/testsuite/cargo_add/add_duplicate/stderr.term.svg
+++ b/tests/testsuite/cargo_add/add_duplicate/stderr.term.svg
@@ -1,0 +1,30 @@
+<svg width="785px" height="74px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-red bold">error</tspan><tspan>: dependency `my-package1` specified multiple times in the same `cargo add` invocation</tspan>
+</tspan>
+    <tspan x="10px" y="64px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/testsuite/cargo_add/mod.rs
+++ b/tests/testsuite/cargo_add/mod.rs
@@ -1,4 +1,5 @@
 mod add_basic;
+mod add_duplicate;
 mod add_multiple;
 mod add_no_vendored_package_with_alter_registry;
 mod add_no_vendored_package_with_vendor;


### PR DESCRIPTION
### What does this PR try to resolve?

Running `cargo add` with the same crate name given twice in one invocation (e.g. with different version requirements) currently prints an "Adding" status line for both, but the resulting `Cargo.toml` only contains the last one — silently, with no warning, no error, and exit code 0. The status output misleads the user into thinking both were added.

Example (before this fix):

    $ cargo add serde@1.0.229 serde@1.0.200
          Adding serde v1.0.229 to dependencies
          ...
          Adding serde v1.0.200 to dependencies
          ...
    $ cat Cargo.toml
    [dependencies]
    serde = "1.0.200"

Root cause: in `src/ops/cargo_add/mod.rs`, the resolved `deps` list was iterated unconditionally to print status and insert into the manifest table, with no check for repeated TOML keys — a second entry with the same key simply overwrote the first.

This PR adds a check right after `deps` is resolved: if the same `toml_key()` (crate name or rename alias) appears more than once, the command now fails with a clear error instead of silently keeping only the last one.

Note: `cargo add foo foo` (identical strings) was already deduplicated earlier, in the CLI arg-parsing layer (`src/bin/cargo/commands/add.rs`, via an `IndexMap` keyed on the raw arg string) — so this fix specifically covers the case where the strings differ but resolve to the same dependency (e.g. two different version reqs for the same crate, or two different specs that alias to the same `--rename` key).

### How to test and review this PR?

    cargo add serde@1.0.229 serde@1.0.200

should now fail with:

    error: dependency `serde` specified multiple times in the same `cargo add` invocation

and leave `Cargo.toml` untouched. A regression test is included at `tests/testsuite/cargo_add/add_duplicate/`, and I manually verified `cargo add serde@1.0.229 anyhow` (distinct crates) still works normally, and ran the broader `cargo_add` test suite locally with no other test needing changes.

Fixes #17320