### PR TITLE
feat(resolver): Report the min-publish-age in the lock message

### DIFF
--- a/src/ops/cargo_update.rs
+++ b/src/ops/cargo_update.rs
@@ -1,4 +1,6 @@
+use crate::context::CargoResolverConfig;
 use crate::context::GlobalContext;
+use crate::context::IncompatiblePublishAge;
 use crate::ops;
 use crate::resolver::PublishAgePolicy;
 use crate::resolver::Resolve;
@@ -575,7 +577,7 @@ fn print_lockfile_generation(
     annotate_required_rust_version(ws, resolve, &mut changes);
     let publish_age = publish_age_policy_for_report(ws);
 
-    status_locking(ws, num_pkgs)?;
+    status_locking(ws, publish_age.as_ref(), num_pkgs)?;
     for change in changes.values() {
         if change.is_member.unwrap_or(false) {
             continue;
@@ -631,7 +633,7 @@ fn print_lockfile_sync(
     annotate_required_rust_version(ws, resolve, &mut changes);
     let publish_age = publish_age_policy_for_report(ws);
 
-    status_locking(ws, num_pkgs)?;
+    status_locking(ws, publish_age.as_ref(), num_pkgs)?;
     for change in changes.values() {
         if change.is_member.unwrap_or(false) {
             continue;
@@ -683,7 +685,7 @@ fn print_lockfile_updates(
     let publish_age = publish_age_policy_for_report(ws);
 
     if !precise {
-        status_locking(ws, num_pkgs)?;
+        status_locking(ws, publish_age.as_ref(), num_pkgs)?;
     }
     let mut unchanged_behind = 0;
     for change in changes.values() {
@@ -758,9 +760,18 @@ fn print_lockfile_updates(
     Ok(())
 }
 
-fn status_locking(ws: &Workspace<'_>, num_pkgs: usize) -> CargoResult<()> {
+fn status_locking(
+    ws: &Workspace<'_>,
+    publish_age: Option<&PublishAgePolicy>,
+    num_pkgs: usize,
+) -> CargoResult<()> {
     use std::fmt::Write as _;
 
+    let resolver_config = ws.gctx().get::<Option<CargoResolverConfig>>("resolver")?;
+    let deny_min_publish_age = resolver_config
+        .and_then(|c| c.incompatible_publish_age)
+        .is_none_or(|v| v == IncompatiblePublishAge::Deny);
+    let publish_age = publish_age.filter(|_| deny_min_publish_age);
     let publish_time = ws.resolve_publish_time();
 
     let plural = if num_pkgs == 1 { "" } else { "s" };
@@ -779,11 +790,17 @@ fn status_locking(ws: &Workspace<'_>, num_pkgs: usize) -> CargoResult<()> {
             write!(&mut cfg, " Rust {rust_version}")?;
         }
         write!(&mut cfg, " compatible version{plural}")?;
-        match publish_time {
-            Some(publish_time) => {
+        match (publish_age, publish_time) {
+            (Some(_publish_age), Some(publish_time)) => {
+                write!(&mut cfg, " as of min-publish-age before {publish_time}",)?;
+            }
+            (Some(_publish_age), None) => {
+                write!(&mut cfg, " as of min-publish-age",)?;
+            }
+            (None, Some(publish_time)) => {
                 write!(&mut cfg, " as of {publish_time}")?;
             }
-            None => {}
+            (None, None) => {}
         }
     }
 

--- a/src/ops/cargo_update.rs
+++ b/src/ops/cargo_update.rs
@@ -856,7 +856,7 @@ fn report_latest(
 
     let publish_note = |summary| {
         let age = publish_age?.too_new(summary)?.age_label();
-        Some(format!(", published {age}"))
+        Some(format!(", published {age} ago"))
     };
 
     let compat_ver_compat_msrv_summary = possibilities

--- a/src/ops/cargo_update.rs
+++ b/src/ops/cargo_update.rs
@@ -761,6 +761,8 @@ fn print_lockfile_updates(
 fn status_locking(ws: &Workspace<'_>, num_pkgs: usize) -> CargoResult<()> {
     use std::fmt::Write as _;
 
+    let publish_time = ws.resolve_publish_time();
+
     let plural = if num_pkgs == 1 { "" } else { "s" };
 
     let mut cfg = String::new();
@@ -777,8 +779,11 @@ fn status_locking(ws: &Workspace<'_>, num_pkgs: usize) -> CargoResult<()> {
             write!(&mut cfg, " Rust {rust_version}")?;
         }
         write!(&mut cfg, " compatible version{plural}")?;
-        if let Some(publish_time) = ws.resolve_publish_time() {
-            write!(&mut cfg, " as of {publish_time}")?;
+        match publish_time {
+            Some(publish_time) => {
+                write!(&mut cfg, " as of {publish_time}")?;
+            }
+            None => {}
         }
     }
 

--- a/src/ops/cargo_update.rs
+++ b/src/ops/cargo_update.rs
@@ -791,11 +791,25 @@ fn status_locking(
         }
         write!(&mut cfg, " compatible version{plural}")?;
         match (publish_age, publish_time) {
-            (Some(_publish_age), Some(publish_time)) => {
-                write!(&mut cfg, " as of min-publish-age before {publish_time}",)?;
+            (Some(publish_age), Some(publish_time)) => {
+                write!(
+                    &mut cfg,
+                    " as of {} before {publish_time}",
+                    publish_age
+                        .common_min_publish_age()
+                        .map(|a| a.age_label())
+                        .unwrap_or_else(|| "min-publish-age".to_owned())
+                )?;
             }
-            (Some(_publish_age), None) => {
-                write!(&mut cfg, " as of min-publish-age",)?;
+            (Some(publish_age), None) => {
+                write!(
+                    &mut cfg,
+                    " as of {}",
+                    publish_age
+                        .common_min_publish_age()
+                        .map(|a| format!("{} ago", a.age_label()))
+                        .unwrap_or_else(|| "min-publish-age".to_owned())
+                )?;
             }
             (None, Some(publish_time)) => {
                 write!(&mut cfg, " as of {publish_time}")?;

--- a/src/resolver/version_prefs.rs
+++ b/src/resolver/version_prefs.rs
@@ -343,7 +343,7 @@ impl PublishAgeViolation {
     pub fn note(&self) -> String {
         let age = self.age_label();
         let config = self.config();
-        format!("published {age}, minimum age {config}",)
+        format!("published {age} ago, minimum age {config}",)
     }
 }
 
@@ -356,7 +356,7 @@ fn format_age_as_single_unit(age: jiff::SignedDuration) -> String {
 
     // An age at or ahead of "now" gives a non-positive age.
     if age <= jiff::SignedDuration::ZERO {
-        return "moments ago".to_string();
+        return "moments".to_string();
     }
 
     let rounded = jiff::Span::try_from(age).and_then(|span| {
@@ -381,10 +381,10 @@ fn format_age_as_single_unit(age: jiff::SignedDuration) -> String {
         .spacing(Spacing::BetweenUnitsAndDesignators);
 
     match rounded {
-        Ok(span) => format!("{} ago", printer.span_to_string(&span)),
+        Ok(span) => printer.span_to_string(&span).to_string(),
         Err(e) => {
             tracing::warn!("failed to round `{age}`: {e}");
-            format!("{} seconds ago", age.as_secs())
+            format!("{} seconds", age.as_secs())
         }
     }
 }
@@ -818,29 +818,29 @@ mod test {
     #[test]
     fn rounds_to_a_single_unit() {
         // `>= 2 days` rounds to the nearest day.
-        assert_age(2 * DAY, "2 days ago");
-        assert_age(2 * DAY + 8 * HOUR + 23 * MIN, "2 days ago");
-        assert_age(2 * DAY + 13 * HOUR, "3 days ago");
-        assert_age(540 * DAY, "540 days ago");
+        assert_age(2 * DAY, "2 days");
+        assert_age(2 * DAY + 8 * HOUR + 23 * MIN, "2 days");
+        assert_age(2 * DAY + 13 * HOUR, "3 days");
+        assert_age(540 * DAY, "540 days");
 
         // `1 hour ..< 2 days` rounds to the nearest hour.
-        assert_age(47 * HOUR, "47 hours ago");
-        assert_age(24 * HOUR, "24 hours ago");
-        assert_age(11 * HOUR + 40 * MIN, "12 hours ago");
-        assert_age(11 * HOUR + 20 * MIN, "11 hours ago");
-        assert_age(HOUR, "1 hour ago");
+        assert_age(47 * HOUR, "47 hours");
+        assert_age(24 * HOUR, "24 hours");
+        assert_age(11 * HOUR + 40 * MIN, "12 hours");
+        assert_age(11 * HOUR + 20 * MIN, "11 hours");
+        assert_age(HOUR, "1 hour");
 
         // `1 minute ..< 1 hour` rounds to the nearest minute.
-        assert_age(40 * MIN, "40 minutes ago");
-        assert_age(MIN, "1 minute ago");
+        assert_age(40 * MIN, "40 minutes");
+        assert_age(MIN, "1 minute");
 
         // `< 1 minute` rounds to the nearest second.
-        assert_age(40, "40 seconds ago");
-        assert_age(1, "1 second ago");
+        assert_age(40, "40 seconds");
+        assert_age(1, "1 second");
 
         // ahead of "now" (clock drift)
-        assert_age(0, "moments ago");
-        assert_age(-20, "moments ago");
-        assert_age(-2 * DAY, "moments ago");
+        assert_age(0, "moments");
+        assert_age(-20, "moments");
+        assert_age(-2 * DAY, "moments");
     }
 }

--- a/src/resolver/version_prefs.rs
+++ b/src/resolver/version_prefs.rs
@@ -297,6 +297,28 @@ impl PublishAgePolicy {
 
         &self.global
     }
+
+    /// A single min-publish-age, if there is one
+    pub fn common_min_publish_age(&self) -> Option<PublishAgeViolation> {
+        if !self.per_registry.is_empty() {
+            return None;
+        }
+
+        if self.crates_io.is_set() {
+            return None;
+        }
+
+        if let MinPublishAge::Age(age, config) = &self.global {
+            jiff::SignedDuration::try_from(*age).ok().and_then(|age| {
+                Some(PublishAgeViolation {
+                    age,
+                    config: config.clone(),
+                })
+            })
+        } else {
+            None
+        }
+    }
 }
 
 /// A configured `min-publish-age` value for one scope.

--- a/tests/testsuite/min_publish_age.rs
+++ b/tests/testsuite/min_publish_age.rs
@@ -208,7 +208,7 @@ fn filters_too_new_versions() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to highest compatible version as of min-publish-age
+[LOCKING] 1 package to highest compatible version as of 7 days ago
 [ADDING] bar v1.0.0 (available: v1.1.0, published 2 days ago)
 
 "#]])
@@ -336,7 +336,7 @@ fn incompatible_publish_age_deny() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to highest compatible version as of min-publish-age
+[LOCKING] 1 package to highest compatible version as of 7 days ago
 [ADDING] bar v1.0.0 (available: v1.1.0, published 2 days ago)
 
 "#]])
@@ -652,7 +652,7 @@ fn patched_versions_preserved() {
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to highest compatible version as of min-publish-age
+[LOCKING] 1 package to highest compatible version as of 7 days ago
 [ADDING] bar v1.1.0 (registry `alternative`) (published 2 days ago, minimum age 7 days)
 
 "#]])
@@ -714,7 +714,7 @@ fn versions_without_pubtime_unaffected() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to highest compatible version as of min-publish-age
+[LOCKING] 1 package to highest compatible version as of 7 days ago
 
 "#]])
         .run();
@@ -847,7 +847,7 @@ fn cargo_install_path_allows_too_new_deps() {
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.0.0 ([ROOT]/foo)
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to highest compatible version as of min-publish-age
+[LOCKING] 1 package to highest compatible version as of 7 days ago
 [ADDING] bar v1.0.0 (available: v1.1.0, published 2 days ago)
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
@@ -945,7 +945,7 @@ fn update_precise_to_too_new() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to highest compatible version as of min-publish-age
+[LOCKING] 1 package to highest compatible version as of 7 days ago
 [ADDING] bar v1.0.0 (available: v1.1.0, published 2 days ago)
 
 "#]])
@@ -1048,7 +1048,7 @@ fn update_precise_with_allow() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to highest compatible version as of min-publish-age
+[LOCKING] 1 package to highest compatible version as of 7 days ago
 [ADDING] bar v1.0.0 (available: v1.2.0, published 24 hours ago)
 
 "#]])
@@ -1696,7 +1696,7 @@ fn registries_alt_respects_global() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 1 package to highest compatible version as of min-publish-age
+[LOCKING] 1 package to highest compatible version as of 7 days ago
 [ADDING] bar v1.0.0 (registry `alternative`) (available: v1.1.0, published 2 days ago)
 
 "#]])
@@ -1916,7 +1916,7 @@ fn resolve_with_backtracking() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to highest compatible versions as of min-publish-age
+[LOCKING] 2 packages to highest compatible versions as of 7 days ago
 [ADDING] dep v1.0.0 (available: v1.1.0)
 
 "#]])
@@ -1984,7 +1984,7 @@ fn cargo_add_skips_too_new() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [ADDING] bar v1.0.0 to dependencies
-[LOCKING] 1 package to highest compatible version as of min-publish-age
+[LOCKING] 1 package to highest compatible version as of 7 days ago
 [ADDING] bar v1.0.0 (available: v1.1.0, published 2 days ago)
 
 "#]])
@@ -2083,7 +2083,7 @@ fn generate_lockfile_with_publish_time_and_min_publish_age() {
     .masquerade_as_nightly_cargo(&["publish-time", "min-publish-age"])
     .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to highest compatible version as of min-publish-age before 2006-08-08T00:00:00Z
+[LOCKING] 1 package to highest compatible version as of 7 days before 2006-08-08T00:00:00Z
 [ADDING] bar v1.0.0 (available: v1.1.0, published 2 days ago)
 
 "#]])

--- a/tests/testsuite/min_publish_age.rs
+++ b/tests/testsuite/min_publish_age.rs
@@ -208,7 +208,7 @@ fn filters_too_new_versions() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to highest compatible version
+[LOCKING] 1 package to highest compatible version as of min-publish-age
 [ADDING] bar v1.0.0 (available: v1.1.0, published 2 days ago)
 
 "#]])
@@ -336,7 +336,7 @@ fn incompatible_publish_age_deny() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to highest compatible version
+[LOCKING] 1 package to highest compatible version as of min-publish-age
 [ADDING] bar v1.0.0 (available: v1.1.0, published 2 days ago)
 
 "#]])
@@ -652,7 +652,7 @@ fn patched_versions_preserved() {
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to highest compatible version
+[LOCKING] 1 package to highest compatible version as of min-publish-age
 [ADDING] bar v1.1.0 (registry `alternative`) (published 2 days ago, minimum age 7 days)
 
 "#]])
@@ -714,7 +714,7 @@ fn versions_without_pubtime_unaffected() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to highest compatible version
+[LOCKING] 1 package to highest compatible version as of min-publish-age
 
 "#]])
         .run();
@@ -847,7 +847,7 @@ fn cargo_install_path_allows_too_new_deps() {
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.0.0 ([ROOT]/foo)
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to highest compatible version
+[LOCKING] 1 package to highest compatible version as of min-publish-age
 [ADDING] bar v1.0.0 (available: v1.1.0, published 2 days ago)
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
@@ -945,7 +945,7 @@ fn update_precise_to_too_new() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to highest compatible version
+[LOCKING] 1 package to highest compatible version as of min-publish-age
 [ADDING] bar v1.0.0 (available: v1.1.0, published 2 days ago)
 
 "#]])
@@ -1048,7 +1048,7 @@ fn update_precise_with_allow() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to highest compatible version
+[LOCKING] 1 package to highest compatible version as of min-publish-age
 [ADDING] bar v1.0.0 (available: v1.2.0, published 24 hours ago)
 
 "#]])
@@ -1143,7 +1143,7 @@ fn publish_age_zero() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to highest compatible version
+[LOCKING] 1 package to highest compatible version as of min-publish-age
 
 "#]])
         .run();
@@ -1240,7 +1240,7 @@ fn registry_default() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to highest compatible version
+[LOCKING] 1 package to highest compatible version as of min-publish-age
 [ADDING] bar v1.0.0 (available: v1.1.0, published 2 days ago)
 
 "#]])
@@ -1302,7 +1302,7 @@ fn registry_default_overrides_global() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to highest compatible version
+[LOCKING] 1 package to highest compatible version as of min-publish-age
 [ADDING] bar v1.0.0 (available: v1.1.0, published 2 days ago)
 
 "#]])
@@ -1364,7 +1364,7 @@ fn registry_default_zero_overrides_global() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to highest compatible version
+[LOCKING] 1 package to highest compatible version as of min-publish-age
 
 "#]])
         .run();
@@ -1424,7 +1424,7 @@ fn registries_crates_io() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to highest compatible version
+[LOCKING] 1 package to highest compatible version as of min-publish-age
 [ADDING] bar v1.0.0 (available: v1.1.0, published 2 days ago)
 
 "#]])
@@ -1488,7 +1488,7 @@ fn registries_crates_io_overrides_registry_default() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to highest compatible version
+[LOCKING] 1 package to highest compatible version as of min-publish-age
 
 "#]])
         .run();
@@ -1556,7 +1556,7 @@ fn registries_alt() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 1 package to highest compatible version
+[LOCKING] 1 package to highest compatible version as of min-publish-age
 [ADDING] bar v1.0.0 (registry `alternative`) (available: v1.1.0, published 2 days ago)
 
 "#]])
@@ -1628,7 +1628,7 @@ fn registries_alt_overrides_global() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 1 package to highest compatible version
+[LOCKING] 1 package to highest compatible version as of min-publish-age
 
 "#]])
         .run();
@@ -1696,7 +1696,7 @@ fn registries_alt_respects_global() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 1 package to highest compatible version
+[LOCKING] 1 package to highest compatible version as of min-publish-age
 [ADDING] bar v1.0.0 (registry `alternative`) (available: v1.1.0, published 2 days ago)
 
 "#]])
@@ -1765,7 +1765,7 @@ fn registries_alt_ignores_registry_default() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 1 package to highest compatible version
+[LOCKING] 1 package to highest compatible version as of min-publish-age
 
 "#]])
         .run();
@@ -1838,7 +1838,7 @@ fn registry_alt_ignores_min_publish_age() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[LOCKING] 1 package to highest compatible version
+[LOCKING] 1 package to highest compatible version as of min-publish-age
 
 "#]])
         .run();
@@ -1916,7 +1916,7 @@ fn resolve_with_backtracking() {
         .env("__CARGO_TEST_INVOCATION_TIME", NOW)
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages to highest compatible versions
+[LOCKING] 2 packages to highest compatible versions as of min-publish-age
 [ADDING] dep v1.0.0 (available: v1.1.0)
 
 "#]])
@@ -1984,7 +1984,7 @@ fn cargo_add_skips_too_new() {
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [ADDING] bar v1.0.0 to dependencies
-[LOCKING] 1 package to highest compatible version
+[LOCKING] 1 package to highest compatible version as of min-publish-age
 [ADDING] bar v1.0.0 (available: v1.1.0, published 2 days ago)
 
 "#]])
@@ -2083,7 +2083,7 @@ fn generate_lockfile_with_publish_time_and_min_publish_age() {
     .masquerade_as_nightly_cargo(&["publish-time", "min-publish-age"])
     .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to highest compatible version as of 2006-08-08T00:00:00Z
+[LOCKING] 1 package to highest compatible version as of min-publish-age before 2006-08-08T00:00:00Z
 [ADDING] bar v1.0.0 (available: v1.1.0, published 2 days ago)
 
 "#]])


### PR DESCRIPTION
### What does this PR try to resolve?

One of the concerns is can we be transparent about how things are resolving. We are already helped by
- error messages
- listing unused dependencies and how old they are

Now we'll report what the unused dependency is compared against.

Part of #17009

### How to test and review this PR?

This is stacked on #17327