### PR TITLE
fix(trim-paths): `/cargo/deps` fallback sources 

### DIFF
--- a/doc/book/src/reference/unstable.md
+++ b/doc/book/src/reference/unstable.md
@@ -1586,6 +1586,10 @@ Paths to all other source files will not be affected.
 
 This will not affect any hard-coded paths in the source code, such as in strings.
 
+The exact remap path prefixes are not stable across Cargo versions.
+Tools that map paths embedded in artifacts back to local sources
+should consume unremap files instead of interpreting these prefixes.
+
 ##### Unremap files
 
 When the `object` scope is active and debuginfo is enabled,

--- a/doc/book/src/reference/unstable.md
+++ b/doc/book/src/reference/unstable.md
@@ -1565,7 +1565,7 @@ If `trim-paths` is not `none` or `false`, then the following paths are sanitized
    which replaces the checkout directory.
    `<revision>` is a prefix of the resolved commit ID recorded in the lockfile.
 5. Path to a path dependency outside the workspace will be replaced with
-   `/cargo/path/<package name>-<package version>`.
+   `/cargo/deps/<package name>-<package version>`.
 6. Path into the build directory, for example `OUT_DIR` generated sources,
    will begin with `/cargo/build-dir`.
 

--- a/src/compiler/trim_paths.rs
+++ b/src/compiler/trim_paths.rs
@@ -83,15 +83,17 @@ pub(crate) fn trim_paths_args(
 /// Order of `--remap-path-prefix` flags is important for `-Zbuild-std`.
 /// We want to show `/rustc/<hash>/library/std` instead of `std-0.0.0`.
 ///
-/// | Category            | From                                         | To                                 |
-/// |---------------------|----------------------------------------------|------------------------------------|
-/// | Sysroot             | `<sysroot>/lib/rustlib/src/rust`             | `/rustc/<commit-hash>`             |
-/// | Registry dep        | `$CARGO_HOME/registry/src/<registry-dir>`        | `/cargo/registry/<registry-id>`    |
-/// | Git dep             | `$CARGO_HOME/git/checkouts/<repo-dir>/<rev-dir>` | `/cargo/git/<git-source-id>/<rev>` |
-/// | Workspace           | `<workspace-root>`                           | `.` (workspace-relative)           |
-/// | Path dep outside ws | `<pkg-root>`                                 | `/cargo/path/<name>-<version>`     |
-/// | Vendored            | `<pkg-root>` (by file location)              | workspace or path rules above      |
-/// | Build directory     | `<build-dir>`                                | `/cargo/build-dir`                 |
+/// | Category     | From                                             | To                                 |
+/// |--------------|--------------------------------------------------|------------------------------------|
+/// | Sysroot      | `<sysroot>/lib/rustlib/src/rust`                 | `/rustc/<commit-hash>`             |
+/// | Registry dep | `$CARGO_HOME/registry/src/<registry-dir>`        | `/cargo/registry/<registry-id>`    |
+/// | Git dep      | `$CARGO_HOME/git/checkouts/<repo-dir>/<rev-dir>` | `/cargo/git/<git-source-id>/<rev>` |
+/// | Workspace    | `<workspace-root>`                               | `.` (workspace-relative)           |
+/// | Path dep†    | `<pkg-root>`                                     | `/cargo/deps/<name>-<version>`     |
+/// | Vendored     | `<pkg-root>` (by file location)                  | workspace or path rules above      |
+/// | Build dir    | `<build-dir>`                                    | `/cargo/build-dir`                 |
+///
+/// **†**: path dependencies outside the workspace and other uncategorized dependencies.
 ///
 /// [RFC 3127]: https://rust-lang.github.io/rfcs/3127-trim-paths.html
 pub(crate) fn trim_paths_remap(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> [OsString; 3] {
@@ -161,7 +163,7 @@ fn package_remap(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> (PathBuf, S
         (ws_root.to_path_buf(), ".".to_owned())
     } else {
         let from = pkg_root.to_path_buf();
-        let to = format!("/cargo/path/{}-{}", unit.pkg.name(), unit.pkg.version());
+        let to = format!("/cargo/deps/{}-{}", unit.pkg.name(), unit.pkg.version());
         (from, to)
     }
 }

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -541,13 +541,13 @@ fn path_dependency_outside_workspace() {
     p.cargo("run --verbose -Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stdout_data(str![[r#"
-/cargo/path/bar-0.0.1/src/lib.rs
+/cargo/deps/bar-0.0.1/src/lib.rs
 
 "#]])
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/bar)
-[RUNNING] `rustc [..]--remap-path-scope=object --remap-path-prefix=[ROOT]/bar=/cargo/path/bar-0.0.1 --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
+[RUNNING] `rustc [..]--remap-path-scope=object --remap-path-prefix=[ROOT]/bar=/cargo/deps/bar-0.0.1 --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc [..]--remap-path-scope=object --remap-path-prefix=[ROOT]/foo=. --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -575,7 +575,7 @@ fn path_dependency_outside_workspace() {
     "to": "[ROOT]/foo/target"
   },
   {
-    "from": "/cargo/path/bar-0.0.1",
+    "from": "/cargo/deps/bar-0.0.1",
     "to": "[ROOT]/bar"
   },
   {
@@ -760,8 +760,8 @@ fn vendored_dependencies_outside_workspace() {
             str![[r#"
 [COMPILING] bar v0.0.1
 [COMPILING] baz v0.0.1 ([ROOTURL]/baz#[..])
-[RUNNING] `rustc --crate-name bar [..]--remap-path-scope=object --remap-path-prefix=[ROOT]/shared-vendor/bar=/cargo/path/bar-0.0.1 --remap-path-prefix=[ROOT]/foo/target=/cargo/build-dir --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
-[RUNNING] `rustc --crate-name baz [..]--remap-path-scope=object --remap-path-prefix=[ROOT]/shared-vendor/baz=/cargo/path/baz-0.0.1 --remap-path-prefix=[ROOT]/foo/target=/cargo/build-dir --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
+[RUNNING] `rustc --crate-name bar [..]--remap-path-scope=object --remap-path-prefix=[ROOT]/shared-vendor/bar=/cargo/deps/bar-0.0.1 --remap-path-prefix=[ROOT]/foo/target=/cargo/build-dir --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
+[RUNNING] `rustc --crate-name baz [..]--remap-path-scope=object --remap-path-prefix=[ROOT]/shared-vendor/baz=/cargo/deps/baz-0.0.1 --remap-path-prefix=[ROOT]/foo/target=/cargo/build-dir --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo [..]--remap-path-scope=object --remap-path-prefix=[ROOT]/foo=. --remap-path-prefix=[ROOT]/foo/target=/cargo/build-dir --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -771,8 +771,8 @@ fn vendored_dependencies_outside_workspace() {
             .unordered(),
         )
         .with_stdout_data(str![[r#"
-/cargo/path/bar-0.0.1/src/lib.rs
-/cargo/path/baz-0.0.1/src/lib.rs
+/cargo/deps/bar-0.0.1/src/lib.rs
+/cargo/deps/baz-0.0.1/src/lib.rs
 
 "#]])
         .run();
@@ -796,11 +796,11 @@ fn vendored_dependencies_outside_workspace() {
     "to": "[ROOT]/foo/target"
   },
   {
-    "from": "/cargo/path/bar-0.0.1",
+    "from": "/cargo/deps/bar-0.0.1",
     "to": "[ROOT]/shared-vendor/bar"
   },
   {
-    "from": "/cargo/path/baz-0.0.1",
+    "from": "/cargo/deps/baz-0.0.1",
     "to": "[ROOT]/shared-vendor/baz"
   },
   {
@@ -2070,7 +2070,7 @@ fn unremap_debugger_project() -> cargo_test_support::Project {
     "to": "[ROOT]/foo/target"
   },
   {
-    "from": "/cargo/path/baz-0.0.1",
+    "from": "/cargo/deps/baz-0.0.1",
     "to": "[ROOT]/baz"
   },
   {


### PR DESCRIPTION
### What does this PR try to resolve?

This is similar to `/rustc/deps` the existing pattern in rustc bootstrap.

The `/cargo/path` is confusing enough, and it also contain vendored dependencies outside workspace root hence so.

### How to test and review this PR?

This also updates the docs to leave the remap prefixes unspecified.
Happy to split them if needed.


LLM disclosure: This was found during the experiment of rust-lang/cargo#17309 with LLM against rust-lang/rust
