### PR TITLE
fix(clean): respect target with --doc

### DIFF
--- a/src/ops/cargo_clean.rs
+++ b/src/ops/cargo_clean.rs
@@ -99,8 +99,17 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
             bail!("--doc cannot be used with -p");
         }
         // If the doc option is set, we just want to delete the doc directory.
-        target_dir = target_dir.join("doc");
-        clean_ctx.remove_paths(&[target_dir.into_path_unlocked()])?;
+        let doc_dirs = CompileKind::from_requested_targets(gctx, &opts.targets)?
+            .into_iter()
+            .map(|kind| {
+                let target_dir = match kind {
+                    CompileKind::Host => target_dir.clone(),
+                    CompileKind::Target(target) => target_dir.join(target.short_name()),
+                };
+                target_dir.join("doc").into_path_unlocked()
+            })
+            .collect::<Vec<_>>();
+        clean_ctx.remove_paths(&doc_dirs)?;
     } else {
         let profiles = Profiles::new(&ws, opts.requested_profile)?;
 

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -355,6 +355,54 @@ fn clean_doc() {
 }
 
 #[cargo_test]
+fn clean_doc_target() {
+    let target = rustc_host();
+    let p = project()
+        .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
+        .file("src/lib.rs", "")
+        .build();
+    let doc_path = p.build_dir().join(target).join("doc");
+
+    p.cargo("doc --target")
+        .arg(target)
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
+    assert!(doc_path.is_dir());
+
+    p.cargo("clean --doc --target")
+        .arg(target)
+        .with_stderr_data(str![[r#"
+[REMOVED] 0 files
+
+"#]])
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
+    assert!(doc_path.is_dir());
+
+    p.change_file(
+        ".cargo/config.toml",
+        &format!("[build]\ntarget = \"{target}\""),
+    );
+    p.cargo("doc")
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
+    assert!(doc_path.is_dir());
+
+    p.cargo("clean --doc")
+        .with_stderr_data(str![[r#"
+[REMOVED] 0 files
+
+"#]])
+        .arg("-Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .run();
+    assert!(doc_path.is_dir());
+}
+
+#[cargo_test]
 fn build_script() {
     let p = project()
         .file(

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -373,13 +373,13 @@ fn clean_doc_target() {
     p.cargo("clean --doc --target")
         .arg(target)
         .with_stderr_data(str![[r#"
-[REMOVED] 0 files
+[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
 "#]])
         .arg("-Zbuild-dir-new-layout")
         .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
-    assert!(doc_path.is_dir());
+    assert!(!doc_path.is_dir());
 
     p.change_file(
         ".cargo/config.toml",
@@ -393,13 +393,13 @@ fn clean_doc_target() {
 
     p.cargo("clean --doc")
         .with_stderr_data(str![[r#"
-[REMOVED] 0 files
+[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
 "#]])
         .arg("-Zbuild-dir-new-layout")
         .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
-    assert!(doc_path.is_dir());
+    assert!(!doc_path.is_dir());
 }
 
 #[cargo_test]

--- a/tests/testsuite/clean_legacy_layout.rs
+++ b/tests/testsuite/clean_legacy_layout.rs
@@ -484,6 +484,50 @@ fn clean_doc() {
 }
 
 #[cargo_test]
+fn clean_doc_target() {
+    let target = rustc_host();
+    let p = project()
+        .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
+        .file("src/lib.rs", "")
+        .build();
+    let doc_path = p.build_dir().join(target).join("doc");
+
+    p.cargo("doc --target")
+        .arg(target)
+        .env("__CARGO_TEMPORARY_BUILD_DIR_NEW_LAYOUT_OPT_OUT", "1")
+        .run();
+    assert!(doc_path.is_dir());
+
+    p.cargo("clean --doc --target")
+        .arg(target)
+        .with_stderr_data(str![[r#"
+[REMOVED] 0 files
+
+"#]])
+        .env("__CARGO_TEMPORARY_BUILD_DIR_NEW_LAYOUT_OPT_OUT", "1")
+        .run();
+    assert!(doc_path.is_dir());
+
+    p.change_file(
+        ".cargo/config.toml",
+        &format!("[build]\ntarget = \"{target}\""),
+    );
+    p.cargo("doc")
+        .env("__CARGO_TEMPORARY_BUILD_DIR_NEW_LAYOUT_OPT_OUT", "1")
+        .run();
+    assert!(doc_path.is_dir());
+
+    p.cargo("clean --doc")
+        .with_stderr_data(str![[r#"
+[REMOVED] 0 files
+
+"#]])
+        .env("__CARGO_TEMPORARY_BUILD_DIR_NEW_LAYOUT_OPT_OUT", "1")
+        .run();
+    assert!(doc_path.is_dir());
+}
+
+#[cargo_test]
 fn build_script() {
     let p = project()
         .file(

--- a/tests/testsuite/clean_legacy_layout.rs
+++ b/tests/testsuite/clean_legacy_layout.rs
@@ -501,12 +501,12 @@ fn clean_doc_target() {
     p.cargo("clean --doc --target")
         .arg(target)
         .with_stderr_data(str![[r#"
-[REMOVED] 0 files
+[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
 "#]])
         .env("__CARGO_TEMPORARY_BUILD_DIR_NEW_LAYOUT_OPT_OUT", "1")
         .run();
-    assert!(doc_path.is_dir());
+    assert!(!doc_path.is_dir());
 
     p.change_file(
         ".cargo/config.toml",
@@ -519,12 +519,12 @@ fn clean_doc_target() {
 
     p.cargo("clean --doc")
         .with_stderr_data(str![[r#"
-[REMOVED] 0 files
+[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
 "#]])
         .env("__CARGO_TEMPORARY_BUILD_DIR_NEW_LAYOUT_OPT_OUT", "1")
         .run();
-    assert!(doc_path.is_dir());
+    assert!(!doc_path.is_dir());
 }
 
 #[cargo_test]


### PR DESCRIPTION
### What does this PR try to resolve?

`cargo clean --doc` always removed `target/doc`, leaving documentation generated for an explicit or configured target in `target/<triple>/doc`. Resolve the requested/default compile kinds before choosing the documentation directories so cleaning matches `cargo doc`.

Fixes #17310.

### How to test and review this PR?

The regression tests cover both `--target <host>` and `[build] target = <host>` in the current and legacy build layouts. Run `cargo test --test testsuite -- clean_doc`.