### PR TITLE
test: Handle non-deterministic compilation order

### DIFF
--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -3598,7 +3598,8 @@ fn cfg_override_test() {
         .file("tests/test.rs", "#[cfg(foo)] #[test] fn test_bar() {}")
         .build();
     p.cargo("test -v")
-        .with_stderr_data(str![[r#"
+        .with_stderr_data(
+            str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo[..]`
 [RUNNING] `rustc --crate-name foo[..]`
@@ -3609,7 +3610,9 @@ fn cfg_override_test() {
 [DOCTEST] foo
 [RUNNING] `rustdoc [..] --cfg foo[..]`
 
-"#]])
+"#]]
+            .unordered(),
+        )
         .with_stdout_data(str![[r#"
 
 running 1 test


### PR DESCRIPTION
### What does this PR try to resolve?



Hit this with #17346
```
thread 'build_script::cfg_override_test' (71300) panicked at tests/testsuite/build_script.rs:3634:10:

---- expected: tests/testsuite/build_script.rs:3601:27
++++ actual:   stderr
   1    1 | [COMPILING] foo v0.0.1 ([ROOT]/foo)
   2    2 | [RUNNING] `rustc --crate-name foo[..]`
   3      - [RUNNING] `rustc --crate-name foo[..]`
   4      - [RUNNING] `rustc --crate-name test[..]`
        3 + [RUNNING] `rustc --crate-name test --edition=2015 tests/test.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --diagnostic-width=400 --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --allow=unexpected_cfgs --test --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values())' -C metadata=7e98bdc87b54be1e -C extra-filename=-46d1fa8b5db2bd02 --out-dir [ROOT]/foo/target/debug/deps -L dependency=[ROOT]/foo/target/debug/deps --extern foo=[ROOT]/foo/target/debug/deps/libfoo-[HASH].rlib --cfg foo`
        4 + [RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --diagnostic-width=400 --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --allow=unexpected_cfgs --test --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values())' -C metadata=e83780a000df3302 -C extra-filename=-e1364ce7fb0b5fef --out-dir [ROOT]/foo/target/debug/deps -L dependency=[ROOT]/foo/target/debug/deps --cfg foo`
   5    5 | [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
   6    6 | [RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
   7    7 | [RUNNING] `[ROOT]/foo/target/debug/deps/test-[HASH][EXE]`
   8    8 | [DOCTEST] foo
   9    9 | [RUNNING] `rustdoc [..] --cfg foo[..]`
```


### How to test and review this PR?

