### PR TITLE
Install cargo tools with locked dependencies

### DIFF
--- a/doc/book/src/reference/build-cache.md
+++ b/doc/book/src/reference/build-cache.md
@@ -94,7 +94,7 @@ re-executed. The paths in the file are absolute by default. See the
 A third party tool, [sccache], can be used to share built dependencies across
 different workspaces.
 
-To setup `sccache`, install it with `cargo install sccache` and set
+To setup `sccache`, install it with `cargo install --locked sccache` and set
 `RUSTC_WRAPPER` environment variable to `sccache` before invoking Cargo. If
 you use bash, it makes sense to add `export RUSTC_WRAPPER=sccache` to
 `.bashrc`. Alternatively, you can set [`build.rustc-wrapper`] in the [Cargo

--- a/doc/book/src/reference/source-replacement.md
+++ b/doc/book/src/reference/source-replacement.md
@@ -122,7 +122,7 @@ made up of a set of `*.crate` files and an index like the normal registry is.
 The primary way to manage and create local registry sources is through the
 [`cargo-local-registry`][cargo-local-registry] subcommand,
 [available on crates.io][cargo-local-registry] and can be installed with
-`cargo install cargo-local-registry`.
+`cargo install --locked cargo-local-registry`.
 
 [cargo-local-registry]: https://crates.io/crates/cargo-local-registry
 

--- a/doc/contrib/src/documentation/index.md
+++ b/doc/contrib/src/documentation/index.md
@@ -30,7 +30,7 @@ Cargo has several types of documentation that contributors work with:
 Building the book requires [mdBook]. To get it:
 
 ```console
-$ cargo install mdbook
+$ cargo install --locked mdbook
 ```
 
 To build the book:


### PR DESCRIPTION
Installing cargo tools (`cargo install`) without locked dependencies exposes users to supply-chain attacks to all the dependencies of the tool (https://blog.rust-lang.org/2026/08/20/supply-chain-attack-on-arrayref/). Using `cargo install --locked` reduces this risk to a compromise of the tool itself, while using the locked and hashed version of the dependencies.

I went through all `rg "cargo install"` hits in the rust-lang/rust and added `--locked` to all but explanatory examples (such as cargo's docs on `cargo install` itself). I validated that those tools publish functioning `Cargo.lock`s with https://gist.github.com/konstin/bcb1169c1c1120c259dca64e777a64d0. These are the broken out changes for cargo.

https://github.com/rust-lang/rust/pull/161428