### PR TITLE
Fix relative symlink handling in write_atomic

### DIFF
--- a/crates/cargo-util/src/paths.rs
+++ b/crates/cargo-util/src/paths.rs
@@ -1034,6 +1034,30 @@ mod tests {
     }
 
     #[test]
+    fn write_atomic_relative_symlink() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let link_dir = tmpdir.path().join("project");
+        let target_dir = link_dir.join("generated");
+        let target_path = target_dir.join("target.txt");
+        let symlink_path = link_dir.join("symlink.txt");
+        let relative_target = std::path::Path::new("generated/target.txt");
+
+        std::fs::create_dir_all(&target_dir).unwrap();
+        write(&target_path, "initial").unwrap();
+
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(relative_target, &symlink_path).unwrap();
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_file(relative_target, &symlink_path).unwrap();
+
+        assert!(write_atomic(&symlink_path, "updated").is_err());
+
+        assert_eq!(std::fs::read_to_string(&target_path).unwrap(), "initial");
+        assert!(symlink_path.is_symlink());
+        assert_eq!(std::fs::read_link(&symlink_path).unwrap(), relative_target);
+    }
+
+    #[test]
     #[cfg(windows)]
     fn test_remove_symlink_dir() {
         use super::*;

--- a/crates/cargo-util/src/paths.rs
+++ b/crates/cargo-util/src/paths.rs
@@ -199,8 +199,9 @@ pub fn write_atomic<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> Res
     // Check if the path is a symlink and follow it if it is
     let resolved_path;
     let path = if path.is_symlink() {
-        resolved_path = fs::read_link(path)
+        let target = fs::read_link(path)
             .with_context(|| format!("failed to read symlink at `{}`", path.display()))?;
+        resolved_path = path.parent().unwrap().join(target);
         &resolved_path
     } else {
         path
@@ -1050,9 +1051,9 @@ mod tests {
         #[cfg(windows)]
         std::os::windows::fs::symlink_file(relative_target, &symlink_path).unwrap();
 
-        assert!(write_atomic(&symlink_path, "updated").is_err());
+        write_atomic(&symlink_path, "updated").unwrap();
 
-        assert_eq!(std::fs::read_to_string(&target_path).unwrap(), "initial");
+        assert_eq!(std::fs::read_to_string(&target_path).unwrap(), "updated");
         assert!(symlink_path.is_symlink());
         assert_eq!(std::fs::read_link(&symlink_path).unwrap(), relative_target);
     }


### PR DESCRIPTION

### What does this PR try to resolve?


Fixes #17361.

`cargo_util::paths::write_atomic` follows symlinks before performing an atomic write. However, `fs::read_link` returns a relative target exactly as stored in the symlink.

The returned target was previously used directly, causing subsequent filesystem operations to interpret it relative to Cargo's process working directory. This could make the write fail or overwrite an unrelated file.

This change resolves the target against the symlink's parent directory:

```rust
resolved_path = path.parent().unwrap().join(target);
```

`Path::join` preserves absolute targets, so the existing behavior for absolute symlinks is unchanged.



### How to test and review this PR?

A new unit test creates a symlink with a relative target in a directory different from the process working directory. The test verifies that:

- the actual target receives the updated contents;
- the symlink remains a symlink;
- the stored relative target remains unchanged.

I ran:

```console
cargo +1.97.1 test -p cargo-util
cargo fmt --all -- --check
```
<img width="1530" height="902" alt="image" src="https://github.com/user-attachments/assets/297dcb6c-3fc2-47af-9ba6-b8650e4d169b" />

All 12 unit tests and the `cargo-util` doc-test passed.