### PR TITLE
feat(trim-paths): honor workspace prefix override from env

### DIFF
--- a/src/compiler/fingerprint/mod.rs
+++ b/src/compiler/fingerprint/mod.rs
@@ -77,6 +77,7 @@
 //! Immediate dependency’s hashes              | ✓[^1]       | ✓                        | ✓
 //! [`CompileKind`] (host/target)              | ✓           | ✓                        | ✓
 //! `__CARGO_DEFAULT_LIB_METADATA`[^4]         |             | ✓                        | ✓
+//! `__CARGO_RUSTC_BOOTSTRAP_WS_REMAP`[^2]     | ✓           |                          |
 //! `package_id`                               |             | ✓                        | ✓
 //! Target src path relative to ws             | ✓           |                          |
 //! Target flags (test/bench/for_host/edition) | ✓           |                          |
@@ -91,6 +92,9 @@
 //! `--extern priv:`                           | ✓           |                          |
 //!
 //! [^1]: Bin dependencies are not included.
+//!
+//! [^2]: `__CARGO_RUSTC_BOOTSTRAP_WS_REMAP` is set by rustc bootstrap
+//!       to customize remap-path-prefix
 //!
 //! [^3]: See below for details on mtime tracking.
 //!
@@ -1631,6 +1635,18 @@ fn calculate_normal(
         build_runner.bcx.extra_args_for(unit),
         build_runner.lto[unit],
         unit.pkg.manifest().lint_rustflags(),
+        unit.profile
+            .trim_paths
+            .as_ref()
+            .filter(|trim_paths| !trim_paths.is_none())
+            .map(|_| {
+                build_runner
+                    .bcx
+                    .gctx
+                    .get_env(super::trim_paths::WS_REMAP_ENV)
+                    .ok()
+                    .filter(|prefix| !prefix.is_empty())
+            }),
     ));
     let mut config = StableHasher::new();
     let linker = if unit.target.for_host() && !build_runner.bcx.gctx.target_applies_to_host()? {

--- a/src/compiler/trim_paths.rs
+++ b/src/compiler/trim_paths.rs
@@ -28,6 +28,12 @@ const CURRENT_UNREMAP_VERSION: u8 = 1;
 /// Filename suffix of the unremap file.
 pub(crate) const UNREMAP_SUFFIX: &str = ".trim-paths.jsonl";
 
+/// This is an internal contract with rustc bootstrap,
+/// which needs workspace sources remapped to `/rust{c,-dev}/<sha>`.
+///
+/// See <https://github.com/rust-lang/cargo/issues/17309>.
+pub(crate) const WS_REMAP_ENV: &str = "__CARGO_RUSTC_BOOTSTRAP_WS_REMAP";
+
 /// Like [`trim_paths_args`] but for rustdoc invocations.
 pub(crate) fn trim_paths_args_rustdoc(
     cmd: &mut ProcessBuilder,
@@ -160,7 +166,6 @@ fn package_remap(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> (PathBuf, S
 
     // Handle path local dependencies and abnormal reg/git deps source location.
     if pkg_root.strip_prefix(ws_root).is_ok() {
-        // remap to relative rustc work dir explicitly
         workspace_remap(build_runner, unit)
     } else {
         let from = pkg_root.to_path_buf();
@@ -183,7 +188,15 @@ fn workspace_remap(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> (PathBuf,
     } else {
         ws_root.to_path_buf()
     };
-    (from, ".".into())
+    let to = build_runner
+        .bcx
+        .gctx
+        .get_env(WS_REMAP_ENV)
+        .ok()
+        .filter(|prefix| !prefix.is_empty())
+        .unwrap_or(".")
+        .to_owned();
+    (from, to)
 }
 
 /// Finds the checkout root and revision directory name of a git dependency.

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -1630,6 +1630,100 @@ fn workspace_remap_with_root_dir() {
 }
 
 #[cargo_test]
+fn workspace_prefix_override_from_env() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                edition = "2015"
+
+                [profile.dev]
+                trim-paths = "object"
+           "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build --verbose -Ztrim-paths")
+        .env("__CARGO_RUSTC_BOOTSTRAP_WS_REMAP", "/rustc-dev/1111111")
+        .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc [..]--remap-path-prefix=[ROOT]/foo=. [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+
+    let unremap_file = unremap_file_path(&p.bin("foo"));
+    assert_e2e().eq(
+        &std::fs::read_to_string(&unremap_file).unwrap(),
+        str![[r#"
+[
+  {
+    "v": 1
+  },
+  {
+    "rust_version": "[..]",
+    "workspace_root": "[ROOT]/foo"
+  },
+  {
+    "from": ".",
+    "to": "[ROOT]/foo"
+  },
+  {
+    "from": "/cargo/build-dir",
+    "to": "[ROOT]/foo/target"
+  },
+  {
+    "from": "/rustc/[..]",
+    "to": "[..]/lib/rustlib/src/rust"
+  }
+]
+"#]]
+        .is_json()
+        .against_jsonlines(),
+    );
+}
+
+#[cargo_test]
+fn workspace_prefix_override_fingerprint() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                edition = "2015"
+
+                [profile.dev]
+                trim-paths = "object"
+           "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build -Ztrim-paths")
+        .env("__CARGO_RUSTC_BOOTSTRAP_WS_REMAP", "/rustc-dev/1111111")
+        .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
+        .run();
+
+    p.cargo("build --verbose -Ztrim-paths")
+        .env("__CARGO_RUSTC_BOOTSTRAP_WS_REMAP", "/rustc-dev/2222222")
+        .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
+        .with_stderr_data(str![[r#"
+[FRESH] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn unremap_file_rebuild() {
     let p = project()
         .file(

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -1652,7 +1652,7 @@ fn workspace_prefix_override_from_env() {
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc [..]--remap-path-prefix=[ROOT]/foo=. [..]`
+[RUNNING] `rustc [..]--remap-path-prefix=[ROOT]/foo=/rustc-dev/1111111 [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -1671,12 +1671,12 @@ fn workspace_prefix_override_from_env() {
     "workspace_root": "[ROOT]/foo"
   },
   {
-    "from": ".",
-    "to": "[ROOT]/foo"
-  },
-  {
     "from": "/cargo/build-dir",
     "to": "[ROOT]/foo/target"
+  },
+  {
+    "from": "/rustc-dev/1111111",
+    "to": "[ROOT]/foo"
   },
   {
     "from": "/rustc/[..]",
@@ -1716,7 +1716,9 @@ fn workspace_prefix_override_fingerprint() {
         .env("__CARGO_RUSTC_BOOTSTRAP_WS_REMAP", "/rustc-dev/2222222")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stderr_data(str![[r#"
-[FRESH] foo v0.0.1 ([ROOT]/foo)
+[DIRTY] foo v0.0.1 ([ROOT]/foo): the profile configuration changed
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc [..]--remap-path-prefix=[ROOT]/foo=/rustc-dev/2222222 [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])


### PR DESCRIPTION
### What does this PR try to resolve?

`__CARGO_RUSTC_BOOTSTRAP_WS_REMAP`
is an internal contract with rustc bootstrap,
which needs workspace sources remapped to `/rustc/<sha>`.

The `to` prefix participates in the fingerprint,
since it is embedded in artifacts.

See <https://github.com/rust-lang/cargo/issues/17309>.

### How to test and review this PR?

While we can make it a `-Z` flag,

* This is modeled after `__CARGO_DEFAULT_LIB_METADATA`
* We cannot test this in `rust-lang/rust` CI without it being at least on one nightly.
  (Maybe there is a way, but I don't know how to set bootstrap cargo to a never built cargo)
  
Hence I chose the easiest way to implement.
