### PR TITLE
docs: document --output-format for cargo doc

### DIFF
--- a/doc/book/src/commands/cargo-doc.md
+++ b/doc/book/src/commands/cargo-doc.md
@@ -391,6 +391,16 @@ first), whereas <code>cargo doc -j1 --keep-going</code> would definitely run bot
 builds, even if the one run first fails.</p>
 </dd>
 
+<dt class="option-term" id="option-cargo-doc---output-format"><a class="option-anchor" href="#option-cargo-doc---output-format"><code>--output-format</code></a></dt>
+<dd class="option-desc"><p>The output type for the documentation emitted. Valid values:</p>
+<ul>
+<li><code>html</code> (default): Emit the documentation in HTML format.</li>
+<li><code>json</code>: Emit the documentation in the <a href="https://doc.rust-lang.org/nightly/nightly-rustc/rustdoc_json_types">experimental JSON format</a>.</li>
+</ul>
+<p>This option is only available on the <a href="https://doc.rust-lang.org/book/appendix-07-nightly-rust.html">nightly channel</a>
+and requires the <code>-Z unstable-options</code> flag to enable.</p>
+</dd>
+
 </dl>
 
 ## ENVIRONMENT

--- a/doc/book/src/reference/unstable.md
+++ b/doc/book/src/reference/unstable.md
@@ -106,7 +106,7 @@ Each new feature described below should explain how to use it.
 * rustdoc
     * [rustdoc-map](#rustdoc-map) --- Provides mappings for documentation to link to external sites like [docs.rs](https://docs.rs/).
     * [scrape-examples](#scrape-examples) --- Shows examples within documentation.
-    * [output-format](#output-format-for-rustdoc-and-cargo-doc) --- Allows documentation to also be emitted in the experimental [JSON format](https://doc.rust-lang.org/nightly/nightly-rustc/rustdoc_json_types/).
+    * [output-format](#output-format-for-rustdoc) --- Allows documentation to also be emitted in the experimental [JSON format](https://doc.rust-lang.org/nightly/nightly-rustc/rustdoc_json_types/).
     * [rustdoc-depinfo](#rustdoc-depinfo) --- Use dep-info files in rustdoc rebuild detection.
     * [rustdoc-mergeable-info](#rustdoc-mergeable-info) --- Use rustdoc mergeable cross-crate-info files.
 * `Cargo.toml` extensions
@@ -1305,7 +1305,7 @@ If you want examples to be scraped from example targets, then you must not satis
 For example, you can set `doc-scrape-examples` to true for one example target, and that signals to Cargo that
 you are ok with dev-deps being build for `cargo doc`.
 
-## output-format for rustdoc and cargo doc
+## output-format for rustdoc
 
 * Tracking Issue: [#13283](https://github.com/rust-lang/cargo/issues/13283)
 

--- a/doc/book/src/reference/unstable.md
+++ b/doc/book/src/reference/unstable.md
@@ -106,7 +106,7 @@ Each new feature described below should explain how to use it.
 * rustdoc
     * [rustdoc-map](#rustdoc-map) --- Provides mappings for documentation to link to external sites like [docs.rs](https://docs.rs/).
     * [scrape-examples](#scrape-examples) --- Shows examples within documentation.
-    * [output-format](#output-format-for-rustdoc) --- Allows documentation to also be emitted in the experimental [JSON format](https://doc.rust-lang.org/nightly/nightly-rustc/rustdoc_json_types/).
+    * [output-format](#output-format-for-rustdoc-and-cargo-doc) --- Allows documentation to also be emitted in the experimental [JSON format](https://doc.rust-lang.org/nightly/nightly-rustc/rustdoc_json_types/).
     * [rustdoc-depinfo](#rustdoc-depinfo) --- Use dep-info files in rustdoc rebuild detection.
     * [rustdoc-mergeable-info](#rustdoc-mergeable-info) --- Use rustdoc mergeable cross-crate-info files.
 * `Cargo.toml` extensions
@@ -1305,16 +1305,17 @@ If you want examples to be scraped from example targets, then you must not satis
 For example, you can set `doc-scrape-examples` to true for one example target, and that signals to Cargo that
 you are ok with dev-deps being build for `cargo doc`.
 
-## output-format for rustdoc
+## output-format for rustdoc and cargo doc
 
 * Tracking Issue: [#13283](https://github.com/rust-lang/cargo/issues/13283)
 
-This flag determines the output format of `cargo rustdoc`, accepting `html` or `json`, providing tools with a way to lean on [rustdoc's experimental JSON format](https://doc.rust-lang.org/nightly/nightly-rustc/rustdoc_json_types/).
+This flag determines the output format of `cargo rustdoc` and `cargo doc`, accepting `html` or `json`, providing tools with a way to lean on [rustdoc's experimental JSON format](https://doc.rust-lang.org/nightly/nightly-rustc/rustdoc_json_types/).
 
 You can use the flag like this:
 
 ```
 cargo rustdoc -Z unstable-options --output-format json
+cargo doc -Z unstable-options --output-format json
 ```
 
 ## codegen-backend

--- a/doc/man/cargo-doc.md
+++ b/doc/man/cargo-doc.md
@@ -116,6 +116,7 @@ and supports common Unix glob patterns.
 {{#options}}
 {{> options-jobs }}
 {{> options-keep-going }}
+{{> options-output-format }}
 {{/options}}
 
 {{> section-environment }}

--- a/doc/man/generated_txt/cargo-doc.txt
+++ b/doc/man/generated_txt/cargo-doc.txt
@@ -323,6 +323,18 @@ OPTIONS
            --keep-going would definitely run both builds, even if the one run
            first fails.
 
+       --output-format
+           The output type for the documentation emitted. Valid values:
+
+           o  html (default): Emit the documentation in HTML format.
+
+           o  json: Emit the documentation in the experimental JSON format
+              <https://doc.rust-lang.org/nightly/nightly-rustc/rustdoc_json_types>.
+
+           This option is only available on the nightly channel
+           <https://doc.rust-lang.org/book/appendix-07-nightly-rust.html> and
+           requires the -Z unstable-options flag to enable.
+
 ENVIRONMENT
        See the reference
        <https://doc.rust-lang.org/cargo/reference/environment-variables.html>

--- a/etc/man/cargo-doc.1
+++ b/etc/man/cargo-doc.1
@@ -389,6 +389,22 @@ one that succeeds (depending on which one of the two builds Cargo picked to run
 first), whereas \fBcargo doc \-j1 \-\-keep\-going\fR would definitely run both
 builds, even if the one run first fails.
 .RE
+.sp
+\fB\-\-output\-format\fR
+.RS 4
+The output type for the documentation emitted. Valid values:
+.sp
+.RS 4
+\h'-04'\(bu\h'+03'\fBhtml\fR (default): Emit the documentation in HTML format.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+03'\fBjson\fR: Emit the documentation in the \fIexperimental JSON format\fR <https://doc.rust\-lang.org/nightly/nightly\-rustc/rustdoc_json_types>\&.
+.RE
+.sp
+This option is only available on the \fInightly channel\fR <https://doc.rust\-lang.org/book/appendix\-07\-nightly\-rust.html>
+and requires the \fB\-Z unstable\-options\fR flag to enable.
+.RE
 .SH "ENVIRONMENT"
 See \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/environment\-variables.html> for
 details on environment variables that Cargo reads.


### PR DESCRIPTION
Closes #17323

Adds the missing --output-format documentation for `cargo doc`:
- doc/man/cargo-doc.md now includes the same options-output-format snippet that cargo-rustdoc.md already has.
- doc/book/src/reference/unstable.md's section is renamed from "output-format for rustdoc" to "output-format for rustdoc and cargo doc", with a cargo doc example added alongside the existing cargo rustdoc one.

Generated outputs (doc/man/generated_txt/cargo-doc.txt, etc/man/cargo-doc.1, doc/book/src/commands/cargo-doc.md) regenerated via `cargo build-man`. Docs-only change, no behavior affected.
