### PR TITLE
fix(git): `git gc` with `safe.bareRepository=explicit`

### DIFF
--- a/src/sources/git/utils.rs
+++ b/src/sources/git/utils.rs
@@ -1462,7 +1462,11 @@ fn maybe_gc_repo(repo: &mut git2::Repository, gctx: &GlobalContext) -> CargoResu
     if let Ok(limit) = gctx.get_env("__CARGO_PACKFILE_LIMIT") {
         cmd.arg(format!("-c gc.autoPackLimit={}", limit));
     }
-    cmd.arg("gc").arg("--auto").current_dir(repo.path());
+    cmd.arg("gc")
+        .arg("--auto")
+        // Explicitly set `GIT_DIR` so `safe.bareRepository=explicit` doesn't reject it.
+        .env("GIT_DIR", repo.path())
+        .current_dir(repo.path());
 
     match cmd.output() {
         Ok(out) => {


### PR DESCRIPTION
### What does this PR try to resolve?

Git v3 will enforce `safe.bareRepository=explicit`,
while older versions don't.
See <https://git-scm.com/docs/BreakingChanges/2.55.0#_git_3_0>

This ensures `git gc` work with `safe.bareRepository=explicit`
by setting an explicit `GIT_DIR` environment variable.

This is not a requirement of making CLI fetch the default,
but better to have before Git CLI v3 is out.
CC https://github.com/rust-lang/cargo/pull/17329

### How to test and review this PR?

You can basically repro this manually today with Git 2.38.0 and later (which `safe.bareRepository` first appears).

1. Set `safe.bareRepository=explicit`
2. `cargo fetch` with config `net.git-fetch-with-cli=true`
3. Put a marker file inside `$CARGO_HOME/git/db/<git-dir>/`
4. `cargo update` to force a git fetch
5. Observe the marker is gone, because Cargo reinitialized the entire db.

I am not sure if there is a better way to test it than a marker file though.


🤖 **LLM disclosure**: I told Codex to check if Cargo's `git fetch` usage is not compatibility with Git CLI v3, and surprisingly it told me `git gc` is not good. I didn't expect this.