### PR TITLE
fix(compiler): uplift `.rmeta` when `-Zembed-metadata=no` is used

### DIFF
--- a/src/compiler/build_runner/compilation_files.rs
+++ b/src/compiler/build_runner/compilation_files.rs
@@ -457,7 +457,17 @@ impl<'a, 'gctx: 'a> CompilationFiles<'a, 'gctx> {
         bcx: &BuildContext<'_, '_>,
     ) -> Option<PathBuf> {
         // Tests, check, doc, etc. should not be uplifted.
-        if unit.mode != CompileMode::Build || file_type.flavor == FileFlavor::Rmeta {
+        if unit.mode != CompileMode::Build {
+            return None;
+        }
+        // `.rmeta` files are normally not uplifted because the metadata is
+        // also embedded inside the rlib. However, when `-Zembed-metadata=no`
+        // is used the metadata is no longer embedded in the rlib, so the
+        // `.rmeta` becomes the only metadata output and has to be uplifted
+        // along with the rlib to remain accessible to external tooling.
+        if file_type.flavor == FileFlavor::Rmeta
+            && bcx.target_data.info(unit.kind).should_embed_metadata()
+        {
             return None;
         }
 

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -6525,6 +6525,32 @@ fn embed_metadata_no_dylib_dep() {
         .run();
 }
 
+// With `-Zembed-metadata=no`, the `.rmeta` file is the only metadata output
+// and must be uplifted along with the rlib (#17359).
+#[cargo_test(nightly, reason = "-Zembed-metadata is nightly only")]
+fn embed_metadata_no_uplifts_rmeta() {
+    let p = project()
+        .file("Cargo.toml", &basic_lib_manifest("foo"))
+        .file("src/lib.rs", "pub fn foo() {}")
+        .build();
+
+    p.cargo("build -Z embed-metadata=no")
+        .masquerade_as_nightly_cargo(&["-Z embed-metadata"])
+        .run();
+
+    assert!(p.root().join("target/debug/libfoo.rlib").is_file());
+    assert!(p.root().join("target/debug/libfoo.rmeta").is_file());
+
+    // The `.rmeta` should not be uplifted when the metadata is embedded in
+    // the rlib.
+    p.root().join("target").rm_rf();
+    p.cargo("build -Z embed-metadata=yes")
+        .masquerade_as_nightly_cargo(&["-Z embed-metadata"])
+        .run();
+    assert!(p.root().join("target/debug/libfoo.rlib").is_file());
+    assert!(!p.root().join("target/debug/libfoo.rmeta").is_file());
+}
+
 #[cargo_test(nightly, reason = "-Zembed-metadata is nightly only")]
 fn embed_metadata_no_invalidate() {
     // Invalidate all deps when -Zembed-metadata is toggled


### PR DESCRIPTION
Closes #17359.

When `-Zembed-metadata=no` is used, metadata is no longer embedded in the rlib, so the `.rmeta` file becomes the only metadata output for a unit. `uplift_to` previously returned `None` for every `FileFlavor::Rmeta`, so the `.rmeta` stayed in the deps directory and was never copied to `target/debug`. That makes the metadata unreachable for external tooling such as rustc's run-make test infrastructure.

This changes the guard so the rmeta is only skipped when the metadata is embedded in the rlib (`should_embed_metadata()` is `true`). When `-Zembed-metadata=no` is enabled, the `.rmeta` is uplifted alongside the rlib.

Existing behavior is preserved: with the default embed-metadata, `target/debug/libfoo.rmeta` is still not produced, and dependency rlibs are still not uplifted.