### PR TITLE
fix(run): Printing a new line to avoid overwriting error code after \r

### DIFF
--- a/src/bin/cargo/commands/run.rs
+++ b/src/bin/cargo/commands/run.rs
@@ -250,6 +250,8 @@ fn to_run_error(gctx: &GlobalContext, err: anyhow::Error) -> CliError {
     if is_quiet {
         CliError::code(exit_code)
     } else {
+        // Ensure a newline between user and cargo's output, especially with trailing "\r"
+        let _ = writeln!(gctx.shell().err());
         CliError::new(err, exit_code)
     }
 }

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -277,6 +277,7 @@ fn exit_code() {
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `target/debug/foo[EXE]`
+
 [ERROR] process didn't exit successfully: `target/debug/foo[EXE]` ([EXIT_STATUS]: 2)
 
 "#]]
@@ -306,6 +307,7 @@ fn exit_code_verbose() {
 [RUNNING] `rustc [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `target/debug/foo[EXE]`
+
 [ERROR] process didn't exit successfully: `target/debug/foo[EXE]` ([EXIT_STATUS]: 2)
 
 "#]]


### PR DESCRIPTION
### What does this PR try to resolve?
Closes #17343
Changes:  
Added newline using `writeln!(gctx.shell().err());`  
Reason:  
Could have used `format!("\n{err}")` but if there's an in-progress status line, `gctx.shell().err()` would erase it then print a newline. If you want I can switch to `format` option but this feels practically safer.

### How to test and review this PR?
- Run `cargo test -p cargo --test testsuite -- run::exit_code run::exit_code_verbose` And both the tests passes.
- Make a program in windows 
```rust
fn main() {
    print!("hewwo\r");
    std::process::exit(1);
}
```
then run `cargo run`. It prints error message just below.
<img width="1425" height="196" alt="image" src="https://github.com/user-attachments/assets/58e88d9a-0764-4dbd-8f9a-d24e78bc1be7" />
(Compiling for windows almost killed my laptop)
### Before (current cargo on windows)
<img width="1421" height="198" alt="image" src="https://github.com/user-attachments/assets/5ea32868-8832-42d2-adbe-2047377ccf08" />
