### PR TITLE
Fix funding link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
 github: rustfoundation
-custom: ["rust-lang.org/funding"]
+custom: ["https://rust-lang.org/funding"]


### PR DESCRIPTION
### What does this PR try to resolve?

Per [#t-infra > funding link on rust-lang/rust is broken @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/funding.20link.20on.20rust-lang.2Frust.20is.20broken/near/615432496), the current link is broken.
