### PR TITLE
docs: describe why `package.authors` is deprecated

### DIFF
--- a/doc/book/src/reference/manifest.md
+++ b/doc/book/src/reference/manifest.md
@@ -121,7 +121,12 @@ This field is optional and defaults to `0.0.0`.  The field is required for publi
 
 ### The `authors` field
 
-> **Warning**: This field is deprecated
+> **Warning**: This field is deprecated and may be considered for removal in
+> the future. The definition of "author" has subjective and context-dependent
+> nuances, listing significant contributors does not scale to projects with
+> many contributors, and the immutability of published releases required by
+> registries such as crates.io makes it impossible to rename or remove authors
+> from published packages. See [Cargo PR #15068] for more details.
 
 The optional `authors` field lists in an array the people or organizations that are considered
 the "authors" of the package. An optional email address may be included within angled brackets at
@@ -135,6 +140,8 @@ authors = ["Graydon Hoare", "Fnu Lnu <no-reply@rust-lang.org>"]
 
 This field is surfaced in package metadata and in the `CARGO_PKG_AUTHORS`
 environment variable within `build.rs` for backwards compatibility.
+
+[Cargo PR #15068]: https://github.com/rust-lang/cargo/pull/15068
 
 ### The `edition` field
 


### PR DESCRIPTION
### What does this PR try to resolve?

Common sense and a range of research findings suggest that making the rationale behind a rule clear and agreeable improves compliance. Applying that observation to the `package.authors` deprecation notice in the Cargo package manifest format documentation, making the rationale for the deprecation more easily accessible should help people make more informed decisions about whether and how to migrate away from it.

Personally, until I decided to dig deeper into the matter, I have been considering `tombi`'s warnings about `package.authors` being deprecated to be noisy lints without a clear reason or an obvious way forward that warranted addressing.

This change expands the `package.authors` deprecation notice to include a summary of the deprecation rationale stated in PR #15068, along with a link to the PR for anyone interested in learning more about the context behind the deprecation.

### How to test and review this PR?

N/A
