### PR TITLE
refactor(resolver): resolve() does not need an optional gctx

### DIFF
--- a/crates/resolver-tests/src/lib.rs
+++ b/crates/resolver-tests/src/lib.rs
@@ -204,7 +204,7 @@ pub fn resolve_with_global_context_raw(
         &mut registry,
         &version_prefs,
         ResolveVersion::with_rust_version(None),
-        Some(gctx),
+        gctx,
     );
 
     // The largest test in our suite takes less then 30 secs.

--- a/src/ops/resolve.rs
+++ b/src/ops/resolve.rs
@@ -534,7 +534,7 @@ pub fn resolve_with_previous<'gctx>(
         registry,
         &version_prefs,
         ResolveVersion::with_rust_version(ws.lowest_rust_version()),
-        Some(ws.gctx()),
+        ws.gctx(),
     )?;
 
     let patches = registry.patches().values().flat_map(|v| v.iter());

--- a/src/resolver/errors.rs
+++ b/src/resolver/errors.rs
@@ -82,7 +82,7 @@ pub(super) fn activation_error(
     dep: &Dependency,
     conflicting_activations: &ConflictMap,
     candidates: &[Summary],
-    gctx: Option<&GlobalContext>,
+    gctx: &GlobalContext,
 ) -> ResolveError {
     let to_resolve_err = |err| {
         ResolveError::new(
@@ -497,16 +497,14 @@ pub(super) fn activation_error(
         );
     }
 
-    if let Some(gctx) = gctx {
-        if let Some(offline_flag) = gctx.offline_flag() {
-            let _ = write!(
-                &mut hints,
-                "\nnote: offline mode (via `{offline_flag}`) \
-                 can sometimes cause surprising resolution failures\
-                 \nhelp: if this error is too confusing you may wish to retry \
-                 without `{offline_flag}`",
-            );
-        }
+    if let Some(offline_flag) = gctx.offline_flag() {
+        let _ = write!(
+            &mut hints,
+            "\nnote: offline mode (via `{offline_flag}`) \
+             can sometimes cause surprising resolution failures\
+             \nhelp: if this error is too confusing you may wish to retry \
+             without `{offline_flag}`",
+        );
     }
 
     to_resolve_err(anyhow::format_err!("{msg}{hints}"))
@@ -598,11 +596,7 @@ fn alt_names(
 /// For path dependencies, scan the dependency directory for any packages
 /// that exist in subdirectories. This helps when the user points to a
 /// directory without a Cargo.toml or with the wrong package name.
-fn alt_paths(
-    dep: &Dependency,
-    gctx: Option<&GlobalContext>,
-) -> Option<Vec<crate::workspace::Package>> {
-    let gctx = gctx?;
+fn alt_paths(dep: &Dependency, gctx: &GlobalContext) -> Option<Vec<crate::workspace::Package>> {
     if !dep.source_id().is_path() {
         return None;
     }

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -120,8 +120,7 @@ mod version_prefs;
 ///
 /// * `resolve_version` - this controls how the lockfile will be serialized.
 ///
-/// * `config` - a location to print warnings and such, or `None` if no warnings
-///   should be printed
+/// * `gctx` - the global context used for configuration and diagnostics.
 #[tracing::instrument(skip_all)]
 pub fn resolve(
     summaries: &[(Summary, ResolveOpts)],
@@ -129,14 +128,12 @@ pub fn resolve(
     registry: &impl Registry,
     version_prefs: &VersionPreferences,
     resolve_version: ResolveVersion,
-    gctx: Option<&GlobalContext>,
+    gctx: &GlobalContext,
 ) -> CargoResult<Resolve> {
-    let first_version = match gctx {
-        Some(config) if config.cli_unstable().direct_minimal_versions => {
-            Some(VersionOrdering::MinimumVersionsFirst)
-        }
-        _ => None,
-    };
+    let first_version = gctx
+        .cli_unstable()
+        .direct_minimal_versions
+        .then_some(VersionOrdering::MinimumVersionsFirst);
     let mut registry = RegistryQueryer::new(registry, replacements, version_prefs);
 
     // Global cache of the reasons for each time we backtrack.
@@ -199,7 +196,7 @@ fn activate_deps_loop(
     registry: &mut RegistryQueryer<'_, impl Registry>,
     summaries: &[(Summary, ResolveOpts)],
     first_version: Option<VersionOrdering>,
-    gctx: Option<&GlobalContext>,
+    gctx: &GlobalContext,
     past_conflicting_activations: &mut conflict_cache::ConflictCache,
 ) -> CargoResult<ResolverContext> {
     let mut resolver_ctx = ResolverContext::new();

--- a/src/resolver/types.rs
+++ b/src/resolver/types.rs
@@ -43,7 +43,7 @@ impl ResolverProgress {
                 .unwrap_or(1),
         }
     }
-    pub fn shell_status(&mut self, gctx: Option<&GlobalContext>) -> CargoResult<()> {
+    pub fn shell_status(&mut self, gctx: &GlobalContext) -> CargoResult<()> {
         // If we spend a lot of time here (we shouldn't in most cases) then give
         // a bit of a visual indicator as to what we're doing. Only enable this
         // when stderr is a tty (a human is likely to be watching) to ensure we
@@ -54,15 +54,13 @@ impl ResolverProgress {
         // like `Instant::now` by only checking every N iterations of this loop
         // to amortize the cost of the current time lookup.
         self.ticks += 1;
-        if let Some(config) = gctx {
-            if config.shell().is_err_tty()
-                && !self.printed
-                && self.ticks % 1000 == 0
-                && self.start.elapsed() - self.deps_time > self.time_to_print
-            {
-                self.printed = true;
-                config.shell().status("Resolving", "dependency graph...")?;
-            }
+        if gctx.shell().is_err_tty()
+            && !self.printed
+            && self.ticks % 1000 == 0
+            && self.start.elapsed() - self.deps_time > self.time_to_print
+        {
+            self.printed = true;
+            gctx.shell().status("Resolving", "dependency graph...")?;
         }
         #[cfg(debug_assertions)]
         {


### PR DESCRIPTION
### What does this PR try to resolve?

In a WIP build-std patch I have, it's convenient for the resolver to unconditionally have a gctx, and the reason for it being optional doesn't seem to exist any more.

### How to test and review this PR?

The PR modifies src/resolver/mod.rs:resolve() to take an non-optional GlobalContext, and then fixes the fallout from that. It's never actually called with None, and so is adequately tested under the existing testsuite.