### PR TITLE
docs: adopt rust-lang/rust's LLM usage policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,3 +17,12 @@ Please read [the process] of how features and bugs are managed in Cargo.
 [file an issue]: https://github.com/rust-lang/cargo/issues
 [the process]: https://doc.crates.io/contrib/process/index.html
 [accepted]: https://github.com/rust-lang/cargo/issues?q=is%3Aissue+is%3Aopen+label%3AS-accepted
+
+## LLM policy
+
+Cargo follows the same [LLM usage policy] as `rust-lang/rust`.
+See the [LLM usage chapter] of the Cargo Contributor Guide
+for how it applies to Cargo.
+
+[LLM usage policy]: https://forge.rust-lang.org/policies/llm-usage.html
+[LLM usage chapter]: https://doc.crates.io/contrib/process/llm-usage.html

--- a/doc/contrib/src/SUMMARY.md
+++ b/doc/contrib/src/SUMMARY.md
@@ -9,6 +9,7 @@
     - [Writing an RFC](./process/rfc.md)
     - [Unstable features](./process/unstable.md)
     - [Security issues](./process/security.md)
+    - [LLM usage](./process/llm-usage.md)
 - [Design Principles](./design.md)
 - [Implementing a Change](./implementation/index.md)
     - [Architecture](./implementation/architecture.md)

--- a/doc/contrib/src/process/llm-usage.md
+++ b/doc/contrib/src/process/llm-usage.md
@@ -1,0 +1,29 @@
+# LLM Usage
+
+Cargo follows the same [LLM usage policy] as `rust-lang/rust`.
+Please read it before using LLM assistance
+when participating in `rust-lang/cargo`.
+
+For clarity,
+this includes any updates to this policy made subsequent to Cargo's adoption of it;
+it is our intention to remain aligned with the current policy on an ongoing basis.
+
+When reading the policy in the context of Cargo:
+
+* Read `rust-lang/rust` as `rust-lang/cargo`.
+* Read the ratifying teams as the Cargo team.
+* Read "diagnostics" as generally encompassing Cargo's user-facing output.
+* Ignore parts that do not apply to Cargo,
+  such as those specific to the compiler or the language.
+* The Cargo team will over time more precisely define what we mean by "critical" areas.
+  We expect to adopt whatever tooling `rust-lang/rust` adopts to specify this more precisely.
+* When in doubt,
+  the Cargo team will provide any and all Cargo-specific interpretations of the policy,
+  until such time as the policy itself is updated to encompass Cargo.
+
+For suggestions about how to use LLMs *well*,
+and how to review LLM-created PRs,
+see [the rustc-dev-guide][llm-guidance].
+
+[LLM usage policy]: https://forge.rust-lang.org/policies/llm-usage.html
+[llm-guidance]: https://rustc-dev-guide.rust-lang.org/llm-guidance.html


### PR DESCRIPTION
### What does this PR try to resolve?

The Cargo team has discussed this for quite some time.
The general consensus is to adopt an existing LLM policy rather creating one from scratch.

While we are adopting the policy as-is,
it is not currently written in a way that can to be directly applied outside `rust-lang/rust`.
For example,
some sections link to compiler specific review doc,
or refer to `rust-lang/rust` specific labeling system.

If there is a conflict between the policy and Cargo's contrib doc,
the Cargo team has the final say on how the policy applies.

### How to test and review this PR?

This will go through a t-cargo FCP.

I want to keep it as lean as possible for now.
In the future, we may add Cargo specific additions to the policy.

🤖 LLM disclosure: I used LLM to fix grammar errors.