### PR TITLE
Re-stabilize build-dir layout v2

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1439,10 +1439,6 @@ pub trait TestEnvCommandExt: Sized {
             .env("CARGO_INCREMENTAL", "0")
             // Don't read the system git config which is out of our control.
             .env("GIT_CONFIG_NOSYSTEM", "1")
-            // See: https://github.com/rust-lang/rust/pull/159857#issuecomment-5119325932
-            // This should be removed once the new build-dir layout is stabilized and the old layout
-            // is removed.
-            .env("__CARGO_TEMPORARY_BUILD_DIR_NEW_LAYOUT_OPT_OUT", "1")
             .env_remove("CI")
             .env_remove("__CARGO_DEFAULT_LIB_METADATA")
             .env_remove("ALL_PROXY")

--- a/doc/book/src/reference/build-cache.md
+++ b/doc/book/src/reference/build-cache.md
@@ -70,9 +70,10 @@ change. Some of these directories are:
 
 Directory | Description
 ----------|------------
-<code style="white-space: nowrap">\<build-dir>/debug/deps/</code> | Dependencies and other artifacts.
 <code style="white-space: nowrap">\<build-dir>/debug/incremental/</code> | `rustc` [incremental output], a cache used to speed up subsequent builds.
-<code style="white-space: nowrap">\<build-dir>/debug/build/</code> | Output from [build scripts].
+<code style="white-space: nowrap">\<build-dir>/debug/build/</code> | Build step results including compilation artifacts and [build script] output.
+
+> **Note**: The build-dir layout was changed in Cargo 1.100.0, thus prior versions use a different layout. (see [#15010](https://github.com/rust-lang/cargo/issues/15010))
 
 ## Dep-info files
 
@@ -107,7 +108,7 @@ configuration][config]. Refer to sccache documentation for more details.
 [`cargo doc`]: ../commands/cargo-doc.md
 [`cargo package`]: ../commands/cargo-package.md
 [`cargo publish`]: ../commands/cargo-publish.md
-[build scripts]: ../reference/build-scripts.md
+[build script]: ../reference/build-scripts.md
 [config]: ../reference/config.md
 [def-workspace]:  ../appendix/glossary.md#workspace  '"workspace" (glossary entry)'
 [target]: ../appendix/glossary.md#target '"target" (glossary entry)'

--- a/doc/book/src/reference/unstable.md
+++ b/doc/book/src/reference/unstable.md
@@ -82,7 +82,6 @@ Each new feature described below should explain how to use it.
     * [min-publish-age](#min-publish-age) --- Filters out dependency versions published more recently than a configured minimum age.
 * Output behavior
     * [artifact-dir](#artifact-dir) --- Adds a directory where artifacts are copied to.
-    * [build-dir-new-layout](#build-dir-new-layout) --- Enables the new build-dir filesystem layout
     * [Different binary name](#different-binary-name) --- Assign a name to the built binary that is separate from the crate name.
     * [root-dir](#root-dir) --- Controls the root directory relative to which paths are printed
 * Compile behavior
@@ -1735,8 +1734,6 @@ panic = "immediate-abort"
 
 Use fine grain locking instead of locking the entire build cache.
 
-Note: Fine grain locking implicitly enables [build-dir-new-layout](#build-dir-new-layout) as fine grain locking builds on that directory reoganization.
-
 ## `[lints.cargo]`
 
 * Tracking Issue: [#12235](https://github.com/rust-lang/cargo/issues/12235)
@@ -2004,14 +2001,6 @@ The following commands are available under `-Zbuild-analysis`:
   similar to `cargo build --timings` but without rebuilding.
 - `cargo report rebuilds` --- Reports why crates were rebuilt,
   helping diagnose unexpected recompilations.
-
-## build-dir-new-layout
-
-* Tracking Issue: [#15010](https://github.com/rust-lang/cargo/issues/15010)
-
-Enables the new build-dir filesystem layout.
-This layout change unblocks work towards caching and locking improvements.
-
 
 ## compile-time-deps
 
@@ -2465,3 +2454,7 @@ The `build.warnings` config field has been stabilized in Rust 1.97.
 
 The `cargo update -Zunstable-options --breaking` flag has been removed in 1.99-nightly.
 See <https://github.com/rust-lang/cargo/pull/17333> fopr the reason for its removal.
+
+## build-dir-new-layout
+
+The new build-dir filesystem layout was stabilized in the 1.100.0 release.

--- a/src/workspace/features.rs
+++ b/src/workspace/features.rs
@@ -838,11 +838,7 @@ macro_rules! unstable_cli_options {
                     ),*
                 };
 
-                // Defaults to enabled on nightly unless explicitly opted out.
-                if !is_new_build_dir_layout_opt_out() {
-                    unstable.build_dir_new_layout =
-                        matches!(crate::version().release_channel.as_deref(), Some("nightly" | "dev"));
-                }
+                unstable.build_dir_new_layout = !is_new_build_dir_layout_opt_out();
 
                 return unstable;
             }
@@ -1022,6 +1018,8 @@ const STABILIZED_CONFIG_INCLUDE: &str = "The `include` config key is now always 
 const STABILIZED_LOCKFILE_PATH: &str = "The `lockfile-path` config key is now always available";
 
 const STABILIZED_WARNINGS: &str = "The `build.warnings` config key is now always available";
+
+const STABILIZED_BUILD_DIR_NEW_LAYOUT: &str = "build.build-dir-new-layout is now always enabled.";
 
 fn deserialize_comma_separated_list<'de, D>(
     deserializer: D,
@@ -1423,6 +1421,7 @@ impl CliUnstable {
             "config-include" => stabilized_warn(k, "1.93", STABILIZED_CONFIG_INCLUDE),
             "lockfile-path" => stabilized_warn(k, "1.97", STABILIZED_LOCKFILE_PATH),
             "warnings" => stabilized_warn(k, "1.97", STABILIZED_WARNINGS),
+            "build-dir-new-layout" => stabilized_warn(k, "1.100", STABILIZED_BUILD_DIR_NEW_LAYOUT),
 
             // Unstable features
             // Sorted alphabetically:
@@ -1433,7 +1432,6 @@ impl CliUnstable {
             "binary-dep-depinfo" => self.binary_dep_depinfo = parse_empty(k, v)?,
             "bindeps" => self.bindeps = parse_empty(k, v)?,
             "build-analysis" => self.build_analysis = parse_empty(k, v)?,
-            "build-dir-new-layout" => self.build_dir_new_layout = parse_empty(k, v)?,
             "build-std" => self.build_std = Some(parse_list(v)),
             "build-std-features" => self.build_std_features = Some(parse_list(v)),
             "cargo-lints" => self.cargo_lints = parse_empty(k, v)?,

--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -168,9 +168,9 @@ fn basic() {
 [COMPILING] [..]
 ...
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/[HOST_TARGET]/debug/deps/foo-[HASH])
-[RUNNING] unittests src/main.rs (target/[HOST_TARGET]/debug/deps/foo-[HASH])
-[RUNNING] tests/smoke.rs (target/[HOST_TARGET]/debug/deps/smoke-[HASH])
+[RUNNING] unittests src/lib.rs (target/[HOST_TARGET]/debug/build/foo/[HASH]/out/foo-[HASH])
+[RUNNING] unittests src/main.rs (target/[HOST_TARGET]/debug/build/foo/[HASH]/out/foo-[HASH])
+[RUNNING] tests/smoke.rs (target/[HOST_TARGET]/debug/build/foo/[HASH]/out/smoke-[HASH])
 [DOCTEST] foo
 
 "#]])
@@ -180,9 +180,9 @@ fn basic() {
     let deps_dir = Path::new("target")
         .join(rustc_host())
         .join("debug")
-        .join("deps");
-    assert!(p.glob(deps_dir.join("*.rlib")).count() > 0);
-    assert_eq!(p.glob(deps_dir.join("*.dylib")).count(), 0);
+        .join("build");
+    assert!(p.glob(deps_dir.join("**/*.rlib")).count() > 0);
+    assert_eq!(p.glob(deps_dir.join("**/*.dylib")).count(), 0);
 }
 
 #[cargo_test(build_std_real)]
@@ -432,7 +432,7 @@ fn test_proc_macro() {
 ...
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH])
 
 "#]])
         .run();

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -620,12 +620,12 @@ fn build_script_with_bin_artifacts() {
         assert_e2e().eq(
             &build_script_output,
             str![[r#"
-[ROOT]/foo/target/debug/deps/artifact/bar-[HASH]/bin/baz[EXE]
-[ROOT]/foo/target/debug/deps/artifact/bar-[HASH]/staticlib/bar-[HASH].lib
-[ROOT]/foo/target/debug/deps/artifact/bar-[HASH]/cdylib/bar.dll
-[ROOT]/foo/target/debug/deps/artifact/bar-[HASH]/bin
-[ROOT]/foo/target/debug/deps/artifact/bar-[HASH]/bin/bar[EXE]
-[ROOT]/foo/target/debug/deps/artifact/bar-[HASH]/bin/bar[EXE]
+[ROOT]/foo/target/debug/build/bar/[HASH]/artifact/bin/baz[EXE]
+[ROOT]/foo/target/debug/build/bar/[HASH]/artifact/staticlib/bar-[HASH].lib
+[ROOT]/foo/target/debug/build/bar/[HASH]/artifact/cdylib/bar.dll
+[ROOT]/foo/target/debug/build/bar/[HASH]/artifact/bin
+[ROOT]/foo/target/debug/build/bar/[HASH]/artifact/bin/bar[EXE]
+[ROOT]/foo/target/debug/build/bar/[HASH]/artifact/bin/bar[EXE]
 
 "#]],
         );
@@ -633,12 +633,12 @@ fn build_script_with_bin_artifacts() {
         assert_e2e().eq(
             &build_script_output,
             str![[r#"
-[ROOT]/foo/target/debug/deps/artifact/bar-[HASH]/bin/baz-[HASH][EXE]
-[ROOT]/foo/target/debug/deps/artifact/bar-[HASH]/staticlib/libbar-[HASH].a
-[ROOT]/foo/target/debug/deps/artifact/bar-[HASH]/cdylib/[..]bar.[..]
-[ROOT]/foo/target/debug/deps/artifact/bar-[HASH]/bin
-[ROOT]/foo/target/debug/deps/artifact/bar-[HASH]/bin/bar-[HASH][EXE]
-[ROOT]/foo/target/debug/deps/artifact/bar-[HASH]/bin/bar-[HASH][EXE]
+[ROOT]/foo/target/debug/build/bar/[HASH]/artifact/bin/baz[EXE]
+[ROOT]/foo/target/debug/build/bar/[HASH]/artifact/staticlib/libbar-[HASH].a
+[ROOT]/foo/target/debug/build/bar/[HASH]/artifact/cdylib/[..]bar.[..]
+[ROOT]/foo/target/debug/build/bar/[HASH]/artifact/bin
+[ROOT]/foo/target/debug/build/bar/[HASH]/artifact/bin/bar[EXE]
+[ROOT]/foo/target/debug/build/bar/[HASH]/artifact/bin/bar[EXE]
 
 "#]],
         );
@@ -810,8 +810,8 @@ fn build_script_with_selected_dashed_bin_artifact_and_lib_true() {
         assert_e2e().eq(
             &build_script_output,
             str![[r#"
-[ROOT]/foo/target/debug/deps/artifact/bar-baz-[HASH]/bin
-[ROOT]/foo/target/debug/deps/artifact/bar-baz-[HASH]/bin/baz_suffix[EXE]
+[ROOT]/foo/target/debug/build/bar-baz/[HASH]/artifact/bin
+[ROOT]/foo/target/debug/build/bar-baz/[HASH]/artifact/bin/baz_suffix[EXE]
 
 "#]],
         );
@@ -819,8 +819,8 @@ fn build_script_with_selected_dashed_bin_artifact_and_lib_true() {
         assert_e2e().eq(
             &build_script_output,
             str![[r#"
-[ROOT]/foo/target/debug/deps/artifact/bar-baz-[HASH]/bin
-[ROOT]/foo/target/debug/deps/artifact/bar-baz-[HASH]/bin/baz_suffix-[HASH][EXE]
+[ROOT]/foo/target/debug/build/bar-baz/[HASH]/artifact/bin
+[ROOT]/foo/target/debug/build/bar-baz/[HASH]/artifact/bin/baz_suffix[EXE]
 
 "#]],
         );
@@ -830,7 +830,7 @@ fn build_script_with_selected_dashed_bin_artifact_and_lib_true() {
         !p.bin("bar").is_file(),
         "artifacts are located in their own directory, exclusively, and won't be lifted up"
     );
-    assert_artifact_executable_output(&p, "debug", "bar", "baz_suffix");
+    assert_artifact_executable_output(&p, "debug", "bar-baz", "baz_suffix");
 }
 
 #[cargo_test]
@@ -900,7 +900,7 @@ fn lib_with_selected_dashed_bin_artifact_and_lib_true() {
         !p.bin("bar").is_file(),
         "artifacts are located in their own directory, exclusively, and won't be lifted up"
     );
-    assert_artifact_executable_output(&p, "debug", "bar", "baz_suffix");
+    assert_artifact_executable_output(&p, "debug", "bar-baz", "baz_suffix");
 }
 
 #[cargo_test]
@@ -943,7 +943,7 @@ fn allow_artifact_and_no_artifact_dep_to_same_package_within_different_dep_categ
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -1292,7 +1292,7 @@ fn cross_doctests_works_with_artifacts() {
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/[HOST_TARGET]/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/[HOST_TARGET]/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -1316,7 +1316,7 @@ fn cross_doctests_works_with_artifacts() {
 [RUNNING] `rustc --crate-name foo [..]
 [RUNNING] `rustc --crate-name foo [..]
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/[ALT_TARGET]/debug/deps/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/[ALT_TARGET]/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
 [DOCTEST] foo
 [RUNNING] `rustdoc [..]--test src/lib.rs --test-run-directory [ROOT]/foo --target [ALT_TARGET] [..]
 
@@ -1422,7 +1422,7 @@ fn profile_override_basic() {
 [RUNNING] `rustc --crate-name bar --edition=2015 bar/src/lib.rs [..] -C opt-level=1 [..]`
 [RUNNING] `rustc --crate-name bar --edition=2015 bar/src/lib.rs [..] -C opt-level=3 [..]`
 [RUNNING] `rustc --crate-name foo [..] -C opt-level=3 [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [FINISHED] `dev` profile [optimized + debuginfo] target(s) in [ELAPSED]s
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 
@@ -2207,8 +2207,8 @@ fn env_vars_and_build_products_for_various_build_targets() {
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
-[RUNNING] tests/main.rs (target/debug/deps/main-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] tests/main.rs (target/debug/build/foo/[HASH]/out/main-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -2416,7 +2416,11 @@ fn doc_lib_true() {
 
     // Verify that it emits rmeta for the bin and lib dependency.
     assert_eq!(p.glob("target/debug/artifact/*.rlib").count(), 0);
-    assert_eq!(p.glob("target/debug/deps/libbar-*.rmeta").count(), 2);
+    assert_eq!(
+        p.glob("target/debug/build/bar/*/out/libbar-*.rmeta")
+            .count(),
+        2
+    );
 
     p.cargo("doc -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
@@ -2508,7 +2512,7 @@ fn assert_artifact_executable_output(
     if cfg!(target_env = "msvc") {
         assert_eq!(
             p.glob(format!(
-                "target/{}/deps/artifact/{}-*/bin/{}{}",
+                "target/{}/build/{}/*/artifact/bin/{}{}",
                 target_name,
                 dep_name,
                 bin_name,
@@ -2521,7 +2525,7 @@ fn assert_artifact_executable_output(
     } else {
         assert_eq!(
             p.glob(format!(
-                "target/{}/deps/artifact/{}-*/bin/{}-*{}",
+                "target/{}/build/{}/*/artifact/bin/{}{}",
                 target_name,
                 dep_name,
                 bin_name,
@@ -2538,7 +2542,7 @@ fn assert_artifact_executable_output(
 
 fn build_script_output_string(p: &Project, package_name: &str) -> String {
     let paths = p
-        .glob(format!("target/debug/build/{}-*/output", package_name))
+        .glob(format!("target/debug/build/{}/*/run/stdout", package_name))
         .collect::<Result<Vec<_>, _>>()
         .unwrap();
     assert_eq!(paths.len(), 1);
@@ -2822,7 +2826,7 @@ fn with_assumed_host_target_and_optional_build_dep() {
 [COMPILING] d1 v0.0.1 ([ROOT]/foo/d1)
 [RUNNING] `rustc --crate-name build_script_build --edition=2021 [..]--crate-type bin[..]
 [RUNNING] `rustc --crate-name d1 --edition=2021 [..]--crate-type bin[..]
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo --edition=2021 [..]--cfg[..]d1[..]
 [FINISHED] `dev` profile [..]
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -3638,7 +3642,7 @@ fn artifact_dep_target_does_not_propagate_to_deps_of_build_script() {
 [COMPILING] artifact v0.0.1 ([ROOT]/foo/artifact)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/main.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .masquerade_as_nightly_cargo(&["bindeps"])
@@ -3730,7 +3734,7 @@ fn artifact_dep_target_does_not_propagate_to_proc_macro() {
 [COMPILING] artifact v0.0.1 ([ROOT]/foo/artifact)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/main.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .masquerade_as_nightly_cargo(&["bindeps"])

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -44,7 +44,7 @@ hello
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] unittests src/main.rs (target/release/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -94,8 +94,8 @@ fn bench_bench_implicit() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/release/deps/foo-[HASH][EXE])
-[RUNNING] [..] (target/release/deps/mybench-[HASH][EXE])
+[RUNNING] [..] (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] [..] (target/release/build/foo/[HASH]/out/mybench-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -151,7 +151,7 @@ fn bench_bin_implicit() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/release/deps/foo-[HASH][EXE])
+[RUNNING] [..] (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -191,7 +191,7 @@ fn bench_tarname() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/release/deps/bin2-[HASH][EXE])
+[RUNNING] [..] (target/release/build/foo/[HASH]/out/bin2-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -240,8 +240,8 @@ fn bench_multiple_targets() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] benches/bin1.rs (target/release/deps/bin1-[HASH][EXE])
-[RUNNING] benches/bin2.rs (target/release/deps/bin2-[HASH][EXE])
+[RUNNING] benches/bin1.rs (target/release/build/foo/[HASH]/out/bin1-[HASH][EXE])
+[RUNNING] benches/bin2.rs (target/release/build/foo/[HASH]/out/bin2-[HASH][EXE])
 
 "#]])
         .run();
@@ -268,7 +268,7 @@ fn cargo_bench_verbose() {
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `rustc [..] src/main.rs [..]`
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[..]target/release/deps/foo-[HASH][EXE] hello --bench`
+[RUNNING] `[..]target/release/build/foo/[HASH]/out/foo-[HASH][EXE] hello --bench`
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -385,7 +385,7 @@ hello
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/release/deps/foo-[HASH][EXE])
+[RUNNING] [..] (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
 [ERROR] bench failed, to rerun pass `--bin foo`
 
 "#]])
@@ -450,8 +450,8 @@ fn bench_with_lib_dep() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/release/deps/foo-[HASH][EXE])
-[RUNNING] [..] (target/release/deps/baz-[HASH][EXE])
+[RUNNING] [..] (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] [..] (target/release/build/foo/[HASH]/out/baz-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -526,7 +526,7 @@ fn bench_with_deep_lib_dep() {
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [COMPILING] bar v0.0.1 ([ROOT]/bar)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/release/deps/bar-[HASH][EXE])
+[RUNNING] [..] (target/release/build/bar/[HASH]/out/bar-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -588,8 +588,8 @@ fn external_bench_explicit() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/release/deps/foo-[HASH][EXE])
-[RUNNING] [..] (target/release/deps/bench-[HASH][EXE])
+[RUNNING] [..] (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] [..] (target/release/build/foo/[HASH]/out/bench-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -644,8 +644,8 @@ fn external_bench_implicit() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/release/deps/foo-[HASH][EXE])
-[RUNNING] [..] (target/release/deps/external-[HASH][EXE])
+[RUNNING] [..] (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] [..] (target/release/build/foo/[HASH]/out/external-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -733,7 +733,7 @@ https://github.com/rust-lang/cargo/issues/5330
 [WARNING] `foo` (manifest) generated 1 warning
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/release/deps/foo-[HASH][EXE])
+[RUNNING] [..] (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .run();
@@ -771,7 +771,7 @@ fn pass_through_command_line() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/release/deps/foo-[HASH][EXE])
+[RUNNING] [..] (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -788,7 +788,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured; 1 filtered out; fini
     p.cargo("bench foo")
         .with_stderr_data(str![[r#"
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/release/deps/foo-[HASH][EXE])
+[RUNNING] [..] (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -874,8 +874,8 @@ fn lib_bin_same_name() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/release/deps/foo-[HASH][EXE])
-[RUNNING] [..] (target/release/deps/foo-[HASH][EXE])
+[RUNNING] [..] (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] [..] (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -933,8 +933,8 @@ fn lib_with_standard_name() {
         .with_stderr_data(str![[r#"
 [COMPILING] syntax v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/release/deps/syntax-[HASH][EXE])
-[RUNNING] [..] (target/release/deps/bench-[HASH][EXE])
+[RUNNING] [..] (target/release/build/syntax/[HASH]/out/syntax-[HASH][EXE])
+[RUNNING] [..] (target/release/build/syntax/[HASH]/out/bench-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -995,7 +995,7 @@ fn lib_with_standard_name2() {
         .with_stderr_data(str![[r#"
 [COMPILING] syntax v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/release/deps/syntax-[HASH][EXE])
+[RUNNING] [..] (target/release/build/syntax/[HASH]/out/syntax-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1082,8 +1082,8 @@ fn bench_dylib() {
 [RUNNING] [..] -C opt-level=3 [..]
 [RUNNING] [..] -C opt-level=3 [..]
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[..]target/release/deps/foo-[HASH][EXE] --bench`
-[RUNNING] `[..]target/release/deps/bench-[HASH][EXE] --bench`
+[RUNNING] `[..]target/release/build/foo/[HASH]/out/foo-[HASH][EXE] --bench`
+[RUNNING] `[..]target/release/build/foo/[HASH]/out/bench-[HASH][EXE] --bench`
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1109,8 +1109,8 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured; 0 filtered out; fini
 [FRESH] bar v0.0.1 ([ROOT]/foo/bar)
 [FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[..]target/release/deps/foo-[HASH][EXE] --bench`
-[RUNNING] `[..]target/release/deps/bench-[HASH][EXE] --bench`
+[RUNNING] `[..]target/release/build/foo/[HASH]/out/foo-[HASH][EXE] --bench`
+[RUNNING] `[..]target/release/build/foo/[HASH]/out/bench-[HASH][EXE] --bench`
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1162,7 +1162,7 @@ fn bench_twice_with_build_cmd() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/release/deps/foo-[HASH][EXE])
+[RUNNING] [..] (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1179,7 +1179,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured; 0 filtered out; fini
     p.cargo("bench")
         .with_stderr_data(str![[r#"
 [FINISHED] `bench` profile [optimized] target(s) in [..]
-[RUNNING] [..] (target/release/deps/foo-[HASH][EXE])
+[RUNNING] [..] (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1269,8 +1269,8 @@ fn bench_with_examples() {
 [RUNNING] `rustc [..]`
 [RUNNING] `rustc [..]`
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/release/deps/foo-[HASH][EXE] --bench`
-[RUNNING] `[ROOT]/foo/target/release/deps/testb1-[HASH][EXE] --bench`
+[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE] --bench`
+[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/testb1-[HASH][EXE] --bench`
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1321,7 +1321,7 @@ fn test_a_bench() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] [..] (target/debug/deps/b-[HASH][EXE])
+[RUNNING] [..] (target/debug/build/foo/[HASH]/out/b-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1359,8 +1359,8 @@ fn test_bench_no_run() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[EXECUTABLE] benches src/lib.rs (target/release/deps/foo-[HASH][EXE])
-[EXECUTABLE] benches/bbaz.rs (target/release/deps/bbaz-[HASH][EXE])
+[EXECUTABLE] benches src/lib.rs (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
+[EXECUTABLE] benches/bbaz.rs (target/release/build/foo/[HASH]/out/bbaz-[HASH][EXE])
 
 "#]])
         .run();
@@ -1439,9 +1439,9 @@ fn test_bench_no_fail_fast() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] unittests src/main.rs (target/release/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
 [ERROR] bench failed, to rerun pass `--bin foo`
-[RUNNING] benches/b1.rs (target/release/deps/b1-[HASH][EXE])
+[RUNNING] benches/b1.rs (target/release/build/foo/[HASH]/out/b1-[HASH][EXE])
 [ERROR] bench failed, to rerun pass `--bench b1`
 [ERROR] 2 targets failed:
     `--bin foo`
@@ -1546,8 +1546,8 @@ fn test_bench_multiple_packages() {
 
     p.cargo("bench -p bar -p baz")
         .with_stderr_data(str![[r#"
-[RUNNING] [..] (target/release/deps/bbaz-[HASH][EXE])
-[RUNNING] [..] (target/release/deps/bbar-[HASH][EXE])
+[RUNNING] [..] (target/release/build/foo/[HASH]/out/bbaz-[HASH][EXE])
+[RUNNING] [..] (target/release/build/foo/[HASH]/out/bbar-[HASH][EXE])
 
 "#]])
         .with_stderr_data(
@@ -1556,10 +1556,10 @@ fn test_bench_multiple_packages() {
 [COMPILING] bar v0.1.0 ([ROOT]/bar)
 [COMPILING] baz v0.1.0 ([ROOT]/baz)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/release/deps/bar-[HASH][EXE])
-[RUNNING] benches/bbar.rs (target/release/deps/bbar-[HASH][EXE])
-[RUNNING] unittests src/lib.rs (target/release/deps/baz-[HASH][EXE])
-[RUNNING] benches/bbaz.rs (target/release/deps/bbaz-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/release/build/bar/[HASH]/out/bar-[HASH][EXE])
+[RUNNING] benches/bbar.rs (target/release/build/bar/[HASH]/out/bbar-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/release/build/baz/[HASH]/out/baz-[HASH][EXE])
+[RUNNING] benches/bbaz.rs (target/release/build/baz/[HASH]/out/bbaz-[HASH][EXE])
 
 "#]]
             .unordered(),
@@ -1618,10 +1618,10 @@ fn bench_all_workspace() {
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/release/deps/bar-[HASH][EXE])
-[RUNNING] benches/bar.rs (target/release/deps/bar-[HASH][EXE])
-[RUNNING] unittests src/main.rs (target/release/deps/foo-[HASH][EXE])
-[RUNNING] benches/foo.rs (target/release/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/release/build/bar/[HASH]/out/bar-[HASH][EXE])
+[RUNNING] benches/bar.rs (target/release/build/bar/[HASH]/out/bar-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] benches/foo.rs (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1809,10 +1809,10 @@ fn bench_all_virtual_manifest() {
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [COMPILING] baz v0.1.0 ([ROOT]/foo/baz)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/release/deps/bar-[HASH][EXE])
-[RUNNING] benches/bar.rs (target/release/deps/bar-[HASH][EXE])
-[RUNNING] unittests src/lib.rs (target/release/deps/baz-[HASH][EXE])
-[RUNNING] benches/baz.rs (target/release/deps/baz-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/release/build/bar/[HASH]/out/bar-[HASH][EXE])
+[RUNNING] benches/bar.rs (target/release/build/bar/[HASH]/out/bar-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/release/build/baz/[HASH]/out/baz-[HASH][EXE])
+[RUNNING] benches/baz.rs (target/release/build/baz/[HASH]/out/baz-[HASH][EXE])
 
 "#]]
             .unordered(),
@@ -1890,8 +1890,8 @@ fn bench_virtual_manifest_glob() {
         .with_stderr_data(str![[r#"
 [COMPILING] baz v0.1.0 ([ROOT]/foo/baz)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/release/deps/baz-[HASH][EXE])
-[RUNNING] benches/baz.rs (target/release/deps/baz-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/release/build/baz/[HASH]/out/baz-[HASH][EXE])
+[RUNNING] benches/baz.rs (target/release/build/baz/[HASH]/out/baz-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1949,8 +1949,8 @@ please set bench.path in Cargo.toml
 [WARNING] `foo` (manifest) generated 1 warning
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/release/deps/foo-[HASH][EXE])
-[RUNNING] src/bench.rs (target/release/deps/bench-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] src/bench.rs (target/release/build/foo/[HASH]/out/bench-[HASH][EXE])
 
 "#]])
         .run();
@@ -2000,10 +2000,10 @@ fn bench_virtual_manifest_all_implied() {
 [COMPILING] bar v0.1.0 ([ROOT]/foo/bar)
 [COMPILING] baz v0.1.0 ([ROOT]/foo/baz)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/release/deps/bar-[HASH][EXE])
-[RUNNING] benches/bar.rs (target/release/deps/bar-[HASH][EXE])
-[RUNNING] unittests src/lib.rs (target/release/deps/baz-[HASH][EXE])
-[RUNNING] benches/baz.rs (target/release/deps/baz-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/release/build/bar/[HASH]/out/bar-[HASH][EXE])
+[RUNNING] benches/bar.rs (target/release/build/bar/[HASH]/out/bar-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/release/build/baz/[HASH]/out/baz-[HASH][EXE])
+[RUNNING] benches/baz.rs (target/release/build/baz/[HASH]/out/baz-[HASH][EXE])
 
 "#]]
             .unordered(),
@@ -2124,7 +2124,7 @@ fn cargo_bench_print_env_verbose() {
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..]CARGO_MANIFEST_DIR=[ROOT]/foo[..] rustc[..]`
 [FINISHED] `bench` profile [optimized] target(s) in [..]
-[RUNNING] `[..]CARGO_MANIFEST_DIR=[ROOT]/foo[..] [ROOT]/foo/target/release/deps/foo-[HASH][EXE] --bench`
+[RUNNING] `[..]CARGO_MANIFEST_DIR=[ROOT]/foo[..] [ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE] --bench`
 
 "#]])
         .run();

--- a/tests/testsuite/binary_name.rs
+++ b/tests/testsuite/binary_name.rs
@@ -195,7 +195,7 @@ fn binary_name2() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/main.rs (target/debug/deps/foo-[..][EXE])
+[RUNNING] unittests src/main.rs (target/debug/build/foo/[HASH]/out/foo-[..][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -128,7 +128,7 @@ fn cargo_compile_incremental() {
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `rustc [..] -C incremental=[ROOT]/foo/target/debug/incremental[..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
 
 "#]])
         .run();
@@ -1590,7 +1590,7 @@ fn cargo_default_env_metadata_env_var() {
         .with_stderr_data(format!(
             "\
 ...
-[RUNNING] `rustc --crate-name foo [..]--extern bar=[ROOT]/foo/target/debug/deps/{dll_prefix}bar{dll_suffix}`
+[RUNNING] `rustc --crate-name foo [..]--extern bar=[ROOT]/foo/target/debug/build/bar/[HASH]/out/{dll_prefix}bar{dll_suffix}[..]`
 ...
 "))
         .run();
@@ -1603,7 +1603,7 @@ fn cargo_default_env_metadata_env_var() {
         .with_stderr_data(format!(
             "\
 ...
-[RUNNING] `rustc --crate-name foo [..]--extern bar=[ROOT]/foo/target/debug/deps/{dll_prefix}bar-[..]{dll_suffix}`
+[RUNNING] `rustc --crate-name foo [..]--extern bar=[ROOT]/foo/target/debug/build/bar/[HASH]/out/{dll_prefix}bar-[..]{dll_suffix}[..]`
 ...
 "))
         .run();
@@ -1708,6 +1708,9 @@ fn crate_env_vars() {
 
                     let exe: PathBuf = env::current_exe().unwrap().into();
                     let mut expected: PathBuf = exe.parent().unwrap()
+                        .parent().unwrap()
+                        .parent().unwrap()
+                        .parent().unwrap()
                         .parent().unwrap()
                         .parent().unwrap()
                         .into();
@@ -3619,7 +3622,7 @@ fn compiler_json_error_format() {
     "env": [],
     "linked_libs": [],
     "linked_paths": [],
-    "out_dir": "[ROOT]/foo/target/debug/build/foo-[HASH]/out",
+    "out_dir": "[ROOT]/foo/target/debug/build/foo/[HASH]/out",
     "package_id": "path+[ROOTURL]/foo#0.5.0",
     "reason": "build-script-executed"
   },
@@ -4755,7 +4758,18 @@ fn cdylib_not_lifted() {
 
     for file in files {
         println!("checking: {}", file);
-        assert!(p.root().join("target/debug/deps").join(&file).is_file());
+        assert_eq!(
+            glob::glob(
+                p.root()
+                    .join("target/debug/build/foo/*/out")
+                    .join(&file)
+                    .to_str()
+                    .unwrap()
+            )
+            .into_iter()
+            .count(),
+            1
+        );
     }
 }
 
@@ -4833,11 +4847,12 @@ fn no_dep_info_collision_when_cdylib_and_bin_coexist() {
         )
         .run();
 
-    let deps_dir = p.target_debug_dir().join("deps");
-    assert!(deps_dir.join("foo.d").exists());
-    let dep_info_count = deps_dir
+    let build_dir = p.target_debug_dir().join("build");
+    let dep_info_count = build_dir
         .read_dir()
         .unwrap()
+        .flat_map(|build_unit| build_unit.unwrap().path().read_dir().unwrap())
+        .flat_map(|hash_dir| hash_dir.unwrap().path().join("out").read_dir().unwrap())
         .filter(|e| {
             let filename = e.as_ref().unwrap().file_name();
             let filename = filename.to_str().unwrap();
@@ -4891,7 +4906,7 @@ fn deterministic_cfg_flags() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [RUNNING] `rustc [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo [..] --cfg[..]default[..]--cfg[..]f_a[..]--cfg[..]f_b[..] --cfg[..]f_c[..]--cfg[..]f_d[..] --cfg cfg_a --cfg cfg_b --cfg cfg_c --cfg cfg_d --cfg cfg_e`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -5909,7 +5924,7 @@ fn build_lib_only() {
     p.cargo("build --lib -v")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..] -L dependency=[ROOT]/foo/target/debug/deps`
+[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -6455,7 +6470,7 @@ fn embed_metadata_no() {
         .arg("-v")
         .with_stderr_contains("[RUNNING] `[..]-Z embed-metadata=no[..]`")
         .with_stderr_contains(
-            "[RUNNING] `[..]--extern bar=[ROOT]/foo/target/debug/deps/libbar-[HASH].rmeta[..]`",
+"[RUNNING] `[..]--extern bar=[ROOT]/foo/target/debug/build/bar/[HASH]/out/libbar-[HASH].rmeta[..]`",
         )
         .run();
 }
@@ -6505,7 +6520,7 @@ fn embed_metadata_no_dylib_dep() {
         .arg("-v")
         .with_stderr_contains("[RUNNING] `[..]-Z embed-metadata=no[..]`")
         .with_stderr_contains(
-            "[RUNNING] `[..]--extern bar=[ROOT]/foo/target/debug/deps/libbar.rmeta[..]`",
+    "[RUNNING] `[..]--extern bar=[ROOT]/foo/target/debug/build/bar/[HASH]/out/libbar.rmeta[..]`",
         )
         .run();
 }
@@ -6574,8 +6589,7 @@ fn should_not_include_current_build_unit_path_in_rustc_args() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout -v build")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("-v build")
         .enable_mac_dsym()
         // Don't pass any `-L` args if there are no dependencies (including our own `out` dir)
         .with_stderr_data(str![[r#"
@@ -6602,8 +6616,7 @@ fn should_not_include_build_script_out_dir_path_in_rustc_args() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout -v build")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("-v build")
         .enable_mac_dsym()
         // Don't pass build script `out` dirs and avoid bloating the rustc command args which can
         // lead to problems on Windows.
@@ -6715,8 +6728,7 @@ fn should_only_include_dylibs_on_lib_search_path() {
         .file("qux/src/lib.rs", r#"pub fn qux_value() -> i32 { 200 }"#)
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout -v run")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("-v run")
         .enable_mac_dsym()
         .with_stdout_data(str![[r#"
 bar (dylib) on search path: true
@@ -6729,6 +6741,7 @@ qux (cdylib) on search path: false
     // Legacy layout
     p.cargo("-v run")
         .enable_mac_dsym()
+        .env("__CARGO_TEMPORARY_BUILD_DIR_NEW_LAYOUT_OPT_OUT", "1")
         .with_stdout_data(str![[r#"
 bar (dylib) on search path: true
 baz (rlib) on search path: true
@@ -6823,8 +6836,7 @@ fn should_not_include_proc_macro_deps_paths_in_rustc_args() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout -v build")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("-v build")
         .enable_mac_dsym()
         // Verify that the proc-macro dependencies (my-rlib and my-dylib) are not added to the rustc
         // invocation for the `foo` crate as `-L` args.

--- a/tests/testsuite/build_analysis.rs
+++ b/tests/testsuite/build_analysis.rs
@@ -439,7 +439,7 @@ fn log_rebuild_reason_file_changed() {
     "cause": {
       "dirty_reason": "fs-status-outdated",
       "fs_status": "stale-item",
-      "reference": "[ROOT]/foo/target/debug/.fingerprint/foo-[HASH]/dep-lib-foo",
+      "reference": "[ROOT]/foo/target/debug/build/foo/[HASH]/fingerprint/dep-lib-foo",
       "reference_mtime": "{...}",
       "stale": "[ROOT]/foo/src/lib.rs",
       "stale_item": "changed-file",

--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -33,10 +33,7 @@ fn binary_with_debug() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout build")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("build").enable_mac_dsym().run();
 
     assert_not_exists(&p.root().join("target"));
 
@@ -79,10 +76,7 @@ fn binary_with_release() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout build --release")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("build --release").enable_mac_dsym().run();
 
     assert_exists_patterns_with_base_dir(
         &p.root(),
@@ -184,10 +178,7 @@ fn libs() {
             )
             .build();
 
-        p.cargo("-Zbuild-dir-new-layout build")
-            .masquerade_as_nightly_cargo(&["new build-dir layout"])
-            .enable_mac_dsym()
-            .run();
+        p.cargo("build").enable_mac_dsym().run();
 
         // Verify lib artifacts were copied into the artifact dir
         assert_exists_patterns_with_base_dir(&p.root().join("target-dir/debug"), &expected_files);
@@ -200,10 +191,7 @@ fn should_default_to_target() {
         .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout build")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("build").enable_mac_dsym().run();
 
     p.root().join("target").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/target/.rustc_info.json
@@ -229,8 +217,7 @@ fn should_respect_env_var() {
         .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout build")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("build")
         .env("CARGO_BUILD_BUILD_DIR", "build-dir")
         .enable_mac_dsym()
         .run();
@@ -245,6 +232,61 @@ fn should_respect_env_var() {
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
 [ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
+
+"#]]);
+}
+
+#[cargo_test]
+fn build_script_should_output_to_build_dir() {
+    let p = project()
+        .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
+        .file(
+            "build.rs",
+            r#"
+            fn main() {
+                std::fs::write(
+                    format!("{}/foo.txt", std::env::var("OUT_DIR").unwrap()),
+                    "Hello, world!",
+                )
+                .unwrap();
+            }
+            "#,
+        )
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [build]
+            target-dir = "target-dir"
+            build-dir = "build-dir"
+            "#,
+        )
+        .build();
+
+    p.cargo("build").enable_mac_dsym().run();
+
+    p.root().join("build-dir").assert_build_dir_layout(str![[r#"
+[ROOT]/foo/build-dir/CACHEDIR.TAG
+[ROOT]/foo/build-dir/debug/.cargo-build-lock
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo.txt
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/build_script_build.d
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/build_script_build[EXE]
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..][EXE]
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/out/foo[..].d
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-bin-foo
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/bin-foo.json
+[ROOT]/foo/build-dir/.rustc_info.json
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/run-build-script-build-script-build
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/run-build-script-build-script-build.json
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/invoked.timestamp
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/dep-build-script-build-script-build
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/build-script-build-script-build
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/fingerprint/build-script-build-script-build.json
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/run/invoked.timestamp
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/run/stdout
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/run/root-output
+[ROOT]/foo/build-dir/debug/build/foo/[HASH]/run/stderr
 
 "#]]);
 }
@@ -276,10 +318,7 @@ fn cargo_tmpdir_should_output_to_build_dir() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout test")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("test").enable_mac_dsym().run();
 
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/CACHEDIR.TAG
@@ -333,10 +372,7 @@ fn examples_should_output_to_build_dir_and_uplift_to_target_dir() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout build --examples")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("build --examples").enable_mac_dsym().run();
 
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/.rustc_info.json
@@ -380,10 +416,7 @@ fn benches_should_output_to_build_dir() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout build --bench=foo")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("build --bench=foo").enable_mac_dsym().run();
 
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/CACHEDIR.TAG
@@ -429,10 +462,7 @@ fn cargo_doc_should_output_to_target_dir() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout doc")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("doc").enable_mac_dsym().run();
 
     let docs_dir = p.root().join("target-dir/doc");
 
@@ -532,10 +562,7 @@ fn cargo_package_should_build_in_build_dir_and_output_to_target_dir() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout package")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("package").enable_mac_dsym().run();
 
     let package_artifact_dir = p.root().join("target-dir/package");
     assert_exists(&package_artifact_dir);
@@ -589,8 +616,7 @@ fn cargo_publish_should_only_touch_build_dir() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout publish")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("publish")
         .replace_crates_io(registry.index_url())
         .enable_mac_dsym()
         .run();
@@ -618,10 +644,7 @@ fn cargo_clean_should_clean_the_target_dir_and_build_dir() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout build")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("build").enable_mac_dsym().run();
 
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/.rustc_info.json
@@ -647,10 +670,7 @@ fn cargo_clean_should_clean_the_target_dir_and_build_dir() {
 
 "#]]);
 
-    p.cargo("-Zbuild-dir-new-layout clean")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("clean").enable_mac_dsym().run();
 
     assert_not_exists(&p.root().join("build-dir"));
     assert_not_exists(&p.root().join("target-dir"));
@@ -688,10 +708,7 @@ fn cargo_clean_should_remove_correct_files() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout build")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("build").enable_mac_dsym().run();
 
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/.rustc_info.json
@@ -713,10 +730,7 @@ fn cargo_clean_should_remove_correct_files() {
 
 "#]]);
 
-    p.cargo("-Zbuild-dir-new-layout clean -p bar")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("clean -p bar").enable_mac_dsym().run();
 
     p.root().join("build-dir").assert_build_dir_layout(str![[r#"
 [ROOT]/foo/build-dir/.rustc_info.json
@@ -746,10 +760,7 @@ fn timings_report_should_output_to_target_dir() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout build --timings")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("build --timings").enable_mac_dsym().run();
 
     assert_exists(&p.root().join("target-dir/cargo-timings/cargo-timing.html"));
 }
@@ -771,8 +782,7 @@ fn future_incompat_should_output_to_build_dir() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout build")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("build")
         .arg("--future-incompat-report")
         .env("RUSTFLAGS", "-Zfuture-incompat-test")
         .run();
@@ -794,8 +804,7 @@ fn template_should_error_for_invalid_variables() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout build")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("build")
         .enable_mac_dsym()
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -820,8 +829,7 @@ fn template_should_suggest_nearest_variable() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout build")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("build")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] unexpected variable `workspace-ro` in build.build-dir path `{workspace-ro}/build-dir`
@@ -846,10 +854,7 @@ fn template_workspace_root() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout build")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("build").enable_mac_dsym().run();
 
     // Verify the binary was uplifted to the target-dir
     assert_exists(&p.root().join(&format!("target-dir/debug/foo{EXE_SUFFIX}")));
@@ -892,10 +897,7 @@ fn template_cargo_cache_home() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout build")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("build").enable_mac_dsym().run();
 
     // Verify the binary was uplifted to the target-dir
     assert_exists(&p.root().join(&format!("target-dir/debug/foo{EXE_SUFFIX}")));
@@ -950,10 +952,7 @@ fn template_workspace_path_hash() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout build")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("build").enable_mac_dsym().run();
 
     let foo_dir = p.root().join("foo");
     assert_exists(&foo_dir);
@@ -1021,10 +1020,7 @@ fn template_workspace_path_hash_should_handle_symlink() {
         .build();
 
     // Build from the non-symlinked directory
-    p.cargo("-Zbuild-dir-new-layout check")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .enable_mac_dsym()
-        .run();
+    p.cargo("check").enable_mac_dsym().run();
 
     // Parse and verify the hash dir created from the non-symlinked dir
     let foo_dir = p.root().join("foo");
@@ -1060,11 +1056,7 @@ fn template_workspace_path_hash_should_handle_symlink() {
     foo_dir.rm_rf();
 
     // Run cargo from the symlinked dir
-    p.cargo("-Zbuild-dir-new-layout check")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .enable_mac_dsym()
-        .cwd(&symlinked_dir)
-        .run();
+    p.cargo("check").enable_mac_dsym().cwd(&symlinked_dir).run();
 
     // Parse and verify the hash created from the symlinked dir
     assert_exists(&foo_dir);
@@ -1106,7 +1098,7 @@ fn template_should_handle_reject_unmatched_brackets() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout build")
+    p.cargo("build")
         .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -1185,8 +1177,8 @@ fn artifact_deps() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("run -Zbuild-dir-new-layout -Z bindeps")
-        .masquerade_as_nightly_cargo(&["bindeps", "build-dir-new-layout"])
+    p.cargo("run -Z bindeps")
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .enable_mac_dsym()
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
@@ -1316,8 +1308,7 @@ fn dylib_deps_output_overwrite() {
         .file("baz/src/lib.rs", r#"pub fn baz_value() -> i32 { 200 }"#)
         .build();
 
-    p.cargo("test -Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["build-dir-new-layout"])
+    p.cargo("test")
         .env("__CARGO_DEFAULT_LIB_METADATA", "1")
         .enable_mac_dsym()
         .with_stderr_data(
@@ -1378,7 +1369,7 @@ fn should_work_with_cargo_default_lib_metadata() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout build")
+    p.cargo("build")
         .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .env("__CARGO_DEFAULT_LIB_METADATA", "true")
         .enable_mac_dsym()
@@ -1432,7 +1423,6 @@ fn new_layout_opt_out_nightly() {
 
     p.cargo("build")
         .env("__CARGO_TEMPORARY_BUILD_DIR_NEW_LAYOUT_OPT_OUT", "1")
-        .masquerade_as_nightly_cargo(&["new build-dir layout enabled by default on nightly"])
         .enable_mac_dsym()
         .run();
 

--- a/tests/testsuite/build_dir_fine_grain_locking.rs
+++ b/tests/testsuite/build_dir_fine_grain_locking.rs
@@ -32,8 +32,8 @@ fn binary_with_debug() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("-Zfine-grain-locking build")
+        .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
 
@@ -79,8 +79,8 @@ fn binary_with_release() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build --release")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("-Zfine-grain-locking build --release")
+        .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
 
@@ -185,8 +185,8 @@ fn libs() {
             )
             .build();
 
-        p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build")
-            .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        p.cargo("-Zfine-grain-locking build")
+            .masquerade_as_nightly_cargo(&["fine grain locking"])
             .enable_mac_dsym()
             .run();
 
@@ -201,8 +201,8 @@ fn should_default_to_target() {
         .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("-Zfine-grain-locking build")
+        .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
 
@@ -231,8 +231,8 @@ fn should_respect_env_var() {
         .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("-Zfine-grain-locking build")
+        .masquerade_as_nightly_cargo(&["fine grain locking"])
         .env("CARGO_BUILD_BUILD_DIR", "build-dir")
         .enable_mac_dsym()
         .run();
@@ -278,8 +278,8 @@ fn build_script_should_output_to_build_dir() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("-Zfine-grain-locking build")
+        .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
 
@@ -340,8 +340,8 @@ fn cargo_tmpdir_should_output_to_build_dir() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking test")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("-Zfine-grain-locking test")
+        .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
 
@@ -400,8 +400,8 @@ fn examples_should_output_to_build_dir_and_uplift_to_target_dir() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build --examples")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("-Zfine-grain-locking build --examples")
+        .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
 
@@ -448,8 +448,8 @@ fn benches_should_output_to_build_dir() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build --bench=foo")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("-Zfine-grain-locking build --bench=foo")
+        .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
 
@@ -499,8 +499,8 @@ fn cargo_doc_should_output_to_target_dir() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking doc")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("-Zfine-grain-locking doc")
+        .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
 
@@ -524,8 +524,8 @@ fn cargo_rustdoc_json_should_output_to_target_dir() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking -Zunstable-options rustdoc --output-format json")
-        .masquerade_as_nightly_cargo(&["new build-dir layout", "rustdoc-output-format"])
+    p.cargo("-Zfine-grain-locking -Zunstable-options rustdoc --output-format json")
+        .masquerade_as_nightly_cargo(&["fine grain locking", "rustdoc-output-format"])
         .enable_mac_dsym()
         .run();
 
@@ -564,8 +564,8 @@ fn cargo_package_should_build_in_build_dir_and_output_to_target_dir() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking package")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("-Zfine-grain-locking package")
+        .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
 
@@ -622,8 +622,8 @@ fn cargo_publish_should_only_touch_build_dir() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking publish")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("-Zfine-grain-locking publish")
+        .masquerade_as_nightly_cargo(&["fine grain locking"])
         .replace_crates_io(registry.index_url())
         .enable_mac_dsym()
         .run();
@@ -651,8 +651,8 @@ fn cargo_clean_should_clean_the_target_dir_and_build_dir() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("-Zfine-grain-locking build")
+        .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
 
@@ -681,8 +681,8 @@ fn cargo_clean_should_clean_the_target_dir_and_build_dir() {
 
 "#]]);
 
-    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking clean")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("-Zfine-grain-locking clean")
+        .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
 
@@ -722,8 +722,8 @@ fn cargo_clean_should_remove_correct_files() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("-Zfine-grain-locking build")
+        .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
 
@@ -749,8 +749,8 @@ fn cargo_clean_should_remove_correct_files() {
 
 "#]]);
 
-    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking clean -p bar")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("-Zfine-grain-locking clean -p bar")
+        .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
 
@@ -783,8 +783,8 @@ fn timings_report_should_output_to_target_dir() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build --timings")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("-Zfine-grain-locking build --timings")
+        .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
 
@@ -808,8 +808,8 @@ fn future_incompat_should_output_to_build_dir() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("-Zfine-grain-locking build")
+        .masquerade_as_nightly_cargo(&["fine grain locking"])
         .arg("--future-incompat-report")
         .env("RUSTFLAGS", "-Zfuture-incompat-test")
         .run();
@@ -831,8 +831,8 @@ fn template_should_error_for_invalid_variables() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("-Zfine-grain-locking build")
+        .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -857,8 +857,8 @@ fn template_should_suggest_nearest_variable() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("-Zfine-grain-locking build")
+        .masquerade_as_nightly_cargo(&["fine grain locking"])
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] unexpected variable `workspace-ro` in build.build-dir path `{workspace-ro}/build-dir`
@@ -883,8 +883,8 @@ fn template_workspace_root() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("-Zfine-grain-locking build")
+        .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
 
@@ -930,8 +930,8 @@ fn template_cargo_cache_home() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("-Zfine-grain-locking build")
+        .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
 
@@ -989,8 +989,8 @@ fn template_workspace_path_hash() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("-Zfine-grain-locking build")
+        .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
 
@@ -1061,8 +1061,8 @@ fn template_workspace_path_hash_should_handle_symlink() {
         .build();
 
     // Build from the non-symlinked directory
-    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking check")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("-Zfine-grain-locking check")
+        .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
 
@@ -1102,8 +1102,8 @@ fn template_workspace_path_hash_should_handle_symlink() {
     foo_dir.rm_rf();
 
     // Run cargo from the symlinked dir
-    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking check")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("-Zfine-grain-locking check")
+        .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .cwd(&symlinked_dir)
         .run();
@@ -1150,8 +1150,8 @@ fn template_should_handle_reject_unmatched_brackets() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+    p.cargo("-Zfine-grain-locking build")
+        .masquerade_as_nightly_cargo(&["fine grain locking"])
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] unexpected opening bracket `{` in build.build-dir path `foo/{bar`
@@ -1229,7 +1229,7 @@ fn artifact_deps() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("run -Zbuild-dir-new-layout -Z bindeps")
+    p.cargo("run -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps", "build-dir-new-layout"])
         .enable_mac_dsym()
         .with_stderr_data(str![[r#"
@@ -1294,9 +1294,9 @@ fn new_layout_opt_out() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout -Zfine-grain-locking build")
+    p.cargo("-Zfine-grain-locking build")
         .env("__CARGO_TEMPORARY_BUILD_DIR_NEW_LAYOUT_OPT_OUT", "1")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
+        .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
 

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -4,6 +4,8 @@ use std::env;
 use std::env::consts::{DLL_PREFIX, DLL_SUFFIX};
 use std::fs;
 use std::io;
+use std::path::Path;
+use std::path::PathBuf;
 use std::thread;
 
 use crate::prelude::*;
@@ -44,11 +46,11 @@ fn custom_build_script_failed() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [ERROR] failed to run custom build command for `foo v0.5.0 ([ROOT]/foo)`
 
 Caused by:
-  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build` ([EXIT_STATUS]: 101)
+  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build` ([EXIT_STATUS]: 101)
 
 "#]])
         .run();
@@ -82,12 +84,12 @@ fn custom_build_script_failed_backtraces_message() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [ERROR] failed to run custom build command for `foo v0.5.0 ([ROOT]/foo)`
 [NOTE] To improve backtraces for build dependencies, set the CARGO_PROFILE_DEV_BUILD_OVERRIDE_DEBUG=true environment variable to enable debug information generation.
 
 Caused by:
-  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build` ([EXIT_STATUS]: 101)
+  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build` ([EXIT_STATUS]: 101)
 
 "#]])
         .run();
@@ -97,12 +99,12 @@ Caused by:
         .with_status(101)
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [ERROR] failed to run custom build command for `foo v0.5.0 ([ROOT]/foo)`
 [NOTE] To improve backtraces for build dependencies, set the CARGO_PROFILE_DEV_BUILD_OVERRIDE_DEBUG=true environment variable to enable debug information generation.
 
 Caused by:
-  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build` ([EXIT_STATUS]: 101)
+  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build` ([EXIT_STATUS]: 101)
 
 "#]])
         .run();
@@ -136,11 +138,11 @@ fn custom_build_script_failed_backtraces_message_with_debuginfo() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [ERROR] failed to run custom build command for `foo v0.5.0 ([ROOT]/foo)`
 
 Caused by:
-  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build` ([EXIT_STATUS]: 101)
+  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build` ([EXIT_STATUS]: 101)
 
 "#]])
         .run();
@@ -524,7 +526,7 @@ fn custom_build_env_var_rustc_linker_bad_host_target() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin [..]-C linker=[..]/path/to/linker [..]`
+[RUNNING] `rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin [..]-C linker=[..]/path/to/linker[..]`
 [ERROR] linker `[..]/path/to/linker` not found
 ...
 "#]])
@@ -660,7 +662,7 @@ fn custom_build_linker_host_target_with_bad_host_config() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin [..]-C linker=[..]/path/to/host/linker [..]`
+[RUNNING] `rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin [..]-C linker=[..]/path/to/host/linker[..]`
 [ERROR] linker `[..]/path/to/host/linker` not found
 ...
 "#]])
@@ -694,7 +696,7 @@ fn custom_build_linker_bad_host() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin [..]-C linker=[..]/path/to/host/linker [..]`
+[RUNNING] `rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin [..]-C linker=[..]/path/to/host/linker[..]`
 [ERROR] linker `[..]/path/to/host/linker` not found
 ...
 "#]])
@@ -730,7 +732,7 @@ fn custom_build_linker_bad_host_with_arch() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin [..]-C linker=[..]/path/to/host/arch/linker [..]`
+[RUNNING] `rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin [..]-C linker=[..]/path/to/host/arch/linker[..]`
 [ERROR] linker `[..]/path/to/host/arch/linker` not found
 ...
 "#]])
@@ -805,7 +807,7 @@ fn custom_build_linker_bad_cross_arch_host() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin [..] -C linker=[..]/path/to/host/linker [..]`
+[RUNNING] `rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin [..] -C linker=[..]/path/to/host/linker[..]`
 [ERROR] linker `[..]/path/to/host/linker` not found
 ...
 "#]])
@@ -829,7 +831,7 @@ fn host_runner_wraps_build_script() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc [..]build.rs [..]`
-[RUNNING] `[..]/rustc-echo-wrapper[EXE] [ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[..]/rustc-echo-wrapper[EXE] [ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc [..]--crate-name foo [..]`
 [FINISHED] [..]
 
@@ -866,7 +868,7 @@ fn host_runner_does_not_apply_to_target() {
 [ERROR] failed to run custom build command for `foo v0.0.1 ([ROOT]/foo)`
 
 Caused by:
-  could not execute process `nonexistent-runner [ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build` (never executed)
+  could not execute process `nonexistent-runner [ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build` (never executed)
 
 Caused by:
   [NOT_FOUND]
@@ -904,7 +906,7 @@ fn host_runner_arch_takes_precedence() {
 [ERROR] failed to run custom build command for `foo v0.0.1 ([ROOT]/foo)`
 
 Caused by:
-  could not execute process `nonexistent-arch-runner [ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build` (never executed)
+  could not execute process `nonexistent-arch-runner [ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build` (never executed)
 
 Caused by:
   [NOT_FOUND]
@@ -956,7 +958,7 @@ fn host_runner_with_args() {
 [ERROR] failed to run custom build command for `foo v0.0.1 ([ROOT]/foo)`
 
 Caused by:
-  could not execute process `nonexistent-runner --flag arg1 [ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build` (never executed)
+  could not execute process `nonexistent-runner --flag arg1 [ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build` (never executed)
 
 Caused by:
   [NOT_FOUND]
@@ -1064,7 +1066,7 @@ fn target_runner_build_script_with_target() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1093,7 +1095,7 @@ fn target_cfg_runner_build_script_with_host_config_and_target() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1123,7 +1125,7 @@ fn host_runner_build_script_without_target() {
 [ERROR] failed to run custom build command for `foo v0.0.1 ([ROOT]/foo)`
 
 Caused by:
-  could not execute process `nonexistent-host-runner [ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build` (never executed)
+  could not execute process `nonexistent-host-runner [ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build` (never executed)
 
 Caused by:
   [NOT_FOUND]
@@ -1150,7 +1152,7 @@ fn target_cfg_linker_build_script() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name build_script_build [..]--crate-type bin [..]-C linker=[..]/path/to/cfg/linker [..]`
+[RUNNING] `rustc --crate-name build_script_build [..]--crate-type bin [..]-C linker=[..]/path/to/cfg/linker[..]`
 [ERROR] linker `[..]/path/to/cfg/linker` not found
 ...
 "#]])
@@ -1177,7 +1179,7 @@ fn target_cfg_linker_build_script_with_target() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name build_script_build [..]--crate-type bin [..]-C linker=[..]/path/to/cfg/linker [..]`
+[RUNNING] `rustc --crate-name build_script_build [..]--crate-type bin [..]-C linker=[..]/path/to/cfg/linker[..]`
 [ERROR] linker `[..]/path/to/cfg/linker` not found
 ...
 "#]])
@@ -1206,7 +1208,7 @@ fn target_linker_build_script_with_target() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name build_script_build [..]--crate-type bin [..]-C linker=[..]/path/to/target/linker [..]`
+[RUNNING] `rustc --crate-name build_script_build [..]--crate-type bin [..]-C linker=[..]/path/to/target/linker[..]`
 [ERROR] linker `[..]/path/to/target/linker` not found
 ...
 "#]])
@@ -1234,7 +1236,7 @@ fn target_cfg_linker_build_script_with_host_config_and_target() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]--crate-type bin [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo [..]-C linker=[..]/path/to/cfg/linker [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1325,10 +1327,10 @@ fn custom_build_script_rustc_flags() {
 [LOCKING] 1 package to highest compatible version
 [COMPILING] foo v0.5.0 ([ROOT]/foo/foo)
 [RUNNING] `rustc --crate-name build_script_build --edition=2015 foo/build.rs [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
-[RUNNING] `rustc --crate-name foo --edition=2015 foo/src/lib.rs [..]-L dependency=[ROOT]/foo/target/debug/deps -L [ROOT]/foo/dummy-path1 -L [ROOT]/foo/dummy-path2 -l nonexistinglib`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `rustc --crate-name foo --edition=2015 foo/src/lib.rs [..] -L [ROOT]/foo/dummy-path1 -L [ROOT]/foo/dummy-path2 -l nonexistinglib`
 [COMPILING] bar v0.5.0 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name bar --edition=2015 src/main.rs [..]-L dependency=[ROOT]/foo/target/debug/deps --extern foo=[ROOT]/foo/target/debug/deps/libfoo-[HASH].rlib -L [ROOT]/foo/dummy-path1 -L [ROOT]/foo/dummy-path2`
+[RUNNING] `rustc --crate-name bar --edition=2015 src/main.rs [..] --extern foo=[ROOT]/foo/target/debug/build/foo/[HASH]/out/libfoo-[HASH].rlib -L [ROOT]/foo/dummy-path1 -L [ROOT]/foo/dummy-path2`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]]).run();
@@ -1384,10 +1386,10 @@ fn custom_build_script_rustc_flags_no_space() {
 [LOCKING] 1 package to highest compatible version
 [COMPILING] foo v0.5.0 ([ROOT]/foo/foo)
 [RUNNING] `rustc --crate-name build_script_build --edition=2015 foo/build.rs [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
-[RUNNING] `rustc --crate-name foo --edition=2015 foo/src/lib.rs [..]-L dependency=[ROOT]/foo/target/debug/deps -L [ROOT]/foo/dummy-path1 -L [ROOT]/foo/dummy-path2 -l nonexistinglib`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `rustc --crate-name foo --edition=2015 foo/src/lib.rs [..] -L [ROOT]/foo/dummy-path1 -L [ROOT]/foo/dummy-path2 -l nonexistinglib`
 [COMPILING] bar v0.5.0 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name bar --edition=2015 src/main.rs [..]-L dependency=[ROOT]/foo/target/debug/deps --extern foo=[ROOT]/foo/target/debug/deps/libfoo-[HASH].rlib -L [ROOT]/foo/dummy-path1 -L [ROOT]/foo/dummy-path2`
+[RUNNING] `rustc --crate-name bar --edition=2015 src/main.rs [..] --extern foo=[ROOT]/foo/target/debug/build/foo/[HASH]/out/libfoo-[HASH].rlib -L [ROOT]/foo/dummy-path1 -L [ROOT]/foo/dummy-path2`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]]).run();
@@ -1703,7 +1705,7 @@ fn overrides_and_links() {
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]`
 [RUNNING] `rustc --crate-name a [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo [..] -L foo -L bar`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2262,7 +2264,7 @@ fn only_rerun_build_script() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.5.0 ([ROOT]/foo): the precalculated components changed
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2371,11 +2373,11 @@ fn testing_and_such() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.5.0 ([ROOT]/foo): the precalculated components changed
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo [..]`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
 [DOCTEST] foo
 [RUNNING] `rustdoc [..]--test [..]`
 
@@ -2606,8 +2608,8 @@ fn build_deps_simple() {
 [COMPILING] a v0.5.0 ([ROOT]/foo/a)
 [RUNNING] `rustc --crate-name a [..]`
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name build_script_build [..] build.rs [..] --extern a=[ROOT]/foo/target/debug/deps/liba-[HASH].rlib`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `rustc --crate-name build_script_build [..] build.rs [..] --extern a=[ROOT]/foo/target/debug/build/a/[HASH]/out/liba-[HASH].rlib`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2719,13 +2721,13 @@ fn build_cmd_with_a_build_cmd() {
 [COMPILING] b v0.5.0 ([ROOT]/foo/b)
 [RUNNING] `rustc --crate-name b [..]`
 [COMPILING] a v0.5.0 ([ROOT]/foo/a)
-[RUNNING] `rustc --crate-name build_script_build [..] a/build.rs [..] --extern b=[ROOT]/foo/target/debug/deps/libb-[HASH].rlib`
-[RUNNING] `[ROOT]/foo/target/debug/build/a-[HASH]/build-script-build`
-[RUNNING] `rustc --crate-name a [..]a/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/deps -L dependency=[ROOT]/foo/target/debug/deps`
+[RUNNING] `rustc --crate-name build_script_build [..] a/build.rs [..] --extern b=[ROOT]/foo/target/debug/build/b/[HASH]/out/libb-[HASH].rlib`
+[RUNNING] `[ROOT]/foo/target/debug/build/a/[HASH]/out/build_script_build`
+[RUNNING] `rustc --crate-name a [..]a/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/build/a/[HASH]/out`
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin --emit=[..]link[..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/build/foo-[HASH] -L dependency=[ROOT]/foo/target/debug/deps --extern a=[ROOT]/foo/target/debug/deps/liba-[HASH].rlib`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
-[RUNNING] `rustc --crate-name foo [..]src/lib.rs [..]--crate-type lib --emit=[..]-C debuginfo=2 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/deps -L dependency=[ROOT]/foo/target/debug/deps`
+[RUNNING] `rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin --emit=[..]link[..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out [..] --extern a=[ROOT]/foo/target/debug/build/a/[HASH]/out/liba-[HASH].rlib`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `rustc --crate-name foo [..]src/lib.rs [..]--crate-type lib --emit=[..]-C debuginfo=2 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]]).run();
@@ -2781,7 +2783,7 @@ fn out_dir_is_preserved() {
 [DIRTY] foo v0.5.0 ([ROOT]/foo): the file `build.rs` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2803,7 +2805,7 @@ fn out_dir_is_preserved() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.5.0 ([ROOT]/foo): the precalculated components changed
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2841,7 +2843,7 @@ fn output_separate_lines() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo [..] -L foo -l static=foo`
 [ERROR] could not find native static library `foo`, perhaps an -L flag is missing?
 ...
@@ -2882,7 +2884,7 @@ fn output_separate_lines_new() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo [..] -L foo -L bar -l static=foo -l bar`
 [ERROR] could not find native static library `foo`, perhaps an -L flag is missing?
 ...
@@ -3464,13 +3466,13 @@ fn cfg_test() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo [..] --cfg foo[..]`
 [RUNNING] `rustc --crate-name foo [..] --cfg foo[..]`
 [RUNNING] `rustc --crate-name test [..] --cfg foo[..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
-[RUNNING] `[ROOT]/foo/target/debug/deps/test-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/test-[HASH][EXE]`
 [DOCTEST] foo
 [RUNNING] `rustdoc [..]--cfg foo[..]`
 
@@ -3605,8 +3607,8 @@ fn cfg_override_test() {
 [RUNNING] `rustc --crate-name foo[..]`
 [RUNNING] `rustc --crate-name test[..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
-[RUNNING] `[ROOT]/foo/target/debug/deps/test-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/test-[HASH][EXE]`
 [DOCTEST] foo
 [RUNNING] `rustdoc [..] --cfg foo[..]`
 
@@ -3759,13 +3761,13 @@ fn env_test() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build[..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo[..]`
 [RUNNING] `rustc --crate-name foo[..]`
 [RUNNING] `rustc --crate-name test[..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
-[RUNNING] `[ROOT]/foo/target/debug/deps/test-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/test-[HASH][EXE]`
 [DOCTEST] foo
 [RUNNING] `rustdoc --edition=2015 --crate-type lib --color auto --crate-name foo[..]`
 
@@ -3881,7 +3883,7 @@ fn flags_go_into_tests() {
 [LOCKING] 2 packages to highest compatible versions
 [COMPILING] a v0.5.0 ([ROOT]/foo/a)
 [RUNNING] `rustc [..] a/build.rs [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/a-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/a/[HASH]/out/build_script_build`
 [RUNNING] `rustc [..] a/src/lib.rs [..] -L [ROOT]/foo/link-dir`
 [COMPILING] b v0.5.0 ([ROOT]/foo/b)
 [RUNNING] `rustc [..] b/src/lib.rs [..] -L [ROOT]/foo/link-dir`
@@ -3889,7 +3891,7 @@ fn flags_go_into_tests() {
 [RUNNING] `rustc [..] src/lib.rs [..] -L [ROOT]/foo/link-dir`
 [RUNNING] `rustc [..] tests/foo.rs [..] -L [ROOT]/foo/link-dir`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -3908,7 +3910,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
 [COMPILING] b v0.5.0 ([ROOT]/foo/b)
 [RUNNING] `rustc --crate-name b [..] -L [ROOT]/foo/link-dir`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/deps/b-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/build/b/[HASH]/out/b-[HASH][EXE]`
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -3995,7 +3997,7 @@ fn diamond_passes_args_only_once() {
 [LOCKING] 3 packages to highest compatible versions
 [COMPILING] c v0.5.0 ([ROOT]/foo/c)
 [RUNNING] `rustc --crate-name build_script_build [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/c-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/c/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name c [..] -L native=test`
 [COMPILING] b v0.5.0 ([ROOT]/foo/b)
 [RUNNING] `rustc --crate-name b [..] -L native=test`
@@ -4041,7 +4043,7 @@ fn adding_an_override_invalidates() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo [..] -L native=foo`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -4419,7 +4421,7 @@ fn rebuild_only_on_explicit_paths() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.5.0 ([ROOT]/foo): the file `foo` is missing
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc [..] src/lib.rs [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -4437,7 +4439,7 @@ fn rebuild_only_on_explicit_paths() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.5.0 ([ROOT]/foo): the file `foo` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc [..] src/lib.rs [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -4473,7 +4475,7 @@ fn rebuild_only_on_explicit_paths() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.5.0 ([ROOT]/foo): the file `foo` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc [..] src/lib.rs [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -4487,7 +4489,7 @@ fn rebuild_only_on_explicit_paths() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.5.0 ([ROOT]/foo): the file `bar` is missing
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc [..] src/lib.rs [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -4915,7 +4917,7 @@ fn warnings_emitted_when_build_script_panics() {
 [ERROR] failed to run custom build command for `foo v0.5.0 ([ROOT]/foo)`
 
 Caused by:
-  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build` ([EXIT_STATUS]: 101)
+  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build` ([EXIT_STATUS]: 101)
   --- stdout
   cargo::warning=foo
   cargo::warning=bar
@@ -4985,7 +4987,7 @@ fn warnings_emitted_when_dependency_panics() {
 [ERROR] failed to run custom build command for `published v0.1.0`
 
 Caused by:
-  process didn't exit successfully: `[ROOT]/foo/target/debug/build/published-[HASH]/build-script-build` ([EXIT_STATUS]: 101)
+  process didn't exit successfully: `[ROOT]/foo/target/debug/build/published/[HASH]/out/build_script_build` ([EXIT_STATUS]: 101)
   --- stdout
   cargo::warning=foo
   cargo::warning=bar
@@ -5112,7 +5114,7 @@ fn warnings_hidden_for_upstream() {
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [COMPILING] bar v0.1.0
 [RUNNING] `rustc --crate-name build_script_build [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/bar-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/bar/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name bar [..]`
 [CHECKING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo [..]`
@@ -5173,7 +5175,7 @@ fn warnings_printed_on_vv() {
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [COMPILING] bar v0.1.0
 [RUNNING] `[..] rustc --crate-name build_script_build [..]`
-[RUNNING] `[..] [ROOT]/foo/target/debug/build/bar-[HASH]/build-script-build`
+[RUNNING] `[..] [ROOT]/foo/target/debug/build/bar/[HASH]/out/build_script_build`
 [WARNING] bar@0.1.0: foo
 [WARNING] bar@0.1.0: bar
 [RUNNING] `[..] rustc --crate-name bar [..]`
@@ -5221,7 +5223,7 @@ fn output_shows_on_vv() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `[..] rustc --crate-name build_script_build [..]`
-[RUNNING] `[..] [ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[..] [ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [foo 0.5.0] stderr
 [RUNNING] `[..] rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -5783,17 +5785,20 @@ fn _rename_with_link_search_path(cross: bool, expected: impl IntoData) {
     // the `p` project. On macOS, the `libfoo.dylib` artifact references the
     // original path in `p` so we want to make sure that it can't find it (hence
     // the deletion).
-    let root = if cross {
-        p.root()
-            .join("target")
-            .join(cross_compile::alternate())
-            .join("debug")
-            .join("deps")
-    } else {
-        p.root().join("target").join("debug").join("deps")
-    };
     let file = format!("{}foo{}", env::consts::DLL_PREFIX, env::consts::DLL_SUFFIX);
-    let src = root.join(&file);
+    let src = if cross {
+        find_file(
+            &p.root()
+                .join("target")
+                .join(cross_compile::alternate())
+                .join("debug"),
+            &file,
+        )
+        .unwrap()
+    } else {
+        find_file(&p.root().join("target").join("debug"), &file).unwrap()
+    };
+    let root = src.parent().unwrap();
 
     let dst = p2.root().join(&file);
 
@@ -5839,6 +5844,14 @@ fn _rename_with_link_search_path(cross: bool, expected: impl IntoData) {
         .cwd(&new)
         .with_stderr_data(expected)
         .run();
+}
+
+fn find_file(root: &Path, file_name: &str) -> Option<PathBuf> {
+    walkdir::WalkDir::new(root)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .find(|e| e.file_name() == file_name)
+        .map(|f| f.into_path())
 }
 
 #[cargo_test]
@@ -6094,7 +6107,7 @@ fn links_interrupted_can_restart() {
         .env("SOMEVAR", "1")
         .with_stderr_data(str![[r#"
 ...
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 ...
 "#]])
         .run();
@@ -6177,7 +6190,7 @@ fn rerun_if_directory() {
     dirty(str![[r#"
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build[..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -6187,7 +6200,7 @@ fn rerun_if_directory() {
     dirty(str![[r#"
 [DIRTY] foo v0.1.0 ([ROOT]/foo): the file `somedir` is missing
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -6202,7 +6215,7 @@ fn rerun_if_directory() {
     dirty(str![[r#"
 [DIRTY] foo v0.1.0 ([ROOT]/foo): the file `somedir` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -6219,7 +6232,7 @@ fn rerun_if_directory() {
     dirty(str![[r#"
 [DIRTY] foo v0.1.0 ([ROOT]/foo): the file `somedir` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -6235,7 +6248,7 @@ fn rerun_if_directory() {
     dirty(str![[r#"
 [DIRTY] foo v0.1.0 ([ROOT]/foo): the file `somedir` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -6252,7 +6265,7 @@ fn rerun_if_directory() {
     dirty(str![[r#"
 [DIRTY] foo v0.1.0 ([ROOT]/foo): the file `somedir` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -6268,7 +6281,7 @@ fn rerun_if_directory() {
     dirty(str![[r#"
 [DIRTY] foo v0.1.0 ([ROOT]/foo): the file `somedir` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -6344,7 +6357,7 @@ fn rerun_if_published_directory() {
         .with_stderr_data(str![[r#"
 [COMPILING] mylib-sys v1.0.1
 [RUNNING] `rustc --crate-name build_script_build [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/mylib-sys-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/mylib-sys/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name mylib_sys [..]`
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo [..]`
@@ -7043,7 +7056,7 @@ fn linker_search_path_preference() {
 
     p.cargo("build -v").with_stderr_data(str![[r#"
 ...
-[RUNNING] `rustc --crate-name foo [..] -L [ROOT]/foo/target/debug/build/foo-[HASH]/out/libs2 -L [ROOT]/foo/target/debug/build/foo-[HASH]/out/libs1 -L [ROOT]/foo/target/debug/build/a-[HASH]/out/libsA.2 -L [ROOT]/foo/target/debug/build/a-[HASH]/out/libsA.1 -L [ROOT]/foo/target/debug/build/b-[HASH]/out/libsB.1 -L [ROOT]/foo/target/debug/build/b-[HASH]/out/libsB.2 -L /usr/lib -L /lib -L /usr/lib3 -L /lib3 -L /usr/lib2 -L /lib2`
+[RUNNING] `rustc --crate-name foo [..] -L [ROOT]/foo/target/debug/build/foo/[HASH]/out/libs2 -L [ROOT]/foo/target/debug/build/foo/[HASH]/out/libs1 -L [ROOT]/foo/target/debug/build/a/[HASH]/out/libsA.2 -L [ROOT]/foo/target/debug/build/a/[HASH]/out/libsA.1 -L [ROOT]/foo/target/debug/build/b/[HASH]/out/libsB.1 -L [ROOT]/foo/target/debug/build/b/[HASH]/out/libsB.2 -L /usr/lib -L /lib -L /usr/lib3 -L /lib3 -L /usr/lib2 -L /lib2`
 ...
 "#]]).run();
 }
@@ -7069,7 +7082,7 @@ fn target_runner_does_not_apply_to_build_script_with_host_config() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 
@@ -7098,7 +7111,7 @@ fn target_linker_does_not_apply_to_build_script_with_host_config() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 

--- a/tests/testsuite/build_script_env.rs
+++ b/tests/testsuite/build_script_env.rs
@@ -223,7 +223,7 @@ fn build_script_env_verbose() {
         .with_stderr_data(
             "\
 ...
-[RUNNING] `[..]CARGO=[..]build-script-build`
+[RUNNING] `[..]CARGO=[..]build_script_build`
 ...",
         )
         .run();

--- a/tests/testsuite/build_script_extra_link_arg.rs
+++ b/tests/testsuite/build_script_extra_link_arg.rs
@@ -219,7 +219,7 @@ fn cdylib_link_arg_transitive() {
 ...
 [COMPILING] bar v1.0.0 ([ROOT]/foo/bar)
 [RUNNING] `rustc --crate-name build_script_build --edition=2015 bar/build.rs [..]
-[RUNNING] `[ROOT]/foo/target/debug/build/bar-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/bar/[HASH]/out/build_script_build`
 [WARNING] bar@1.0.0: cargo::rustc-link-arg-cdylib was specified in the build script of bar v1.0.0 \
 ([ROOT]/foo/bar), but that package does not contain a cdylib target
 
@@ -279,7 +279,7 @@ fn link_arg_transitive_not_allowed() {
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [COMPILING] bar v1.0.0
 [RUNNING] `rustc --crate-name build_script_build [..]
-[RUNNING] `[ROOT]/foo/target/debug/build/bar-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/bar/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name bar [..]
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]
@@ -437,7 +437,7 @@ fn cdylib_both_forms() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo [..]--crate-type cdylib [..]-C link-arg=--bogus-flag-one -C link-arg=--bogus-flag-two[..]
 ...
 "#]])

--- a/tests/testsuite/build_scripts_multiple.rs
+++ b/tests/testsuite/build_scripts_multiple.rs
@@ -441,7 +441,7 @@ fn custom_build_script_first_index_script_failed() {
 [ERROR] failed to run custom build command for `foo v0.1.0 ([ROOT]/foo)`
 
 Caused by:
-  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build1` ([EXIT_STATUS]: 101)
+  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build1` ([EXIT_STATUS]: 101)
 ...
 "#]])
         .run();
@@ -479,7 +479,7 @@ fn custom_build_script_second_index_script_failed() {
 [ERROR] failed to run custom build command for `foo v0.1.0 ([ROOT]/foo)`
 
 Caused by:
-  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build2` ([EXIT_STATUS]: 101)
+  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build2` ([EXIT_STATUS]: 101)
 ...
 "#]])
         .run();
@@ -741,7 +741,7 @@ fn bar() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.1.0 ([ROOT]/foo): the [..]
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build1`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build1`
 [RUNNING] `rustc --crate-name foo --edition=2024 src/main.rs [..] --crate-type bin [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -756,8 +756,8 @@ fn bar() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.1.0 ([ROOT]/foo): the [..]
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build[..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build[..]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build[..]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build[..]`
 [RUNNING] `rustc --crate-name foo --edition=2024 src/main.rs [..] --crate-type bin [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/cache_messages.rs
+++ b/tests/testsuite/cache_messages.rs
@@ -143,7 +143,7 @@ fn clears_cache_after_fix() {
 "#]])
         .run();
     let cpath = p
-        .glob("target/debug/.fingerprint/foo-*/output-*")
+        .glob("target/debug/build/foo/*/fingerprint/output-*")
         .next()
         .unwrap()
         .unwrap();
@@ -164,7 +164,8 @@ fn clears_cache_after_fix() {
 "#]])
         .run();
     assert_eq!(
-        p.glob("target/debug/.fingerprint/foo-*/output-*").count(),
+        p.glob("target/debug/build/foo/*/fingerprint/output-*")
+            .count(),
         0
     );
 
@@ -196,7 +197,8 @@ fn rustdoc() {
     assert!(rustdoc_stderr.contains("missing"));
     assert!(rustdoc_stderr.contains("\x1b["));
     assert_eq!(
-        p.glob("target/debug/.fingerprint/foo-*/output-*").count(),
+        p.glob("target/debug/build/foo/*/fingerprint/output-*")
+            .count(),
         1
     );
 
@@ -302,11 +304,13 @@ fn doesnt_create_extra_files() {
     p.cargo("check").run();
 
     assert_eq!(
-        p.glob("target/debug/.fingerprint/foo-*/output-*").count(),
+        p.glob("target/debug/build/foo/*/fingerprint/output-*")
+            .count(),
         0
     );
     assert_eq!(
-        p.glob("target/debug/.fingerprint/dep-*/output-*").count(),
+        p.glob("target/debug/build/foo/*/fingerprint/dep-*/output-*")
+            .count(),
         0
     );
     if is_coarse_mtime() {
@@ -315,7 +319,8 @@ fn doesnt_create_extra_files() {
     p.change_file("src/lib.rs", "fn unused() {}");
     p.cargo("check").run();
     assert_eq!(
-        p.glob("target/debug/.fingerprint/foo-*/output-*").count(),
+        p.glob("target/debug/build/foo/*/fingerprint/output-*")
+            .count(),
         1
     );
 }

--- a/tests/testsuite/cargo_alias_config.rs
+++ b/tests/testsuite/cargo_alias_config.rs
@@ -156,7 +156,7 @@ fn builtin_alias_shadowing_external_subcommand() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/main.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .run();

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -773,21 +773,33 @@ fn check_artifacts() {
     assert!(!p.root().join("target/debug/libfoo.rmeta").is_file());
     assert!(!p.root().join("target/debug/libfoo.rlib").is_file());
     assert!(!p.root().join("target/debug").join(exe("foo")).is_file());
-    assert_eq!(p.glob("target/debug/deps/libfoo-*.rmeta").count(), 2);
+    assert_eq!(
+        p.glob("target/debug/build/foo/*/out/libfoo-*.rmeta")
+            .count(),
+        2
+    );
 
     p.root().join("target").rm_rf();
     p.cargo("check --lib").run();
     assert!(!p.root().join("target/debug/libfoo.rmeta").is_file());
     assert!(!p.root().join("target/debug/libfoo.rlib").is_file());
     assert!(!p.root().join("target/debug").join(exe("foo")).is_file());
-    assert_eq!(p.glob("target/debug/deps/libfoo-*.rmeta").count(), 1);
+    assert_eq!(
+        p.glob("target/debug/build/foo/*/out/libfoo-*.rmeta")
+            .count(),
+        1
+    );
 
     p.root().join("target").rm_rf();
     p.cargo("check --bin foo").run();
     assert!(!p.root().join("target/debug/libfoo.rmeta").is_file());
     assert!(!p.root().join("target/debug/libfoo.rlib").is_file());
     assert!(!p.root().join("target/debug").join(exe("foo")).is_file());
-    assert_eq!(p.glob("target/debug/deps/libfoo-*.rmeta").count(), 2);
+    assert_eq!(
+        p.glob("target/debug/build/foo/*/out/libfoo-*.rmeta")
+            .count(),
+        2
+    );
 
     p.root().join("target").rm_rf();
     p.cargo("check --test t1").run();
@@ -795,8 +807,15 @@ fn check_artifacts() {
     assert!(!p.root().join("target/debug/libfoo.rlib").is_file());
     assert!(!p.root().join("target/debug").join(exe("foo")).is_file());
     assert_eq!(p.glob("target/debug/t1-*").count(), 0);
-    assert_eq!(p.glob("target/debug/deps/libfoo-*.rmeta").count(), 1);
-    assert_eq!(p.glob("target/debug/deps/libt1-*.rmeta").count(), 1);
+    assert_eq!(
+        p.glob("target/debug/build/foo/*/out/libfoo-*.rmeta")
+            .count(),
+        1
+    );
+    assert_eq!(
+        p.glob("target/debug/build/foo/*/out/libt1-*.rmeta").count(),
+        1
+    );
 
     p.root().join("target").rm_rf();
     p.cargo("check --example ex1").run();
@@ -808,8 +827,16 @@ fn check_artifacts() {
             .join(exe("ex1"))
             .is_file()
     );
-    assert_eq!(p.glob("target/debug/deps/libfoo-*.rmeta").count(), 1);
-    assert_eq!(p.glob("target/debug/examples/libex1-*.rmeta").count(), 1);
+    assert_eq!(
+        p.glob("target/debug/build/foo/*/out/libfoo-*.rmeta")
+            .count(),
+        1
+    );
+    assert_eq!(
+        p.glob("target/debug/build/foo/*/out/libex1-*.rmeta")
+            .count(),
+        1
+    );
 
     p.root().join("target").rm_rf();
     p.cargo("check --bench b1").run();
@@ -817,8 +844,15 @@ fn check_artifacts() {
     assert!(!p.root().join("target/debug/libfoo.rlib").is_file());
     assert!(!p.root().join("target/debug").join(exe("foo")).is_file());
     assert_eq!(p.glob("target/debug/b1-*").count(), 0);
-    assert_eq!(p.glob("target/debug/deps/libfoo-*.rmeta").count(), 1);
-    assert_eq!(p.glob("target/debug/deps/libb1-*.rmeta").count(), 1);
+    assert_eq!(
+        p.glob("target/debug/build/foo/*/out/libfoo-*.rmeta")
+            .count(),
+        1
+    );
+    assert_eq!(
+        p.glob("target/debug/build/foo/*/out/libb1-*.rmeta").count(),
+        1
+    );
 }
 
 #[cargo_test]

--- a/tests/testsuite/check_cfg.rs
+++ b/tests/testsuite/check_cfg.rs
@@ -397,7 +397,7 @@ fn build_script_doc() {
             "\
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc [..] build.rs [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
 {running_rustdoc}
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -18,16 +18,10 @@ fn cargo_clean_simple() {
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .build();
 
-    p.cargo("build")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("build").run();
     assert!(p.build_dir().is_dir());
 
-    p.cargo("clean")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("clean").run();
     assert!(!p.build_dir().is_dir());
 }
 
@@ -39,10 +33,7 @@ fn different_dir() {
         .file("src/bar/a.rs", "")
         .build();
 
-    p.cargo("build")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("build").run();
     assert!(p.build_dir().is_dir());
 
     p.cargo("clean")
@@ -51,8 +42,6 @@ fn different_dir() {
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
 "#]])
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
     assert!(!p.build_dir().is_dir());
 }
@@ -85,10 +74,7 @@ fn clean_multiple_packages() {
         .file("d2/src/main.rs", "fn main() { println!(\"d2\"); }")
         .build();
 
-    p.cargo("build -p d1 -p d2 -p foo")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("build -p d1 -p d2 -p foo").run();
 
     let d1_path = &p
         .build_dir()
@@ -109,8 +95,6 @@ fn clean_multiple_packages() {
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
 "#]])
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
     assert!(p.bin("foo").is_file());
     assert!(!d1_path.is_file());
@@ -132,16 +116,11 @@ fn clean_multiple_packages_in_glob_char_path() {
     let file_glob = "foo/*/out/foo.pdb";
 
     // Assert that build artifacts are produced
-    p.cargo("build")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("build").run();
     assert_ne!(get_build_artifacts(foo_path, file_glob).len(), 0);
 
     // Assert that build artifacts are destroyed
     p.cargo("clean -p foo")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .with_stderr_data(str![[r#"
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
@@ -186,10 +165,7 @@ fn clean_p_only_cleans_specified_package() {
 
     let units_path = &p.build_dir().join("debug").join("build");
 
-    p.cargo("build -p foo -p foo_core -p foo-base")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("build -p foo -p foo_core -p foo-base").run();
 
     let mut fingerprint_names = get_fingerprints_without_hashes(units_path);
 
@@ -206,10 +182,7 @@ fn clean_p_only_cleans_specified_package() {
         .count();
     assert_ne!(num_foo_base_artifacts, 0);
 
-    p.cargo("clean -p foo")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("clean -p foo").run();
 
     fingerprint_names = get_fingerprints_without_hashes(units_path);
 
@@ -264,48 +237,28 @@ fn clean_release() {
         .file("a/src/lib.rs", "")
         .build();
 
-    p.cargo("build --release")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("build --release").run();
 
-    p.cargo("clean -p foo")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("clean -p foo").run();
     p.cargo("build --release")
         .with_stderr_data(str![[r#"
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 
 "#]])
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
 
-    p.cargo("clean -p foo --release")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("clean -p foo --release").run();
     p.cargo("build --release")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 
 "#]])
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
 
-    p.cargo("build")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("build").run();
 
-    p.cargo("clean")
-        .arg("--release")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("clean").arg("--release").run();
     assert!(p.build_dir().is_dir());
     assert!(p.build_dir().join("debug").is_dir());
     assert!(!p.build_dir().join("release").is_dir());
@@ -332,10 +285,7 @@ fn clean_doc() {
         .file("a/src/lib.rs", "")
         .build();
 
-    p.cargo("doc")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("doc").run();
 
     let doc_path = &p.build_dir().join("doc");
 
@@ -346,8 +296,6 @@ fn clean_doc() {
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
 "#]])
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
 
     assert!(!doc_path.is_dir());
@@ -363,11 +311,7 @@ fn clean_doc_target() {
         .build();
     let doc_path = p.build_dir().join(target).join("doc");
 
-    p.cargo("doc --target")
-        .arg(target)
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("doc --target").arg(target).run();
     assert!(doc_path.is_dir());
 
     p.cargo("clean --doc --target")
@@ -376,8 +320,6 @@ fn clean_doc_target() {
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
 "#]])
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
     assert!(!doc_path.is_dir());
 
@@ -385,10 +327,7 @@ fn clean_doc_target() {
         ".cargo/config.toml",
         &format!("[build]\ntarget = \"{target}\""),
     );
-    p.cargo("doc")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("doc").run();
     assert!(doc_path.is_dir());
 
     p.cargo("clean --doc")
@@ -396,8 +335,6 @@ fn clean_doc_target() {
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
 "#]])
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
     assert!(!doc_path.is_dir());
 }
@@ -436,15 +373,8 @@ fn build_script() {
         .file("a/src/lib.rs", "")
         .build();
 
-    p.cargo("build")
-        .env("FIRST", "1")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
-    p.cargo("clean -p foo")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("build").env("FIRST", "1").run();
+    p.cargo("clean -p foo").run();
     p.cargo("build -v")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -454,8 +384,6 @@ fn build_script() {
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
 }
 
@@ -487,22 +415,14 @@ fn clean_git() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("build").run();
     p.cargo("clean -p dep")
         .with_stderr_data(str![[r#"
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
 "#]])
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
-    p.cargo("build")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("build").run();
 }
 
 #[cargo_test]
@@ -526,22 +446,14 @@ fn registry() {
 
     Package::new("bar", "0.1.0").publish();
 
-    p.cargo("build")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("build").run();
     p.cargo("clean -p bar")
         .with_stderr_data(str![[r#"
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
 "#]])
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
-    p.cargo("build")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("build").run();
 }
 
 #[cargo_test]
@@ -564,23 +476,15 @@ fn clean_verbose() {
 
     Package::new("bar", "0.1.0").publish();
 
-    p.cargo("build")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("build").run();
     p.cargo("clean -p bar --verbose")
         .with_stderr_data(str![[r#"
 [REMOVING] [ROOT]/foo/target/debug/build/bar
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
 "#]])
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
-    p.cargo("build")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("build").run();
 }
 
 #[cargo_test]
@@ -598,10 +502,7 @@ fn clean_remove_rlib_rmeta() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("build").run();
     assert!(p.target_debug_dir().join("libfoo.rlib").exists());
     let rmeta = p
         .glob("target/debug/build/*/*/out/*.rmeta")
@@ -609,10 +510,7 @@ fn clean_remove_rlib_rmeta() {
         .unwrap()
         .unwrap();
     assert!(rmeta.exists());
-    p.cargo("clean -p foo")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("clean -p foo").run();
     assert!(!p.target_debug_dir().join("libfoo.rlib").exists());
     assert!(!rmeta.exists());
 }
@@ -642,14 +540,8 @@ fn package_cleans_all_the_things() {
             )
             .file("src/lib.rs", "")
             .build();
-        p.cargo("build")
-            .arg("-Zbuild-dir-new-layout")
-            .masquerade_as_nightly_cargo(&["new build-dir layout"])
-            .run();
-        p.cargo("clean -p foo-bar")
-            .arg("-Zbuild-dir-new-layout")
-            .masquerade_as_nightly_cargo(&["new build-dir layout"])
-            .run();
+        p.cargo("build").run();
+        p.cargo("clean -p foo-bar").run();
         assert_all_clean(&p.build_dir());
     }
     let p = project()
@@ -692,36 +584,21 @@ fn package_cleans_all_the_things() {
 
     p.cargo("build --all-targets")
         .env("CARGO_INCREMENTAL", "1")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
     p.cargo("test --all-targets")
         .env("CARGO_INCREMENTAL", "1")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
     p.cargo("check --all-targets")
         .env("CARGO_INCREMENTAL", "1")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
-    p.cargo("clean -p foo-bar")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("clean -p foo-bar").run();
     assert_all_clean(&p.build_dir());
 
     // Try some targets.
     p.cargo("build --all-targets --target")
         .arg(rustc_host())
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
-    p.cargo("clean -p foo-bar --target")
-        .arg(rustc_host())
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("clean -p foo-bar --target").arg(rustc_host()).run();
     assert_all_clean(&p.build_dir());
 }
 
@@ -787,10 +664,7 @@ fn clean_spec_version() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("build").run();
 
     // Check suggestion for bad pkgid.
     p.cargo("clean -p baz")
@@ -801,8 +675,6 @@ fn clean_spec_version() {
 [HELP] a package with a similar name exists: `bar`
 
 "#]])
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
 
     p.cargo("clean -p bar:0.1.0")
@@ -811,8 +683,6 @@ fn clean_spec_version() {
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
 "#]])
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
     let mut walker = walkdir::WalkDir::new(p.build_dir())
         .into_iter()
@@ -849,10 +719,7 @@ fn clean_spec_partial_version() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("build").run();
 
     // Check suggestion for bad pkgid.
     p.cargo("clean -p baz")
@@ -863,8 +730,6 @@ fn clean_spec_partial_version() {
 [HELP] a package with a similar name exists: `bar`
 
 "#]])
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
 
     p.cargo("clean -p bar:0.1")
@@ -873,8 +738,6 @@ fn clean_spec_partial_version() {
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
 "#]])
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
     let mut walker = walkdir::WalkDir::new(p.build_dir())
         .into_iter()
@@ -911,10 +774,7 @@ fn clean_spec_partial_version_ambiguous() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("build").run();
 
     // Check suggestion for bad pkgid.
     p.cargo("clean -p baz")
@@ -925,8 +785,6 @@ fn clean_spec_partial_version_ambiguous() {
 [HELP] a package with a similar name exists: `bar`
 
 "#]])
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
 
     p.cargo("clean -p bar:0")
@@ -935,8 +793,6 @@ fn clean_spec_partial_version_ambiguous() {
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
 "#]])
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
     let mut walker = walkdir::WalkDir::new(p.build_dir())
         .into_iter()
@@ -977,10 +833,7 @@ fn clean_spec_reserved() {
         .file("tests/build.rs", "")
         .build();
 
-    p.cargo("build --all-targets")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("build --all-targets").run();
     assert!(p.target_debug_dir().join("build").is_dir());
     let build_test = p
         .glob("target/debug/build/*/*/out/build-*")
@@ -991,10 +844,7 @@ fn clean_spec_reserved() {
     // Tests are never "uplifted".
     assert!(p.glob("target/debug/build-*").next().is_none());
 
-    p.cargo("clean -p foo")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("clean -p foo").run();
     // Should not delete this.
     assert!(p.target_debug_dir().join("build").is_dir());
 
@@ -1009,8 +859,6 @@ fn clean_spec_reserved() {
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
 }
 
@@ -1042,13 +890,8 @@ fn clean_dry_run() {
 [WARNING] no files deleted due to --dry-run
 
 "#]])
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
-    p.cargo("check")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("check").run();
     let before = p.build_dir().ls_r();
     p.cargo("clean --dry-run")
         .with_stderr_data(str![[r#"
@@ -1056,8 +899,6 @@ fn clean_dry_run() {
 [WARNING] no files deleted due to --dry-run
 
 "#]])
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
     // Verify it didn't delete anything.
     let after = p.build_dir().ls_r();
@@ -1075,8 +916,6 @@ fn clean_dry_run() {
 [WARNING] no files deleted due to --dry-run
 
 "#]])
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
 }
 
@@ -1090,8 +929,6 @@ fn doc_with_package_selection() {
 [ERROR] --doc cannot be used with -p
 
 "#]])
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
 }
 
@@ -1104,15 +941,10 @@ fn quiet_does_not_show_summary() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("check")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("check").run();
     p.cargo("clean --quiet --dry-run")
         .with_stdout_data("")
         .with_stderr_data("")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
     // Verify exact same command without -q would actually display something.
     p.cargo("clean --dry-run")
@@ -1122,8 +954,6 @@ fn quiet_does_not_show_summary() {
 [WARNING] no files deleted due to --dry-run
 
 "#]])
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
 }
 
@@ -1138,8 +968,6 @@ fn explicit_target_dir_tag_not_present() {
         .build();
 
     p.cargo("clean --target-dir bar")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [ERROR] cannot clean `[ROOT]/foo/bar`: missing or invalid `CACHEDIR.TAG` file
@@ -1160,8 +988,6 @@ fn explicit_target_dir_tag_invalid_signature() {
         .build();
 
     p.cargo("clean --target-dir bar")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [ERROR] cannot clean `[ROOT]/foo/bar`: invalid signature in `CACHEDIR.TAG` file
@@ -1186,8 +1012,6 @@ fn explicit_target_dir_tag_symlink() {
         .build();
 
     p.cargo("clean --target-dir bar")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
 [ERROR] cannot clean `[ROOT]/foo/bar`: expect `CACHEDIR.TAG` to be a regular file, got a symlink
@@ -1210,10 +1034,7 @@ fn explicit_target_dir_tag_valid() {
         )
         .build();
 
-    p.cargo("clean --target-dir bar")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("clean --target-dir bar").run();
 }
 
 #[cargo_test]
@@ -1227,8 +1048,6 @@ fn env_target_dir_tag_not_present() {
         .build();
 
     p.cargo("clean")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .env("CARGO_TARGET_DIR", "bar")
         .with_stderr_data(str![[r#"
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
@@ -1246,8 +1065,6 @@ fn env_target_dir_tag_invalid_signature() {
         .build();
 
     p.cargo("clean")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .env("CARGO_TARGET_DIR", "bar")
         .with_stderr_data(str![[r#"
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
@@ -1269,8 +1086,6 @@ fn env_target_dir_tag_symlink() {
         .build();
 
     p.cargo("clean")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .env("CARGO_TARGET_DIR", "bar")
         .with_stderr_data(str![[r#"
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
@@ -1290,11 +1105,7 @@ fn env_target_dir_tag_valid() {
         )
         .build();
 
-    p.cargo("clean")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .env("CARGO_TARGET_DIR", "bar")
-        .run();
+    p.cargo("clean").env("CARGO_TARGET_DIR", "bar").run();
 }
 
 #[cargo_test]
@@ -1313,8 +1124,6 @@ fn config_target_dir_tag_not_present() {
         .build();
 
     p.cargo("clean")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .with_stderr_data(str![[r#"
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
@@ -1336,8 +1145,6 @@ fn config_target_dir_tag_invalid_signature() {
         .build();
 
     p.cargo("clean")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .with_stderr_data(str![[r#"
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
@@ -1363,8 +1170,6 @@ fn config_target_dir_tag_symlink() {
         .build();
 
     p.cargo("clean")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .with_stderr_data(str![[r#"
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
 
@@ -1388,10 +1193,7 @@ fn config_target_dir_tag_valid() {
         )
         .build();
 
-    p.cargo("clean")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
-        .run();
+    p.cargo("clean").run();
 }
 
 #[cargo_test]
@@ -1403,8 +1205,6 @@ fn explicit_target_dir_not_exists() {
 
     // should not error if target_dir does not exist
     p.cargo("clean --target-dir bar")
-        .arg("-Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .with_stderr_data(str![[r#"
 [REMOVED] 0 files
 

--- a/tests/testsuite/collisions.rs
+++ b/tests/testsuite/collisions.rs
@@ -55,7 +55,7 @@ fn collision_dylib() {
     p.cargo("build -j=1")
         .with_stderr_data(&format!("\
 ...
-[WARNING] output filename collision at [ROOT]/foo/target/debug/deps/{}a{}
+[WARNING] output filename collision at [ROOT]/foo/target/debug/{}a{}
   |
   = [NOTE] the lib target `a` in package `b v1.0.0 ([ROOT]/foo/b)` has the same output filename as the lib target `a` in package `a v1.0.0 ([ROOT]/foo/a)`
   = [NOTE] this may become a hard error in the future; see <https://github.com/rust-lang/cargo/issues/6313>

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -494,7 +494,7 @@ fn linker() {
 please set bin.path in Cargo.toml
 [WARNING] `foo` (manifest) generated 1 warning
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo --edition=2015 src/foo.rs [..]--crate-type bin --emit=[..]link[..]-C debuginfo=2 [..] -C metadata=[..] --out-dir [ROOT]/foo/target/[ALT_TARGET]/debug/deps --target [ALT_TARGET] -C linker=my-linker-tool -L dependency=[ROOT]/foo/target/[ALT_TARGET]/debug/deps -L dependency=[ROOT]/foo/target/debug/deps`
+[RUNNING] `rustc --crate-name foo --edition=2015 src/foo.rs [..]--crate-type bin --emit=[..]link[..]-C debuginfo=2 [..] -C metadata=[..] --out-dir [ROOT]/foo/target/[ALT_TARGET]/debug/build/foo/[HASH]/out --target [ALT_TARGET] -C linker=my-linker-tool -L dependency=[ROOT]/foo/target/debug/build/foo/[HASH]/out[..]`
 [ERROR] linker `my-linker-tool` not found
 ...
 "#]])
@@ -560,8 +560,8 @@ fn cross_tests() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/[ALT_TARGET]/debug/deps/foo-[HASH][EXE])
-[RUNNING] unittests src/bin/bar.rs (target/[ALT_TARGET]/debug/deps/bar-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/[ALT_TARGET]/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/bin/bar.rs (target/[ALT_TARGET]/debug/build/foo/[HASH]/out/bar-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -644,8 +644,9 @@ fn cross_with_a_build_script() {
                         let mut path = PathBuf::from(env::var_os("OUT_DIR").unwrap());
                         assert_eq!(path.file_name().unwrap().to_str().unwrap(), "out");
                         path.pop();
-                        assert!(path.file_name().unwrap().to_str().unwrap()
-                                    .starts_with("foo-"));
+                        assert_eq!(path.file_name().unwrap().to_str().unwrap().len(), 16);
+                        path.pop();
+                        assert_eq!(path.file_name().unwrap().to_str().unwrap(), "foo");
                         path.pop();
                         assert_eq!(path.file_name().unwrap().to_str().unwrap(), "build");
                         path.pop();
@@ -666,8 +667,8 @@ fn cross_with_a_build_script() {
         .arg(&target)
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustc [..] build.rs [..] --out-dir [ROOT]/foo/target/debug/build/foo-[HASH] [..]
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `rustc [..] build.rs [..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out[..]
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc [..] src/main.rs [..] --target [ALT_TARGET] [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -769,17 +770,17 @@ fn build_script_needed_for_host_and_target() {
         .with_stderr_data(str![[r#"
 [LOCKING] 2 packages to highest compatible versions
 [COMPILING] d1 v0.0.0 ([ROOT]/foo/d1)
-[RUNNING] `rustc [..] d1/build.rs [..] --out-dir [ROOT]/foo/target/debug/build/d1-[HASH] [..]
-[RUNNING] `[ROOT]/foo/target/debug/build/d1-[HASH]/build-script-build`
-[RUNNING] `[ROOT]/foo/target/debug/build/d1-[HASH]/build-script-build`
-[RUNNING] `rustc [..] d1/src/lib.rs [..] --out-dir [ROOT]/foo/target/debug/deps [..]
-[RUNNING] `rustc [..] d1/src/lib.rs [..] --out-dir [ROOT]/foo/target/[ALT_TARGET]/debug/deps [..]
+[RUNNING] `rustc [..] d1/build.rs [..] --out-dir [ROOT]/foo/target/debug/build/d1/[HASH]/out[..]
+[RUNNING] `[ROOT]/foo/target/debug/build/d1/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/d1/[HASH]/out/build_script_build`
+[RUNNING] `rustc [..] d1/src/lib.rs [..] --out-dir [ROOT]/foo/target/debug/build/d1/[HASH]/out [..]
+[RUNNING] `rustc [..] d1/src/lib.rs [..] --out-dir [ROOT]/foo/target/[ALT_TARGET]/debug/build/d1/[HASH]/out [..]
 [COMPILING] d2 v0.0.0 ([ROOT]/foo/d2)
-[RUNNING] `rustc [..] d2/src/lib.rs [..] --out-dir [ROOT]/foo/target/debug/deps [..]-L [ROOT]/foo/link-[HOST_TARGET]`
+[RUNNING] `rustc [..] d2/src/lib.rs [..] --out-dir [ROOT]/foo/target/debug/build/d2/[HASH]/out [..]-L [ROOT]/foo/link-[HOST_TARGET]`
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustc [..] build.rs [..] --out-dir [ROOT]/foo/target/debug/build/foo-[HASH] [..]-L [ROOT]/foo/link-[HOST_TARGET]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
-[RUNNING] `rustc [..] src/main.rs [..] --out-dir [ROOT]/foo/target/[ALT_TARGET]/debug/deps --target [ALT_TARGET] [..]-L [ROOT]/foo/link-[ALT_TARGET]`
+[RUNNING] `rustc [..] build.rs [..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out [..]-L [ROOT]/foo/link-[HOST_TARGET]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `rustc [..] src/main.rs [..] --out-dir [ROOT]/foo/target/[ALT_TARGET]/debug/build/foo/[HASH]/out --target [ALT_TARGET] [..]-L [ROOT]/foo/link-[ALT_TARGET]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]].unordered())
@@ -873,7 +874,7 @@ fn build_script_only_host() {
 
                 fn main() {
                     assert!(env::var("OUT_DIR").unwrap().replace("\\", "/")
-                                               .contains("target/debug/build/d1-"),
+                                               .contains("target/debug/build/d1/"),
                             "bad: {:?}", env::var("OUT_DIR"));
                 }
             "#,
@@ -950,7 +951,7 @@ fn build_script_with_platform_specific_dependencies() {
 [RUNNING] `rustc [..] d1/src/lib.rs [..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc [..] build.rs [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc [..] src/lib.rs [..] --target [ALT_TARGET] [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -1198,8 +1199,8 @@ fn cross_test_dylib() {
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/[ALT_TARGET]/debug/deps/foo-[HASH][EXE])
-[RUNNING] tests/test.rs (target/[ALT_TARGET]/debug/deps/test-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/[ALT_TARGET]/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] tests/test.rs (target/[ALT_TARGET]/debug/build/foo/[HASH]/out/test-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1256,7 +1257,7 @@ fn doctest_xcompile_linker() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..] --out-dir [ROOT]/foo/target/[ALT_TARGET]/debug/deps --target [ALT_TARGET] [..]
+[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..] --out-dir [ROOT]/foo/target/[ALT_TARGET]/debug/build/foo/[HASH]/out --target [ALT_TARGET] [..]
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [DOCTEST] foo
 [RUNNING] `rustdoc [..] src/lib.rs [..]

--- a/tests/testsuite/dep_info.rs
+++ b/tests/testsuite/dep_info.rs
@@ -266,32 +266,41 @@ fn relative_depinfo_paths_ws() {
 
     assert_deps_contains(
         &p,
-        "target/debug/.fingerprint/pm-*/dep-lib-pm",
-        &[(0, "src/lib.rs"), (1, "debug/deps/libpmdep-*.rlib")],
-    );
-
-    assert_deps_contains(
-        &p,
-        &format!("target/{}/debug/.fingerprint/foo-*/dep-bin-foo", host),
+        "target/debug/build/pm/*/fingerprint/dep-lib-pm",
         &[
-            (0, "src/main.rs"),
-            (
-                1,
-                &format!(
-                    "debug/deps/{}pm-*.{}",
-                    paths::get_lib_prefix("proc-macro"),
-                    paths::get_lib_extension("proc-macro")
-                ),
-            ),
-            (1, &format!("{}/debug/deps/libbar-*.rlib", host)),
-            (1, &format!("{}/debug/deps/libregdep-*.rlib", host)),
+            (0, "src/lib.rs"),
+            (1, "debug/build/pmdep/*/out/libpmdep-*.rlib"),
         ],
     );
 
     assert_deps_contains(
         &p,
-        "target/debug/.fingerprint/foo-*/dep-build-script-build-script-build",
-        &[(0, "build.rs"), (1, "debug/deps/libbdep-*.rlib")],
+        &format!("target/{}/debug/build/foo/*/fingerprint/dep-bin-foo", host),
+        &[
+            (0, "src/main.rs"),
+            (
+                1,
+                &format!(
+                    "debug/build/pm/*/out/{}pm-*.{}",
+                    paths::get_lib_prefix("proc-macro"),
+                    paths::get_lib_extension("proc-macro")
+                ),
+            ),
+            (1, &format!("{}/debug/build/bar/*/out/libbar-*.rlib", host)),
+            (
+                1,
+                &format!("{}/debug/build/regdep/*/out/libregdep-*.rlib", host),
+            ),
+        ],
+    );
+
+    assert_deps_contains(
+        &p,
+        "target/debug/build/foo/*/fingerprint/dep-build-script-build-script-build",
+        &[
+            (0, "build.rs"),
+            (1, "debug/build/bdep/*/out/libbdep-*.rlib"),
+        ],
     );
 
     // Make sure it stays fresh.
@@ -396,32 +405,38 @@ fn relative_depinfo_paths_no_ws() {
 
     assert_deps_contains(
         &p,
-        "target/debug/.fingerprint/pm-*/dep-lib-pm",
-        &[(0, "src/lib.rs"), (1, "debug/deps/libpmdep-*.rlib")],
-    );
-
-    assert_deps_contains(
-        &p,
-        "target/debug/.fingerprint/foo-*/dep-bin-foo",
+        "target/debug/build/pm/*/fingerprint/dep-lib-pm",
         &[
-            (0, "src/main.rs"),
-            (
-                1,
-                &format!(
-                    "debug/deps/{}pm-*.{}",
-                    paths::get_lib_prefix("proc-macro"),
-                    paths::get_lib_extension("proc-macro")
-                ),
-            ),
-            (1, "debug/deps/libbar-*.rlib"),
-            (1, "debug/deps/libregdep-*.rlib"),
+            (0, "src/lib.rs"),
+            (1, "debug/build/pmdep/*/out/libpmdep-*.rlib"),
         ],
     );
 
     assert_deps_contains(
         &p,
-        "target/debug/.fingerprint/foo-*/dep-build-script-build-script-build",
-        &[(0, "build.rs"), (1, "debug/deps/libbdep-*.rlib")],
+        "target/debug/build/foo/*/fingerprint/dep-bin-foo",
+        &[
+            (0, "src/main.rs"),
+            (
+                1,
+                &format!(
+                    "debug/build/pm/*/out/{}pm-*.{}",
+                    paths::get_lib_prefix("proc-macro"),
+                    paths::get_lib_extension("proc-macro")
+                ),
+            ),
+            (1, "debug/build/bar/*/out/libbar-*.rlib"),
+            (1, "debug/build/regdep/*/out/libregdep-*.rlib"),
+        ],
+    );
+
+    assert_deps_contains(
+        &p,
+        "target/debug/build/foo/*/fingerprint/dep-build-script-build-script-build",
+        &[
+            (0, "build.rs"),
+            (1, "debug/build/bdep/*/out/libbdep-*.rlib"),
+        ],
     );
 
     // Make sure it stays fresh.
@@ -460,7 +475,7 @@ fn reg_dep_source_not_tracked() {
 
     assert_deps(
         &p,
-        "target/debug/.fingerprint/regdep-*/dep-lib-regdep",
+        "target/debug/build/regdep/*/fingerprint/dep-lib-regdep",
         |info_path, entries| {
             for (kind, path) in entries {
                 if *kind == 1 {
@@ -508,8 +523,11 @@ fn canonical_path() {
 
     assert_deps_contains(
         &p,
-        "target/debug/.fingerprint/foo-*/dep-lib-foo",
-        &[(0, "src/lib.rs"), (1, "debug/deps/libregdep-*.rmeta")],
+        "target/debug/build/foo/*/fingerprint/dep-lib-foo",
+        &[
+            (0, "src/lib.rs"),
+            (1, "debug/build/regdep/*/out/libregdep-*.rmeta"),
+        ],
     );
 }
 

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -137,7 +137,11 @@ fn doc_deps() {
 
     // Verify that it only emits rmeta for the dependency.
     assert_eq!(p.glob("target/debug/**/*.rlib").count(), 0);
-    assert_eq!(p.glob("target/debug/deps/libbar-*.rmeta").count(), 1);
+    assert_eq!(
+        p.glob("target/debug/build/bar/*/out/libbar-*.rmeta")
+            .count(),
+        1
+    );
 
     // Make sure it doesn't recompile.
     p.cargo("doc")
@@ -1914,7 +1918,7 @@ fn doc_json_artifacts() {
     "executable": null,
     "features": [],
     "filenames": [
-      "[ROOT]/foo/target/debug/deps/libfoo-[HASH].rmeta"
+      "[ROOT]/foo/target/debug/build/foo/[HASH]/out/libfoo-[HASH].rmeta"
     ],
     "fresh": false,
     "manifest_path": "[ROOT]/foo/Cargo.toml",
@@ -3249,13 +3253,13 @@ fn mergeable_info_with_deps() {
 [LOCKING] 1 package to highest compatible version
 [DOCUMENTING] dep v0.0.0 ([ROOT]/foo/dep)
 [CHECKING] dep v0.0.0 ([ROOT]/foo/dep)
-[RUNNING] `rustdoc [..]--crate-name dep [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name dep [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/out [..]`
 [RUNNING] `rustc --crate-name dep [..]`
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out[..]`
+[RUNNING] `rustdoc [..]--crate-name foo [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 2 docs for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/out --read-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/out --read-doc-meta-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 
@@ -3265,16 +3269,16 @@ fn mergeable_info_with_deps() {
 
     assert!(p.root().join("target/doc/foo/index.html").is_file());
     assert!(p.root().join("target/doc/dep/index.html").is_file());
-    assert_eq!(p.glob("target/debug/build/foo-*/out/foo.json").count(), 1);
-    assert_eq!(p.glob("target/debug/build/dep-*/out/dep.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/foo/*/out/foo.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/dep/*/out/dep.json").count(), 1);
 
     assert_e2e().eq(
         fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/dep-[HASH]/out/dep.json",
-    "debug/build/foo-[HASH]/out/foo.json"
+    "debug/build/dep/[HASH]/out/dep.json",
+    "debug/build/foo/[HASH]/out/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3298,10 +3302,10 @@ fn mergeable_info_with_rustdocflags() {
         .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info"])
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.5.0 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]-o [ROOT]/foo/target/doc [..]-Zunstable-options --write-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out [..]--markdown-playground-url=example.com --crate-version 0.5.0`
+[RUNNING] `rustdoc [..]--crate-name foo [..]-o [ROOT]/foo/target/doc [..]-Zunstable-options --write-doc-meta-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out [..]--markdown-playground-url=example.com --crate-version 0.5.0`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --markdown-playground-url=example.com --read-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --markdown-playground-url=example.com --read-doc-meta-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 
@@ -3336,10 +3340,10 @@ fn mergeable_info_no_deps() {
 [CHECKING] dep v0.0.0 ([ROOT]/foo/dep)
 [RUNNING] `rustc --crate-name dep --edition=2015 [..]`
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name foo [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 
@@ -3349,15 +3353,15 @@ fn mergeable_info_no_deps() {
 
     assert!(p.root().join("target/doc/foo/index.html").is_file());
     assert!(!p.root().join("target/doc/dep/index.html").is_file());
-    assert_eq!(p.glob("target/debug/build/foo-*/out/foo.json").count(), 1);
-    assert_eq!(p.glob("target/debug/build/dep-*/out/dep.json").count(), 0);
+    assert_eq!(p.glob("target/debug/build/foo/*/out/foo.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/dep/*/out/dep.json").count(), 0);
 
     assert_e2e().eq(
         fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/foo-[HASH]/out/foo.json"
+    "debug/build/foo/[HASH]/out/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3402,14 +3406,14 @@ fn mergeable_info_workspace() {
 [DOCUMENTING] dep v0.0.0 ([ROOT]/foo/dep)
 [CHECKING] dep v0.0.0 ([ROOT]/foo/dep)
 [DOCUMENTING] bar v0.0.0 ([ROOT]/foo/bar)
-[RUNNING] `rustdoc [..]--crate-name dep [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/out [..]`
-[RUNNING] `rustdoc [..]--crate-name bar [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/bar-[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name dep [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name bar [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/bar/[HASH]/out [..]`
 [RUNNING] `rustc --crate-name dep [..]`
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name foo [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 3 docs for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/bar-[HASH]/out --read-doc-meta-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/out --read-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/bar/[HASH]/out --read-doc-meta-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/out --read-doc-meta-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/bar/index.html
 [GENERATED] [ROOT]/foo/target/doc/dep/index.html
@@ -3422,18 +3426,18 @@ fn mergeable_info_workspace() {
     assert!(p.root().join("target/doc/foo/index.html").is_file());
     assert!(p.root().join("target/doc/bar/index.html").is_file());
     assert!(p.root().join("target/doc/dep/index.html").is_file());
-    assert_eq!(p.glob("target/debug/build/foo-*/out/foo.json").count(), 1);
-    assert_eq!(p.glob("target/debug/build/bar-*/out/bar.json").count(), 1);
-    assert_eq!(p.glob("target/debug/build/dep-*/out/dep.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/foo/*/out/foo.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/bar/*/out/bar.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/dep/*/out/dep.json").count(), 1);
 
     assert_e2e().eq(
         fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/bar-[HASH]/out/bar.json",
-    "debug/build/dep-[HASH]/out/dep.json",
-    "debug/build/foo-[HASH]/out/foo.json"
+    "debug/build/bar/[HASH]/out/bar.json",
+    "debug/build/dep/[HASH]/out/dep.json",
+    "debug/build/foo/[HASH]/out/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3469,13 +3473,13 @@ fn mergeable_info_multi_targets() {
         .with_stderr_data(
             str![[r#"
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo src/lib.rs --target [HOST_TARGET] [..]--write-doc-meta-dir=[ROOT]/foo/target/[HOST_TARGET]/debug/build/foo-[HASH]/out [..]`
-[RUNNING] `rustdoc [..]--crate-name foo src/lib.rs --target [ALT_TARGET] [..]--write-doc-meta-dir=[ROOT]/foo/target/[ALT_TARGET]/debug/build/foo-[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name foo src/lib.rs --target [HOST_TARGET] [..]--write-doc-meta-dir=[ROOT]/foo/target/[HOST_TARGET]/debug/build/foo/[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name foo src/lib.rs --target [ALT_TARGET] [..]--write-doc-meta-dir=[ROOT]/foo/target/[ALT_TARGET]/debug/build/foo/[HASH]/out [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for [ALT_TARGET]
-[RUNNING] `rustdoc -o [ROOT]/foo/target/[ALT_TARGET]/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/[ALT_TARGET]/debug/build/foo-[HASH]/out`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/[ALT_TARGET]/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/[ALT_TARGET]/debug/build/foo/[HASH]/out`
 [MERGING] 1 doc for [HOST_TARGET]
-[RUNNING] `rustdoc -o [ROOT]/foo/target/[HOST_TARGET]/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/[HOST_TARGET]/debug/build/foo-[HASH]/out`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/[HOST_TARGET]/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/[HOST_TARGET]/debug/build/foo/[HASH]/out`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/[HOST_TARGET]/doc/foo/index.html
 [GENERATED] [ROOT]/foo/target/[ALT_TARGET]/doc/foo/index.html
@@ -3490,9 +3494,9 @@ fn mergeable_info_multi_targets() {
     assert!(p.root().join(path).is_file());
     let path = format!("target/{target}/doc/foo/index.html");
     assert!(p.root().join(path).is_file());
-    let path = format!("target/{host}/debug/build/foo-*/out/foo.json");
+    let path = format!("target/{host}/debug/build/foo/*/out/foo.json");
     assert_eq!(p.glob(path).count(), 1);
-    let path = format!("target/{target}/debug/build/foo-*/out/foo.json");
+    let path = format!("target/{target}/debug/build/foo/*/out/foo.json");
     assert_eq!(p.glob(path).count(), 1);
 
     assert_e2e().eq(
@@ -3500,7 +3504,7 @@ fn mergeable_info_multi_targets() {
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/foo-[HASH]/out/foo.json"
+    "debug/build/foo/[HASH]/out/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3513,7 +3517,7 @@ fn mergeable_info_multi_targets() {
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/foo-[HASH]/out/foo.json"
+    "debug/build/foo/[HASH]/out/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3541,10 +3545,10 @@ fn mergeable_info_rebuild_detection() {
         .with_stderr_data(
             str![[r#"
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name foo [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 
@@ -3553,14 +3557,14 @@ fn mergeable_info_rebuild_detection() {
         .run();
 
     assert!(p.root().join("target/doc/foo/index.html").is_file());
-    assert_eq!(p.glob("target/debug/build/foo-*/out/foo.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/foo/*/out/foo.json").count(), 1);
 
     assert_e2e().eq(
         fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/foo-[HASH]/out/foo.json"
+    "debug/build/foo/[HASH]/out/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3587,7 +3591,7 @@ fn mergeable_info_rebuild_detection() {
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/foo-[HASH]/out/foo.json"
+    "debug/build/foo/[HASH]/out/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3605,10 +3609,10 @@ fn mergeable_info_rebuild_detection() {
             str![[r#"
 [DIRTY] foo v0.0.0 ([ROOT]/foo): the precalculated components changed
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name foo [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 
@@ -3648,7 +3652,7 @@ fn mergeable_info_rebuild_detection() {
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/foo-[HASH]/out/foo.json"
+    "debug/build/foo/[HASH]/out/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3679,10 +3683,10 @@ fn mergeable_info_rebuild_with_depinfo() {
         .with_stderr_data(
             str![[r#"
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--emit=html-non-static-files,dep-info=[..] --write-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name foo [..]--emit=html-non-static-files,dep-info=[..] --write-doc-meta-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 
@@ -3691,14 +3695,14 @@ fn mergeable_info_rebuild_with_depinfo() {
         .run();
 
     assert!(p.root().join("target/doc/foo/index.html").is_file());
-    assert_eq!(p.glob("target/debug/build/foo-*/out/foo.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/foo/*/out/foo.json").count(), 1);
 
     assert_e2e().eq(
         fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/foo-[HASH]/out/foo.json"
+    "debug/build/foo/[HASH]/out/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3725,7 +3729,7 @@ fn mergeable_info_rebuild_with_depinfo() {
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/foo-[HASH]/out/foo.json"
+    "debug/build/foo/[HASH]/out/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3743,10 +3747,10 @@ fn mergeable_info_rebuild_with_depinfo() {
             str![[r#"
 [DIRTY] foo v0.0.0 ([ROOT]/foo): the file `src/lib.rs` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--emit=html-non-static-files,dep-info=[..] --write-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name foo [..]--emit=html-non-static-files,dep-info=[..] --write-doc-meta-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 
@@ -3786,7 +3790,7 @@ fn mergeable_info_rebuild_with_depinfo() {
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/foo-[HASH]/out/foo.json"
+    "debug/build/foo/[HASH]/out/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3831,10 +3835,10 @@ fn mergeable_info_additive() {
 [CHECKING] dep v0.0.0 ([ROOT]/foo/dep)
 [RUNNING] `rustc --crate-name dep [..]`
 [DOCUMENTING] foo v0.0.0 ([ROOT]/foo/foo)
-[RUNNING] `rustdoc [..]--crate-name foo [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name foo [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 
@@ -3845,16 +3849,16 @@ fn mergeable_info_additive() {
     assert!(p.root().join("target/doc/foo/index.html").is_file());
     assert!(!p.root().join("target/doc/bar/index.html").is_file());
     assert!(!p.root().join("target/doc/dep/index.html").is_file());
-    assert_eq!(p.glob("target/debug/build/foo-*/out/foo.json").count(), 1);
-    assert_eq!(p.glob("target/debug/build/bar-*/out/bar.json").count(), 0);
-    assert_eq!(p.glob("target/debug/build/dep-*/out/dep.json").count(), 0);
+    assert_eq!(p.glob("target/debug/build/foo/*/out/foo.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/bar/*/out/bar.json").count(), 0);
+    assert_eq!(p.glob("target/debug/build/dep/*/out/dep.json").count(), 0);
 
     assert_e2e().eq(
         fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/foo-[HASH]/out/foo.json"
+    "debug/build/foo/[HASH]/out/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3867,10 +3871,10 @@ fn mergeable_info_additive() {
         .with_stderr_data(
             str![[r#"
 [DOCUMENTING] dep v0.0.0 ([ROOT]/foo/dep)
-[RUNNING] `rustdoc [..]--crate-name dep [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name dep [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/out [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 2 docs for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/out --read-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/out --read-doc-meta-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/dep/index.html
 
@@ -3881,17 +3885,17 @@ fn mergeable_info_additive() {
     assert!(p.root().join("target/doc/foo/index.html").is_file());
     assert!(!p.root().join("target/doc/bar/index.html").is_file());
     assert!(p.root().join("target/doc/dep/index.html").is_file());
-    assert_eq!(p.glob("target/debug/build/foo-*/out/foo.json").count(), 1);
-    assert_eq!(p.glob("target/debug/build/bar-*/out/bar.json").count(), 0);
-    assert_eq!(p.glob("target/debug/build/dep-*/out/dep.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/foo/*/out/foo.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/bar/*/out/bar.json").count(), 0);
+    assert_eq!(p.glob("target/debug/build/dep/*/out/dep.json").count(), 1);
 
     assert_e2e().eq(
         fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/dep-[HASH]/out/dep.json",
-    "debug/build/foo-[HASH]/out/foo.json"
+    "debug/build/dep/[HASH]/out/dep.json",
+    "debug/build/foo/[HASH]/out/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3904,10 +3908,10 @@ fn mergeable_info_additive() {
         .with_stderr_data(
             str![[r#"
 [DOCUMENTING] bar v0.0.0 ([ROOT]/foo/bar)
-[RUNNING] `rustdoc [..]--crate-name bar [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/bar-[HASH]/out [..]`
+[RUNNING] `rustdoc [..]--crate-name bar [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/bar/[HASH]/out [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 3 docs for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/bar-[HASH]/out --read-doc-meta-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/out --read-doc-meta-dir=[ROOT]/foo/target/debug/build/foo-[HASH]/out`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/bar/[HASH]/out --read-doc-meta-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/out --read-doc-meta-dir=[ROOT]/foo/target/debug/build/foo/[HASH]/out`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/bar/index.html
 
@@ -3918,18 +3922,18 @@ fn mergeable_info_additive() {
     assert!(p.root().join("target/doc/foo/index.html").is_file());
     assert!(p.root().join("target/doc/bar/index.html").is_file());
     assert!(p.root().join("target/doc/dep/index.html").is_file());
-    assert_eq!(p.glob("target/debug/build/foo-*/out/foo.json").count(), 1);
-    assert_eq!(p.glob("target/debug/build/bar-*/out/bar.json").count(), 1);
-    assert_eq!(p.glob("target/debug/build/dep-*/out/dep.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/foo/*/out/foo.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/bar/*/out/bar.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/dep/*/out/dep.json").count(), 1);
 
     assert_e2e().eq(
         fs::read_to_string(p.build_dir().join(".rustdoc_fingerprint.json")).unwrap(),
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/bar-[HASH]/out/bar.json",
-    "debug/build/dep-[HASH]/out/dep.json",
-    "debug/build/foo-[HASH]/out/foo.json"
+    "debug/build/bar/[HASH]/out/bar.json",
+    "debug/build/dep/[HASH]/out/dep.json",
+    "debug/build/foo/[HASH]/out/foo.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -3980,10 +3984,10 @@ fn mergeable_info_dep_collision() {
 [DOWNLOADED] dep v0.1.0 (registry `dummy-registry`)
 [DOWNLOADED] dep v0.2.0 (registry `dummy-registry`)
 [DOCUMENTING] dep v0.1.0
-[RUNNING] `rustdoc [..]--crate-name dep [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/out [..]--crate-version 0.1.0`
+[RUNNING] `rustdoc [..]--crate-name dep [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/out [..]--crate-version 0.1.0`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/out`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/out`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/dep/index.html
 
@@ -3992,7 +3996,7 @@ fn mergeable_info_dep_collision() {
         .run();
 
     assert!(p.root().join("target/doc/dep/index.html").is_file());
-    assert_eq!(p.glob("target/debug/build/dep-*/out/dep.json").count(), 1);
+    assert_eq!(p.glob("target/debug/build/dep/*/out/dep.json").count(), 1);
 
     // See `fn dep010()`
     assert!(p.build_dir().join("doc/dep/fn.dep010.html").exists());
@@ -4005,7 +4009,7 @@ fn mergeable_info_dep_collision() {
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/dep-[HASH]/out/dep.json"
+    "debug/build/dep/[HASH]/out/dep.json"
   ],
   "rustc_vv": "{...}"
 }
@@ -4019,10 +4023,10 @@ fn mergeable_info_dep_collision() {
         .with_stderr_data(
             str![[r#"
 [DOCUMENTING] dep v0.2.0
-[RUNNING] `rustdoc [..]--crate-name dep [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/out [..]--crate-version 0.2.0`
+[RUNNING] `rustdoc [..]--crate-name dep [..]--write-doc-meta-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/out [..]--crate-version 0.2.0`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [MERGING] 1 doc for host
-[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/dep-[HASH]/out`
+[RUNNING] `rustdoc -o [ROOT]/foo/target/doc -Zunstable-options --read-doc-meta-dir=[ROOT]/foo/target/debug/build/dep/[HASH]/out`
 [FINISHED] documentation merge in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/dep/index.html
 
@@ -4032,7 +4036,7 @@ fn mergeable_info_dep_collision() {
 
     assert!(p.root().join("target/doc/dep/index.html").is_file());
     // We'll have two dep.json
-    assert_eq!(p.glob("target/debug/build/dep-*/out/dep.json").count(), 2);
+    assert_eq!(p.glob("target/debug/build/dep/*/out/dep.json").count(), 2);
 
     // ...but only the selected dep@0.2.0 would be merged
     assert!(!p.build_dir().join("doc/dep/fn.dep010.html").exists());
@@ -4045,7 +4049,7 @@ fn mergeable_info_dep_collision() {
         str![[r#"
 {
   "doc_parts": [
-    "debug/build/dep-[HASH]/out/dep.json"
+    "debug/build/dep/[HASH]/out/dep.json"
   ],
   "rustc_vv": "{...}"
 }

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -674,28 +674,15 @@ fn no_feature_doesnt_build() {
         .run();
     p.process(&p.bin("foo")).with_stdout_data("").run();
 
-    let expected = if cfg!(target_os = "windows") && cfg!(target_env = "msvc") {
-        str![[r#"
-[COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
-[RUNNING] `rustc --crate-name bar [..]`
-[DIRTY] foo v0.0.1 ([ROOT]/foo): the list of features changed
-[COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-
-"#]]
-    } else {
-        str![[r#"
-[COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
-[RUNNING] `rustc --crate-name bar [..]`
-[COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-
-"#]]
-    };
     p.cargo("build --features bar -v")
-        .with_stderr_data(expected)
+        .with_stderr_data(str![[r#"
+[COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
+[RUNNING] `rustc --crate-name bar [..]`
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
     p.process(&p.bin("foo"))
         .with_stdout_data(str![[r#"
@@ -756,24 +743,13 @@ bar
 "#]])
         .run();
 
-    let expected = if cfg!(target_os = "windows") && cfg!(target_env = "msvc") {
-        str![[r#"
-[DIRTY] foo v0.0.1 ([ROOT]/foo): the list of features changed
-[COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-
-"#]]
-    } else {
-        str![[r#"
-[COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-
-"#]]
-    };
     p.cargo("build --no-default-features -v")
-        .with_stderr_data(expected)
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
     p.process(&p.bin("foo")).with_stdout_data("").run();
 }

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -2292,7 +2292,7 @@ fn minimal_download() {
 [COMPILING] dev_dep_pm v1.0.0
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[EXECUTABLE] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]]
             .unordered(),

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -280,7 +280,7 @@ fn changing_profiles_caches_targets() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -298,7 +298,7 @@ fn changing_profiles_caches_targets() {
     p.cargo("test foo")
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .run();
@@ -545,26 +545,13 @@ feature on
         .run();
 
     /* Targets should be cached from the first build */
-
-    let mut e = p.cargo("build -v");
-
-    // MSVC does not include hash in binary filename, so it gets recompiled.
-    if cfg!(target_env = "msvc") {
-        e.with_stderr_data(str![[r#"
-[DIRTY] foo v0.0.1 ([ROOT]/foo): the list of features changed
-[COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name [..]
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-
-"#]]);
-    } else {
-        e.with_stderr_data(str![[r#"
+    p.cargo("build -v")
+        .with_stderr_data(str![[r#"
 [FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
-"#]]);
-    }
-    e.run();
+"#]])
+        .run();
     p.rename_run("foo", "off2")
         .with_stdout_data(str![[r#"
 feature off
@@ -572,23 +559,13 @@ feature off
 "#]])
         .run();
 
-    let mut e = p.cargo("build --features foo -v");
-    if cfg!(target_env = "msvc") {
-        e.with_stderr_data(str![[r#"
-[DIRTY] foo v0.0.1 ([ROOT]/foo): the list of features changed
-[COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc [..]
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-
-"#]]);
-    } else {
-        e.with_stderr_data(str![[r#"
+    p.cargo("build --features foo -v")
+        .with_stderr_data(str![[r#"
 [FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
-"#]]);
-    }
-    e.run();
+"#]])
+        .run();
     p.rename_run("foo", "on2")
         .with_stdout_data(str![[r#"
 feature on
@@ -617,7 +594,7 @@ fn rebuild_tests_if_lib_changes() {
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo_test [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/deps/foo_test-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo_test-[HASH][EXE]`
 
 "#]])
         .run();
@@ -682,8 +659,8 @@ fn no_rebuild_transitive_target_deps() {
 [COMPILING] b v0.0.1 ([ROOT]/foo/b)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
-[EXECUTABLE] tests/foo.rs (target/debug/deps/foo-[HASH][EXE])
+[EXECUTABLE] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[EXECUTABLE] tests/foo.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .run();
@@ -1267,7 +1244,7 @@ fn reuse_workspace_lib() {
 [COMPILING] baz v0.1.1 ([ROOT]/foo/baz)
 [RUNNING] `rustc --crate-name baz [..]
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] `[ROOT]/foo/target/debug/deps/baz-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/build/baz/[HASH]/out/baz-[HASH][EXE]`
 
 "#]])
         .run();
@@ -1458,21 +1435,23 @@ fn fingerprint_cleaner(mut dir: PathBuf, timestamp: filetime::FileTime) {
     // if all the files in the fingerprint's folder are older then a time stamp without
     // effecting any builds that happened since that time stamp.
     let mut cleaned = false;
-    dir.push(".fingerprint");
-    for fingerprint in fs::read_dir(&dir).unwrap() {
-        let fingerprint = fingerprint.unwrap();
-
-        let outdated = |f: io::Result<fs::DirEntry>| {
-            filetime::FileTime::from_last_modification_time(&f.unwrap().metadata().unwrap())
-                <= timestamp
-        };
-        if fs::read_dir(fingerprint.path()).unwrap().all(outdated) {
-            fs::remove_dir_all(fingerprint.path()).unwrap();
-            println!("remove: {:?}", fingerprint.path());
-            // a real cleaner would remove the big files in deps and build as well
-            // but fingerprint is sufficient for our tests
-            cleaned = true;
-        } else {
+    dir.push("build");
+    let outdated = |f: io::Result<fs::DirEntry>| {
+        filetime::FileTime::from_last_modification_time(&f.unwrap().metadata().unwrap())
+            <= timestamp
+    };
+    for build_unit in fs::read_dir(&dir).unwrap() {
+        let build_unit = build_unit.unwrap();
+        for hash_dir in fs::read_dir(&build_unit.path()).unwrap() {
+            let hash_dir = hash_dir.unwrap();
+            let fingerprint = hash_dir.path().join("fingerprint");
+            if fs::read_dir(fingerprint).unwrap().all(outdated) {
+                fs::remove_dir_all(hash_dir.path()).unwrap();
+                println!("remove: {:?}", hash_dir.path());
+                // a real cleaner would remove the big files in deps and build as well
+                // but fingerprint is sufficient for our tests
+                cleaned = true;
+            }
         }
     }
     assert!(
@@ -1585,10 +1564,10 @@ fn reuse_panic_build_dep_test() {
 [RUNNING] `rustc --crate-name bar [..]
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo [..] src/lib.rs [..]--test[..]
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
 
 "#]])
         .run();
@@ -2100,7 +2079,7 @@ fn simulated_docker_deps_stay_cached() {
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FRESH] regdep_rerun [..]
 [FRESH] regdep_old_style [..]
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2271,7 +2250,10 @@ fn edition_change_invalidates() {
 
 "#]])
         .run();
-    assert_eq!(p.glob("target/debug/deps/libfoo-*.rlib").count(), 1);
+    assert_eq!(
+        p.glob("target/debug/build/foo/*/out/libfoo-*.rlib").count(),
+        1
+    );
 }
 
 #[cargo_test]
@@ -2439,7 +2421,7 @@ fn rerun_if_changes() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.0.1 ([ROOT]/foo): the env variable FOO changed
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2459,7 +2441,7 @@ fn rerun_if_changes() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.0.1 ([ROOT]/foo): the env variable BAR changed
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2479,7 +2461,7 @@ fn rerun_if_changes() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.0.1 ([ROOT]/foo): the env variable FOO changed
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2784,7 +2766,7 @@ fn linking_interrupted() {
 [RUNNING] `rustc --crate-name foo [..]
 [RUNNING] `rustc --crate-name t1 [..]
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/deps/t1-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/t1-[HASH][EXE]`
 
 "#]])
         .run();
@@ -3042,7 +3024,7 @@ fn changing_linker() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.0.1 ([ROOT]/foo): the config settings changed
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo [..] -C linker=nonexistent-linker [..]`
+[RUNNING] `rustc --crate-name foo [..] -C linker=nonexistent-linker[..]`
 [ERROR] linker `nonexistent-linker` not found
 ...
 "#]])
@@ -3220,7 +3202,7 @@ fn incremental_build_script_execution_got_new_mtime_and_cargo_check() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.0.1 ([ROOT]/foo): the file `touch-me` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/freshness_checksum.rs
+++ b/tests/testsuite/freshness_checksum.rs
@@ -181,11 +181,14 @@ fn binary_depinfo_correctly_encoded() {
 
     assert_deps_contains(
         &p,
-        &format!("target/{}/debug/.fingerprint/foo-*/dep-bin-foo", host),
+        &format!("target/{}/debug/build/foo/*/fingerprint/dep-bin-foo", host),
         &[
             (0, "src/main.rs"),
-            (1, &format!("{}/debug/deps/libbar-*.rlib", host)),
-            (1, &format!("{}/debug/deps/libregdep-*.rlib", host)),
+            (1, &format!("{}/debug/build/bar/*/out/libbar-*.rlib", host)),
+            (
+                1,
+                &format!("{}/debug/build/regdep/*/out/libregdep-*.rlib", host),
+            ),
         ],
     );
 
@@ -432,7 +435,7 @@ fn changing_profiles_caches_targets() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -452,7 +455,7 @@ fn changing_profiles_caches_targets() {
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .run();
@@ -707,27 +710,14 @@ feature on
         .run();
 
     /* Targets should be cached from the first build */
-
-    let mut e = p.cargo("build -Zchecksum-freshness -v");
-    e.masquerade_as_nightly_cargo(&["checksum-freshness"]);
-
-    // MSVC does not include hash in binary filename, so it gets recompiled.
-    if cfg!(target_env = "msvc") {
-        e.with_stderr_data(str![[r#"
-[DIRTY] foo v0.0.1 ([ROOT]/foo): the list of features changed
-[COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name [..]
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-
-"#]]);
-    } else {
-        e.with_stderr_data(str![[r#"
+    p.cargo("build -Zchecksum-freshness -v")
+        .masquerade_as_nightly_cargo(&["checksum-freshness"])
+        .with_stderr_data(str![[r#"
 [FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
-"#]]);
-    }
-    e.run();
+"#]])
+        .run();
     p.rename_run("foo", "off2")
         .with_stdout_data(str![[r#"
 feature off
@@ -735,24 +725,14 @@ feature off
 "#]])
         .run();
 
-    let mut e = p.cargo("build -Zchecksum-freshness --features foo -v");
-    e.masquerade_as_nightly_cargo(&["checksum-freshness"]);
-    if cfg!(target_env = "msvc") {
-        e.with_stderr_data(str![[r#"
-[DIRTY] foo v0.0.1 ([ROOT]/foo): the list of features changed
-[COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc [..]
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-
-"#]]);
-    } else {
-        e.with_stderr_data(str![[r#"
+    p.cargo("build -Zchecksum-freshness --features foo -v")
+        .masquerade_as_nightly_cargo(&["checksum-freshness"])
+        .with_stderr_data(str![[r#"
 [FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
-"#]]);
-    }
-    e.run();
+"#]])
+        .run();
     p.rename_run("foo", "on2")
         .with_stdout_data(str![[r#"
 feature on
@@ -787,7 +767,7 @@ fn rebuild_tests_if_lib_changes() {
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo_test [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/deps/foo_test-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo_test-[HASH][EXE]`
 
 "#]])
         .run();
@@ -855,8 +835,8 @@ fn no_rebuild_transitive_target_deps() {
 [COMPILING] b v0.0.1 ([ROOT]/foo/b)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
-[EXECUTABLE] tests/foo.rs (target/debug/deps/foo-[HASH][EXE])
+[EXECUTABLE] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[EXECUTABLE] tests/foo.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .run();
@@ -1434,7 +1414,7 @@ fn reuse_workspace_lib() {
 [COMPILING] baz v0.1.1 ([ROOT]/foo/baz)
 [RUNNING] `rustc --crate-name baz [..]
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] `[ROOT]/foo/target/debug/deps/baz-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/build/baz/[HASH]/out/baz-[HASH][EXE]`
 
 "#]])
         .run();
@@ -1612,10 +1592,10 @@ fn reuse_panic_build_dep_test() {
 [RUNNING] `rustc --crate-name bar [..]
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo [..] src/lib.rs [..]--test[..]
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
 
 "#]])
         .run();
@@ -2047,7 +2027,10 @@ fn edition_change_invalidates() {
 
 "#]])
         .run();
-    assert_eq!(p.glob("target/debug/deps/libfoo-*.rlib").count(), 1);
+    assert_eq!(
+        p.glob("target/debug/build/foo/*/out/libfoo-*.rlib").count(),
+        1
+    );
 }
 
 #[cargo_test(nightly, reason = "requires -Zchecksum-hash-algorithm")]
@@ -2225,7 +2208,7 @@ fn rerun_if_changes() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.0.1 ([ROOT]/foo): the env variable FOO changed
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2247,7 +2230,7 @@ fn rerun_if_changes() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.0.1 ([ROOT]/foo): the env variable BAR changed
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2269,7 +2252,7 @@ fn rerun_if_changes() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.0.1 ([ROOT]/foo): the env variable FOO changed
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -2590,7 +2573,7 @@ fn linking_interrupted() {
 [RUNNING] `rustc --crate-name foo [..]
 [RUNNING] `rustc --crate-name t1 [..]
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/deps/t1-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/t1-[HASH][EXE]`
 
 "#]])
         .run();
@@ -2997,7 +2980,7 @@ fn incremental_build_script_execution_got_new_mtime_and_cargo_check() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.0.1 ([ROOT]/foo): the file `touch-me` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -1779,7 +1779,7 @@ fn dev_deps_with_testing() {
 [COMPILING] bar v0.5.0 ([ROOTURL]/bar#[..])
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/main.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -2864,7 +2864,7 @@ fn include_overrides_gitignore() {
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.5.0 ([ROOT]/foo): the precalculated components changed
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/glob_targets.rs
+++ b/tests/testsuite/glob_targets.rs
@@ -217,7 +217,7 @@ fn test_example() {
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name example1 [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/examples/example1-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/example1-[HASH][EXE]`
 
 "#]])
         .run();
@@ -231,7 +231,7 @@ fn test_bin() {
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name bin1 [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/deps/bin1-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/bin1-[HASH][EXE]`
 
 "#]])
         .run();
@@ -249,7 +249,7 @@ fn test_bench() {
 [RUNNING] `rustc --crate-name bench1 [..]`
 [RUNNING] `rustc --crate-name bin1 [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/deps/bench1-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/bench1-[HASH][EXE]`
 
 "#]]
             .unordered(),
@@ -269,7 +269,7 @@ fn test_test() {
 [RUNNING] `rustc --crate-name foo [..]`
 [RUNNING] `rustc --crate-name bin2 [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/deps/test1-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/test1-[HASH][EXE]`
 
 "#]]
             .unordered(),
@@ -285,7 +285,7 @@ fn bench_example() {
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name example1 [..]`
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/release/examples/example1-[HASH][EXE] --bench`
+[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/example1-[HASH][EXE] --bench`
 
 "#]])
         .run();
@@ -299,7 +299,7 @@ fn bench_bin() {
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name bin1 [..]`
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/release/deps/bin1-[HASH][EXE] --bench`
+[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/bin1-[HASH][EXE] --bench`
 
 "#]])
         .run();
@@ -317,7 +317,7 @@ fn bench_bench() {
 [RUNNING] `rustc --crate-name foo [..]`
 [RUNNING] `rustc --crate-name bench1 [..]`
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/release/deps/bench1-[HASH][EXE] --bench`
+[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/bench1-[HASH][EXE] --bench`
 
 "#]]
             .unordered(),
@@ -337,7 +337,7 @@ fn bench_test() {
 [RUNNING] `rustc --crate-name test1 [..]`
 [RUNNING] `rustc --crate-name bin1 [..]`
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/release/deps/test1-[HASH][EXE] --bench`
+[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/test1-[HASH][EXE] --bench`
 
 "#]]
             .unordered(),

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -2614,7 +2614,7 @@ To reuse those artifacts with a future compilation, set the environment variable
     let end = stderr.find('.').unwrap() - 1;
     let path = Path::new(&stderr[..end]);
     assert!(path.exists());
-    assert!(path.join("release/deps").exists());
+    assert!(path.join("release/build/foo").exists());
 }
 
 #[cargo_test]

--- a/tests/testsuite/jobserver.rs
+++ b/tests/testsuite/jobserver.rs
@@ -220,7 +220,7 @@ this is a runner
         .arg("-j2")
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/cargo_jobserver_check-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/cargo-jobserver-check/[HASH]/out/cargo_jobserver_check-[HASH][EXE])
 this is a runner
 
 "#]])
@@ -264,7 +264,7 @@ this is a runner
         .with_status(101)
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/cargo_jobserver_check-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/cargo-jobserver-check/[HASH]/out/cargo_jobserver_check-[HASH][EXE])
 this is a runner
 ...
 

--- a/tests/testsuite/lints/unused_dependencies.rs
+++ b/tests/testsuite/lints/unused_dependencies.rs
@@ -933,8 +933,8 @@ fn unused_dev_deps() {
 [COMPILING] doctest_used v0.1.0
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
-[EXECUTABLE] tests/hello.rs (target/debug/deps/hello-[HASH][EXE])
+[EXECUTABLE] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[EXECUTABLE] tests/hello.rs (target/debug/build/foo/[HASH]/out/hello-[HASH][EXE])
 
 "#]]
             .unordered(),
@@ -947,10 +947,10 @@ fn unused_dev_deps() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
-[EXECUTABLE] tests/hello.rs (target/debug/deps/hello-[HASH][EXE])
-[EXECUTABLE] benches/hello.rs (target/debug/deps/hello-[HASH][EXE])
-[EXECUTABLE] unittests examples/hello.rs (target/debug/examples/hello-[HASH][EXE])
+[EXECUTABLE] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[EXECUTABLE] tests/hello.rs (target/debug/build/foo/[HASH]/out/hello-[HASH][EXE])
+[EXECUTABLE] benches/hello.rs (target/debug/build/foo/[HASH]/out/hello-[HASH][EXE])
+[EXECUTABLE] unittests examples/hello.rs (target/debug/build/foo/[HASH]/out/hello-[HASH][EXE])
 
 "#]])
         .run();
@@ -961,8 +961,8 @@ fn unused_dev_deps() {
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
-[RUNNING] tests/hello.rs (target/debug/deps/hello-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] tests/hello.rs (target/debug/build/foo/[HASH]/out/hello-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])

--- a/tests/testsuite/lto.rs
+++ b/tests/testsuite/lto.rs
@@ -80,7 +80,7 @@ fn shared_deps() {
 [RUNNING] `rustc --crate-name bar [..]-C embed-bitcode=no [..]`
 [COMPILING] test v0.0.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]`
-[RUNNING] `[ROOT]/foo/target/release/build/test-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/release/build/test/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name test [..]-C lto [..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 
@@ -123,7 +123,7 @@ fn build_dep_not_ltod() {
 [RUNNING] `rustc --crate-name bar [..]-C embed-bitcode=no [..]`
 [COMPILING] test v0.0.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]`
-[RUNNING] `[ROOT]/foo/target/release/build/test-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/release/build/test/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name test [..]-C lto [..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 
@@ -375,9 +375,9 @@ fn test_all() {
 [RUNNING] `rustc --crate-name foo [..]-C lto [..]--test [..]`
 [RUNNING] `rustc --crate-name foo [..]--crate-type bin [..]-C lto [..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/release/deps/foo-[HASH][EXE]`
-[RUNNING] `[ROOT]/foo/target/release/deps/a-[HASH][EXE]`
-[RUNNING] `[ROOT]/foo/target/release/deps/b-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/a-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/b-[HASH][EXE]`
 
 "#]]
             .unordered(),
@@ -415,9 +415,9 @@ fn test_all_and_bench() {
 [RUNNING] `rustc --crate-name foo [..]-C lto [..]--test [..]`
 [RUNNING] `rustc --crate-name foo [..]--crate-type bin [..]-C lto [..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/release/deps/foo-[HASH][EXE]`
-[RUNNING] `[ROOT]/foo/target/release/deps/a-[HASH][EXE]`
-[RUNNING] `[ROOT]/foo/target/release/deps/b-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/a-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/b-[HASH][EXE]`
 
 "#]]
             .unordered(),
@@ -587,8 +587,8 @@ fn cdylib_and_rlib() {
 [RUNNING] `rustc --crate-name foo [..]-C lto [..]--test [..]`
 [RUNNING] `rustc --crate-name a [..]-C lto [..]--test [..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/release/deps/foo-[HASH][EXE]`
-[RUNNING] `[ROOT]/foo/target/release/deps/a-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/a-[HASH][EXE]`
 
 "#]]
             .unordered(),
@@ -614,8 +614,8 @@ fn cdylib_and_rlib() {
 [RUNNING] `rustc --crate-name bar [..]-C lto [..]--test [..]`
 [RUNNING] `rustc --crate-name b [..]-C lto [..]--test [..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/release/deps/bar-[HASH][EXE]`
-[RUNNING] `[ROOT]/foo/target/release/deps/b-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/build/bar/[HASH]/out/bar-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/build/bar/[HASH]/out/b-[HASH][EXE]`
 [DOCTEST] bar
 [RUNNING] `rustdoc --edition=2015 --crate-type cdylib --crate-type rlib --color auto --crate-name bar --test [..]-C lto [..]
 
@@ -654,8 +654,8 @@ fn dylib() {
 [RUNNING] `rustc --crate-name foo [..]-C lto [..]--test [..]`
 [RUNNING] `rustc --crate-name a [..]-C lto [..]--test [..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/release/deps/foo-[HASH][EXE]`
-[RUNNING] `[ROOT]/foo/target/release/deps/a-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/a-[HASH][EXE]`
 
 "#]]
             .unordered(),
@@ -672,7 +672,6 @@ fn dylib() {
 [COMPILING] registry-shared v0.0.1
 [FRESH] registry v0.0.1
 [RUNNING] `rustc --crate-name registry_shared [..]-C embed-bitcode=no [..]`
-[DIRTY] bar v0.0.0 ([ROOT]/foo/bar): info of dependency `registry-shared` changed
 [COMPILING] bar v0.0.0 ([ROOT]/foo/bar)
 [RUNNING] `rustc --crate-name bar [..]--crate-type dylib [..]-C embed-bitcode=no [..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
@@ -692,14 +691,13 @@ fn dylib() {
 [FRESH] registry-shared v0.0.1
 [COMPILING] registry v0.0.1
 [RUNNING] `rustc --crate-name registry [..]`
-[DIRTY] bar v0.0.0 ([ROOT]/foo/bar): info of dependency `registry` changed
 [COMPILING] bar v0.0.0 ([ROOT]/foo/bar)
 [RUNNING] `rustc --crate-name bar [..]--crate-type dylib [..]-C embed-bitcode=no [..]`
 [RUNNING] `rustc --crate-name bar [..]-C lto [..]--test [..]`
 [RUNNING] `rustc --crate-name b [..]-C lto [..]--test [..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/release/deps/bar-[HASH][EXE]`
-[RUNNING] `[ROOT]/foo/target/release/deps/b-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/build/bar/[HASH]/out/bar-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/build/bar/[HASH]/out/b-[HASH][EXE]`
 
 "#]]
             .unordered(),
@@ -758,7 +756,7 @@ fn test_profile() {
 [RUNNING] `rustc --crate-name foo [..]--crate-type lib --emit=dep-info,metadata,link -C linker-plugin-lto [..]`
 [RUNNING] `rustc --crate-name foo [..]--emit=dep-info,link -C lto=thin [..]--test [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
 [DOCTEST] foo
 [RUNNING] `rustdoc [..]
 
@@ -916,7 +914,7 @@ fn fresh_swapping_commands() {
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]-C lto [..]--test [..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/release/deps/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE]`
 [DOCTEST] foo
 [RUNNING] `rustdoc [..]-C lto [..]`
 
@@ -938,7 +936,7 @@ fn fresh_swapping_commands() {
 [FRESH] bar v1.0.0
 [FRESH] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[EXECUTABLE] `[ROOT]/foo/target/release/deps/foo-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE]`
 
 "#]])
         .run();

--- a/tests/testsuite/messages.rs
+++ b/tests/testsuite/messages.rs
@@ -73,7 +73,7 @@ fn deduplicate_messages_basic() {
 [WARNING] `foo` (lib) generated 1 warning[..]
 [WARNING] `foo` (lib test) generated 1 warning (1 duplicate)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[EXECUTABLE] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 ",
         rustc_message
     );
@@ -122,7 +122,7 @@ fn deduplicate_messages_mismatched_warnings() {
 {}\
 [WARNING] `foo` (lib test) generated 2 warnings (1 duplicate)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[EXECUTABLE] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 ",
         lib_output, lib_test_output
     );

--- a/tests/testsuite/metabuild.rs
+++ b/tests/testsuite/metabuild.rs
@@ -649,7 +649,7 @@ fn metabuild_json_artifact() {
     "env": [],
     "linked_libs": [],
     "linked_paths": [],
-    "out_dir": "[ROOT]/foo/target/debug/build/foo-[HASH]/out",
+    "out_dir": "[ROOT]/foo/target/debug/build/foo/[HASH]/out",
     "package_id": "path+[ROOTURL]/foo#0.0.1",
     "reason": "build-script-executed"
   },

--- a/tests/testsuite/multitarget.rs
+++ b/tests/testsuite/multitarget.rs
@@ -75,8 +75,8 @@ fn simple_test() {
         .arg(&t2)
         .with_stderr_data(
             str![[r#"
-[RUNNING] unittests src/lib.rs (target/[ALT_TARGET]/debug/deps/foo-[HASH][EXE])
-[RUNNING] unittests src/lib.rs (target/[HOST_TARGET]/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/[ALT_TARGET]/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/[HOST_TARGET]/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 ...
 
 "#]]

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -211,7 +211,7 @@ fn cargo_compile_with_root_dev_deps_with_testing() {
 [COMPILING] bar v0.5.0 ([ROOT]/bar)
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/main.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1445,7 +1445,7 @@ fn dev_deps_no_rebuild_lib() {
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"

--- a/tests/testsuite/proc_macro.rs
+++ b/tests/testsuite/proc_macro.rs
@@ -562,7 +562,7 @@ fn proc_macro_built_once() {
 [RUNNING] `rustc --crate-name b [..]`
 [COMPILING] a v0.1.0 ([ROOT]/foo/a)
 [RUNNING] `rustc --crate-name build_script_build [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/a-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/a/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name a [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -261,7 +261,7 @@ fn profile_config_all_options() {
         .env_remove("CARGO_INCREMENTAL")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo [..] -C opt-level=1 -C panic=abort -C lto[..]-C codegen-units=2 -C debuginfo=2 [..]-C debug-assertions=on -C overflow-checks=off [..]-C rpath --out-dir [ROOT]/foo/target/release/deps -C incremental=[ROOT]/foo/target/release/incremental[..]`
+[RUNNING] `rustc --crate-name foo [..] -C opt-level=1 -C panic=abort -C lto[..]-C codegen-units=2 -C debuginfo=2 [..]-C debug-assertions=on -C overflow-checks=off [..]-C rpath --out-dir [ROOT]/foo/target/release/build/foo/[HASH]/out -C incremental=[ROOT]/foo/target/release/incremental[..]`
 [FINISHED] `release` profile [optimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])

--- a/tests/testsuite/profile_custom.rs
+++ b/tests/testsuite/profile_custom.rs
@@ -706,7 +706,7 @@ fn test_inherits_dev() {
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `test` profile [optimized] target(s) in [ELAPSED]s
-[EXECUTABLE] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
 
 "#]])
         .with_stderr_does_not_contain("[..] -C debuginfo=0[..]")
@@ -736,7 +736,7 @@ fn change_test_inheritance() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
 [FINISHED] `test` profile [optimized] target(s) in [ELAPSED]s
-[EXECUTABLE] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[EXECUTABLE] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .run();

--- a/tests/testsuite/profile_overrides.rs
+++ b/tests/testsuite/profile_overrides.rs
@@ -235,8 +235,8 @@ fn profile_override_hierarchy() {
 [RUNNING] `rustc --crate-name build_script_build --edition=2015 m1/build.rs [..] --crate-type bin --emit=[..]link[..]-C codegen-units=4 [..]`
 [COMPILING] m2 v0.0.1 ([ROOT]/foo/m2)
 [RUNNING] `rustc --crate-name build_script_build --edition=2015 m2/build.rs [..] --crate-type bin --emit=[..]link[..]-C codegen-units=2 [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/m1-[HASH]/build-script-build`
-[RUNNING] `[ROOT]/foo/target/debug/build/m2-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/m1/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/m2/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name m2 --edition=2015 m2/src/lib.rs [..] --crate-type lib --emit=[..]link[..]-C codegen-units=2 [..]`
 [COMPILING] m1 v0.0.1 ([ROOT]/foo/m1)
 [RUNNING] `rustc --crate-name m1 --edition=2015 m1/src/lib.rs [..] --crate-type lib --emit=[..]link[..]-C codegen-units=1 [..]`

--- a/tests/testsuite/profile_settings.rs
+++ b/tests/testsuite/profile_settings.rs
@@ -29,7 +29,7 @@ fn profile_overrides() {
         .build();
     p.cargo("build -v").with_stderr_data(str![[r#"
 [COMPILING] test v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name test --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..] -C opt-level=1[..] -C debug-assertions=on[..] -C metadata=[..] -C rpath --out-dir [ROOT]/foo/target/debug/deps [..] -L dependency=[ROOT]/foo/target/debug/deps`
+[RUNNING] `rustc --crate-name test --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..] -C opt-level=1[..] -C debug-assertions=on[..] -C metadata=[..] -C rpath --out-dir [ROOT]/foo/target/debug/build/test/[HASH]/out [..]`
 [FINISHED] `dev` profile [optimized] target(s) in [ELAPSED]s
 
 "#]]).run();
@@ -56,7 +56,7 @@ fn opt_level_override_0() {
         .build();
     p.cargo("build -v").with_stderr_data(str![[r#"
 [COMPILING] test v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name test --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=2 [..] -C metadata=[..] --out-dir [ROOT]/foo/target/debug/deps -L dependency=[ROOT]/foo/target/debug/deps`
+[RUNNING] `rustc --crate-name test --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=2 [..] -C metadata=[..] --out-dir [ROOT]/foo/target/debug/build/test/[HASH]/out`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]]).run();
@@ -82,7 +82,7 @@ fn debug_override_1() {
         .build();
     p.cargo("build -v").with_stderr_data(str![[r#"
 [COMPILING] test v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name test --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=1 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/deps -L dependency=[ROOT]/foo/target/debug/deps`
+[RUNNING] `rustc --crate-name test --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=1 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/build/test/[HASH]/out`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]]).run();
@@ -119,8 +119,7 @@ fn check_opt_level_override(profile_level: &str, rustc_level: &str) {
         -C debuginfo=2 [..]\
         -C debug-assertions=on[..] \
         -C metadata=[..] \
-        --out-dir [..] \
-        -L dependency=[ROOT]/foo/target/debug/deps`
+        --out-dir [..]`
 [FINISHED] `dev` profile [..]+ debuginfo] target(s) in [ELAPSED]s
 ",
             level = rustc_level
@@ -196,8 +195,7 @@ fn top_level_overrides_deps() {
         -C opt-level=1[..]\
         -C debuginfo=2 [..]\
         -C metadata=[..] \
-        --out-dir [ROOT]/foo/target/release/deps \
-        -L dependency=[ROOT]/foo/target/release/deps`
+        --out-dir [ROOT]/foo/target/release/build/foo/[HASH]/out`
 [COMPILING] test v0.0.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name test --edition=2015 src/lib.rs [..]--crate-type lib \
         --emit=[..]link \
@@ -205,10 +203,9 @@ fn top_level_overrides_deps() {
         -C debuginfo=2 [..]\
         -C metadata=[..] \
         --out-dir [..] \
-        -L dependency=[ROOT]/foo/target/release/deps \
-        --extern foo=[ROOT]/foo/target/release/deps/\
+        --extern foo=[ROOT]/foo/target/release/build/foo/[HASH]/out/\
                      {prefix}foo[..]{suffix} \
-        --extern foo=[ROOT]/foo/target/release/deps/libfoo.rlib`
+        --extern foo=[ROOT]/foo/target/release/build/foo/[HASH]/out/libfoo.rlib`
 [FINISHED] `release` profile [optimized + debuginfo] target(s) in [ELAPSED]s
 ",
             prefix = env::consts::DLL_PREFIX,
@@ -430,9 +427,9 @@ fn panic_unwind_does_not_build_twice() {
 [RUNNING] `rustc --crate-name foo --edition=2015 src/main.rs [..] --test [..]`
 [RUNNING] `rustc --crate-name t1 --edition=2015 tests/t1.rs [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
-[EXECUTABLE] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
-[EXECUTABLE] `[ROOT]/foo/target/debug/deps/t1-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/t1-[HASH][EXE]`
 
 "#]]
             .unordered(),
@@ -520,7 +517,7 @@ fn strip_works() {
     p.cargo("build --release -v")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
-[RUNNING] `rustc [..] -C strip=symbols [..]`
+[RUNNING] `rustc [..] -C strip=symbols[..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 
 "#]])
@@ -549,7 +546,7 @@ fn strip_passes_unknown_option_to_rustc() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
-[RUNNING] `rustc [..] -C strip=unknown [..]`
+[RUNNING] `rustc [..] -C strip=unknown[..]`
 [ERROR] incorrect value `unknown` for [..] `strip` [..] was expected
 ...
 "#]])
@@ -577,7 +574,7 @@ fn strip_accepts_true_to_strip_symbols() {
     p.cargo("build --release -v")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
-[RUNNING] `rustc [..] -C strip=symbols [..]`
+[RUNNING] `rustc [..] -C strip=symbols[..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 
 "#]])

--- a/tests/testsuite/profile_targets.rs
+++ b/tests/testsuite/profile_targets.rs
@@ -97,7 +97,7 @@ fn profile_selection_build() {
 [RUNNING] `[..] rustc --crate-name bdep --edition=2015 bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..] rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 [..]
-[RUNNING] `[..][ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[..][ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/main.rs [..]--crate-type bin --emit=[..]link -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]
@@ -135,7 +135,7 @@ fn profile_selection_build_release() {
 [RUNNING] `[..] rustc --crate-name bdep --edition=2015 bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=6 [..]
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..] rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=6 [..]
-[RUNNING] `[..][ROOT]/foo/target/release/build/foo-[HASH]/build-script-build`
+[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/build_script_build`
 [foo 0.0.1] foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3 -C panic=abort[..]-C codegen-units=2 [..]
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/main.rs [..]--crate-type bin --emit=[..]link -C opt-level=3 -C panic=abort[..]-C codegen-units=2 [..]
@@ -201,7 +201,7 @@ fn profile_selection_build_all_targets() {
 [RUNNING] `[..] rustc --crate-name bdep --edition=2015 bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..] rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 [..]`
-[RUNNING] `[..][ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[..][ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]`
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--emit=[..]link[..]-C codegen-units=1 -C debuginfo=2 [..]--test [..]`
@@ -274,7 +274,7 @@ fn profile_selection_build_all_targets_release() {
 [RUNNING] `[..] rustc --crate-name bdep --edition=2015 bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=6 [..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..] rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=6 [..]`
-[RUNNING] `[..][ROOT]/foo/target/release/build/foo-[HASH]/build-script-build`
+[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/build_script_build`
 [foo 0.0.1] foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3 -C panic=abort[..]-C codegen-units=2 [..]`
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--emit=[..]link -C opt-level=3[..]-C codegen-units=2 --test [..]`
@@ -337,7 +337,7 @@ fn profile_selection_test() {
 [RUNNING] `[..] rustc --crate-name bdep --edition=2015 bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..] rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 [..]`
-[RUNNING] `[..][ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[..][ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort[..]-C codegen-units=3 -C debuginfo=2 [..]`
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=3 -C debuginfo=2 [..]`
@@ -347,9 +347,9 @@ fn profile_selection_test() {
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/main.rs [..]--emit=[..]link[..]-C codegen-units=3 -C debuginfo=2 [..]--test [..]`
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/main.rs [..]--crate-type bin --emit=[..]link -C panic=abort[..]-C codegen-units=3 -C debuginfo=2 [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[..][ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
-[RUNNING] `[..][ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
-[RUNNING] `[..][ROOT]/foo/target/debug/deps/test1-[HASH][EXE]`
+[RUNNING] `[..][ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[RUNNING] `[..][ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[RUNNING] `[..][ROOT]/foo/target/debug/build/foo/[HASH]/out/test1-[HASH][EXE]`
 [DOCTEST] foo
 [RUNNING] `[..] rustdoc [..]--test [..]
 
@@ -362,9 +362,9 @@ fn profile_selection_test() {
 [FRESH] bar v0.0.1 ([ROOT]/foo/bar)
 [FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[..][ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
-[RUNNING] `[..][ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
-[RUNNING] `[..][ROOT]/foo/target/debug/deps/test1-[HASH][EXE]`
+[RUNNING] `[..][ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[RUNNING] `[..][ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[RUNNING] `[..][ROOT]/foo/target/debug/build/foo/[HASH]/out/test1-[HASH][EXE]`
 [DOCTEST] foo
 [RUNNING] `[..] rustdoc [..]--test [..]
 
@@ -410,7 +410,7 @@ fn profile_selection_test_release() {
 [RUNNING] `[..] rustc --crate-name bdep --edition=2015 bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=6 [..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..] rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=6 [..]`
-[RUNNING] `[..][ROOT]/foo/target/release/build/foo-[HASH]/build-script-build`
+[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/build_script_build`
 [foo 0.0.1] foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3 -C panic=abort[..]-C codegen-units=2 [..]`
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3[..]-C codegen-units=2 [..]`
@@ -420,9 +420,9 @@ fn profile_selection_test_release() {
 [RUNNING] `[..] rustc --crate-name ex1 --edition=2015 examples/ex1.rs [..]--crate-type bin --emit=[..]link -C opt-level=3[..]-C codegen-units=2 [..]`
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/main.rs [..]--crate-type bin --emit=[..]link -C opt-level=3 -C panic=abort[..]-C codegen-units=2 [..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[..][ROOT]/foo/target/release/deps/foo-[HASH][EXE]`
-[RUNNING] `[..][ROOT]/foo/target/release/deps/foo-[HASH][EXE]`
-[RUNNING] `[..][ROOT]/foo/target/release/deps/test1-[HASH][EXE]`
+[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/test1-[HASH][EXE]`
 [DOCTEST] foo
 [RUNNING] `[..] rustdoc [..]--test [..]`
 
@@ -435,9 +435,9 @@ fn profile_selection_test_release() {
 [FRESH] bar v0.0.1 ([ROOT]/foo/bar)
 [FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[..][ROOT]/foo/target/release/deps/foo-[HASH][EXE]`
-[RUNNING] `[..][ROOT]/foo/target/release/deps/foo-[HASH][EXE]`
-[RUNNING] `[..][ROOT]/foo/target/release/deps/test1-[HASH][EXE]`
+[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/test1-[HASH][EXE]`
 [DOCTEST] foo
 [RUNNING] `[..] rustdoc [..]--test [..]
 
@@ -482,7 +482,7 @@ fn profile_selection_bench() {
 [RUNNING] `[..] rustc --crate-name bdep --edition=2015 bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=6 [..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..] rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=6 [..]`
-[RUNNING] `[..][ROOT]/foo/target/release/build/foo-[HASH]/build-script-build`
+[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/build_script_build`
 [foo 0.0.1] foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3 -C panic=abort[..]-C codegen-units=4 [..]`
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3[..]-C codegen-units=4 [..]`
@@ -491,9 +491,9 @@ fn profile_selection_bench() {
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/main.rs [..]--emit=[..]link -C opt-level=3[..]-C codegen-units=4 --test [..]`
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/main.rs [..]--crate-type bin --emit=[..]link -C opt-level=3 -C panic=abort[..]-C codegen-units=4 [..]`
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[..][ROOT]/foo/target/release/deps/foo-[HASH][EXE] --bench`
-[RUNNING] `[..][ROOT]/foo/target/release/deps/foo-[HASH][EXE] --bench`
-[RUNNING] `[..][ROOT]/foo/target/release/deps/bench1-[HASH][EXE] --bench`
+[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE] --bench`
+[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE] --bench`
+[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/bench1-[HASH][EXE] --bench`
 
 "#]].unordered())
         .run();
@@ -504,9 +504,9 @@ fn profile_selection_bench() {
 [FRESH] bar v0.0.1 ([ROOT]/foo/bar)
 [FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[..][ROOT]/foo/target/release/deps/foo-[HASH][EXE] --bench`
-[RUNNING] `[..][ROOT]/foo/target/release/deps/foo-[HASH][EXE] --bench`
-[RUNNING] `[..][ROOT]/foo/target/release/deps/bench1-[HASH][EXE] --bench`
+[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE] --bench`
+[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE] --bench`
+[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/bench1-[HASH][EXE] --bench`
 
 "#]]
             .unordered(),
@@ -553,7 +553,7 @@ fn profile_selection_check_all_targets() {
 [RUNNING] `[..] rustc --crate-name bdep --edition=2015 bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..] rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 [..]`
-[RUNNING] `[..][ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[..][ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]metadata -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]`
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]metadata[..]-C codegen-units=1 -C debuginfo=2 [..]`
@@ -604,7 +604,7 @@ fn profile_selection_check_all_targets_release() {
 [RUNNING] `[..] rustc --crate-name bdep --edition=2015 bdep/src/lib.rs [..]--crate-type lib --emit=[..]link [..]-C codegen-units=6 [..]
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..] rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=6 [..]
-[RUNNING] `[..][ROOT]/foo/target/release/build/foo-[HASH]/build-script-build`
+[RUNNING] `[..][ROOT]/foo/target/release/build/foo/[HASH]/out/build_script_build`
 [foo 0.0.1] foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]metadata -C opt-level=3 -C panic=abort[..]-C codegen-units=2 [..]
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]metadata -C opt-level=3[..]-C codegen-units=2 [..]
@@ -668,7 +668,7 @@ fn profile_selection_check_all_targets_test() {
 [RUNNING] `[..] rustc --crate-name bdep --edition=2015 bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..] rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 [..]`
-[RUNNING] `[..][ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[..][ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]metadata[..]-C codegen-units=3 -C debuginfo=2 [..]`
 [RUNNING] `[..] rustc --crate-name foo --edition=2015 src/lib.rs [..]--emit=[..]metadata[..]-C codegen-units=3 -C debuginfo=2 [..]--test [..]`
@@ -721,7 +721,7 @@ fn profile_selection_doc() {
 [RUNNING] `[..] rustc --crate-name bdep --edition=2015 bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..] rustc --crate-name build_script_build --edition=2015 build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 [..]`
-[RUNNING] `[..][ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[..][ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..] rustdoc [..]--crate-name foo src/lib.rs [..]

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -334,7 +334,7 @@ fn registry_dependency_with_build_script_codegen() {
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         // Macros should be sanitized
         .with_stdout_data(str![[r#"
-/cargo/build-dir/debug/build/bar-[HASH]/out/bindings.rs
+/cargo/build-dir/debug/build/bar/[HASH]/out/bindings.rs
 
 "#]]) // Omit the hash of Source URL
         .with_stderr_data(str![[r#"
@@ -344,7 +344,7 @@ fn registry_dependency_with_build_script_codegen() {
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [COMPILING] bar v0.0.1
 [RUNNING] `rustc --crate-name build_script_build [..]--remap-path-scope=object --remap-path-prefix=[ROOT]/home/.cargo/registry/src/[..]=/cargo/registry/[..] --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/bar-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/bar/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name bar [..]--remap-path-scope=object --remap-path-prefix=[ROOT]/home/.cargo/registry/src/[..]=/cargo/registry/[..] --remap-path-prefix=[ROOT]/foo/target=/cargo/build-dir --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo [..]--remap-path-scope=object --remap-path-prefix=[ROOT]/foo=. --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
@@ -881,13 +881,13 @@ fn local_package_with_build_script_codegen() {
     p.cargo("run --verbose -Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stdout_data(str![[r#"
-/cargo/build-dir/debug/build/foo-[HASH]/out/bindings.rs
+/cargo/build-dir/debug/build/foo/[HASH]/out/bindings.rs
 
 "#]])
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]--remap-path-scope=object --remap-path-prefix=[ROOT]/foo=. --remap-path-prefix=[ROOT]/foo/target=/cargo/build-dir --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name foo [..]--remap-path-scope=object --remap-path-prefix=[ROOT]/foo=. --remap-path-prefix=[ROOT]/foo/target=/cargo/build-dir --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `target/debug/foo[EXE]`
@@ -1844,26 +1844,6 @@ fn unremap_file_with_cargo_clean() {
 
     assert!(!unremap_file_path(&p.bin("foo")).exists());
     assert_eq!(p.glob("target/**/*.trim-paths.jsonl").count(), 0);
-
-    // Test the new layout
-
-    p.cargo("clean -Ztrim-paths")
-        .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
-        .run();
-
-    p.cargo("build -Ztrim-paths -Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
-        .run();
-
-    assert!(unremap_file_path(&p.bin("foo")).exists());
-    assert_eq!(p.glob("target/**/*.trim-paths.jsonl").count(), 2);
-
-    p.cargo("clean -p foo -Ztrim-paths -Zbuild-dir-new-layout")
-        .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
-        .run();
-
-    assert!(!unremap_file_path(&p.bin("foo")).exists());
-    assert_eq!(p.glob("target/**/*.trim-paths.jsonl").count(), 0);
 }
 
 // MSVC always emits a PDB when debuginfo is on (which the unremap file requires),
@@ -1980,12 +1960,9 @@ fn unremap_file_for_all_bin_types() {
     // and receive unremap files.
     assert_eq!(p.glob("target/**/foo-*.trim-paths.jsonl").count(), 1);
     assert_eq!(p.glob("target/**/it-*.trim-paths.jsonl").count(), 1);
-    // MSVC executables don't get a hashed filename
-    // The PDB path is embedded in the executable.
-    let expected = if cfg!(target_env = "msvc") { 1 } else { 2 };
     assert_eq!(
         p.glob("target/debug/examples/*.trim-paths.jsonl").count(),
-        expected
+        1
     );
 }
 

--- a/tests/testsuite/rename_deps.rs
+++ b/tests/testsuite/rename_deps.rs
@@ -282,7 +282,7 @@ fn can_run_doc_tests() {
     foo.cargo("test -v").with_stderr_data(str![[r#"
 ...
 [DOCTEST] foo
-[RUNNING] `rustdoc [..]--test src/lib.rs [..] --extern bar=[ROOT]/foo/target/debug/deps/libbar-[HASH].rlib --extern baz=[ROOT]/foo/target/debug/deps/libbar-[HASH].rlib [..]`
+[RUNNING] `rustdoc [..]--test src/lib.rs [..] --extern bar=[ROOT]/foo/target/debug/build/bar/[HASH]/out/libbar-[HASH].rlib --extern baz=[ROOT]/foo/target/debug/build/bar/[HASH]/out/libbar-[HASH].rlib [..]`
 
 "#]]).run();
 }

--- a/tests/testsuite/required_features.rs
+++ b/tests/testsuite/required_features.rs
@@ -295,7 +295,7 @@ fn test_default_features() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] tests/foo.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] tests/foo.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -320,7 +320,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
     p.cargo("test --test=foo")
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] tests/foo.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] tests/foo.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -371,7 +371,7 @@ fn test_arg_features() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] tests/foo.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] tests/foo.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -421,7 +421,7 @@ fn test_multiple_required_features() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] tests/foo_2.rs (target/debug/deps/foo_2-[HASH][EXE])
+[RUNNING] tests/foo_2.rs (target/debug/build/foo/[HASH]/out/foo_2-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -439,8 +439,8 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] tests/foo_1.rs (target/debug/deps/foo_1-[HASH][EXE])
-[RUNNING] tests/foo_2.rs (target/debug/deps/foo_2-[HASH][EXE])
+[RUNNING] tests/foo_1.rs (target/debug/build/foo/[HASH]/out/foo_1-[HASH][EXE])
+[RUNNING] tests/foo_2.rs (target/debug/build/foo/[HASH]/out/foo_2-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -507,7 +507,7 @@ fn bench_default_features() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] benches/foo.rs (target/release/deps/foo-[HASH][EXE])
+[RUNNING] benches/foo.rs (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -532,7 +532,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured; 0 filtered out; fini
     p.cargo("bench --bench=foo")
         .with_stderr_data(str![[r#"
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] benches/foo.rs (target/release/deps/foo-[HASH][EXE])
+[RUNNING] benches/foo.rs (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -593,7 +593,7 @@ fn bench_arg_features() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] benches/foo.rs (target/release/deps/foo-[HASH][EXE])
+[RUNNING] benches/foo.rs (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -663,7 +663,7 @@ fn bench_multiple_required_features() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] benches/foo_2.rs (target/release/deps/foo_2-[HASH][EXE])
+[RUNNING] benches/foo_2.rs (target/release/build/foo/[HASH]/out/foo_2-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -681,8 +681,8 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured; 0 filtered out; fini
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] benches/foo_1.rs (target/release/deps/foo_1-[HASH][EXE])
-[RUNNING] benches/foo_2.rs (target/release/deps/foo_2-[HASH][EXE])
+[RUNNING] benches/foo_1.rs (target/release/build/foo/[HASH]/out/foo_1-[HASH][EXE])
+[RUNNING] benches/foo_2.rs (target/release/build/foo/[HASH]/out/foo_2-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1036,7 +1036,7 @@ fn dep_feature_in_toml() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] tests/foo.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] tests/foo.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1057,7 +1057,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] benches/foo.rs (target/release/deps/foo-[HASH][EXE])
+[RUNNING] benches/foo.rs (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
             .with_stdout_data(str![[r#"
@@ -1203,7 +1203,7 @@ Consider enabling them by passing, e.g., `--features="bar/a"`
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] tests/foo.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] tests/foo.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1232,7 +1232,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] benches/foo.rs (target/release/deps/foo-[HASH][EXE])
+[RUNNING] benches/foo.rs (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
             .with_stdout_data(str![[r#"
@@ -1297,7 +1297,7 @@ fn test_skips_compiling_bin_with_missing_required_features() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] tests/foo.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] tests/foo.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1324,7 +1324,7 @@ error[E0463]: can't find crate for `bar`
             .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] benches/foo.rs (target/release/deps/foo-[HASH][EXE])
+[RUNNING] benches/foo.rs (target/release/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
             .with_stdout_data(str![[r#"

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -1105,9 +1105,9 @@ fn example_with_release_flag() {
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
-[RUNNING] `rustc --crate-name bar --edition=2015 bar/src/bar.rs [..]--crate-type lib --emit=[..]link -C opt-level=3[..] -C metadata=[..] --out-dir [ROOT]/foo/target/release/deps -C strip=debuginfo -L dependency=[ROOT]/foo/target/release/deps`
+[RUNNING] `rustc --crate-name bar --edition=2015 bar/src/bar.rs [..]--crate-type lib --emit=[..]link -C opt-level=3[..] -C metadata=[..] --out-dir [ROOT]/foo/target/release/build/bar/[HASH]/out -C strip=debuginfo`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name a --edition=2015 examples/a.rs [..]--crate-type bin --emit=[..]link -C opt-level=3[..] -C metadata=[..] --out-dir [ROOT]/foo/target/release/examples -C strip=debuginfo -L dependency=[ROOT]/foo/target/release/deps --extern bar=[ROOT]/foo/target/release/deps/libbar-[HASH].rlib`
+[RUNNING] `rustc --crate-name a --edition=2015 examples/a.rs [..]--crate-type bin --emit=[..]link -C opt-level=3[..] -C metadata=[..] --out-dir [ROOT]/foo/target/release/build/foo/[HASH]/out -C strip=debuginfo -L dependency=[ROOT]/foo/target/release/build/bar/[HASH]/out --extern bar=[ROOT]/foo/target/release/build/bar/[HASH]/out/libbar-[HASH].rlib`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 [RUNNING] `target/release/examples/a[EXE]`
 
@@ -1122,9 +1122,9 @@ fast2
     p.cargo("run -v --example a")
         .with_stderr_data(str![[r#"
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
-[RUNNING] `rustc --crate-name bar --edition=2015 bar/src/bar.rs [..]--crate-type lib --emit=[..]link [..]-C debuginfo=2 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/deps -L dependency=[ROOT]/foo/target/debug/deps`
+[RUNNING] `rustc --crate-name bar --edition=2015 bar/src/bar.rs [..]--crate-type lib --emit=[..]link [..]-C debuginfo=2 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/build/bar/[HASH]/out`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name a --edition=2015 examples/a.rs [..]--crate-type bin --emit=[..]link [..]-C debuginfo=2 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/examples -L dependency=[ROOT]/foo/target/debug/deps --extern bar=[ROOT]/foo/target/debug/deps/libbar-[HASH].rlib`
+[RUNNING] `rustc --crate-name a --edition=2015 examples/a.rs [..]--crate-type bin --emit=[..]link [..]-C debuginfo=2 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/bar/[HASH]/out --extern bar=[ROOT]/foo/target/debug/build/bar/[HASH]/out/libbar-[HASH].rlib`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `target/debug/examples/a[EXE]`
 

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -17,7 +17,7 @@ fn build_lib_for_foo() {
 
     p.cargo("rustc --lib -v").with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=2 [..]-C metadata=[..] [..]--out-dir [ROOT]/foo/target/debug/deps -L dependency=[ROOT]/foo/target/debug/deps`
+[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=2 [..]-C metadata=[..] [..]--out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]]).run();
@@ -33,7 +33,7 @@ fn lib() {
     p.cargo("rustc --lib -v -- -C debug-assertions=off")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=2 [..]-C metadata=[..] [..]--out-dir [ROOT]/foo/target/debug/deps -L dependency=[ROOT]/foo/target/debug/deps[..]-C debug-assertions=off[..]`
+[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=2 [..]-C metadata=[..] [..]--out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out[..]-C debug-assertions=off[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -50,8 +50,8 @@ fn build_main_and_allow_unstable_options() {
     p.cargo("rustc -v --bin foo -- -C debug-assertions")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=2 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/deps -L dependency=[ROOT]/foo/target/debug/deps`
-[RUNNING] `rustc --crate-name foo --edition=2015 src/main.rs [..]--crate-type bin --emit=[..]link[..]-C debuginfo=2 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/deps -L dependency=[ROOT]/foo/target/debug/deps --extern foo=[ROOT]/foo/target/debug/deps/libfoo-[HASH].rlib[..]-C debug-assertions[..]`
+[RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=2 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out`
+[RUNNING] `rustc --crate-name foo --edition=2015 src/main.rs [..]--crate-type bin --emit=[..]link[..]-C debuginfo=2 [..]-C metadata=[..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/foo/[HASH]/out --extern foo=[ROOT]/foo/target/debug/build/foo/[HASH]/out/libfoo-[HASH].rlib[..]-C debug-assertions[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])

--- a/tests/testsuite/rustdoc.rs
+++ b/tests/testsuite/rustdoc.rs
@@ -15,7 +15,7 @@ fn rustdoc_simple() {
     p.cargo("rustdoc -v")
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustdoc [..] --crate-name foo src/lib.rs -o [ROOT]/foo/target/doc [..] -L dependency=[ROOT]/foo/target/debug/deps [..]`
+[RUNNING] `rustdoc [..] --crate-name foo src/lib.rs -o [ROOT]/foo/target/doc [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 
@@ -43,23 +43,6 @@ fn rustdoc_simple_json() {
     let p = project().file("src/lib.rs", "").build();
 
     p.cargo("rustdoc -Z unstable-options --output-format json -v")
-        .masquerade_as_nightly_cargo(&["rustdoc-output-format"])
-        .with_stderr_data(str![[r#"
-[DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustdoc [..] --crate-name foo [..]-o [ROOT]/foo/target/debug/build/foo-[HASH]/out [..] --output-format=json[..]
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[GENERATED] [ROOT]/foo/target/doc/foo.json
-
-"#]])
-        .run();
-    assert!(p.root().join("target/doc/foo.json").is_file());
-}
-
-#[cargo_test(nightly, reason = "--output-format is unstable")]
-fn rustdoc_json_with_new_layout() {
-    let p = project().file("src/lib.rs", "").build();
-
-    p.cargo("rustdoc -Z unstable-options -Z build-dir-new-layout  --output-format json -v")
         .masquerade_as_nightly_cargo(&["rustdoc-output-format"])
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
@@ -127,7 +110,7 @@ fn rustdoc_args() {
     p.cargo("rustdoc -v -- --cfg=foo")
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustdoc [..] --crate-name foo src/lib.rs -o [ROOT]/foo/target/doc [..]-C metadata=[..] -L dependency=[ROOT]/foo/target/debug/deps [..]--cfg=foo[..]`
+[RUNNING] `rustdoc [..] --crate-name foo src/lib.rs -o [ROOT]/foo/target/doc [..]-C metadata=[..]--cfg=foo[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 
@@ -180,7 +163,7 @@ fn rustdoc_foo_with_bar_dependency() {
 [CHECKING] bar v0.0.1 ([ROOT]/bar)
 [RUNNING] `rustc [..] [ROOT]/bar/src/lib.rs [..]`
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustdoc [..] --crate-name foo src/lib.rs -o [ROOT]/foo/target/doc [..]-C metadata=[..] -L dependency=[ROOT]/foo/target/debug/deps --extern [..]--cfg=foo[..]`
+[RUNNING] `rustdoc [..] --crate-name foo src/lib.rs -o [ROOT]/foo/target/doc [..]-C metadata=[..] --extern [..]--cfg=foo[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 
@@ -216,7 +199,7 @@ fn rustdoc_only_bar_dependency() {
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
 [DOCUMENTING] bar v0.0.1 ([ROOT]/bar)
-[RUNNING] `rustdoc [..] --crate-name bar [ROOT]/bar/src/lib.rs -o [ROOT]/foo/target/doc [..]-C metadata=[..] -L dependency=[ROOT]/foo/target/debug/deps [..]--cfg=foo[..]`
+[RUNNING] `rustdoc [..] --crate-name bar [ROOT]/bar/src/lib.rs -o [ROOT]/foo/target/doc [..]-C metadata=[..]--cfg=foo[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/bar/index.html
 
@@ -234,7 +217,7 @@ fn rustdoc_same_name_documents_lib() {
     p.cargo("rustdoc -v -- --cfg=foo")
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustdoc [..] --crate-name foo src/lib.rs -o [ROOT]/foo/target/doc [..]-C metadata=[..] -L dependency=[ROOT]/foo/target/debug/deps [..]--cfg=foo[..]`
+[RUNNING] `rustdoc [..] --crate-name foo src/lib.rs -o [ROOT]/foo/target/doc [..]-C metadata=[..]--cfg=foo[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/doc/foo/index.html
 
@@ -311,7 +294,7 @@ fn rustdoc_target() {
         .arg(cross_compile::alternate())
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustdoc [..]--crate-name foo src/lib.rs [..]--target [ALT_TARGET] -o [ROOT]/foo/target/[ALT_TARGET]/doc [..] -L dependency=[ROOT]/foo/target/[ALT_TARGET]/debug/deps -L dependency=[ROOT]/foo/target/debug/deps[..]`
+[RUNNING] `rustdoc [..]--crate-name foo src/lib.rs [..]--target [ALT_TARGET] -o [ROOT]/foo/target/[ALT_TARGET]/doc [..] -L dependency=[ROOT]/foo/target/debug/build/foo/[HASH]/out[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [GENERATED] [ROOT]/foo/target/[..]/doc/foo/index.html
 

--- a/tests/testsuite/rustflags.rs
+++ b/tests/testsuite/rustflags.rs
@@ -1197,9 +1197,9 @@ fn cfg_rustflags_normal_source() {
 [RUNNING] `rustc [..] --cfg bar`
 [RUNNING] `rustc [..] --cfg bar`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
-[EXECUTABLE] `[ROOT]/foo/target/debug/deps/a-[HASH][EXE]`
-[EXECUTABLE] `[ROOT]/foo/target/debug/deps/c-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/a-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/c-[HASH][EXE]`
 
 "#]])
         .run();
@@ -1211,8 +1211,8 @@ fn cfg_rustflags_normal_source() {
 [RUNNING] `rustc [..] --cfg bar`
 [RUNNING] `rustc [..] --cfg bar`
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[EXECUTABLE] `[ROOT]/foo/target/release/deps/foo-[HASH][EXE]`
-[EXECUTABLE] `[ROOT]/foo/target/release/deps/a-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/release/build/foo/[HASH]/out/a-[HASH][EXE]`
 
 "#]])
         .run();
@@ -1279,9 +1279,9 @@ fn cfg_rustflags_precedence() {
 [RUNNING] `rustc [..] --cfg bar`
 [RUNNING] `rustc [..] --cfg bar`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
-[EXECUTABLE] `[ROOT]/foo/target/debug/deps/a-[HASH][EXE]`
-[EXECUTABLE] `[ROOT]/foo/target/debug/deps/c-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/a-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/c-[HASH][EXE]`
 
 "#]])
         .run();
@@ -1293,8 +1293,8 @@ fn cfg_rustflags_precedence() {
 [RUNNING] `rustc [..] --cfg bar`
 [RUNNING] `rustc [..] --cfg bar`
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[EXECUTABLE] `[ROOT]/foo/target/release/deps/foo-[HASH][EXE]`
-[EXECUTABLE] `[ROOT]/foo/target/release/deps/a-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/release/build/foo/[HASH]/out/a-[HASH][EXE]`
 
 "#]])
         .run();
@@ -1783,7 +1783,7 @@ fn host_config_shared_build_dep() {
 [RUNNING] `rustc --crate-name cc [..]--cfg from_target[..]`
 [COMPILING] bootstrap v0.0.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name build_script_build [..]--cfg from_host[..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/bootstrap-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/bootstrap/[HASH]/out/build_script_build`
 [RUNNING] `rustc --crate-name bootstrap[..]--cfg from_target[..]`
 [FINISHED] `dev` profile [unoptimized] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/script/cargo.rs
+++ b/tests/testsuite/script/cargo.rs
@@ -1770,7 +1770,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
 [HELP] to pin the edition, run `cargo fix --manifest-path [ROOT]/foo/script.rs`
 [COMPILING] script v0.0.0 ([ROOT]/foo/script.rs)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests script.rs ([ROOT]/home/.cargo/build/[HASH]/debug/deps/script-[HASH][EXE])
+[RUNNING] unittests script.rs ([ROOT]/home/.cargo/build/[HASH]/debug/build/script/[HASH]/out/script-[HASH][EXE])
 
 "#]])
         .run();

--- a/tests/testsuite/standard_lib.rs
+++ b/tests/testsuite/standard_lib.rs
@@ -420,7 +420,7 @@ fn build_std_with_no_arg_for_core_only_target() {
 [COMPILING] core v0.1.0 ([..]/library/core)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `[..] rustc --crate-name build_script_build [..]/compiler_builtins/build.rs [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/compiler_builtins-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/compiler_builtins/[HASH]/out/build_script_build`
 [RUNNING] `[..] rustc --crate-name compiler_builtins [..]--target aarch64-unknown-none[..]`
 [RUNNING] `[..] rustc --crate-name core [..]--target aarch64-unknown-none[..]`
 [RUNNING] `[..] rustc --crate-name foo [..]--target aarch64-unknown-none[..]`
@@ -459,8 +459,8 @@ fn build_std_with_no_arg_for_core_only_target() {
 [COMPILING] registry-dep-using-alloc v1.0.0
 [COMPILING] std v0.1.0 ([..]/library/std)
 [RUNNING] `[..] rustc --crate-name build_script_build [..]/compiler_builtins/build.rs [..]`
-[RUNNING] `[ROOT]/foo/target/debug/build/compiler_builtins-[HASH]/build-script-build`
-[RUNNING] `[ROOT]/foo/target/debug/build/compiler_builtins-[HASH]/build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/compiler_builtins/[HASH]/out/build_script_build`
+[RUNNING] `[ROOT]/foo/target/debug/build/compiler_builtins/[HASH]/out/build_script_build`
 [RUNNING] `[..]rustc --crate-name compiler_builtins [..]--target aarch64-unknown-none[..]`
 [RUNNING] `[..]rustc --crate-name core [..]--target aarch64-unknown-none[..]`
 [RUNNING] `[..]rustc --crate-name foo [..]--target aarch64-unknown-none[..]`

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -49,7 +49,7 @@ hello
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/main.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -109,8 +109,8 @@ fn cargo_test_release() {
 [RUNNING] `rustc [..]-C opt-level=3 [..]`
 [RUNNING] `rustc [..]-C opt-level=3 [..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/release/deps/foo-[HASH][EXE]`
-[RUNNING] `[ROOT]/foo/target/release/deps/test-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/test-[HASH][EXE]`
 [DOCTEST] foo
 [RUNNING] `rustdoc [..]--test src/lib.rs[..]`
 
@@ -329,7 +329,7 @@ fn cargo_test_verbose() {
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [RUNNING] `rustc [..] src/main.rs [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE] hello`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE] hello`
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -417,7 +417,7 @@ hello
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/main.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 [ERROR] test failed, to rerun pass `--bin foo`
 
 "#]])
@@ -451,8 +451,8 @@ hello
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/main.rs (target/debug/deps/foo-[HASH][EXE])
-[RUNNING] tests/footest.rs (target/debug/deps/footest-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] tests/footest.rs (target/debug/build/foo/[HASH]/out/footest-[HASH][EXE])
 [ERROR] test failed, to rerun pass `--test footest`
 
 "#]])
@@ -488,7 +488,7 @@ fn cargo_test_failing_test_in_lib() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 [ERROR] test failed, to rerun pass `--lib`
 
 "#]])
@@ -553,8 +553,8 @@ fn test_with_lib_dep() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
-[RUNNING] unittests src/main.rs (target/debug/deps/baz-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/build/foo/[HASH]/out/baz-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -615,7 +615,7 @@ fn test_with_deep_lib_dep() {
 [COMPILING] bar v0.0.1 ([ROOT]/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -671,8 +671,8 @@ fn external_test_explicit() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
-[RUNNING] src/test.rs (target/debug/deps/test-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] src/test.rs (target/debug/build/foo/[HASH]/out/test-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -738,8 +738,8 @@ fn external_test_implicit() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
-[RUNNING] tests/external.rs (target/debug/deps/external-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] tests/external.rs (target/debug/build/foo/[HASH]/out/external-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -803,7 +803,7 @@ fn pass_through_escaped() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -818,7 +818,7 @@ test test_bar ... ok
     p.cargo("test -- foo")
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -833,7 +833,7 @@ test test_foo ... ok
     p.cargo("test -- foo bar")
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -884,7 +884,7 @@ fn pass_through_testname() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -898,7 +898,7 @@ test test_bar ... ok
     p.cargo("test foo")
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -912,7 +912,7 @@ test test_foo ... ok
     p.cargo("test foo -- bar")
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(
@@ -984,8 +984,8 @@ fn lib_bin_same_name() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
-[RUNNING] unittests src/main.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -1032,8 +1032,8 @@ fn lib_with_standard_name() {
         .with_stderr_data(str![[r#"
 [COMPILING] syntax v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/syntax-[HASH][EXE])
-[RUNNING] tests/test.rs (target/debug/deps/test-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/syntax/[HASH]/out/syntax-[HASH][EXE])
+[RUNNING] tests/test.rs (target/debug/build/syntax/[HASH]/out/test-[HASH][EXE])
 [DOCTEST] syntax
 
 "#]])
@@ -1085,7 +1085,7 @@ fn lib_with_standard_name2() {
         .with_stderr_data(str![[r#"
 [COMPILING] syntax v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/main.rs (target/debug/deps/syntax-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/build/syntax/[HASH]/out/syntax-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1131,7 +1131,7 @@ fn lib_without_name() {
         .with_stderr_data(str![[r#"
 [COMPILING] syntax v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/main.rs (target/debug/deps/syntax-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/build/syntax/[HASH]/out/syntax-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1460,8 +1460,8 @@ fn test_dylib() {
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
-[RUNNING] tests/test.rs (target/debug/deps/test-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] tests/test.rs (target/debug/build/foo/[HASH]/out/test-[HASH][EXE])
 
 "#]])
         .with_stdout_data(
@@ -1478,8 +1478,8 @@ test foo ... ok
     p.cargo("test")
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
-[RUNNING] tests/test.rs (target/debug/deps/test-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] tests/test.rs (target/debug/build/foo/[HASH]/out/test-[HASH][EXE])
 
 "#]])
         .with_stdout_data(
@@ -1515,7 +1515,7 @@ fn test_twice_with_build_cmd() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -1532,7 +1532,7 @@ running 0 tests
     p.cargo("test")
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -1555,7 +1555,7 @@ fn test_then_build() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -1587,7 +1587,7 @@ fn test_no_run() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[EXECUTABLE] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .run();
@@ -1637,7 +1637,7 @@ fn test_run_specific_bin_target() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/bin2.rs (target/debug/deps/bin2-[HASH][EXE])
+[RUNNING] unittests src/bin2.rs (target/debug/build/foo/[HASH]/out/bin2-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1683,7 +1683,7 @@ fn test_run_implicit_bin_target() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/mybin.rs (target/debug/deps/mybin-[HASH][EXE])
+[RUNNING] unittests src/mybin.rs (target/debug/build/foo/[HASH]/out/mybin-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1707,7 +1707,7 @@ fn test_run_specific_test_target() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] tests/b.rs (target/debug/deps/b-[HASH][EXE])
+[RUNNING] tests/b.rs (target/debug/build/foo/[HASH]/out/b-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1752,8 +1752,8 @@ fn test_run_implicit_test_target() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/mybin.rs (target/debug/deps/mybin-[HASH][EXE])
-[RUNNING] tests/mytest.rs (target/debug/deps/mytest-[HASH][EXE])
+[RUNNING] unittests src/mybin.rs (target/debug/build/foo/[HASH]/out/mybin-[HASH][EXE])
+[RUNNING] tests/mytest.rs (target/debug/build/foo/[HASH]/out/mytest-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1798,8 +1798,8 @@ fn test_run_implicit_bench_target() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/mybin.rs (target/debug/deps/mybin-[HASH][EXE])
-[RUNNING] benches/mybench.rs (target/debug/deps/mybench-[HASH][EXE])
+[RUNNING] unittests src/mybin.rs (target/debug/build/foo/[HASH]/out/mybin-[HASH][EXE])
+[RUNNING] benches/mybench.rs (target/debug/build/foo/[HASH]/out/mybench-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1863,21 +1863,21 @@ fn test_run_implicit_example_target() {
         .with_stderr_does_not_contain("[RUNNING] [..]myexm1-[..]")
         // profile.test panic settings shouldn't be applied even to myexm1
         .with_stderr_line_without(&["[RUNNING] `rustc --crate-name myexm1"], &["panic=abort"])
-        .with_stderr_contains("[RUNNING] [..]target/debug/examples/myexm2-[..]")
+        .with_stderr_contains("[RUNNING] [..]target/debug/build/foo/[HASH]/out/myexm2-[..]")
         .run();
 
     // Only tests myexm2.
     prj.cargo("test --tests")
         .with_stderr_does_not_contain("[RUNNING] [..]myexm1-[..]")
-        .with_stderr_contains("[RUNNING] [..]target/debug/examples/myexm2-[..]")
+        .with_stderr_contains("[RUNNING] [..]target/debug/build/foo/[HASH]/out/myexm2-[..]")
         .run();
 
     // Tests all examples.
     prj.cargo("test --examples")
         .with_stderr_data(str![[r#"
 ...
-[RUNNING] unittests examples/myexm1.rs (target/debug/examples/myexm1-[HASH][EXE])
-[RUNNING] unittests examples/myexm2.rs (target/debug/examples/myexm2-[HASH][EXE])
+[RUNNING] unittests examples/myexm1.rs (target/debug/build/foo/[HASH]/out/myexm1-[HASH][EXE])
+[RUNNING] unittests examples/myexm2.rs (target/debug/build/foo/[HASH]/out/myexm2-[HASH][EXE])
 ...
 "#]])
         .run();
@@ -1886,7 +1886,7 @@ fn test_run_implicit_example_target() {
     prj.cargo("test --example myexm1")
         .with_stderr_data(str![[r#"
 ...
-[RUNNING] unittests examples/myexm1.rs (target/debug/examples/myexm1-[HASH][EXE])
+[RUNNING] unittests examples/myexm1.rs (target/debug/build/foo/[HASH]/out/myexm1-[HASH][EXE])
 ...
 "#]])
         .run();
@@ -1895,8 +1895,8 @@ fn test_run_implicit_example_target() {
     prj.cargo("test --all-targets")
         .with_stderr_data(str![[r#"
 ...
-[RUNNING] unittests examples/myexm1.rs (target/debug/examples/myexm1-[HASH][EXE])
-[RUNNING] unittests examples/myexm2.rs (target/debug/examples/myexm2-[HASH][EXE])
+[RUNNING] unittests examples/myexm1.rs (target/debug/build/foo/[HASH]/out/myexm1-[HASH][EXE])
+[RUNNING] unittests examples/myexm2.rs (target/debug/build/foo/[HASH]/out/myexm2-[HASH][EXE])
 ...
 "#]])
         .run();
@@ -1964,14 +1964,14 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
 [RUNNING] `rustc --crate-name mybin --edition=2015 src/bin/mybin.rs [..] --crate-type bin [..]`
 [RUNNING] `rustc --crate-name mytest --edition=2015 tests/mytest.rs [..] --test [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE] test_in_`
-[RUNNING] `[ROOT]/foo/target/debug/deps/mytest-[HASH][EXE] test_in_`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE] test_in_`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/mytest-[HASH][EXE] test_in_`
 
 "#]]
             .unordered(),
         )
         .with_stderr_does_not_contain("[RUNNING][..]rustc[..]myexm1[..]")
-        .with_stderr_does_not_contain("[RUNNING][..]deps/mybin-[..] test_in_")
+        .with_stderr_does_not_contain("[RUNNING][..]build/foo/[HASH]/out/mybin-[..] test_in_")
         .run();
 }
 
@@ -2005,7 +2005,7 @@ fn test_no_harness() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] foo.rs (target/debug/deps/bar-[HASH][EXE])
+[RUNNING] foo.rs (target/debug/build/foo/[HASH]/out/bar-[HASH][EXE])
 
 "#]])
         .run();
@@ -2080,8 +2080,8 @@ fn selective_testing() {
 [LOCKING] 2 packages to highest compatible versions
 [COMPILING] d1 v0.0.1 ([ROOT]/foo/d1)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/d1-[HASH][EXE])
-[RUNNING] unittests src/main.rs (target/debug/deps/d1-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/d1/[HASH]/out/d1-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/build/d1/[HASH]/out/d1-[HASH][EXE])
 
 "#]])
         .with_stdout_data(
@@ -2099,8 +2099,8 @@ running 0 tests
         .with_stderr_data(str![[r#"
 [COMPILING] d2 v0.0.1 ([ROOT]/foo/d2)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/d2-[HASH][EXE])
-[RUNNING] unittests src/main.rs (target/debug/deps/d2-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/d2/[HASH]/out/d2-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/build/d2/[HASH]/out/d2-[HASH][EXE])
 
 "#]])
         .with_stdout_data(
@@ -2118,7 +2118,7 @@ running 0 tests
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -2310,7 +2310,7 @@ fn selective_testing_with_docs() {
 [LOCKING] 1 package to highest compatible version
 [COMPILING] d1 v0.0.1 ([ROOT]/foo/d1)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests d1.rs (target/debug/deps/d1-[HASH][EXE])
+[RUNNING] unittests d1.rs (target/debug/build/d1/[HASH]/out/d1-[HASH][EXE])
 [DOCTEST] d1
 
 "#]])
@@ -2338,7 +2338,7 @@ fn example_bin_same_name() {
 [RUNNING] `rustc [..]`
 [RUNNING] `rustc [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
 
 "#]])
         .run();
@@ -2497,7 +2497,7 @@ fn doctest_feature() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -2651,7 +2651,7 @@ fn filter_no_doc_tests() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] tests/foo.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] tests/foo.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -2795,7 +2795,7 @@ fn cyclic_dev_dep_doc_test() {
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -2899,10 +2899,10 @@ fn no_fail_fast() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
-[RUNNING] tests/test_add_one.rs (target/debug/deps/test_add_one-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
+[RUNNING] tests/test_add_one.rs (target/debug/build/foo/[HASH]/out/test_add_one-[HASH][EXE])
 [ERROR] test failed, to rerun pass `--test test_add_one`
-[RUNNING] tests/test_sub_one.rs (target/debug/deps/test_sub_one-[HASH][EXE])
+[RUNNING] tests/test_sub_one.rs (target/debug/build/foo/[HASH]/out/test_sub_one-[HASH][EXE])
 [DOCTEST] foo
 [ERROR] 1 target failed:
     `--test test_add_one`
@@ -2977,8 +2977,8 @@ fn test_multiple_packages() {
     p.cargo("test -p d1 -p d2")
         .with_stderr_data(str![[r#"
 ...
-[RUNNING] unittests src/lib.rs (target/debug/deps/d1-[HASH][EXE])
-[RUNNING] unittests src/lib.rs (target/debug/deps/d2-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/d1/[HASH]/out/d1-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/d2/[HASH]/out/d2-[HASH][EXE])
 ...
 "#]])
         .with_stdout_data(
@@ -3012,9 +3012,9 @@ fn bin_does_not_rebuild_tests() {
 [RUNNING] `rustc [..] src/main.rs [..]`
 [RUNNING] `rustc [..] src/main.rs [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
-[EXECUTABLE] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
-[EXECUTABLE] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
 
 "#]])
         .run();
@@ -3075,7 +3075,7 @@ fn selective_test_optional_dep() {
 [RUNNING] `rustc [..] a/src/lib.rs [..]`
 [RUNNING] `rustc [..] a/src/lib.rs [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[EXECUTABLE] `[ROOT]/foo/target/debug/deps/a-[HASH][EXE]`
+[EXECUTABLE] `[ROOT]/foo/target/debug/build/a/[HASH]/out/a-[HASH][EXE]`
 
 "#]])
         .run();
@@ -3230,7 +3230,7 @@ hello!
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
 
 "#]])
         .run();
@@ -4315,8 +4315,8 @@ fn test_hint_workspace_virtual() {
 [COMPILING] a v0.1.0 ([ROOT]/foo/a)
 [COMPILING] b v0.1.0 ([ROOT]/foo/b)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/a-[HASH][EXE])
-[RUNNING] unittests src/lib.rs (target/debug/deps/b-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/a/[HASH]/out/a-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/b/[HASH]/out/b-[HASH][EXE])
 [ERROR] test failed, to rerun pass `-p b --lib`
 
 "#]]
@@ -4328,7 +4328,7 @@ fn test_hint_workspace_virtual() {
         .cwd("b")
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs ([ROOT]/foo/target/debug/deps/b-[HASH][EXE])
+[RUNNING] unittests src/lib.rs ([ROOT]/foo/target/debug/build/b/[HASH]/out/b-[HASH][EXE])
 [ERROR] test failed, to rerun pass `--lib`
 
 "#]])
@@ -4337,13 +4337,13 @@ fn test_hint_workspace_virtual() {
     p.cargo("test --no-fail-fast")
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/a-[HASH][EXE])
-[RUNNING] unittests src/lib.rs (target/debug/deps/b-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/a/[HASH]/out/a-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/b/[HASH]/out/b-[HASH][EXE])
 [ERROR] test failed, to rerun pass `-p b --lib`
-[RUNNING] unittests src/lib.rs (target/debug/deps/c-[HASH][EXE])
-[RUNNING] unittests src/main.rs (target/debug/deps/c-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/c/[HASH]/out/c-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/build/c/[HASH]/out/c-[HASH][EXE])
 [ERROR] test failed, to rerun pass `-p c --bin c`
-[RUNNING] tests/t1.rs (target/debug/deps/t1-[HASH][EXE])
+[RUNNING] tests/t1.rs (target/debug/build/c/[HASH]/out/t1-[HASH][EXE])
 [ERROR] test failed, to rerun pass `-p c --test t1`
 [DOCTEST] a
 [DOCTEST] b
@@ -4363,12 +4363,12 @@ fn test_hint_workspace_virtual() {
         .with_stderr_data(str![[r#"
 [COMPILING] c v0.1.0 ([ROOT]/foo/c)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/c-[HASH][EXE])
-[RUNNING] unittests src/main.rs (target/debug/deps/c-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/c/[HASH]/out/c-[HASH][EXE])
+[RUNNING] unittests src/main.rs (target/debug/build/c/[HASH]/out/c-[HASH][EXE])
 [ERROR] test failed, to rerun pass `-p c --bin c`
-[RUNNING] benches/b1.rs (target/debug/deps/b1-[HASH][EXE])
+[RUNNING] benches/b1.rs (target/debug/build/c/[HASH]/out/b1-[HASH][EXE])
 [ERROR] test failed, to rerun pass `-p c --bench b1`
-[RUNNING] unittests examples/ex1.rs (target/debug/examples/ex1-[HASH][EXE])
+[RUNNING] unittests examples/ex1.rs (target/debug/build/c/[HASH]/out/ex1-[HASH][EXE])
 [ERROR] test failed, to rerun pass `-p c --example ex1`
 [ERROR] 3 targets failed:
     `-p c --bin c`
@@ -4443,7 +4443,7 @@ fn json_artifact_includes_test_flag() {
             str![[r#"
 [
   {
-    "executable": "[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]",
+    "executable": "[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]",
     "features": [],
     "filenames": "{...}",
     "fresh": false,
@@ -4490,7 +4490,7 @@ fn json_artifact_includes_executable_for_library_tests() {
             str![[r#"
 [
   {
-    "executable": "[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]",
+    "executable": "[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]",
     "features": [],
     "filenames": "{...}",
     "fresh": false,
@@ -4580,7 +4580,7 @@ fn json_artifact_includes_executable_for_integration_tests() {
             str![[r#"
 [
   {
-    "executable": "[ROOT]/foo/target/debug/deps/integration_test-[HASH][EXE]",
+    "executable": "[ROOT]/foo/target/debug/build/foo/[HASH]/out/integration_test-[HASH][EXE]",
     "features": [],
     "filenames": "{...}",
     "fresh": false,
@@ -4676,7 +4676,7 @@ fn doctest_skip_staticlib() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .run();
@@ -4704,7 +4704,7 @@ pub fn foo() -> u8 { 1 }
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 [DOCTEST] foo
 
 "#]])
@@ -4728,7 +4728,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
     p.cargo("test --lib")
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -4805,7 +4805,7 @@ fn test_all_targets_lib() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] unittests src/lib.rs (target/debug/deps/foo-[HASH][EXE])
+[RUNNING] unittests src/lib.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
         .run();
@@ -5476,11 +5476,11 @@ fn execution_error() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] tests/t1.rs (target/debug/deps/t1-[HASH][EXE])
+[RUNNING] tests/t1.rs (target/debug/build/foo/[HASH]/out/t1-[HASH][EXE])
 [ERROR] test failed, to rerun pass `--test t1`
 
 Caused by:
-  could not execute process `does_not_exist [ROOT]/foo/target/debug/deps/t1-[HASH][EXE]` (never executed)
+  could not execute process `does_not_exist [ROOT]/foo/target/debug/build/foo/[HASH]/out/t1-[HASH][EXE]` (never executed)
 
 Caused by:
   [NOT_FOUND]
@@ -5514,7 +5514,7 @@ fn nonzero_exit_status() {
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] tests/t1.rs (target/debug/deps/t1-[HASH][EXE])
+[RUNNING] tests/t1.rs (target/debug/build/foo/[HASH]/out/t1-[HASH][EXE])
 [ERROR] test failed, to rerun pass `--test t1`
 
 "#]])
@@ -5530,11 +5530,11 @@ this is a normal error
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] tests/t2.rs (target/debug/deps/t2-[HASH][EXE])
+[RUNNING] tests/t2.rs (target/debug/build/foo/[HASH]/out/t2-[HASH][EXE])
 [ERROR] test failed, to rerun pass `--test t2`
 
 Caused by:
-  process didn't exit successfully: `[ROOT]/foo/target/debug/deps/t2-[HASH][EXE]` ([EXIT_STATUS]: 4)
+  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo/[HASH]/out/t2-[HASH][EXE]` ([EXIT_STATUS]: 4)
 [NOTE] test exited abnormally; to see the full output pass --no-capture to the harness.
 
 "#]])
@@ -5544,11 +5544,11 @@ Caused by:
     p.cargo("test --test t2 -- --no-capture")
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] tests/t2.rs (target/debug/deps/t2-[HASH][EXE])
+[RUNNING] tests/t2.rs (target/debug/build/foo/[HASH]/out/t2-[HASH][EXE])
 [ERROR] test failed, to rerun pass `--test t2`
 
 Caused by:
-  process didn't exit successfully: `[ROOT]/foo/target/debug/deps/t2-[HASH][EXE] --no-capture` ([EXIT_STATUS]: 4)
+  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo/[HASH]/out/t2-[HASH][EXE] --no-capture` ([EXIT_STATUS]: 4)
 
 "#]])
         .with_status(4)
@@ -5558,13 +5558,13 @@ Caused by:
     p.cargo("test --no-fail-fast")
         .with_stderr_data(str![[r#"
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] tests/t1.rs (target/debug/deps/t1-[HASH][EXE])
+[RUNNING] tests/t1.rs (target/debug/build/foo/[HASH]/out/t1-[HASH][EXE])
 [ERROR] test failed, to rerun pass `--test t1`
-[RUNNING] tests/t2.rs (target/debug/deps/t2-[HASH][EXE])
+[RUNNING] tests/t2.rs (target/debug/build/foo/[HASH]/out/t2-[HASH][EXE])
 [ERROR] test failed, to rerun pass `--test t2`
 
 Caused by:
-  process didn't exit successfully: `[ROOT]/foo/target/debug/deps/t2-[HASH][EXE]` ([EXIT_STATUS]: 4)
+  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo/[HASH]/out/t2-[HASH][EXE]` ([EXIT_STATUS]: 4)
 [NOTE] test exited abnormally; to see the full output pass --no-capture to the harness.
 [ERROR] 2 targets failed:
     `--test t1`
@@ -5582,7 +5582,7 @@ Caused by:
 [..]thread [..]panicked [..] tests/t1.rs[..]
 [NOTE] run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 Caused by:
-  process didn't exit successfully: `[ROOT]/foo/target/debug/deps/t2-[HASH][EXE] --no-capture` ([EXIT_STATUS]: 4)
+  process didn't exit successfully: `[ROOT]/foo/target/debug/build/foo/[HASH]/out/t2-[HASH][EXE] --no-capture` ([EXIT_STATUS]: 4)
 ...
 "#]].unordered())
         .with_status(101)
@@ -5601,7 +5601,7 @@ fn cargo_test_print_env_verbose() {
 [RUNNING] `[..]CARGO_MANIFEST_DIR=[ROOT]/foo[..] rustc --crate-name foo[..]`
 [RUNNING] `[..]CARGO_MANIFEST_DIR=[ROOT]/foo[..] rustc --crate-name foo[..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `[..]CARGO_MANIFEST_DIR=[ROOT]/foo[..] [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[RUNNING] `[..]CARGO_MANIFEST_DIR=[ROOT]/foo[..] [ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
 [DOCTEST] foo
 [RUNNING] `[..]CARGO_MANIFEST_DIR=[ROOT]/foo[..] rustdoc --edition=2015 --crate-type lib --color auto --crate-name foo[..]`
 

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -27,7 +27,7 @@ fn pathless_tools() {
     foo.cargo("build --verbose")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
-[RUNNING] `rustc [..]-C linker=nonexistent-linker [..]`
+[RUNNING] `rustc [..]-C linker=nonexistent-linker[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -52,7 +52,7 @@ fn custom_linker_cfg() {
     foo.cargo("build --verbose")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
-[RUNNING] `rustc [..]-C linker=nonexistent-linker [..]`
+[RUNNING] `rustc [..]-C linker=nonexistent-linker[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -84,7 +84,7 @@ fn custom_linker_cfg_precedence() {
     foo.cargo("build --verbose")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
-[RUNNING] `rustc [..]-C linker=nonexistent-linker [..]`
+[RUNNING] `rustc [..]-C linker=nonexistent-linker[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -148,7 +148,7 @@ fn absolute_tools() {
     foo.cargo("build --verbose")
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
-[RUNNING] `rustc [..]-C linker=[..]/bogus/nonexistent-linker [..]`
+[RUNNING] `rustc [..]-C linker=[..]/bogus/nonexistent-linker[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -189,7 +189,7 @@ fn relative_tools() {
         .cwd("bar")
         .with_stderr_data(str![[r#"
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
-[RUNNING] `rustc [..]-C linker=[ROOT]/foo/./tools/nonexistent-linker [..]`
+[RUNNING] `rustc [..]-C linker=[ROOT]/foo/./tools/nonexistent-linker[..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -232,7 +232,7 @@ fn custom_runner() {
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc [..]`
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-[RUNNING] `nonexistent-runner -r [ROOT]/foo/target/debug/deps/test-[HASH][EXE] --param`
+[RUNNING] `nonexistent-runner -r [ROOT]/foo/target/debug/build/foo/[HASH]/out/test-[HASH][EXE] --param`
 ...
 "#]])
         .run();
@@ -244,7 +244,7 @@ fn custom_runner() {
 [RUNNING] `rustc [..]`
 [RUNNING] `rustc [..]`
 [FINISHED] `bench` profile [optimized] target(s) in [ELAPSED]s
-[RUNNING] `nonexistent-runner -r [ROOT]/foo/target/release/deps/bench-[HASH][EXE] --param --bench`
+[RUNNING] `nonexistent-runner -r [ROOT]/foo/target/release/build/foo/[HASH]/out/bench-[HASH][EXE] --param --bench`
 ...
 "#]])
         .run();
@@ -462,11 +462,11 @@ fn custom_runner_proc_macro_test() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 ...
-[RUNNING] `nonexistent-runner -r [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[RUNNING] `nonexistent-runner -r [ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
 [ERROR] test failed, to rerun pass `--lib`
 
 Caused by:
-  could not execute process `nonexistent-runner -r [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]` (never executed)
+  could not execute process `nonexistent-runner -r [ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]` (never executed)
 
 Caused by:
   [NOT_FOUND]
@@ -490,11 +490,11 @@ fn custom_runner_cfg_proc_macro_test() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 ...
-[RUNNING] `nonexistent-runner -r [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[RUNNING] `nonexistent-runner -r [ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
 [ERROR] test failed, to rerun pass `--lib`
 
 Caused by:
-  could not execute process `nonexistent-runner -r [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]` (never executed)
+  could not execute process `nonexistent-runner -r [ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]` (never executed)
 
 Caused by:
   [NOT_FOUND]
@@ -522,11 +522,11 @@ fn custom_runner_proc_macro_test_with_target() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 ...
-[RUNNING] `nonexistent-runner -r [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[RUNNING] `nonexistent-runner -r [ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
 [ERROR] test failed, to rerun pass `--lib`
 
 Caused by:
-  could not execute process `nonexistent-runner -r [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]` (never executed)
+  could not execute process `nonexistent-runner -r [ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]` (never executed)
 
 Caused by:
   [NOT_FOUND]
@@ -552,11 +552,11 @@ fn custom_runner_cfg_proc_macro_test_with_target() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 ...
-[RUNNING] `nonexistent-runner -r [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[RUNNING] `nonexistent-runner -r [ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
 [ERROR] test failed, to rerun pass `--lib`
 
 Caused by:
-  could not execute process `nonexistent-runner -r [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]` (never executed)
+  could not execute process `nonexistent-runner -r [ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]` (never executed)
 
 Caused by:
   [NOT_FOUND]
@@ -587,11 +587,11 @@ fn custom_runner_proc_macro_test_with_host_config() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 ...
-[RUNNING] `nonexistent-target-runner [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[RUNNING] `nonexistent-target-runner [ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
 [ERROR] test failed, to rerun pass `--lib`
 
 Caused by:
-  could not execute process `nonexistent-target-runner [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]` (never executed)
+  could not execute process `nonexistent-target-runner [ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]` (never executed)
 
 Caused by:
   [NOT_FOUND]
@@ -620,11 +620,11 @@ fn custom_runner_cfg_proc_macro_test_with_host_config() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 ...
-[RUNNING] `nonexistent-cfg-runner [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[RUNNING] `nonexistent-cfg-runner [ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
 [ERROR] test failed, to rerun pass `--lib`
 
 Caused by:
-  could not execute process `nonexistent-cfg-runner [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]` (never executed)
+  could not execute process `nonexistent-cfg-runner [ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]` (never executed)
 
 Caused by:
   [NOT_FOUND]
@@ -651,11 +651,11 @@ fn custom_runner_cfg_proc_macro_test_with_host_config_no_target() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 ...
-[RUNNING] `nonexistent-cfg-runner [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[RUNNING] `nonexistent-cfg-runner [ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
 [ERROR] test failed, to rerun pass `--lib`
 
 Caused by:
-  could not execute process `nonexistent-cfg-runner [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]` (never executed)
+  could not execute process `nonexistent-cfg-runner [ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]` (never executed)
 
 Caused by:
   [NOT_FOUND]
@@ -681,7 +681,7 @@ fn host_runner_proc_macro_test() {
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_stderr_data(str![[r#"
 ...
-[RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -695,7 +695,7 @@ running 1 test
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_stderr_data(str![[r#"
 ...
-[RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -731,11 +731,11 @@ fn custom_runner_proc_macro_test_with_cross_target() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 ...
-[RUNNING] `nonexistent-runner -r [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[RUNNING] `nonexistent-runner -r [ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
 [ERROR] test failed, to rerun pass `--lib`
 
 Caused by:
-  could not execute process `nonexistent-runner -r [ROOT]/foo/target/debug/deps/foo-[HASH][EXE]` (never executed)
+  could not execute process `nonexistent-runner -r [ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]` (never executed)
 
 Caused by:
   [NOT_FOUND]
@@ -771,7 +771,7 @@ fn custom_runner_proc_macro_test_with_cross_target_host_config() {
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_stderr_data(str![[r#"
 ...
-[RUNNING] `[ROOT]/foo/target/debug/deps/foo-[HASH][EXE]`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo/[HASH]/out/foo-[HASH][EXE]`
 
 "#]])
         .with_stdout_data(str![[r#"
@@ -1064,7 +1064,7 @@ fn custom_linker_env() {
         .with_status(101)
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc [..]-C linker=nonexistent-linker [..]`
+[RUNNING] `rustc [..]-C linker=nonexistent-linker[..]`
 ...
 "#]])
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

This PR restabilizes the new build-dir layout tracked in https://github.com/rust-lang/cargo/issues/15010.

The previous stablization in https://github.com/rust-lang/cargo/pull/16807 was rolled back due to performance and scaling issues discovered on nightly.
These issues were mitigated in https://github.com/rust-lang/cargo/pull/17191, https://github.com/rust-lang/cargo/pull/17168, and https://github.com/rust-lang/cargo/pull/17236.

The new layout was re-enabled on nightly in https://github.com/rust-lang/cargo/pull/17258 and there has been no reported issues. Many tools have started migrating and the majority of well known tools have already added support for the new build-dir layout.

closes #15010

### How to test and review this PR?

`cargo test` and the new layout has been enabled on nightly for ~2 weeks.