### PR TITLE
Remove unremap file when running cargo clean -p in new build-dir layout

### DIFF
--- a/src/ops/cargo_clean.rs
+++ b/src/ops/cargo_clean.rs
@@ -322,6 +322,11 @@ fn clean_specs(
                                     .to_string_lossy()
                                     .into_owned();
 
+                                let uplifted_path = uplift_dir.join(&uplifted_filename);
+                                // Unremap file emitted for `-Ztrim-paths`.
+                                let unremap = trim_paths::append_unremap_suffix(&uplifted_path);
+                                clean_ctx.rm_rf(&unremap)?;
+
                                 dirs_to_clean.mark_utf(uplift_dir, |filename| {
                                     filename == uplifted_filename || filename == dep_info
                                 });

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -1844,6 +1844,26 @@ fn unremap_file_with_cargo_clean() {
 
     assert!(!unremap_file_path(&p.bin("foo")).exists());
     assert_eq!(p.glob("target/**/*.trim-paths.jsonl").count(), 0);
+
+    // Test the new layout
+
+    p.cargo("clean -Ztrim-paths")
+        .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
+        .run();
+
+    p.cargo("build -Ztrim-paths -Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
+        .run();
+
+    assert!(unremap_file_path(&p.bin("foo")).exists());
+    assert_eq!(p.glob("target/**/*.trim-paths.jsonl").count(), 2);
+
+    p.cargo("clean -p foo -Ztrim-paths -Zbuild-dir-new-layout")
+        .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
+        .run();
+
+    assert!(unremap_file_path(&p.bin("foo")).exists());
+    assert_eq!(p.glob("target/**/*.trim-paths.jsonl").count(), 1);
 }
 
 // MSVC always emits a PDB when debuginfo is on (which the unremap file requires),

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -1862,8 +1862,8 @@ fn unremap_file_with_cargo_clean() {
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .run();
 
-    assert!(unremap_file_path(&p.bin("foo")).exists());
-    assert_eq!(p.glob("target/**/*.trim-paths.jsonl").count(), 1);
+    assert!(!unremap_file_path(&p.bin("foo")).exists());
+    assert_eq!(p.glob("target/**/*.trim-paths.jsonl").count(), 0);
 }
 
 // MSVC always emits a PDB when debuginfo is on (which the unremap file requires),


### PR DESCRIPTION
### What does this PR try to resolve?

See https://github.com/rust-lang/cargo/pull/17354#discussion_r3769061336 for the motivating context.

In https://github.com/rust-lang/cargo/pull/17303 we started emitting unremap files to final artifacts.
This included logic for cleaning the unremap file when running `cargo clean -p` but the logic was not added in the `.build_dir_new_layout` branch in the cargo clean logic.

This PR adds the logic to both branches.


### How to test and review this PR?

Primarily using the existing tests

r? @weihanglo 