### PR TITLE
fix(clean): Improving description for clean options

### DIFF
--- a/doc/book/src/commands/cargo-clean.md
+++ b/doc/book/src/commands/cargo-clean.md
@@ -54,12 +54,12 @@ the target directory.</p>
 
 
 <dt class="option-term" id="option-cargo-clean---release"><a class="option-anchor" href="#option-cargo-clean---release"><code>--release</code></a></dt>
-<dd class="option-desc"><p>Remove all artifacts in the <code>release</code> directory.</p>
+<dd class="option-desc"><p>Remove artifacts only in the <code>release</code> directory.</p>
 </dd>
 
 
 <dt class="option-term" id="option-cargo-clean---profile"><a class="option-anchor" href="#option-cargo-clean---profile"><code>--profile</code> <em>name</em></a></dt>
-<dd class="option-desc"><p>Remove all artifacts in the directory with the given profile name.</p>
+<dd class="option-desc"><p>Remove artifacts only in the directory with the given profile name.</p>
 </dd>
 
 

--- a/doc/man/cargo-clean.md
+++ b/doc/man/cargo-clean.md
@@ -53,11 +53,11 @@ the target directory.
 {{/option}}
 
 {{#option "`--release`" }}
-Remove all artifacts in the `release` directory.
+Remove artifacts only in the `release` directory.
 {{/option}}
 
 {{#option "`--profile` _name_" }}
-Remove all artifacts in the directory with the given profile name.
+Remove artifacts only in the directory with the given profile name.
 {{/option}}
 
 {{> options-target-dir }}

--- a/doc/man/generated_txt/cargo-clean.txt
+++ b/doc/man/generated_txt/cargo-clean.txt
@@ -35,10 +35,10 @@ OPTIONS
            in the target directory.
 
        --release
-           Remove all artifacts in the release directory.
+           Remove artifacts only in the release directory.
 
        --profile name
-           Remove all artifacts in the directory with the given profile name.
+           Remove artifacts only in the directory with the given profile name.
 
        --target-dir directory
            Directory for all generated artifacts and intermediate files. May

--- a/etc/man/cargo-clean.1
+++ b/etc/man/cargo-clean.1
@@ -44,12 +44,12 @@ the target directory.
 .sp
 \fB\-\-release\fR
 .RS 4
-Remove all artifacts in the \fBrelease\fR directory.
+Remove artifacts only in the \fBrelease\fR directory.
 .RE
 .sp
 \fB\-\-profile\fR \fIname\fR
 .RS 4
-Remove all artifacts in the directory with the given profile name.
+Remove artifacts only in the directory with the given profile name.
 .RE
 .sp
 \fB\-\-target\-dir\fR \fIdirectory\fR

--- a/src/bin/cargo/commands/clean.rs
+++ b/src/bin/cargo/commands/clean.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 pub fn cli() -> Command {
     subcommand("clean")
         .about("Remove artifacts that cargo has generated in the past")
-        .arg_doc("Whether or not to clean just the documentation directory")
+        .arg_doc("Clean only the documentation directory")
         .arg_silent_suggestion()
         .arg_package_spec_simple(
             "Package to clean artifacts for",
@@ -26,8 +26,8 @@ pub fn cli() -> Command {
             flag("workspace", "Clean artifacts of the workspace members")
                 .help_heading(heading::PACKAGE_SELECTION),
         )
-        .arg_release("Whether or not to clean release artifacts")
-        .arg_profile("Clean artifacts of the specified profile")
+        .arg_release("Clean only release artifacts")
+        .arg_profile("Clean only artifacts of the specified profile")
         .arg_target_triple("Target triple to clean output for")
         .arg_target_dir()
         .arg_manifest_path()

--- a/tests/testsuite/cargo_clean/help/stdout.term.svg
+++ b/tests/testsuite/cargo_clean/help/stdout.term.svg
@@ -30,7 +30,7 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--doc</tspan><tspan>                      Whether or not to clean just the documentation directory</tspan>
+    <tspan x="10px" y="118px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--doc</tspan><tspan>                      Clean only the documentation directory</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-n</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--dry-run</tspan><tspan>                  Display what would be deleted without deleting anything</tspan>
 </tspan>
@@ -60,9 +60,9 @@
 </tspan>
     <tspan x="10px" y="370px"><tspan class="fg-bright-green bold">Compilation Options:</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-r</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--release</tspan><tspan>                 Whether or not to clean release artifacts</tspan>
+    <tspan x="10px" y="388px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-r</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--release</tspan><tspan>                 Clean only release artifacts</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Clean artifacts of the specified profile</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE-NAME&gt;</tspan><tspan>  Clean only artifacts of the specified profile</tspan>
 </tspan>
     <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target</tspan><tspan class="fg-cyan"> [</tspan><tspan class="fg-cyan">&lt;TRIPLE&gt;</tspan><tspan class="fg-cyan">]</tspan><tspan>       Target triple to clean output for</tspan>
 </tspan>


### PR DESCRIPTION
### What does this PR try to resolve?
Closes issue #17129
Changes:
1. The find and replace of description as mentioned in issue description.
2. Used "only" in description as recommended by author [here](https://github.com/rust-lang/cargo/pull/17132/changes#r3582344112) and also fixed the doc description.
### How to test and review this PR?
Run `man etc/man/cargo-clean.1`
<img width="1166" height="598" alt="image" src="https://github.com/user-attachments/assets/b2139826-732c-4dfa-b95e-eda9384bb249" />

Run `cargo run -- clean -h`
![Output](https://raw.githubusercontent.com/Suryansh-Dey/cargo/3ae202fb6e79b4e946bac93985553ff54317587d/tests/testsuite/cargo_clean/help/stdout.term.svg)

Run `cargo test clean::help` and this passes
