### PR TITLE
fix(trim-paths): workspace remap under -Zroot-dir

### DIFF
--- a/doc/book/src/reference/unstable.md
+++ b/doc/book/src/reference/unstable.md
@@ -1618,6 +1618,7 @@ An example of the unremap file:
 ```json
 {"v":1}
 {"rust_version":"1.96.0-nightly","workspace_root":"/home/me/app"}
+{"from":".","to":"/home/me/app"}
 {"from":"/cargo/build-dir","to":"/home/me/app/target"}
 {"from":"/cargo/registry/6f17d22d3f0a95d1","to":"/home/me/.cargo/registry/src/index.crates.io-6f17d22d3f0a95d1"}
 {"from":"/rustc/abc123","to":"/home/me/.rustup/toolchains/nightly/lib/rustlib/src/rust"}

--- a/src/compiler/trim_paths.rs
+++ b/src/compiler/trim_paths.rs
@@ -20,6 +20,7 @@ use super::Unit;
 use crate::util::data_structures::HashSet;
 use crate::util::errors::CargoResult;
 use crate::util::hex;
+use crate::util::path_args;
 
 /// The current version of the unremap file.
 const CURRENT_UNREMAP_VERSION: u8 = 1;
@@ -160,12 +161,29 @@ fn package_remap(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> (PathBuf, S
     // Handle path local dependencies and abnormal reg/git deps source location.
     if pkg_root.strip_prefix(ws_root).is_ok() {
         // remap to relative rustc work dir explicitly
-        (ws_root.to_path_buf(), ".".to_owned())
+        workspace_remap(build_runner, unit)
     } else {
         let from = pkg_root.to_path_buf();
         let to = format!("/cargo/deps/{}-{}", unit.pkg.name(), unit.pkg.version());
         (from, to)
     }
+}
+
+/// Path prefix remap rules for dependencies within workspaces.
+fn workspace_remap(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> (PathBuf, String) {
+    let ws_root = build_runner.bcx.ws.root();
+    // rustc working directory is usually workspace root.
+    // However, when `-Zroot-dir` is set, it may not be.
+    // We may need to remap to that otherwise debuginfo like `DW_AT_comp_dir`
+    // would point to rustc working directory,
+    // and won't be remapped by workspace root.
+    let (_, rustc_workdir) = path_args(build_runner.bcx.ws, unit);
+    let from = if ws_root.starts_with(&rustc_workdir) {
+        rustc_workdir
+    } else {
+        ws_root.to_path_buf()
+    };
+    (from, ".".into())
 }
 
 /// Finds the checkout root and revision directory name of a git dependency.

--- a/src/compiler/trim_paths.rs
+++ b/src/compiler/trim_paths.rs
@@ -276,14 +276,7 @@ pub(crate) fn write_unremap_file(
         for dep in build_runner.unit_deps(&unit) {
             stack.push(dep.unit.clone());
         }
-        let (from, to) = package_remap(build_runner, &unit);
-
-        // Skipping workspace remap because debugger substitutions are global in a session.
-        // If two unremap files with different workspace roots are loaded.
-        // substitutions of `.` would override each others.
-        if to != "." {
-            insert((from, to));
-        }
+        insert(package_remap(build_runner, &unit));
     }
 
     serde_json::to_writer(

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -261,6 +261,10 @@ fn registry_dependency() {
     "workspace_root": "[ROOT]/foo"
   },
   {
+    "from": ".",
+    "to": "[ROOT]/foo"
+  },
+  {
     "from": "/cargo/build-dir",
     "to": "[ROOT]/foo/target"
   },
@@ -420,6 +424,10 @@ fn git_dependency() {
     "workspace_root": "[ROOT]/foo"
   },
   {
+    "from": ".",
+    "to": "[ROOT]/foo"
+  },
+  {
     "from": "/cargo/build-dir",
     "to": "[ROOT]/foo/target"
   },
@@ -497,6 +505,10 @@ cocktail-bar/src/lib.rs
     "workspace_root": "[ROOT]/foo"
   },
   {
+    "from": ".",
+    "to": "[ROOT]/foo"
+  },
+  {
     "from": "/cargo/build-dir",
     "to": "[ROOT]/foo/target"
   },
@@ -569,6 +581,10 @@ fn path_dependency_outside_workspace() {
   {
     "rust_version": "[..]",
     "workspace_root": "[ROOT]/foo"
+  },
+  {
+    "from": ".",
+    "to": "[ROOT]/foo"
   },
   {
     "from": "/cargo/build-dir",
@@ -683,6 +699,10 @@ fn vendored_dependencies() {
     "workspace_root": "[ROOT]/foo"
   },
   {
+    "from": ".",
+    "to": "[ROOT]/foo"
+  },
+  {
     "from": "/cargo/build-dir",
     "to": "[ROOT]/foo/target"
   },
@@ -790,6 +810,10 @@ fn vendored_dependencies_outside_workspace() {
   {
     "rust_version": "[..]",
     "workspace_root": "[ROOT]/foo"
+  },
+  {
+    "from": ".",
+    "to": "[ROOT]/foo"
   },
   {
     "from": "/cargo/build-dir",
@@ -1587,6 +1611,10 @@ fn workspace_remap_with_root_dir() {
     "workspace_root": "[ROOT]/foo"
   },
   {
+    "from": ".",
+    "to": "[ROOT]/foo"
+  },
+  {
     "from": "/cargo/build-dir",
     "to": "[ROOT]/foo/target"
   },
@@ -2129,6 +2157,10 @@ fn unremap_debugger_project() -> cargo_test_support::Project {
     "workspace_root": "[ROOT]/foo"
   },
   {
+    "from": ".",
+    "to": "[ROOT]/foo"
+  },
+  {
     "from": "/cargo/build-dir",
     "to": "[ROOT]/foo/target"
   },
@@ -2164,7 +2196,7 @@ fn unremap_substitutions(artifact: &std::path::Path) -> Vec<(String, String)> {
     let version = values.next().unwrap().unwrap();
     assert_eq!(version["v"], 1);
 
-    let metadata = values.next().unwrap().unwrap();
+    let _metadata = values.next().unwrap().unwrap();
 
     let mut pairs = Vec::new();
 
@@ -2175,12 +2207,6 @@ fn unremap_substitutions(artifact: &std::path::Path) -> Vec<(String, String)> {
             record["to"].as_str().unwrap().to_owned(),
         ));
     }
-
-    // remap local workspace source
-    pairs.push((
-        ".".to_owned(),
-        metadata["workspace_root"].as_str().unwrap().to_owned(),
-    ));
 
     pairs
 }

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -1590,9 +1590,9 @@ fn workspace_remap_with_root_dir() {
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
-[RUNNING] `rustc [..]--remap-path-scope=object --remap-path-prefix=[ROOT]/foo=. --remap-path-prefix=[ROOT]/foo/target=/cargo/build-dir --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
+[RUNNING] `rustc [..]--remap-path-scope=object --remap-path-prefix=[ROOT]=. --remap-path-prefix=[ROOT]/foo/target=/cargo/build-dir --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc [..]--remap-path-scope=object --remap-path-prefix=[ROOT]/foo=. --remap-path-prefix=[ROOT]/foo/target=/cargo/build-dir --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
+[RUNNING] `rustc [..]--remap-path-scope=object --remap-path-prefix=[ROOT]=. --remap-path-prefix=[ROOT]/foo/target=/cargo/build-dir --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -1612,7 +1612,7 @@ fn workspace_remap_with_root_dir() {
   },
   {
     "from": ".",
-    "to": "[ROOT]/foo"
+    "to": "[ROOT]"
   },
   {
     "from": "/cargo/build-dir",

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -1539,6 +1539,69 @@ fn command_output(command: &mut std::process::Command, name: &str) -> std::proce
 }
 
 #[cargo_test]
+fn workspace_remap_with_root_dir() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                edition = "2015"
+
+                [dependencies]
+                bar = { path = "bar" }
+
+                [profile.dev]
+                trim-paths = "object"
+           "#,
+        )
+        .file("src/main.rs", "fn main() { bar::f(); }")
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
+        .file("bar/src/lib.rs", "pub fn f() {}")
+        .build();
+
+    p.cargo("build --verbose -Ztrim-paths -Zroot-dir=..")
+        .masquerade_as_nightly_cargo(&["-Ztrim-paths", "-Zroot-dir"])
+        .with_stderr_data(str![[r#"
+[LOCKING] 1 package to highest compatible version
+[COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
+[RUNNING] `rustc [..]--remap-path-scope=object --remap-path-prefix=[ROOT]/foo=. --remap-path-prefix=[ROOT]/foo/target=/cargo/build-dir --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc [..]--remap-path-scope=object --remap-path-prefix=[ROOT]/foo=. --remap-path-prefix=[ROOT]/foo/target=/cargo/build-dir --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+
+    let unremap_file = unremap_file_path(&p.bin("foo"));
+    assert_e2e().eq(
+        &std::fs::read_to_string(&unremap_file).unwrap(),
+        str![[r#"
+[
+  {
+    "v": 1
+  },
+  {
+    "rust_version": "[..]",
+    "workspace_root": "[ROOT]/foo"
+  },
+  {
+    "from": "/cargo/build-dir",
+    "to": "[ROOT]/foo/target"
+  },
+  {
+    "from": "/rustc/[..]",
+    "to": "[..]/lib/rustlib/src/rust"
+  }
+]
+"#]]
+        .is_json()
+        .against_jsonlines(),
+    );
+}
+
+#[cargo_test]
 fn unremap_file_rebuild() {
     let p = project()
         .file(


### PR DESCRIPTION
### What does this PR try to resolve?

With `-Zroot-dir`,
rustc runs from the specified root dir,
so its working directory is not covered by workspace remap rule and absolute paths were leaking there.

The proposed fix here:

* Cargo unconditionally adds the workspace remap as an `{"from":".","to":...}` record in the unremap file.
* When the rusc cwd `-Zroot-dir` changes, the workspace remap record would reflect the change.

Part of rust-lang/cargo#12137

### How to test and review this PR?

See commit message for why this is fine.

### Note

LLM disclosure: This was found during the experiment of rust-lang/cargo#17309 with LLM.
bootstrap invokes cargo with `-Zroot-dir={src}`,
and std started leaking checkout path from there.

