### PR TITLE
WIP: feat(hints): support minimum optimization levels

### DIFF
--- a/crates/cargo-util-schemas/manifest.schema.json
+++ b/crates/cargo-util-schemas/manifest.schema.json
@@ -1059,6 +1059,16 @@
     "Hints": {
       "type": "object",
       "properties": {
+        "min-opt-level": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TomlValue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "mostly-unused": {
           "anyOf": [
             {

--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -1677,6 +1677,11 @@ pub struct Hints {
         feature = "unstable-schema",
         schemars(with = "Option<TomlValueWrapper>")
     )]
+    pub min_opt_level: Option<toml::Value>,
+    #[cfg_attr(
+        feature = "unstable-schema",
+        schemars(with = "Option<TomlValueWrapper>")
+    )]
     pub mostly_unused: Option<toml::Value>,
 }
 

--- a/doc/book/src/reference/manifest.md
+++ b/doc/book/src/reference/manifest.md
@@ -595,9 +595,9 @@ Individual hints may have an associated unstable feature gate that you need to
 pass in order to apply the configuration they specify, but if you don't specify
 that unstable feature gate, you will again get only a warning, not an error.
 
-There are no stable hints at this time. See the [hint-mostly-unused
-documentation](unstable.md#profile-hint-mostly-unused-option) for information
-on an unstable hint.
+There are no stable hints at this time. See the documentation for the unstable
+[`mostly-unused`](unstable.md#profile-hint-mostly-unused-option) and
+[`min-opt-level`](unstable.md#package-min-opt-level-hint) hints.
 
 > **MSRV:** Respected as of 1.90.
 

--- a/doc/book/src/reference/unstable.md
+++ b/doc/book/src/reference/unstable.md
@@ -109,6 +109,7 @@ Each new feature described below should explain how to use it.
 * `Cargo.toml` extensions
     * [Profile `rustflags` option](#profile-rustflags-option) --- Passed directly to rustc.
     * [Profile `hint-mostly-unused` option](#profile-hint-mostly-unused-option) --- Hint that a dependency is mostly unused, to optimize compilation time.
+    * [Package `min-opt-level` hint](#package-min-opt-level-hint) --- Request a numeric optimization floor for one package.
     * [codegen-backend](#codegen-backend) --- Select the codegen backend used by rustc.
     * [per-package-target](#per-package-target) --- Sets the `--target` to use for each individual package.
     * [artifact dependencies](#artifact-dependencies) --- Allow build artifacts to be included into other build artifacts and build them for different targets.
@@ -923,6 +924,80 @@ mostly-unused = true
 This will cause the crate to default to hint-mostly-unused, unless overridden
 via `profile`, which takes precedence, and which can only be specified in the
 top-level crate being built.
+
+## Package `min-opt-level` hint
+* Tracking Issue: [#17334](https://github.com/rust-lang/cargo/issues/17334)
+* RFC: [#3924](https://github.com/rust-lang/rfcs/pull/3924)
+
+This feature adds the `min-opt-level` key to the `[hints]` table. It lets a
+package set the lowest optimization level that Cargo will use to build it:
+
+```toml
+[hints]
+min-opt-level = 2
+```
+
+To enable this feature, pass `-Zhint-min-opt-level`. Without the flag, Cargo
+warns and ignores the hint. Versions of Cargo prior to the introduction of this
+feature will give an "unused manifest key" warning, but will otherwise function
+without erroring. This means using the hint does not change the package's MSRV.
+
+### Documentation updates
+
+#### `min-opt-level`
+
+*as a new subsection of ["The `[hints]` section"](./manifest.html#the-hints-section),
+which would gain one subsection per hint*
+
+The `min-opt-level` hint sets the lowest [`opt-level`](profiles.md#opt-level)
+that Cargo will use to build this package. Some packages are very slow without
+optimization, or take longer to build without it. Such a package can ask for a
+minimum optimization level:
+
+```toml
+# In example-dependency's Cargo.toml
+[hints]
+min-opt-level = 2
+```
+
+The valid values are `0`, `1`, `2`, and `3`. Cargo warns about and ignores any
+other value. The `"s"` and `"z"` levels are not valid, because they cannot be
+compared with the numeric levels, and the top-level package is in a better
+position to choose them.
+
+When the selected [profile](profiles.md) has a lower `opt-level` than the hint,
+Cargo builds the package at the hinted level instead. When the profile has a
+higher `opt-level`, Cargo keeps the higher level. This is true whether the
+profile's `opt-level` is the default or is set by the user. It also applies to
+the `opt-level = 0` default for
+[build dependencies](profiles.md#build-dependencies).
+
+The top-level package can override a hint with a profile
+[override](profiles.md#overrides). Any `opt-level` set in a `package` table, in
+the `"*"` package, or in the `build-override` table takes precedence over the
+hint. Setting `opt-level = "s"` or `"z"` in the profile also takes precedence,
+because a package that optimizes for size usually wants its dependencies to do
+the same.
+
+```toml
+# Does not lower the `opt-level` below a dependency's hint.
+[profile.dev]
+opt-level = 0
+
+# Overrides the hint for the `example-dependency` package.
+[profile.dev.package.example-dependency]
+opt-level = 0
+
+# Overrides the hint for all dependencies.
+[profile.dev.package."*"]
+opt-level = 1
+```
+
+A hint only applies to the package that sets it, not to its dependencies. If
+the slow code is in a dependency, that dependency needs to set its own hint.
+
+Only use this hint when optimizing the package makes a full build faster, or
+when the package is many times slower without optimization.
 
 ## rustdoc-map
 * Tracking Issue: [#8296](https://github.com/rust-lang/cargo/issues/8296)

--- a/src/compiler/standard_lib.rs
+++ b/src/compiler/standard_lib.rs
@@ -127,6 +127,7 @@ pub fn generate_std_roots(
     interner: &UnitInterner,
     profiles: &Profiles,
     target_data: &RustcTargetData<'_>,
+    hint_min_opt_level: bool,
 ) -> CargoResult<HashMap<CompileKind, Vec<Unit>>> {
     // Generate a map of Units for each kind requested.
     let mut ret = HashMap::default();
@@ -149,6 +150,7 @@ pub fn generate_std_roots(
             interner,
             profiles,
             target_data,
+            hint_min_opt_level,
         )?;
     }
 
@@ -167,6 +169,7 @@ fn generate_roots(
     interner: &UnitInterner,
     profiles: &Profiles,
     target_data: &RustcTargetData<'_>,
+    hint_min_opt_level: bool,
 ) -> CargoResult<()> {
     let std_ids = std_crates(crates, default, units)
         .iter()
@@ -191,6 +194,8 @@ fn generate_roots(
             let unit_for = UnitFor::new_normal(kind);
             let profile = profiles.get_profile(
                 pkg.package_id(),
+                pkg.hints(),
+                hint_min_opt_level,
                 /*is_member*/ false,
                 /*is_local*/ false,
                 unit_for,

--- a/src/compiler/unit_dependencies.rs
+++ b/src/compiler/unit_dependencies.rs
@@ -885,6 +885,8 @@ fn new_unit_dep(
     let is_local = pkg.package_id().source_id().is_path() && !state.is_std;
     let profile = state.profiles.get_profile(
         pkg.package_id(),
+        pkg.hints(),
+        state.gctx.cli_unstable().hint_min_opt_level,
         state.ws.is_member(pkg),
         is_local,
         unit_for,

--- a/src/diagnostics/mod.rs
+++ b/src/diagnostics/mod.rs
@@ -20,7 +20,7 @@
 //! - TOML syntax or manifest schema: [`passes::emit_parse_diagnostics`], [`rules::PARSE_PASS_RULES`]
 //! - Lockfile
 //!   - May be overly broad for what dependencies are checked
-//! - Pre-build unit graph
+//! - Pre-build unit graph: [`rules::min_opt_level_hint::diagnose`]
 //!   - Tailored to a specific configuration (features, targets) but requires users to enumerate every configuration
 //! - Post-build unit graph: [`rules::unused_dependencies::lint_build_results`]
 //!   - Slow feedback cycle since a build needs to happen
@@ -69,7 +69,9 @@ pub mod passes;
 pub mod rules;
 
 pub use lint::{Lint, LintGroup, LintLevel, LintLevelProduct, LintLevelSource};
-pub use report::{AsIndex, cwd_rel_path, get_key_value, get_key_value_span, workspace_rel_path};
+pub use report::{
+    AsIndex, TomlSpan, cwd_rel_path, get_key_value, get_key_value_span, workspace_rel_path,
+};
 pub use rules::{LINT_GROUPS, LINTS};
 
 pub struct PassOutput {

--- a/src/diagnostics/rules/min_opt_level_hint.rs
+++ b/src/diagnostics/rules/min_opt_level_hint.rs
@@ -1,0 +1,88 @@
+use cargo_util_terminal::report::AnnotationKind;
+use cargo_util_terminal::report::Group;
+use cargo_util_terminal::report::Level;
+use cargo_util_terminal::report::Origin;
+use cargo_util_terminal::report::Snippet;
+
+use crate::CargoResult;
+use crate::compiler::BuildContext;
+use crate::diagnostics::TomlSpan;
+use crate::diagnostics::get_key_value_span;
+use crate::diagnostics::workspace_rel_path;
+use crate::workspace::Package;
+use crate::workspace::profiles::{MinOptLevelHintError, parse_min_opt_level_hint};
+
+/// Emits diagnostics for `hints.min-opt-level` once per package selected for compilation.
+#[tracing::instrument(skip_all)]
+pub(crate) fn diagnose(bcx: &BuildContext<'_, '_>) -> CargoResult<()> {
+    let gctx = bcx.gctx;
+    let mut packages = bcx
+        .unit_graph
+        .keys()
+        .filter(|unit| !unit.skip_non_compile_time_dep && unit.show_warnings(gctx))
+        .map(|unit| unit.pkg.clone())
+        .collect::<Vec<_>>();
+    packages.sort_by_key(|pkg| pkg.package_id());
+    packages.dedup_by_key(|pkg| pkg.package_id());
+
+    for pkg in packages {
+        let manifest_path = workspace_rel_path(bcx.ws, pkg.manifest_path());
+        let min_opt_level = match parse_min_opt_level_hint(
+            pkg.hints().and_then(|hints| hints.min_opt_level.as_ref()),
+        ) {
+            Ok(level) => level,
+            Err(err) => {
+                let (title, label) = match err {
+                    MinOptLevelHintError::OutOfRange(level) => (
+                        format!("ignoring unsupported value ({level}) for `hints.min-opt-level`"),
+                        "expected an integer from 0 to 3",
+                    ),
+                    MinOptLevelHintError::WrongType(value_type) => (
+                        format!(
+                            "ignoring unsupported value type ({value_type}) for `hints.min-opt-level`"
+                        ),
+                        "expected an integer",
+                    ),
+                };
+                let group = Group::with_title(Level::WARNING.primary_title(title));
+                let group = match hint_span(&pkg) {
+                    Some((contents, span)) => group.element(
+                        Snippet::source(contents)
+                            .path(&manifest_path)
+                            .annotation(AnnotationKind::Primary.span(span.value).label(label)),
+                    ),
+                    None => group.element(Origin::path(&manifest_path)),
+                };
+                gctx.shell().print_report(&[group], false)?;
+                None
+            }
+        };
+
+        if matches!(min_opt_level, Some(1..=3)) && !gctx.cli_unstable().hint_min_opt_level {
+            let group =
+                Group::with_title(Level::WARNING.primary_title("ignoring `hints.min-opt-level`"));
+            let group = match hint_span(&pkg) {
+                Some((contents, span)) => group.element(
+                    Snippet::source(contents)
+                        .path(&manifest_path)
+                        .annotation(AnnotationKind::Primary.span(span.key.start..span.value.end)),
+                ),
+                None => group.element(Origin::path(&manifest_path)),
+            };
+            let group =
+                group.element(Level::HELP.message("pass `-Zhint-min-opt-level` to enable it"));
+            gctx.shell().print_report(&[group], false)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Locates `hints.min-opt-level` in the package's original manifest, if its source is available.
+fn hint_span(pkg: &Package) -> Option<(&str, TomlSpan)> {
+    let manifest = pkg.manifest();
+    let contents = manifest.contents()?;
+    let document = manifest.document()?;
+    let span = get_key_value_span(document, &["hints", "min-opt-level"])?;
+    Some((contents, span))
+}

--- a/src/diagnostics/rules/mod.rs
+++ b/src/diagnostics/rules/mod.rs
@@ -2,6 +2,7 @@ mod blanket_hint_mostly_unused;
 mod deferred_parse_diagnostics;
 mod im_a_teapot;
 mod manual_readme;
+pub mod min_opt_level_hint;
 mod missing_lints_features;
 mod missing_lints_inheritance;
 mod non_kebab_case_bins;

--- a/src/ops/cargo_compile/mod.rs
+++ b/src/ops/cargo_compile/mod.rs
@@ -196,6 +196,7 @@ fn compile_ws<'a>(
     }
 
     let bcx = create_bcx(ws, options, &interner, logger.as_ref())?;
+    crate::diagnostics::rules::min_opt_level_hint::diagnose(&bcx)?;
 
     if options.build_config.unit_graph {
         unit_graph::emit_serialized_unit_graph(&bcx.roots, &bcx.unit_graph, ws.gctx())?;
@@ -497,6 +498,7 @@ pub fn create_bcx<'a, 'gctx>(
                 interner,
                 &profiles,
                 &target_data,
+                gctx.cli_unstable().hint_min_opt_level,
             )?
         } else {
             Default::default()

--- a/src/ops/cargo_compile/unit_generator.rs
+++ b/src/ops/cargo_compile/unit_generator.rs
@@ -148,6 +148,8 @@ impl<'a> UnitGenerator<'a, '_> {
                 };
                 let profile = self.profiles.get_profile(
                     pkg.package_id(),
+                    pkg.hints(),
+                    self.ws.gctx().cli_unstable().hint_min_opt_level,
                     self.ws.is_member(pkg),
                     is_local,
                     unit_for,

--- a/src/workspace/features.rs
+++ b/src/workspace/features.rs
@@ -902,6 +902,7 @@ unstable_cli_options!(
     git: Option<GitFeatures> = ("Enable support for shallow git fetch operations"),
     #[serde(deserialize_with = "deserialize_gitoxide_features")]
     gitoxide: Option<GitoxideFeatures> = ("Use gitoxide for the given git interactions, or all of them if no argument is given"),
+    hint_min_opt_level: bool = ("Enable the `hints.min-opt-level` manifest key"),
     hint_msrv: bool = ("Enable passing `package.rust-version` to rustc for lints"),
     host_config: bool = ("Enable the `[host]` section in the .cargo/config.toml file"),
     json_target_spec: bool = ("Enable `.json` target spec files"),
@@ -1440,6 +1441,7 @@ impl CliUnstable {
                     |v| parse_gitoxide(v.split(',')),
                 )?
             }
+            "hint-min-opt-level" => self.hint_min_opt_level = parse_empty(k, v)?,
             "host-config" => self.host_config = parse_empty(k, v)?,
             "json-target-spec" => self.json_target_spec = parse_empty(k, v)?,
             "hint-msrv" => self.hint_msrv = parse_empty(k, v)?,

--- a/src/workspace/profiles.rs
+++ b/src/workspace/profiles.rs
@@ -33,7 +33,7 @@ use crate::workspace::parser::validate_profile;
 use crate::workspace::{PackageId, PackageIdSpec, PackageIdSpecQuery, Target, Workspace};
 use anyhow::{Context as _, bail};
 use cargo_util::is_ci;
-use cargo_util_schemas::manifest::TomlTrimPaths;
+use cargo_util_schemas::manifest::{Hints, TomlTrimPaths};
 use cargo_util_schemas::manifest::{
     ProfilePackageSpec, StringOrBool, TomlDebugInfo, TomlProfile, TomlProfiles,
 };
@@ -272,16 +272,33 @@ impl Profiles {
     /// Retrieves the profile for a target.
     /// `is_member` is whether or not this package is a member of the
     /// workspace.
+    /// `hint_min_opt_level` is whether `-Zhint-min-opt-level` was passed,
+    /// enabling the `hints.min-opt-level` manifest key.
     pub fn get_profile(
         &self,
         pkg_id: PackageId,
+        pkg_hints: Option<&Hints>,
+        hint_min_opt_level: bool,
         is_member: bool,
         is_local: bool,
         unit_for: UnitFor,
         kind: CompileKind,
     ) -> Profile {
         let maker = self.get_profile_maker(&self.requested_profile).unwrap();
-        let mut profile = maker.get_profile(Some(pkg_id), is_member, unit_for.is_for_host());
+        let min_opt_level = if hint_min_opt_level {
+            parse_min_opt_level_hint(pkg_hints.and_then(|hints| hints.min_opt_level.as_ref()))
+                .ok()
+                .flatten()
+        } else {
+            None
+        };
+
+        let mut profile = maker.get_profile(
+            Some(pkg_id),
+            is_member,
+            unit_for.is_for_host(),
+            min_opt_level,
+        );
 
         // Dealing with `panic=abort` and `panic=unwind` requires some special
         // treatment. Be sure to process all the various options here.
@@ -345,7 +362,9 @@ impl Profiles {
     pub fn base_profile(&self) -> Profile {
         let profile_name = self.requested_profile;
         let maker = self.get_profile_maker(&profile_name).unwrap();
-        maker.get_profile(None, /*is_member*/ true, /*is_for_host*/ false)
+        maker.get_profile(
+            None, /*is_member*/ true, /*is_for_host*/ false, None,
+        )
     }
 
     /// Gets the directory name for a profile, like `debug` or `release`.
@@ -403,6 +422,27 @@ impl Profiles {
     }
 }
 
+pub(crate) enum MinOptLevelHintError {
+    OutOfRange(i64),
+    WrongType(&'static str),
+}
+
+pub(crate) fn parse_min_opt_level_hint(
+    value: Option<&toml::Value>,
+) -> Result<Option<u32>, MinOptLevelHintError> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let Some(level) = value.as_integer() else {
+        return Err(MinOptLevelHintError::WrongType(value.type_str()));
+    };
+    if (0..=3).contains(&level) {
+        Ok(Some(level as u32))
+    } else {
+        Err(MinOptLevelHintError::OutOfRange(level))
+    }
+}
+
 /// An object used for handling the profile hierarchy.
 ///
 /// The precedence of profiles are (first one wins):
@@ -440,6 +480,7 @@ impl ProfileMaker {
         pkg_id: Option<PackageId>,
         is_member: bool,
         is_for_host: bool,
+        min_opt_level: Option<u32>,
     ) -> Profile {
         let mut profile = self.default.clone();
 
@@ -474,6 +515,13 @@ impl ProfileMaker {
             // below so the unit can be reused, otherwise we can avoid emitting
             // the unit's debuginfo.
             profile.debuginfo = DebugInfo::Deferred(profile.debuginfo.into_inner());
+        }
+        if let (Some(min_opt_level), Ok(opt_level)) =
+            (min_opt_level, profile.opt_level.as_str().parse::<u32>())
+        {
+            if opt_level < min_opt_level {
+                profile.opt_level = min_opt_level.to_string().into();
+            }
         }
         // ... and next comes any other sorts of overrides specified in
         // profiles, such as `[profile.release.build-override]` or

--- a/tests/testsuite/cargo/z_help/stdout.term.svg
+++ b/tests/testsuite/cargo/z_help/stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="1255px" height="974px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1255px" height="992px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -62,65 +62,67 @@
 </tspan>
     <tspan x="10px" y="424px"><tspan>    -Z gitoxide                    Use gitoxide for the given git interactions, or all of them if no argument is given</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>    -Z hint-msrv                   Enable passing `package.rust-version` to rustc for lints</tspan>
+    <tspan x="10px" y="442px"><tspan>    -Z hint-min-opt-level          Enable the `hints.min-opt-level` manifest key</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>    -Z host-config                 Enable the `[host]` section in the .cargo/config.toml file</tspan>
+    <tspan x="10px" y="460px"><tspan>    -Z hint-msrv                   Enable passing `package.rust-version` to rustc for lints</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>    -Z json-target-spec            Enable `.json` target spec files</tspan>
+    <tspan x="10px" y="478px"><tspan>    -Z host-config                 Enable the `[host]` section in the .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>    -Z minimal-versions            Resolve minimal dependency versions instead of maximum</tspan>
+    <tspan x="10px" y="496px"><tspan>    -Z json-target-spec            Enable `.json` target spec files</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>    -Z msrv-policy                 Enable rust-version aware policy within cargo</tspan>
+    <tspan x="10px" y="514px"><tspan>    -Z minimal-versions            Resolve minimal dependency versions instead of maximum</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>    -Z mtime-on-use                Configure Cargo to update the mtime of used files</tspan>
+    <tspan x="10px" y="532px"><tspan>    -Z msrv-policy                 Enable rust-version aware policy within cargo</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>    -Z no-index-update             Do not update the registry index even if the cache is outdated</tspan>
+    <tspan x="10px" y="550px"><tspan>    -Z mtime-on-use                Configure Cargo to update the mtime of used files</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>    -Z panic-abort-tests           Enable support to run tests with -Cpanic=abort</tspan>
+    <tspan x="10px" y="568px"><tspan>    -Z no-index-update             Do not update the registry index even if the cache is outdated</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>    -Z panic-immediate-abort       Enable setting `panic = "immediate-abort"` in profiles</tspan>
+    <tspan x="10px" y="586px"><tspan>    -Z panic-abort-tests           Enable support to run tests with -Cpanic=abort</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>    -Z profile-hint-mostly-unused  Enable the `hint-mostly-unused` setting in profiles to mark a crate as mostly unused.</tspan>
+    <tspan x="10px" y="604px"><tspan>    -Z panic-immediate-abort       Enable setting `panic = "immediate-abort"` in profiles</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>    -Z profile-rustflags           Enable the `rustflags` option in profiles in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="622px"><tspan>    -Z profile-hint-mostly-unused  Enable the `hint-mostly-unused` setting in profiles to mark a crate as mostly unused.</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>    -Z public-dependency           Respect a dependency's `public` field in Cargo.toml to control public/private dependencies</tspan>
+    <tspan x="10px" y="640px"><tspan>    -Z profile-rustflags           Enable the `rustflags` option in profiles in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>    -Z publish-timeout             Enable the `publish.timeout` key in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="658px"><tspan>    -Z public-dependency           Respect a dependency's `public` field in Cargo.toml to control public/private dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan>    -Z root-dir                    Set the root directory relative to which paths are printed (defaults to workspace root)</tspan>
+    <tspan x="10px" y="676px"><tspan>    -Z publish-timeout             Enable the `publish.timeout` key in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan>    -Z rustc-unicode               Enable `rustc`'s unicode error format in Cargo's error messages</tspan>
+    <tspan x="10px" y="694px"><tspan>    -Z root-dir                    Set the root directory relative to which paths are printed (defaults to workspace root)</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>    -Z rustdoc-depinfo             Use dep-info files in rustdoc rebuild detection</tspan>
+    <tspan x="10px" y="712px"><tspan>    -Z rustc-unicode               Enable `rustc`'s unicode error format in Cargo's error messages</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>    -Z rustdoc-map                 Allow passing external documentation mappings to rustdoc</tspan>
+    <tspan x="10px" y="730px"><tspan>    -Z rustdoc-depinfo             Use dep-info files in rustdoc rebuild detection</tspan>
 </tspan>
-    <tspan x="10px" y="748px"><tspan>    -Z rustdoc-mergeable-info      Use rustdoc mergeable cross-crate-info files</tspan>
+    <tspan x="10px" y="748px"><tspan>    -Z rustdoc-map                 Allow passing external documentation mappings to rustdoc</tspan>
 </tspan>
-    <tspan x="10px" y="766px"><tspan>    -Z rustdoc-scrape-examples     Allows Rustdoc to scrape code examples from reverse-dependencies</tspan>
+    <tspan x="10px" y="766px"><tspan>    -Z rustdoc-mergeable-info      Use rustdoc mergeable cross-crate-info files</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan>    -Z sbom                        Enable the `sbom` option in build config in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="784px"><tspan>    -Z rustdoc-scrape-examples     Allows Rustdoc to scrape code examples from reverse-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan>    -Z script                      Enable support for single-file, `.rs` packages</tspan>
+    <tspan x="10px" y="802px"><tspan>    -Z sbom                        Enable the `sbom` option in build config in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="820px"><tspan>    -Z section-timings             Enable support for extended compilation sections in --timings output</tspan>
+    <tspan x="10px" y="820px"><tspan>    -Z script                      Enable support for single-file, `.rs` packages</tspan>
 </tspan>
-    <tspan x="10px" y="838px"><tspan>    -Z target-applies-to-host      Enable the `target-applies-to-host` key in the .cargo/config.toml file</tspan>
+    <tspan x="10px" y="838px"><tspan>    -Z section-timings             Enable support for extended compilation sections in --timings output</tspan>
 </tspan>
-    <tspan x="10px" y="856px"><tspan>    -Z trim-paths                  Enable the `trim-paths` option in profiles</tspan>
+    <tspan x="10px" y="856px"><tspan>    -Z target-applies-to-host      Enable the `target-applies-to-host` key in the .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="874px"><tspan>    -Z unstable-options            Allow the usage of unstable options</tspan>
+    <tspan x="10px" y="874px"><tspan>    -Z trim-paths                  Enable the `trim-paths` option in profiles</tspan>
 </tspan>
-    <tspan x="10px" y="892px">
+    <tspan x="10px" y="892px"><tspan>    -Z unstable-options            Allow the usage of unstable options</tspan>
 </tspan>
-    <tspan x="10px" y="910px"><tspan>Run with `cargo -Z [FLAG] [COMMAND]`</tspan>
+    <tspan x="10px" y="910px">
 </tspan>
-    <tspan x="10px" y="928px">
+    <tspan x="10px" y="928px"><tspan>Run with `cargo -Z [FLAG] [COMMAND]`</tspan>
 </tspan>
-    <tspan x="10px" y="946px"><tspan>See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html for more information about these flags.</tspan>
+    <tspan x="10px" y="946px">
 </tspan>
-    <tspan x="10px" y="964px">
+    <tspan x="10px" y="964px"><tspan>See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html for more information about these flags.</tspan>
+</tspan>
+    <tspan x="10px" y="982px">
 </tspan>
   </text>
 

--- a/tests/testsuite/hints.rs
+++ b/tests/testsuite/hints.rs
@@ -409,21 +409,33 @@ fn min_opt_level_with_numeric_profiles() {
         .build();
 
     let mut cargo = p.cargo("check -v");
-    with_opt_level(&mut cargo, "dep", "0");
+    cargo
+        .arg("-Zhint-min-opt-level")
+        .masquerade_as_nightly_cargo(&["hint-min-opt-level"]);
+    with_opt_level(&mut cargo, "dep", "2");
     with_opt_level(&mut cargo, "foo", "0");
     cargo.run();
 
     let mut cargo = p.cargo("check -v --profile low");
-    with_opt_level(&mut cargo, "dep", "1");
+    cargo
+        .arg("-Zhint-min-opt-level")
+        .masquerade_as_nightly_cargo(&["hint-min-opt-level"]);
+    with_opt_level(&mut cargo, "dep", "2");
     with_opt_level(&mut cargo, "foo", "1");
     cargo.run();
 
     let mut cargo = p.cargo("check -v --profile high");
+    cargo
+        .arg("-Zhint-min-opt-level")
+        .masquerade_as_nightly_cargo(&["hint-min-opt-level"]);
     with_opt_level(&mut cargo, "dep", "3");
     with_opt_level(&mut cargo, "foo", "3");
     cargo.run();
 
     let mut cargo = p.cargo("check -v --release");
+    cargo
+        .arg("-Zhint-min-opt-level")
+        .masquerade_as_nightly_cargo(&["hint-min-opt-level"]);
     with_opt_level(&mut cargo, "dep", "3");
     with_opt_level(&mut cargo, "foo", "3");
     cargo.run();
@@ -448,7 +460,10 @@ fn min_opt_level_on_root_package() {
         .build();
 
     let mut cargo = p.cargo("check -v");
-    with_opt_level(&mut cargo, "foo", "0");
+    cargo
+        .arg("-Zhint-min-opt-level")
+        .masquerade_as_nightly_cargo(&["hint-min-opt-level"]);
+    with_opt_level(&mut cargo, "foo", "3");
     cargo.run();
 }
 
@@ -494,10 +509,16 @@ fn min_opt_level_with_size_profiles() {
         .build();
 
     let mut cargo = p.cargo("check -v --profile small");
+    cargo
+        .arg("-Zhint-min-opt-level")
+        .masquerade_as_nightly_cargo(&["hint-min-opt-level"]);
     with_opt_level(&mut cargo, "dep", "s");
     cargo.run();
 
     let mut cargo = p.cargo("check -v --profile tiny");
+    cargo
+        .arg("-Zhint-min-opt-level")
+        .masquerade_as_nightly_cargo(&["hint-min-opt-level"]);
     with_opt_level(&mut cargo, "dep", "z");
     cargo.run();
 }
@@ -548,10 +569,16 @@ fn min_opt_level_with_package_overrides() {
         .build();
 
     let mut cargo = p.cargo("check -v --profile wildcard");
+    cargo
+        .arg("-Zhint-min-opt-level")
+        .masquerade_as_nightly_cargo(&["hint-min-opt-level"]);
     with_opt_level(&mut cargo, "dep", "1");
     cargo.run();
 
     let mut cargo = p.cargo("check -v --profile specific");
+    cargo
+        .arg("-Zhint-min-opt-level")
+        .masquerade_as_nightly_cargo(&["hint-min-opt-level"]);
     with_opt_level(&mut cargo, "dep", "0");
     cargo.run();
 }
@@ -595,7 +622,10 @@ fn min_opt_level_with_transitive_dependency() {
         .build();
 
     let mut cargo = p.cargo("check -v");
-    with_opt_level(&mut cargo, "dep", "0");
+    cargo
+        .arg("-Zhint-min-opt-level")
+        .masquerade_as_nightly_cargo(&["hint-min-opt-level"]);
+    with_opt_level(&mut cargo, "dep", "2");
     with_opt_level(&mut cargo, "leaf", "0");
     cargo.run();
 }
@@ -641,10 +671,16 @@ fn min_opt_level_with_build_dependencies() {
         .build();
 
     let mut cargo = p.cargo("check -v");
-    with_opt_level(&mut cargo, "dep", "0");
+    cargo
+        .arg("-Zhint-min-opt-level")
+        .masquerade_as_nightly_cargo(&["hint-min-opt-level"]);
+    with_opt_level(&mut cargo, "dep", "2");
     cargo.run();
 
     let mut cargo = p.cargo("check -v --profile overridden");
+    cargo
+        .arg("-Zhint-min-opt-level")
+        .masquerade_as_nightly_cargo(&["hint-min-opt-level"]);
     with_opt_level(&mut cargo, "dep", "0");
     cargo.run();
 }
@@ -668,11 +704,17 @@ fn min_opt_level_with_wrong_type() {
         .build();
 
     let mut cargo = p.cargo("check -v");
+    cargo
+        .arg("-Zhint-min-opt-level")
+        .masquerade_as_nightly_cargo(&["hint-min-opt-level"]);
     with_opt_level(&mut cargo, "foo", "0");
     cargo
         .with_stderr_data(str![[r#"
-[WARNING] Cargo.toml: unused manifest key: hints.min-opt-level
-[WARNING] `foo` (manifest) generated 1 warning
+[WARNING] ignoring unsupported value type (string) for `hints.min-opt-level`
+ --> Cargo.toml:8:29
+  |
+8 |             min-opt-level = "s"
+  |                             ^^^ expected an integer
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -704,11 +746,17 @@ fn min_opt_level_with_out_of_range_values() {
             .build();
 
         let mut cargo = p.cargo("check -v");
+        cargo
+            .arg("-Zhint-min-opt-level")
+            .masquerade_as_nightly_cargo(&["hint-min-opt-level"]);
         with_opt_level(&mut cargo, name, "0");
         cargo
             .with_stderr_data(str![[r#"
-[WARNING] Cargo.toml: unused manifest key: hints.min-opt-level
-[WARNING] [..] (manifest) generated 1 warning
+[WARNING] ignoring unsupported value ([..]) for `hints.min-opt-level`
+ --> Cargo.toml:8:37
+  |
+8 |                     min-opt-level = [..]
+  |                                     [..] expected an integer from 0 to 3
 [CHECKING] [..] v0.0.1 ([ROOT]/[..])
 [RUNNING] `rustc --crate-name [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -721,7 +769,7 @@ fn min_opt_level_with_out_of_range_values() {
 #[cargo_test]
 fn min_opt_level_registry_dependency_warnings_are_suppressed() {
     for (path, name, level, expected_opt_level) in [
-        ("positive", "positive", "2", "0"),
+        ("positive", "positive", "2", "2"),
         ("wrong-type", "wrong_type", r#""s""#, "0"),
         ("out-of-range", "out_of_range", "4", "0"),
     ] {
@@ -762,6 +810,9 @@ fn min_opt_level_registry_dependency_warnings_are_suppressed() {
             .build();
 
         let mut cargo = p.cargo("check -v");
+        cargo
+            .arg("-Zhint-min-opt-level")
+            .masquerade_as_nightly_cargo(&["hint-min-opt-level"]);
         with_opt_level(&mut cargo, name, expected_opt_level);
         cargo
             .with_stderr_does_not_contain("[WARNING] [..]hints.min-opt-level[..]")
@@ -791,8 +842,13 @@ fn min_opt_level_without_feature_gate() {
     with_opt_level(&mut cargo, "foo", "0");
     cargo
         .with_stderr_data(str![[r#"
-[WARNING] Cargo.toml: unused manifest key: hints.min-opt-level
-[WARNING] `foo` (manifest) generated 1 warning
+[WARNING] ignoring `hints.min-opt-level`
+ --> Cargo.toml:8:13
+  |
+8 |             min-opt-level = 2
+  |             ^^^^^^^^^^^^^^^^^
+  |
+  = [HELP] pass `-Zhint-min-opt-level` to enable it
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -802,8 +858,13 @@ fn min_opt_level_without_feature_gate() {
 
     p.cargo("check -v")
         .with_stderr_data(str![[r#"
-[WARNING] Cargo.toml: unused manifest key: hints.min-opt-level
-[WARNING] `foo` (manifest) generated 1 warning
+[WARNING] ignoring `hints.min-opt-level`
+ --> Cargo.toml:8:13
+  |
+8 |             min-opt-level = 2
+  |             ^^^^^^^^^^^^^^^^^
+  |
+  = [HELP] pass `-Zhint-min-opt-level` to enable it
 [FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -832,8 +893,13 @@ fn min_opt_level_warning_is_emitted_once_per_package() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] Cargo.toml: unused manifest key: hints.min-opt-level
-[WARNING] `foo` (manifest) generated 1 warning
+[WARNING] ignoring `hints.min-opt-level`
+ --> Cargo.toml:8:13
+  |
+8 |             min-opt-level = 2
+  |             ^^^^^^^^^^^^^^^^^
+  |
+  = [HELP] pass `-Zhint-min-opt-level` to enable it
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -898,6 +964,13 @@ fn min_opt_level_on_local_dependencies_without_feature_gate() {
     cargo
         .with_stderr_data(str![[r#"
 [LOCKING] 2 packages to highest Rust [..] compatible versions
+[WARNING] ignoring `hints.min-opt-level`
+  --> bar/Cargo.toml:11:13
+   |
+11 |             min-opt-level = 3
+   |             ^^^^^^^^^^^^^^^^^
+   |
+   = [HELP] pass `-Zhint-min-opt-level` to enable it
 [CHECKING] zero v1.0.0 ([ROOT]/foo/zero)
 [RUNNING] `rustc --crate-name zero [..]`
 [CHECKING] bar v1.0.0 ([ROOT]/foo/bar)

--- a/tests/testsuite/hints.rs
+++ b/tests/testsuite/hints.rs
@@ -2,7 +2,7 @@
 
 use crate::prelude::*;
 use cargo_test_support::registry::Package;
-use cargo_test_support::{project, str};
+use cargo_test_support::{Execs, project, str};
 
 #[cargo_test]
 fn empty_hints_no_warn() {
@@ -354,5 +354,558 @@ fn mostly_unused_profile_overrides_hints_on_self_nightly() {
 
 "#]])
         .with_stderr_does_not_contain("-Zhint-mostly-unused")
+        .run();
+}
+
+fn with_opt_level(cargo: &mut Execs, crate_name: &str, level: &str) {
+    let crate_marker = format!("[RUNNING] `rustc --crate-name {crate_name}");
+    if level == "0" {
+        // Cargo omits `-C opt-level` entirely at level 0.
+        cargo.with_stderr_line_without(&[crate_marker], &["-C opt-level".to_owned()]);
+    } else {
+        cargo.with_stderr_line_without(&[crate_marker, format!("-C opt-level={level}")], &[]);
+    }
+}
+
+#[cargo_test]
+fn min_opt_level_with_numeric_profiles() {
+    Package::new("dep", "1.0.0")
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "dep"
+            version = "1.0.0"
+            edition = "2024"
+
+            [hints]
+            min-opt-level = 2
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            edition = "2024"
+
+            [dependencies]
+            dep = "1.0"
+
+            [profile.low]
+            inherits = "dev"
+            opt-level = 1
+
+            [profile.high]
+            inherits = "dev"
+            opt-level = 3
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    let mut cargo = p.cargo("check -v");
+    with_opt_level(&mut cargo, "dep", "0");
+    with_opt_level(&mut cargo, "foo", "0");
+    cargo.run();
+
+    let mut cargo = p.cargo("check -v --profile low");
+    with_opt_level(&mut cargo, "dep", "1");
+    with_opt_level(&mut cargo, "foo", "1");
+    cargo.run();
+
+    let mut cargo = p.cargo("check -v --profile high");
+    with_opt_level(&mut cargo, "dep", "3");
+    with_opt_level(&mut cargo, "foo", "3");
+    cargo.run();
+
+    let mut cargo = p.cargo("check -v --release");
+    with_opt_level(&mut cargo, "dep", "3");
+    with_opt_level(&mut cargo, "foo", "3");
+    cargo.run();
+}
+
+#[cargo_test]
+fn min_opt_level_on_root_package() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            edition = "2024"
+
+            [hints]
+            min-opt-level = 3
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    let mut cargo = p.cargo("check -v");
+    with_opt_level(&mut cargo, "foo", "0");
+    cargo.run();
+}
+
+#[cargo_test]
+fn min_opt_level_with_size_profiles() {
+    Package::new("dep", "1.0.0")
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "dep"
+            version = "1.0.0"
+            edition = "2024"
+
+            [hints]
+            min-opt-level = 2
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            edition = "2024"
+
+            [dependencies]
+            dep = "1.0"
+
+            [profile.small]
+            inherits = "dev"
+            opt-level = "s"
+
+            [profile.tiny]
+            inherits = "dev"
+            opt-level = "z"
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    let mut cargo = p.cargo("check -v --profile small");
+    with_opt_level(&mut cargo, "dep", "s");
+    cargo.run();
+
+    let mut cargo = p.cargo("check -v --profile tiny");
+    with_opt_level(&mut cargo, "dep", "z");
+    cargo.run();
+}
+
+#[cargo_test]
+fn min_opt_level_with_package_overrides() {
+    Package::new("dep", "1.0.0")
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "dep"
+            version = "1.0.0"
+            edition = "2024"
+
+            [hints]
+            min-opt-level = 2
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            edition = "2024"
+
+            [dependencies]
+            dep = "1.0"
+
+            [profile.wildcard]
+            inherits = "dev"
+
+            [profile.wildcard.package."*"]
+            opt-level = 1
+
+            [profile.specific]
+            inherits = "dev"
+
+            [profile.specific.package.dep]
+            opt-level = 0
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    let mut cargo = p.cargo("check -v --profile wildcard");
+    with_opt_level(&mut cargo, "dep", "1");
+    cargo.run();
+
+    let mut cargo = p.cargo("check -v --profile specific");
+    with_opt_level(&mut cargo, "dep", "0");
+    cargo.run();
+}
+
+#[cargo_test]
+fn min_opt_level_with_transitive_dependency() {
+    Package::new("leaf", "1.0.0").publish();
+    Package::new("dep", "1.0.0")
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "dep"
+            version = "1.0.0"
+            edition = "2024"
+
+            [dependencies]
+            leaf = "1.0"
+
+            [hints]
+            min-opt-level = 2
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .dep("leaf", "1.0")
+        .publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            edition = "2024"
+
+            [dependencies]
+            dep = "1.0"
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    let mut cargo = p.cargo("check -v");
+    with_opt_level(&mut cargo, "dep", "0");
+    with_opt_level(&mut cargo, "leaf", "0");
+    cargo.run();
+}
+
+#[cargo_test]
+fn min_opt_level_with_build_dependencies() {
+    Package::new("dep", "1.0.0")
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "dep"
+            version = "1.0.0"
+            edition = "2024"
+
+            [hints]
+            min-opt-level = 2
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            edition = "2024"
+
+            [build-dependencies]
+            dep = "1.0"
+
+            [profile.overridden]
+            inherits = "dev"
+
+            [profile.overridden.build-override]
+            opt-level = 0
+            "#,
+        )
+        .file("build.rs", "fn main() {}")
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    let mut cargo = p.cargo("check -v");
+    with_opt_level(&mut cargo, "dep", "0");
+    cargo.run();
+
+    let mut cargo = p.cargo("check -v --profile overridden");
+    with_opt_level(&mut cargo, "dep", "0");
+    cargo.run();
+}
+
+#[cargo_test]
+fn min_opt_level_with_wrong_type() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            edition = "2024"
+
+            [hints]
+            min-opt-level = "s"
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    let mut cargo = p.cargo("check -v");
+    with_opt_level(&mut cargo, "foo", "0");
+    cargo
+        .with_stderr_data(str![[r#"
+[WARNING] Cargo.toml: unused manifest key: hints.min-opt-level
+[WARNING] `foo` (manifest) generated 1 warning
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn min_opt_level_with_out_of_range_values() {
+    for (path, name, level) in [("negative", "negative", "-1"), ("high", "high", "4")] {
+        let p = project()
+            .at(path)
+            .file(
+                "Cargo.toml",
+                &format!(
+                    r#"
+                    [package]
+                    name = "{name}"
+                    version = "0.0.1"
+                    edition = "2024"
+
+                    [hints]
+                    min-opt-level = {level}
+                    "#,
+                ),
+            )
+            .file("src/main.rs", "fn main() {}")
+            .build();
+
+        let mut cargo = p.cargo("check -v");
+        with_opt_level(&mut cargo, name, "0");
+        cargo
+            .with_stderr_data(str![[r#"
+[WARNING] Cargo.toml: unused manifest key: hints.min-opt-level
+[WARNING] [..] (manifest) generated 1 warning
+[CHECKING] [..] v0.0.1 ([ROOT]/[..])
+[RUNNING] `rustc --crate-name [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+            .run();
+    }
+}
+
+#[cargo_test]
+fn min_opt_level_registry_dependency_warnings_are_suppressed() {
+    for (path, name, level, expected_opt_level) in [
+        ("positive", "positive", "2", "0"),
+        ("wrong-type", "wrong_type", r#""s""#, "0"),
+        ("out-of-range", "out_of_range", "4", "0"),
+    ] {
+        Package::new(name, "1.0.0")
+            .file(
+                "Cargo.toml",
+                &format!(
+                    r#"
+                    [package]
+                    name = "{name}"
+                    version = "1.0.0"
+                    edition = "2024"
+
+                    [hints]
+                    min-opt-level = {level}
+                    "#,
+                ),
+            )
+            .file("src/lib.rs", "")
+            .publish();
+        let p = project()
+            .at(path)
+            .file(
+                "Cargo.toml",
+                &format!(
+                    r#"
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    edition = "2024"
+
+                    [dependencies]
+                    {name} = "1.0"
+                    "#,
+                ),
+            )
+            .file("src/main.rs", "fn main() {}")
+            .build();
+
+        let mut cargo = p.cargo("check -v");
+        with_opt_level(&mut cargo, name, expected_opt_level);
+        cargo
+            .with_stderr_does_not_contain("[WARNING] [..]hints.min-opt-level[..]")
+            .run();
+    }
+}
+
+#[cargo_test]
+fn min_opt_level_without_feature_gate() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            edition = "2024"
+
+            [hints]
+            min-opt-level = 2
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    let mut cargo = p.cargo("check -v");
+    with_opt_level(&mut cargo, "foo", "0");
+    cargo
+        .with_stderr_data(str![[r#"
+[WARNING] Cargo.toml: unused manifest key: hints.min-opt-level
+[WARNING] `foo` (manifest) generated 1 warning
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+
+    p.cargo("check -v")
+        .with_stderr_data(str![[r#"
+[WARNING] Cargo.toml: unused manifest key: hints.min-opt-level
+[WARNING] `foo` (manifest) generated 1 warning
+[FRESH] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn min_opt_level_warning_is_emitted_once_per_package() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            edition = "2024"
+
+            [hints]
+            min-opt-level = 2
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("check")
+        .with_stderr_data(str![[r#"
+[WARNING] Cargo.toml: unused manifest key: hints.min-opt-level
+[WARNING] `foo` (manifest) generated 1 warning
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn min_opt_level_on_local_dependencies_without_feature_gate() {
+    // Keep the local hinting packages in a dependency chain so their output
+    // order is stable. They must remain path dependencies because hint gate
+    // warnings are suppressed for non-local units, which would make the
+    // silent-zero case vacuous.
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            edition = "2024"
+
+            [dependencies]
+            bar = { path = "bar" }
+            "#,
+        )
+        .file("src/main.rs", "fn main() { bar::bar(); }")
+        .file(
+            "bar/Cargo.toml",
+            r#"
+            [package]
+            name = "bar"
+            version = "1.0.0"
+            edition = "2024"
+
+            [dependencies]
+            zero = { path = "../zero" }
+
+            [hints]
+            min-opt-level = 3
+            "#,
+        )
+        .file("bar/src/lib.rs", "pub fn bar() {}")
+        .file(
+            "zero/Cargo.toml",
+            r#"
+            [package]
+            name = "zero"
+            version = "1.0.0"
+            edition = "2024"
+
+            [hints]
+            min-opt-level = 0
+            "#,
+        )
+        .file("zero/src/lib.rs", "")
+        .build();
+
+    let mut cargo = p.cargo("check -v");
+    with_opt_level(&mut cargo, "bar", "0");
+    with_opt_level(&mut cargo, "zero", "0");
+    cargo
+        .with_stderr_data(str![[r#"
+[LOCKING] 2 packages to highest Rust [..] compatible versions
+[CHECKING] zero v1.0.0 ([ROOT]/foo/zero)
+[RUNNING] `rustc --crate-name zero [..]`
+[CHECKING] bar v1.0.0 ([ROOT]/foo/bar)
+[RUNNING] `rustc --crate-name bar [..]`
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -433,7 +433,15 @@ fn named_config_profile() {
 
     // normal package
     let kind = CompileKind::Host;
-    let p = profiles.get_profile(a_pkg, true, true, UnitFor::new_normal(kind), kind);
+    let p = profiles.get_profile(
+        a_pkg,
+        None,
+        false,
+        true,
+        true,
+        UnitFor::new_normal(kind),
+        kind,
+    );
     assert_eq!(p.name, "foo");
     assert_eq!(p.codegen_units, Some(2)); // "foo" from config
     assert_eq!(p.opt_level, "1"); // "middle" from manifest
@@ -442,7 +450,15 @@ fn named_config_profile() {
     assert_eq!(p.overflow_checks, true); // "dev" built-in (ignore package override)
 
     // build-override
-    let bo = profiles.get_profile(a_pkg, true, true, UnitFor::new_host(false, kind), kind);
+    let bo = profiles.get_profile(
+        a_pkg,
+        None,
+        false,
+        true,
+        true,
+        UnitFor::new_host(false, kind),
+        kind,
+    );
     assert_eq!(bo.name, "foo");
     assert_eq!(bo.codegen_units, Some(6)); // "foo" build override from config
     assert_eq!(bo.opt_level, "0"); // default to zero
@@ -451,7 +467,15 @@ fn named_config_profile() {
     assert_eq!(bo.overflow_checks, true); // SAME as normal
 
     // package overrides
-    let po = profiles.get_profile(dep_pkg, false, true, UnitFor::new_normal(kind), kind);
+    let po = profiles.get_profile(
+        dep_pkg,
+        None,
+        false,
+        false,
+        true,
+        UnitFor::new_normal(kind),
+        kind,
+    );
     assert_eq!(po.name, "foo");
     assert_eq!(po.codegen_units, Some(7)); // "foo" package override from config
     assert_eq!(po.opt_level, "1"); // SAME as normal


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/cargo/pull/17368)*

### What does this PR try to resolve?

ref https://github.com/rust-lang/cargo/issues/17334 

This PR would allow Rust library to provide a simple hint about the minimum opt-level to build them with via the `hint.min-opt-level` setting in the manifest.

### How to test and review this PR?

Check the unit tests and review it commit by commit.

r?@ghost
