### PR TITLE
fix(trim-paths): custom workspace-relative member paths remap

### DIFF
--- a/src/compiler/trim_paths.rs
+++ b/src/compiler/trim_paths.rs
@@ -34,6 +34,9 @@ pub(crate) const UNREMAP_SUFFIX: &str = ".trim-paths.jsonl";
 /// See <https://github.com/rust-lang/cargo/issues/17309>.
 pub(crate) const WS_REMAP_ENV: &str = "__CARGO_RUSTC_BOOTSTRAP_WS_REMAP";
 
+/// A single `<from>=<to>` remap rule.
+type RemapPair = (PathBuf, String);
+
 /// Like [`trim_paths_args`] but for rustdoc invocations.
 pub(crate) fn trim_paths_args_rustdoc(
     cmd: &mut ProcessBuilder,
@@ -111,7 +114,7 @@ pub(crate) fn trim_paths_remap(build_runner: &BuildRunner<'_, '_>, unit: &Unit) 
     ]
 }
 
-fn join_remap((from, to): (PathBuf, String)) -> OsString {
+fn join_remap((from, to): RemapPair) -> OsString {
     let mut remap = OsString::with_capacity(from.as_os_str().len() + 1 + to.len());
     remap.push(from);
     remap.push("=");
@@ -123,7 +126,7 @@ fn join_remap((from, to): (PathBuf, String)) -> OsString {
 ///
 /// This remap logic aligns with rustc:
 /// <https://github.com/rust-lang/rust/blob/c2ef3516/src/bootstrap/src/lib.rs#L1113-L1116>
-fn sysroot_remap(build_runner: &BuildRunner<'_, '_>) -> (PathBuf, String) {
+fn sysroot_remap(build_runner: &BuildRunner<'_, '_>) -> RemapPair {
     // See also `detect_sysroot_src_path()`.
     let sysroot = build_runner
         .bcx
@@ -142,7 +145,7 @@ fn sysroot_remap(build_runner: &BuildRunner<'_, '_>) -> (PathBuf, String) {
 }
 
 /// Path prefix remap rules for dependencies.
-fn package_remap(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> (PathBuf, String) {
+fn package_remap(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> RemapPair {
     let pkg_root = unit.pkg.root();
     let ws_root = build_runner.bcx.ws.root();
     let source_id = unit.pkg.package_id().source_id();
@@ -175,7 +178,7 @@ fn package_remap(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> (PathBuf, S
 }
 
 /// Path prefix remap rules for dependencies within workspaces.
-fn workspace_remap(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> (PathBuf, String) {
+fn workspace_remap(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> RemapPair {
     let ws_root = build_runner.bcx.ws.root();
     // rustc working directory is usually workspace root.
     // However, when `-Zroot-dir` is set, it may not be.
@@ -231,7 +234,7 @@ fn git_checkout<'a>(
 ///   [`file!`] macro in-place via the `OUT_DIR` environment.
 /// * On Linux, `DW_AT_GNU_dwo_name` that contains paths to split debuginfo
 ///   files (dwp and dwo).
-fn build_dir_remap(build_runner: &BuildRunner<'_, '_>) -> (PathBuf, String) {
+fn build_dir_remap(build_runner: &BuildRunner<'_, '_>) -> RemapPair {
     let from = build_runner.bcx.ws.build_dir().into_path_unlocked();
     let to = "/cargo/build-dir".to_owned();
     (from, to)
@@ -280,7 +283,7 @@ pub(crate) fn write_unremap_file(
 ) -> CargoResult<()> {
     let mut remaps = BTreeMap::new();
 
-    let mut insert = |(from, to): (PathBuf, String)| match remaps.entry(to) {
+    let mut insert = |(from, to): RemapPair| match remaps.entry(to) {
         Entry::Vacant(entry) => {
             entry.insert(from);
         }

--- a/src/compiler/trim_paths.rs
+++ b/src/compiler/trim_paths.rs
@@ -189,21 +189,47 @@ fn workspace_remap(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> Vec<Remap
     // We may need to remap to that otherwise debuginfo like `DW_AT_comp_dir`
     // would point to rustc working directory,
     // and won't be remapped by workspace root.
-    let (_, rustc_workdir) = path_args(build_runner.bcx.ws, unit);
+    let (src, rustc_workdir) = path_args(build_runner.bcx.ws, unit);
+
+    let custom_prefix = build_runner
+        .bcx
+        .gctx
+        .get_env(WS_REMAP_ENV)
+        .ok()
+        .filter(|prefix| !prefix.is_empty());
+
+    // When custom prefix for workspace remap is set via `WS_REMAP_ENV`,
+    // an extra remap rule for relative member paths is required
+    // for correctly adding prefix to member paths.
+    //
+    // For more, see <https://github.com/rust-lang/cargo/pull/17366>
+    let relative_remap = if let Some(prefix) = custom_prefix
+        && src.is_relative()
+        && let Ok(rel) = unit.pkg.root().strip_prefix(&rustc_workdir)
+        && !rel.is_empty()
+    {
+        let mut rel_to = prefix.to_owned();
+        for comp in rel.components() {
+            // e.g., library -> <custom-prefix>/library
+            rel_to.push('/');
+            rel_to.push_str(&comp.as_os_str().to_string_lossy());
+        }
+        Some((rel.to_path_buf(), rel_to))
+    } else {
+        None
+    };
+
     let from = if ws_root.starts_with(&rustc_workdir) {
         rustc_workdir
     } else {
         ws_root.to_path_buf()
     };
-    let to = build_runner
-        .bcx
-        .gctx
-        .get_env(WS_REMAP_ENV)
-        .ok()
-        .filter(|prefix| !prefix.is_empty())
-        .unwrap_or(".")
-        .to_owned();
-    vec![(from, to)]
+
+    let absolute_remap = (from, custom_prefix.unwrap_or(".").to_owned());
+
+    let mut remaps = vec![absolute_remap];
+    remaps.extend(relative_remap);
+    remaps
 }
 
 /// Finds the checkout root and revision directory name of a git dependency.
@@ -314,8 +340,13 @@ pub(crate) fn write_unremap_file(
         for dep in build_runner.unit_deps(&unit) {
             stack.push(dep.unit.clone());
         }
-        for pair in package_remap(build_runner, &unit) {
-            insert(pair);
+        for (from, to) in package_remap(build_runner, &unit) {
+            // No need to emit records for relative rules as
+            // the absolute workspace record already covers their prefixes.
+            if from.is_relative() {
+                continue;
+            }
+            insert((from, to));
         }
     }
 

--- a/src/compiler/trim_paths.rs
+++ b/src/compiler/trim_paths.rs
@@ -106,12 +106,16 @@ pub(crate) fn trim_paths_args(
 /// **†**: path dependencies outside the workspace and other uncategorized dependencies.
 ///
 /// [RFC 3127]: https://rust-lang.github.io/rfcs/3127-trim-paths.html
-pub(crate) fn trim_paths_remap(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> [OsString; 3] {
-    [
-        join_remap(package_remap(build_runner, unit)),
-        join_remap(build_dir_remap(build_runner)),
-        join_remap(sysroot_remap(build_runner)),
-    ]
+pub(crate) fn trim_paths_remap(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> Vec<OsString> {
+    let mut remaps = Vec::with_capacity(4);
+    remaps.extend(
+        package_remap(build_runner, unit)
+            .into_iter()
+            .map(join_remap),
+    );
+    remaps.push(join_remap(build_dir_remap(build_runner)));
+    remaps.push(join_remap(sysroot_remap(build_runner)));
+    remaps
 }
 
 fn join_remap((from, to): RemapPair) -> OsString {
@@ -145,7 +149,7 @@ fn sysroot_remap(build_runner: &BuildRunner<'_, '_>) -> RemapPair {
 }
 
 /// Path prefix remap rules for dependencies.
-fn package_remap(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> RemapPair {
+fn package_remap(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> Vec<RemapPair> {
     let pkg_root = unit.pkg.root();
     let ws_root = build_runner.bcx.ws.root();
     let source_id = unit.pkg.package_id().source_id();
@@ -155,7 +159,7 @@ fn package_remap(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> RemapPair {
             const GIT_OID_LEN: usize = 7; // This matches MIN_ABBREV_LEN in git source
             let repo = hex::short_hash(source_id.canonical_url());
             let rev = &rev[..rev.len().min(GIT_OID_LEN)];
-            return (from.to_path_buf(), format!("/cargo/git/{repo}/{rev}"));
+            return vec![(from.to_path_buf(), format!("/cargo/git/{repo}/{rev}"))];
         }
     } else if source_id.is_registry() {
         let registry_src = build_runner.bcx.gctx.registry_source_path();
@@ -163,7 +167,7 @@ fn package_remap(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> RemapPair {
         let from = pkg_root.parent().unwrap();
         if from.starts_with(registry_src) {
             let registry = hex::short_hash(&source_id);
-            return (from.to_path_buf(), format!("/cargo/registry/{registry}"));
+            return vec![(from.to_path_buf(), format!("/cargo/registry/{registry}"))];
         }
     }
 
@@ -173,12 +177,12 @@ fn package_remap(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> RemapPair {
     } else {
         let from = pkg_root.to_path_buf();
         let to = format!("/cargo/deps/{}-{}", unit.pkg.name(), unit.pkg.version());
-        (from, to)
+        vec![(from, to)]
     }
 }
 
 /// Path prefix remap rules for dependencies within workspaces.
-fn workspace_remap(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> RemapPair {
+fn workspace_remap(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> Vec<RemapPair> {
     let ws_root = build_runner.bcx.ws.root();
     // rustc working directory is usually workspace root.
     // However, when `-Zroot-dir` is set, it may not be.
@@ -199,7 +203,7 @@ fn workspace_remap(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> RemapPair
         .filter(|prefix| !prefix.is_empty())
         .unwrap_or(".")
         .to_owned();
-    (from, to)
+    vec![(from, to)]
 }
 
 /// Finds the checkout root and revision directory name of a git dependency.
@@ -310,7 +314,9 @@ pub(crate) fn write_unremap_file(
         for dep in build_runner.unit_deps(&unit) {
             stack.push(dep.unit.clone());
         }
-        insert(package_remap(build_runner, &unit));
+        for pair in package_remap(build_runner, &unit) {
+            insert(pair);
+        }
     }
 
     serde_json::to_writer(

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -1640,19 +1640,27 @@ fn workspace_prefix_override_from_env() {
                 version = "0.0.1"
                 edition = "2015"
 
+                [dependencies]
+                member = { path = "member" }
+
                 [profile.dev]
                 trim-paths = "object"
            "#,
         )
-        .file("src/main.rs", "fn main() {}")
+        .file("src/main.rs", "extern crate member; fn main() {}")
+        .file("member/Cargo.toml", &basic_manifest("member", "0.0.1"))
+        .file("member/src/lib.rs", "")
         .build();
 
     p.cargo("build --verbose -Ztrim-paths")
         .env("__CARGO_RUSTC_BOOTSTRAP_WS_REMAP", "/rustc-dev/1111111")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stderr_data(str![[r#"
+[LOCKING] 1 package to highest compatible version
+[COMPILING] member v0.0.1 ([ROOT]/foo/member)
+[RUNNING] `rustc [..]--remap-path-prefix=[ROOT]/foo=/rustc-dev/1111111 --remap-path-prefix=[ROOT]/foo/target=/cargo/build-dir [..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc [..]--remap-path-prefix=[ROOT]/foo=/rustc-dev/1111111 [..]`
+[RUNNING] `rustc [..]--remap-path-prefix=[ROOT]/foo=/rustc-dev/1111111 --remap-path-prefix=[ROOT]/foo/target=/cargo/build-dir [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -1658,7 +1658,7 @@ fn workspace_prefix_override_from_env() {
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
 [COMPILING] member v0.0.1 ([ROOT]/foo/member)
-[RUNNING] `rustc [..]--remap-path-prefix=[ROOT]/foo=/rustc-dev/1111111 --remap-path-prefix=[ROOT]/foo/target=/cargo/build-dir [..]`
+[RUNNING] `rustc [..]--remap-path-prefix=[ROOT]/foo=/rustc-dev/1111111 --remap-path-prefix=member=/rustc-dev/1111111/member --remap-path-prefix=[ROOT]/foo/target=/cargo/build-dir [..]`
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc [..]--remap-path-prefix=[ROOT]/foo=/rustc-dev/1111111 --remap-path-prefix=[ROOT]/foo/target=/cargo/build-dir [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s


### PR DESCRIPTION
### What does this PR try to resolve?

This adds the missing rustc bootstrap custom remap prefix
for packages relative to the working directory.

Cargo's [workspace remap rule][ws-remap] was pretty simple:
everything under the working directory[^1] becomes relative to the working directory
(like `strip_prefix(root)`).

For supporting rustc bootstrap remaps (rust-lang/cargo#17309),
we added specific env var `__CARGO_RUSTC_BOOTSTRAP_WS_REMAP`
to set custom prefix for workspace remap rule.
That covers absolute paths starting with `<ws-root>

Unfortunately,
it didn't cover paths already relative to the working directory.
The reason is that
Cargo already passes workspace member paths relative to the working directory.
For example,
the path rustc saw was already relative like `library/std/src/lib.rs`.
The path never matches the remap prefix `<ws-root>`
so cannot be remapped by Cargo's `-Ztrim-paths`.

Below are incorrect and expected diagnostics:

```
    note: required by a bound in `std::fs::read_to_string`
     --> library/std/src/fs.rs:383:0               (before this PR, wrong)
     --> /rustc/<sha>/library/std/src/fs.rs:383:0  (expected)
```

This PR extends `__CARGO_RUSTC_BOOTSTRAP_WS_REMAP`
to additionally add a remap rule for everything relative to workspace.
The new remap rule joisn the prefix with the relative path,
so `library/std/src/lib.rs` becomes `/<custom-prefix>/library/std/src/lib.rs`.

Full comparsion:

| rule | old handwritten remap| `-Ztrim-paths` before this | `-Ztrim-paths` after this |
|---|---|---|---|
| ws  | `<root>` -> `/rustc/<sha>` | `<root>` -> `/rustc/<sha>` | `<root>` → `/rustc/<sha>` |
| ws relative | `library/` -> `/rustc/<sha>/library/` | `library/` -> `library/` (no remap at all)  | `library/` -> `/rustc/<sha>/library` |

[ws-remap]: https://github.com/rust-lang/cargo/blob/2305ac97ea879ad32ea0dd6366b5f8dad1ba4ce7/src/compiler/trim_paths.rs#L98

[^1]: by default it is Cargo workspace root but rustc bootstrap use `-Zroot-dir` to set the working directory always to the repo root (or checkout out, whatever you like, it is the directory that has the x.py)

See <https://github.com/rust-lang/rust/pull/161049#discussion_r3789350209>

Part of <https://github.com/rust-lang/cargo/issues/17309>

### How to test and review this PR?

cc @Urgau 

**🤖 LLM disclosure**: Used for verifying it actually works with rustc bootstrap, which has been signed off on rust-lang/rust side (https://github.com/rust-lang/rust/pull/161049).

