### PR TITLE
feat(config): Add build.fingerprint

### DIFF
--- a/doc/book/src/reference/unstable.md
+++ b/doc/book/src/reference/unstable.md
@@ -608,6 +608,29 @@ between cargo versions. Fingerprints are used by cargo to determine when a crate
 For the time being files ingested by build script will continue to use mtimes, even when `checksum-freshness`
 is enabled. This is not intended as a long term solution.
 
+```toml
+# .cargo/config.toml
+[unstable]
+checksum-freshness = true
+
+[build]
+fingerprint = "content"
+```
+
+### `build.fingerprint`
+
+* Type: string
+* Default: `"mtime"`
+* Environment: `CARGO_BUILD_FINGERPRINT`
+
+Select the method used for detecting when a build should occur based on source input changes.
+
+* `mtime`: Last modified time of the input
+* `content`: Checksum of the input
+
+> [!NOTE]
+> This does not affect the build script `cargo::rerun-if-changed` directive.
+
 ## panic-abort-tests
 * Tracking Issue: [#67650](https://github.com/rust-lang/rust/issues/67650)
 * Original Pull Request: [#7460](https://github.com/rust-lang/cargo/pull/7460)

--- a/src/compiler/fingerprint/dirty_reason.rs
+++ b/src/compiler/fingerprint/dirty_reason.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 
 use super::*;
 use crate::compiler::UnitIndex;
+use crate::context::FingerprintMethod;
 use cargo_util_terminal::Shell;
 
 /// Tells a better story of why a build is considered "dirty" that leads
@@ -38,8 +39,9 @@ pub enum DirtyReason {
         old: String,
         new: String,
     },
-    ChecksumUseChanged {
-        old: bool,
+    FingerprintMethodChanged {
+        old: FingerprintMethod,
+        new: FingerprintMethod,
     },
     DepInfoOutputChanged {
         old: PathBuf,
@@ -188,16 +190,10 @@ impl DirtyReason {
             DirtyReason::PrecalculatedComponentsChanged { .. } => {
                 s.dirty_because(unit, "the precalculated components changed")
             }
-            DirtyReason::ChecksumUseChanged { old } => {
-                if *old {
-                    s.dirty_because(
-                        unit,
-                        "the prior compilation used checksum freshness and this one does not",
-                    )
-                } else {
-                    s.dirty_because(unit, "checksum freshness requested, prior compilation did not use checksum freshness")
-                }
-            }
+            DirtyReason::FingerprintMethodChanged { old, new } => s.dirty_because(
+                unit,
+                format_args!("the prior compilation fingerprinted build inputs using `{old}` and this one used `{new}`"),
+            ),
             DirtyReason::DepInfoOutputChanged { .. } => {
                 s.dirty_because(unit, "the dependency info output changed")
             }
@@ -793,14 +789,18 @@ mod json_schema {
     }
 
     #[test]
-    fn checksum_use_changed() {
-        let reason = DirtyReason::ChecksumUseChanged { old: false };
+    fn fingerprint_method_changed() {
+        let reason = DirtyReason::FingerprintMethodChanged {
+            old: FingerprintMethod::Mtime,
+            new: FingerprintMethod::Content,
+        };
         assert_data_eq!(
             to_json(&reason),
             str![[r#"
 {
-  "dirty_reason": "checksum-use-changed",
-  "old": false
+  "dirty_reason": "fingerprint-method-changed",
+  "new": "content",
+  "old": "mtime"
 }
 "#]]
             .is_json()

--- a/src/compiler/fingerprint/mod.rs
+++ b/src/compiler/fingerprint/mod.rs
@@ -403,6 +403,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
 
 use crate::compiler::unit_graph::UnitDep;
+use crate::context::FingerprintMethod;
 use crate::util;
 use crate::util::errors::CargoResult;
 use crate::util::interning::InternedString;
@@ -833,7 +834,10 @@ enum LocalFingerprint {
     ///
     /// If the `checksum` bool is true then the `dep_info` file is expected to
     /// contain file checksums instead of file mtimes.
-    CheckDepInfo { dep_info: PathBuf, checksum: bool },
+    CheckDepInfo {
+        dep_info: PathBuf,
+        fingerprint: FingerprintMethod,
+    },
 
     /// This represents a nonempty set of `rerun-if-changed` annotations printed
     /// out by a build script. The `output` file is a relative file anchored at
@@ -948,7 +952,10 @@ impl LocalFingerprint {
             // matches, and for each file we see if any of them are newer than
             // the `dep_info` file itself whose mtime represents the start of
             // rustc.
-            LocalFingerprint::CheckDepInfo { dep_info, checksum } => {
+            LocalFingerprint::CheckDepInfo {
+                dep_info,
+                fingerprint,
+            } => {
                 let dep_info = build_root.join(dep_info);
                 let Some(info) = parse_dep_info(pkg_root, build_root, &dep_info)? else {
                     return Ok(Some(StaleItem::MissingFile { path: dep_info }));
@@ -983,22 +990,21 @@ impl LocalFingerprint {
                         current: current.map(Into::into),
                     }));
                 }
-                if *checksum {
-                    Ok(find_stale_file(
+                match fingerprint {
+                    FingerprintMethod::Content => Ok(find_stale_file(
                         mtime_cache,
                         checksum_cache,
                         &dep_info,
                         info.files.iter().map(|(file, checksum)| (file, *checksum)),
-                        *checksum,
-                    ))
-                } else {
-                    Ok(find_stale_file(
+                        *fingerprint,
+                    )),
+                    FingerprintMethod::Mtime => Ok(find_stale_file(
                         mtime_cache,
                         checksum_cache,
                         &dep_info,
                         info.files.into_keys().map(|p| (p, None)),
-                        *checksum,
-                    ))
+                        *fingerprint,
+                    )),
                 }
             }
 
@@ -1009,7 +1015,7 @@ impl LocalFingerprint {
                 checksum_cache,
                 &build_root.join(output),
                 paths.iter().map(|p| (pkg_root.join(p), None)),
-                false,
+                FingerprintMethod::Mtime,
             )),
 
             // These have no dependencies on the filesystem, and their values
@@ -1130,11 +1136,11 @@ impl Fingerprint {
                 (
                     LocalFingerprint::CheckDepInfo {
                         dep_info: a_dep,
-                        checksum: checksum_a,
+                        fingerprint: fingerprint_a,
                     },
                     LocalFingerprint::CheckDepInfo {
                         dep_info: b_dep,
-                        checksum: checksum_b,
+                        fingerprint: fingerprint_b,
                     },
                 ) => {
                     if a_dep != b_dep {
@@ -1143,8 +1149,11 @@ impl Fingerprint {
                             new: a_dep.clone(),
                         };
                     }
-                    if checksum_a != checksum_b {
-                        return DirtyReason::ChecksumUseChanged { old: *checksum_b };
+                    if fingerprint_a != fingerprint_b {
+                        return DirtyReason::FingerprintMethodChanged {
+                            old: *fingerprint_b,
+                            new: *fingerprint_a,
+                        };
                     }
                 }
                 (
@@ -1604,9 +1613,19 @@ fn calculate_normal(
     } else {
         let dep_info = dep_info_loc(build_runner, unit);
         let dep_info = dep_info.strip_prefix(&build_root).unwrap().to_path_buf();
+        let fingerprint = if build_runner.bcx.gctx.cli_unstable().checksum_freshness {
+            build_runner
+                .bcx
+                .gctx
+                .build_config()?
+                .fingerprint
+                .unwrap_or_default()
+        } else {
+            FingerprintMethod::Mtime
+        };
         vec![LocalFingerprint::CheckDepInfo {
             dep_info,
-            checksum: build_runner.bcx.gctx.cli_unstable().checksum_freshness,
+            fingerprint,
         }]
     };
 
@@ -2086,7 +2105,7 @@ fn find_stale_file<I, P>(
     checksum_cache: &mut HashMap<PathBuf, Checksum>,
     reference: &Path,
     paths: I,
-    use_checksums: bool,
+    fingerprint: FingerprintMethod,
 ) -> Option<StaleItem>
 where
     I: IntoIterator<Item = (P, Option<(u64, Checksum)>)>,
@@ -2122,91 +2141,94 @@ where
                 continue;
             }
         }
-        if use_checksums {
-            let Some((file_len, prior_checksum)) = prior_checksum else {
-                return Some(StaleItem::MissingChecksum {
-                    path: path.to_path_buf(),
-                });
-            };
-            let path_buf = path.to_path_buf();
+        match fingerprint {
+            FingerprintMethod::Content => {
+                let Some((file_len, prior_checksum)) = prior_checksum else {
+                    return Some(StaleItem::MissingChecksum {
+                        path: path.to_path_buf(),
+                    });
+                };
+                let path_buf = path.to_path_buf();
 
-            let path_checksum = match checksum_cache.entry(path_buf) {
-                Entry::Occupied(o) => *o.get(),
-                Entry::Vacant(v) => {
-                    let Ok(current_file_len) = fs::metadata(&path).map(|m| m.len()) else {
-                        return Some(StaleItem::FailedToReadMetadata {
-                            path: path.to_path_buf(),
-                        });
-                    };
-                    if current_file_len != file_len {
-                        return Some(StaleItem::FileSizeChanged {
-                            path: path.to_path_buf(),
-                            new_size: current_file_len,
-                            old_size: file_len,
-                        });
+                let path_checksum = match checksum_cache.entry(path_buf) {
+                    Entry::Occupied(o) => *o.get(),
+                    Entry::Vacant(v) => {
+                        let Ok(current_file_len) = fs::metadata(&path).map(|m| m.len()) else {
+                            return Some(StaleItem::FailedToReadMetadata {
+                                path: path.to_path_buf(),
+                            });
+                        };
+                        if current_file_len != file_len {
+                            return Some(StaleItem::FileSizeChanged {
+                                path: path.to_path_buf(),
+                                new_size: current_file_len,
+                                old_size: file_len,
+                            });
+                        }
+                        let Ok(file) = File::open(path) else {
+                            return Some(StaleItem::MissingFile {
+                                path: path.to_path_buf(),
+                            });
+                        };
+                        let Ok(checksum) = Checksum::compute(prior_checksum.algo(), file) else {
+                            return Some(StaleItem::UnableToReadFile {
+                                path: path.to_path_buf(),
+                            });
+                        };
+                        *v.insert(checksum)
                     }
-                    let Ok(file) = File::open(path) else {
-                        return Some(StaleItem::MissingFile {
-                            path: path.to_path_buf(),
-                        });
-                    };
-                    let Ok(checksum) = Checksum::compute(prior_checksum.algo(), file) else {
-                        return Some(StaleItem::UnableToReadFile {
-                            path: path.to_path_buf(),
-                        });
-                    };
-                    *v.insert(checksum)
+                };
+                if path_checksum == prior_checksum {
+                    continue;
                 }
-            };
-            if path_checksum == prior_checksum {
-                continue;
+                return Some(StaleItem::ChangedChecksum {
+                    source: path.to_path_buf(),
+                    stored_checksum: prior_checksum,
+                    new_checksum: path_checksum,
+                });
             }
-            return Some(StaleItem::ChangedChecksum {
-                source: path.to_path_buf(),
-                stored_checksum: prior_checksum,
-                new_checksum: path_checksum,
-            });
-        } else {
-            let path_mtime = match mtime_cache.entry(path.to_path_buf()) {
-                Entry::Occupied(o) => *o.get(),
-                Entry::Vacant(v) => {
-                    let Ok(mtime) = paths::mtime_recursive(path) else {
-                        return Some(StaleItem::MissingFile {
-                            path: path.to_path_buf(),
-                        });
-                    };
-                    *v.insert(mtime)
+            FingerprintMethod::Mtime => {
+                let path_mtime = match mtime_cache.entry(path.to_path_buf()) {
+                    Entry::Occupied(o) => *o.get(),
+                    Entry::Vacant(v) => {
+                        let Ok(mtime) = paths::mtime_recursive(path) else {
+                            return Some(StaleItem::MissingFile {
+                                path: path.to_path_buf(),
+                            });
+                        };
+                        *v.insert(mtime)
+                    }
+                };
+
+                // TODO: fix #5918.
+                // Note that equal mtimes should be considered "stale". For filesystems with
+                // not much timestamp precision like 1s this is would be a conservative approximation
+                // to handle the case where a file is modified within the same second after
+                // a build starts. We want to make sure that incremental rebuilds pick that up!
+                //
+                // For filesystems with nanosecond precision it's been seen in the wild that
+                // its "nanosecond precision" isn't really nanosecond-accurate. It turns out that
+                // kernels may cache the current time so files created at different times actually
+                // list the same nanosecond precision. Some digging on #5919 picked up that the
+                // kernel caches the current time between timer ticks, which could mean that if
+                // a file is updated at most 10ms after a build starts then Cargo may not
+                // pick up the build changes.
+                //
+                // All in all, an equality check here would be a conservative assumption that,
+                // if equal, files were changed just after a previous build finished.
+                // Unfortunately this became problematic when (in #6484) cargo switch to more accurately
+                // measuring the start time of builds.
+                if path_mtime <= reference_mtime {
+                    continue;
                 }
-            };
 
-            // TODO: fix #5918.
-            // Note that equal mtimes should be considered "stale". For filesystems with
-            // not much timestamp precision like 1s this is would be a conservative approximation
-            // to handle the case where a file is modified within the same second after
-            // a build starts. We want to make sure that incremental rebuilds pick that up!
-            //
-            // For filesystems with nanosecond precision it's been seen in the wild that
-            // its "nanosecond precision" isn't really nanosecond-accurate. It turns out that
-            // kernels may cache the current time so files created at different times actually
-            // list the same nanosecond precision. Some digging on #5919 picked up that the
-            // kernel caches the current time between timer ticks, which could mean that if
-            // a file is updated at most 10ms after a build starts then Cargo may not
-            // pick up the build changes.
-            //
-            // All in all, an equality check here would be a conservative assumption that,
-            // if equal, files were changed just after a previous build finished.
-            // Unfortunately this became problematic when (in #6484) cargo switch to more accurately
-            // measuring the start time of builds.
-            if path_mtime <= reference_mtime {
-                continue;
+                return Some(StaleItem::ChangedFile {
+                    reference: reference.to_path_buf(),
+                    reference_mtime,
+                    stale: path.to_path_buf(),
+                    stale_mtime: path_mtime,
+                });
             }
-
-            return Some(StaleItem::ChangedFile {
-                reference: reference.to_path_buf(),
-                reference_mtime,
-                stale: path.to_path_buf(),
-                stale_mtime: path_mtime,
-            });
         }
     }
 

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -106,6 +106,7 @@ use crate::compiler::timings::SectionTiming;
 pub use crate::compiler::unit::Unit;
 pub use crate::compiler::unit::UnitIndex;
 pub use crate::compiler::unit::UnitInterner;
+use crate::context::FingerprintMethod;
 use crate::diagnostics::get_key_value;
 use crate::util::OnceExt;
 use crate::util::errors::{CargoResult, VerboseError};
@@ -198,6 +199,23 @@ fn compile<'gctx>(
     } else {
         None
     };
+
+    match build_runner
+        .bcx
+        .gctx
+        .build_config()?
+        .fingerprint
+        .unwrap_or_default()
+    {
+        FingerprintMethod::Content => {
+            if !build_runner.bcx.gctx.cli_unstable().checksum_freshness {
+                build_runner.bcx.gctx.shell().warn(
+                    r#"ignoring `build.fingerprint = "content"` without `-Zchecksum-freshness`"#,
+                )?;
+            }
+        }
+        FingerprintMethod::Mtime => {}
+    }
 
     // If we are in `--compile-time-deps` and the given unit is not a compile time
     // dependency, skip compiling the unit and jumps to dependencies, which still
@@ -831,7 +849,18 @@ fn prepare_rustc(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> CargoResult
         base.arg("-Z").arg("binary-dep-depinfo");
     }
     if build_runner.bcx.gctx.cli_unstable().checksum_freshness {
-        base.arg("-Z").arg("checksum-hash-algorithm=blake3");
+        match build_runner
+            .bcx
+            .gctx
+            .build_config()?
+            .fingerprint
+            .unwrap_or_default()
+        {
+            FingerprintMethod::Content => {
+                base.arg("-Z").arg("checksum-hash-algorithm=blake3");
+            }
+            FingerprintMethod::Mtime => {}
+        }
     }
 
     if is_primary {
@@ -922,7 +951,18 @@ fn prepare_rustdoc(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> CargoResu
         rustdoc.arg(arg);
 
         if build_runner.bcx.gctx.cli_unstable().checksum_freshness {
-            rustdoc.arg("-Z").arg("checksum-hash-algorithm=blake3");
+            match build_runner
+                .bcx
+                .gctx
+                .build_config()?
+                .fingerprint
+                .unwrap_or_default()
+            {
+                FingerprintMethod::Content => {
+                    rustdoc.arg("-Z").arg("checksum-hash-algorithm=blake3");
+                }
+                FingerprintMethod::Mtime => {}
+            }
         }
     } else if build_runner.bcx.gctx.cli_unstable().rustdoc_mergeable_info && !wants_json_output {
         // toolchain resources are written at the end, at the same time as merging

--- a/src/context/schema.rs
+++ b/src/context/schema.rs
@@ -16,6 +16,7 @@ use std::ffi::OsStr;
 
 use cargo_credential::Secret;
 use serde::Deserialize;
+use serde::Serialize;
 use serde_untagged::UntaggedEnumVisitor;
 
 use std::path::Path;
@@ -218,6 +219,8 @@ pub struct CargoBuildConfig {
     pub sbom: Option<bool>,
     /// Unstable feature `-Zbuild-analysis`.
     pub analysis: Option<CargoBuildAnalysis>,
+    /// Unstable feature `-Zchecksum-freshness`.
+    pub fingerprint: Option<FingerprintMethod>,
 }
 
 /// Metrics collection for build analysis.
@@ -238,6 +241,29 @@ pub enum WarningHandling {
     Allow,
     /// Error if  warnings are emitted.
     Deny,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Deserialize, Serialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum FingerprintMethod {
+    #[default]
+    Mtime,
+    Content,
+}
+
+impl FingerprintMethod {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Mtime => "mtime",
+            Self::Content => "content",
+        }
+    }
+}
+
+impl std::fmt::Display for FingerprintMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.as_str().fmt(f)
+    }
 }
 
 /// Configuration for `build.target`.

--- a/src/ops/cargo_report/rebuilds.rs
+++ b/src/ops/cargo_report/rebuilds.rs
@@ -501,12 +501,8 @@ fn format_dirty_reason(
         DirtyReason::PrecalculatedComponentsChanged { old, new } => {
             format!("precalculated components changed: {old} -> {new}")
         }
-        DirtyReason::ChecksumUseChanged { old } => {
-            if *old {
-                "checksum use changed: enabled -> disabled".to_string()
-            } else {
-                "checksum use changed: disabled -> enabled".to_string()
-            }
+        DirtyReason::FingerprintMethodChanged { old, new } => {
+            format!("fingerprinty changed: {old} -> {new}")
         }
         DirtyReason::DepInfoOutputChanged { old, new } => {
             let old = old.strip_prefix(ws_root).unwrap_or(old).display();

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -3178,6 +3178,7 @@ fn rebuild_tracks_checksum() {
         .build();
 
     p.cargo("doc -Zrustdoc-depinfo -Zchecksum-freshness")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .masquerade_as_nightly_cargo(&["rustdoc-depinfo", "checksum-freshness"])
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.5.0 ([ROOT]/parent/foo)
@@ -3195,6 +3196,7 @@ fn rebuild_tracks_checksum() {
     p.root().move_into_the_future();
 
     p.cargo("doc --verbose -Zrustdoc-depinfo -Zchecksum-freshness")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.5.0 ([ROOT]/parent/foo): file size changed (16 != 15) for `src/../../README`

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -24,6 +24,7 @@ fn checksum_build_compatible_with_mtime_build() {
         .build();
 
     p.cargo("check")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -40,6 +41,7 @@ fn checksum_build_compatible_with_mtime_build() {
 "#]])
         .run();
     p.cargo("check")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"

--- a/tests/testsuite/freshness_checksum.rs
+++ b/tests/testsuite/freshness_checksum.rs
@@ -23,6 +23,7 @@ use filetime::FileTime;
 fn non_nightly_fails() {
     let p = project().file("src/main.rs", "fn main() {}").build();
     p.cargo("build")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .with_stderr_data(str![[r#"
 [ERROR] the `-Z` flag is only accepted on the nightly channel of Cargo, but this is the `stable` channel
@@ -39,6 +40,7 @@ fn warn_on_missing_feature() {
     p.cargo("check")
         .env("CARGO_BUILD_FINGERPRINT", "content")
         .with_stderr_data(str![[r#"
+[WARNING] ignoring `build.fingerprint = "content"` without `-Zchecksum-freshness`
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -61,6 +63,7 @@ fn checksum_actually_uses_checksum() {
         .build();
 
     p.cargo("check")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -72,6 +75,7 @@ fn checksum_actually_uses_checksum() {
     p.root().move_into_the_future();
 
     p.cargo("check")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -89,6 +93,7 @@ fn same_size_different_content() {
         .build();
 
     p.cargo("check")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -100,6 +105,7 @@ fn same_size_different_content() {
     p.change_file("src/main.rs", "mod a;fn main() { }");
 
     p.cargo("check -v")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -112,6 +118,7 @@ fn same_size_different_content() {
         .run();
 
     p.cargo("check")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -161,6 +168,7 @@ fn binary_depinfo_correctly_encoded() {
     let host = rustc_host();
     p.cargo("build -Zbinary-dep-depinfo --target")
         .arg(&host)
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["binary-dep-depinfo", "checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -187,6 +195,7 @@ fn binary_depinfo_correctly_encoded() {
     // Make sure it stays fresh.
     p.cargo("build -Zbinary-dep-depinfo --target")
         .arg(&host)
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["binary-dep-depinfo", "checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -204,6 +213,7 @@ fn modifying_and_moving() {
         .build();
 
     p.cargo("build")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -214,6 +224,7 @@ fn modifying_and_moving() {
         .run();
 
     p.cargo("build")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -226,6 +237,7 @@ fn modifying_and_moving() {
 
     p.change_file("src/a.rs", "#[allow(unused)]fn main() {}");
     p.cargo("build -v")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -239,6 +251,7 @@ fn modifying_and_moving() {
 
     fs::rename(&p.root().join("src/a.rs"), &p.root().join("src/b.rs")).unwrap();
     p.cargo("build")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_status(101)
@@ -263,6 +276,7 @@ fn modify_only_some_files() {
         .build();
 
     p.cargo("build")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -272,6 +286,7 @@ fn modify_only_some_files() {
 "#]])
         .run();
     p.cargo("test")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .run();
@@ -285,6 +300,7 @@ fn modify_only_some_files() {
 
     // Despite mtime change, lib rebuilds and fails
     p.cargo("build -v")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_status(101)
@@ -329,6 +345,7 @@ fn rebuild_sub_package_then_while_package() {
         .build();
 
     p.cargo("build")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -344,6 +361,7 @@ fn rebuild_sub_package_then_while_package() {
     p.change_file("b/src/lib.rs", "pub fn b() {}");
 
     p.cargo("build -pb -v")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -361,6 +379,7 @@ fn rebuild_sub_package_then_while_package() {
     );
 
     p.cargo("build -v")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -385,10 +404,12 @@ fn rebuild_tests_if_lib_changes() {
         .build();
 
     p.cargo("build")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .run();
     p.cargo("test")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .run();
@@ -396,10 +417,12 @@ fn rebuild_tests_if_lib_changes() {
     p.change_file("src/lib.rs", "");
 
     p.cargo("build")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .run();
     p.cargo("test -v --test foo-test")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -435,6 +458,7 @@ fn no_rebuild_if_build_artifacts_move_backwards_in_time() {
         .build();
 
     p.cargo("build")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .run();
@@ -442,6 +466,7 @@ fn no_rebuild_if_build_artifacts_move_backwards_in_time() {
     p.root().move_into_the_past();
 
     p.cargo("build")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stdout_data(str![])
@@ -474,6 +499,7 @@ fn no_rebuild_if_build_artifacts_move_forward_in_time() {
         .build();
 
     p.cargo("build")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .run();
@@ -481,6 +507,7 @@ fn no_rebuild_if_build_artifacts_move_forward_in_time() {
     p.root().move_into_the_future();
 
     p.cargo("build")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .env("CARGO_LOG", "")
@@ -523,6 +550,7 @@ fn no_rebuild_when_rename_dir() {
     fs::write(p.root().join("src/lib.rs"), "").unwrap();
 
     p.cargo("build")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .run();
@@ -532,6 +560,7 @@ fn no_rebuild_when_rename_dir() {
     fs::rename(p.root(), &new).unwrap();
 
     p.cargo("build")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .cwd(&new)
@@ -563,6 +592,7 @@ fn update_dependency_mtime_does_not_rebuild() {
         .build();
 
     p.cargo("build -Z mtime-on-use")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["mtime-on-use", "checksum-freshness"])
         .env("RUSTFLAGS", "-C linker=cc")
@@ -576,6 +606,7 @@ fn update_dependency_mtime_does_not_rebuild() {
         .run();
     // This does not make new files, but it does update the mtime of the dependency.
     p.cargo("build -p bar -Z mtime-on-use")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["mtime-on-use", "checksum-freshness"])
         .env("RUSTFLAGS", "-C linker=cc")
@@ -586,6 +617,7 @@ fn update_dependency_mtime_does_not_rebuild() {
         .run();
     // This should not recompile!
     p.cargo("build -Z mtime-on-use")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["mtime-on-use", "checksum-freshness"])
         .env("RUSTFLAGS", "-C linker=cc")
@@ -654,10 +686,12 @@ fn fingerprint_cleaner_does_not_rebuild() {
         .build();
 
     p.cargo("build -Z mtime-on-use")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["mtime-on-use", "checksum-freshness"])
         .run();
     p.cargo("build -Z mtime-on-use --features a")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["mtime-on-use", "checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -675,6 +709,7 @@ fn fingerprint_cleaner_does_not_rebuild() {
     }
     // This does not make new files, but it does update the mtime.
     p.cargo("build -Z mtime-on-use --features a")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["mtime-on-use", "checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -685,6 +720,7 @@ fn fingerprint_cleaner_does_not_rebuild() {
     fingerprint_cleaner(p.target_debug_dir(), timestamp);
     // This should not recompile!
     p.cargo("build -Z mtime-on-use --features a")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["mtime-on-use", "checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -694,6 +730,7 @@ fn fingerprint_cleaner_does_not_rebuild() {
         .run();
     // But this should be cleaned and so need a rebuild
     p.cargo("build -Z mtime-on-use")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["mtime-on-use", "checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -733,6 +770,7 @@ fn bust_patched_dep() {
         .build();
 
     p.cargo("build")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .run();
@@ -740,6 +778,7 @@ fn bust_patched_dep() {
     p.change_file("reg1new/src/lib.rs", "// modified");
 
     p.cargo("build -v")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -758,6 +797,7 @@ fn bust_patched_dep() {
         .run();
 
     p.cargo("build -v")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -857,6 +897,7 @@ fn rebuild_on_mid_build_file_modification() {
     });
 
     p.cargo("build")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -868,6 +909,7 @@ fn rebuild_on_mid_build_file_modification() {
         .run();
 
     p.cargo("build -v")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -956,12 +998,14 @@ fn dirty_both_lib_and_test() {
         .build();
 
     p.cargo("build")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .run();
 
     // 2 != 1
     p.cargo("test --lib")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_status(101)
@@ -972,11 +1016,13 @@ fn dirty_both_lib_and_test() {
     p.change_file("slib.rs", &slib(1));
 
     p.cargo("build")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .run();
     // This should recompile with the new static lib, and the test should pass.
     p.cargo("test --lib")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .run();
@@ -1006,11 +1052,13 @@ fn script_fails_stay_dirty() {
         .build();
 
     p.cargo("build")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .run();
     p.change_file("helper.rs", r#"pub fn doit() {panic!("Crash!");}"#);
     p.cargo("build")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data("...\n[..]Crash![..]\n...")
@@ -1018,6 +1066,7 @@ fn script_fails_stay_dirty() {
         .run();
     // There was a bug where this second call would be "fresh".
     p.cargo("build")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data("...\n[..]Crash![..]\n...")
@@ -1089,6 +1138,7 @@ fn simulated_docker_deps_stay_cached() {
         .build();
 
     p.cargo("build")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .run();
@@ -1134,6 +1184,7 @@ fn simulated_docker_deps_stay_cached() {
         println!("already zero");
         // If it was already truncated, then everything stays fresh.
         p.cargo("build -v")
+            .env("CARGO_BUILD_FINGERPRINT", "content")
             .arg("-Zchecksum-freshness")
             .masquerade_as_nightly_cargo(&["checksum-freshness"])
             .with_stderr_data(
@@ -1162,6 +1213,7 @@ fn simulated_docker_deps_stay_cached() {
         // in it. It differs between builds because one has nsec=0 and the other
         // likely has a nonzero nsec. Hence, the rebuild.
         p.cargo("build -v")
+            .env("CARGO_BUILD_FINGERPRINT", "content")
             .arg("-Zchecksum-freshness")
             .masquerade_as_nightly_cargo(&["checksum-freshness"])
             .with_stderr_data(
@@ -1229,6 +1281,7 @@ fn rename_with_path_deps() {
     let p = p.build();
 
     p.cargo("build")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .run();
@@ -1242,6 +1295,7 @@ fn rename_with_path_deps() {
     fs::rename(p.root(), &new).unwrap();
 
     p.cargo("build")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .cwd(&new)
@@ -1311,6 +1365,7 @@ fn move_target_directory_with_path_deps() {
     parent.pop();
 
     p.cargo("build")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .run();
@@ -1319,6 +1374,7 @@ fn move_target_directory_with_path_deps() {
     fs::rename(p.root().join("target"), &new_target).unwrap();
 
     p.cargo("build")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .env("CARGO_TARGET_DIR", &new_target)
@@ -1363,6 +1419,7 @@ fn verify_source_before_recompile() {
     );
     // Sanity check: vendoring works correctly.
     p.cargo("check --verbose")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -1381,6 +1438,7 @@ fn verify_source_before_recompile() {
     );
     // Should ignore modified sources without any recompile.
     p.cargo("check --verbose")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -1396,6 +1454,7 @@ fn verify_source_before_recompile() {
     // Cargo should refuse to build because of checksum verification failure.
     // Cargo shouldn't recompile dependency `bar`.
     p.cargo("check --verbose")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .env("RUSTFLAGS", "-W warnings")
@@ -1421,6 +1480,7 @@ fn skip_checksum_check_in_selected_cargo_home_subdirs() {
     let project_root = p.root();
     let cargo_home = project_root.parent().unwrap().parent().unwrap();
     p.cargo("check -v")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .env("CARGO_HOME", &cargo_home)
@@ -1433,6 +1493,7 @@ fn skip_checksum_check_in_selected_cargo_home_subdirs() {
         .run();
     p.change_file("src/lib.rs", "illegal syntax");
     p.cargo("check -v")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .env("CARGO_HOME", &cargo_home)
@@ -1454,6 +1515,7 @@ fn use_checksum_cache_in_cargo_home() {
     let project_root = p.root();
     let cargo_home = project_root.parent().unwrap();
     p.cargo("check -v")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .env("CARGO_HOME", &cargo_home)
@@ -1466,6 +1528,7 @@ fn use_checksum_cache_in_cargo_home() {
         .run();
     p.change_file("src/lib.rs", "illegal syntax");
     p.cargo("check -v")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .env("CARGO_HOME", &cargo_home)
@@ -1494,6 +1557,7 @@ fn incremental_build_script_execution_got_new_mtime_and_cargo_check() {
         .build();
 
     p.cargo("check")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .env("CARGO_INCREMENTAL", "1")
@@ -1508,6 +1572,7 @@ fn incremental_build_script_execution_got_new_mtime_and_cargo_check() {
 
     // The first one is expected to rerun build script
     p.cargo("check -v")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .env("CARGO_INCREMENTAL", "1")
@@ -1523,6 +1588,7 @@ fn incremental_build_script_execution_got_new_mtime_and_cargo_check() {
 
     // subsequent cargo check gets stuck...
     p.cargo("check -v")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .env("CARGO_INCREMENTAL", "1")
@@ -1534,6 +1600,7 @@ fn incremental_build_script_execution_got_new_mtime_and_cargo_check() {
         .run();
 
     p.cargo("check -v")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .env("CARGO_INCREMENTAL", "1")
@@ -1593,6 +1660,7 @@ fn symlink_to_package() {
         .symlink_dir("bar1", "bar")
         .build();
     p.cargo("check")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -1608,6 +1676,7 @@ fn symlink_to_package() {
     p.symlink("bar2", "bar");
     // Checksums detect the changed source behind the symlink.
     p.cargo("check")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["checksum-freshness"])
         .with_stderr_data(str![[r#"

--- a/tests/testsuite/freshness_checksum.rs
+++ b/tests/testsuite/freshness_checksum.rs
@@ -33,6 +33,26 @@ See https://doc.rust-lang.org/book/appendix-07-nightly-rust.html for more inform
         .run();
 }
 
+#[cargo_test]
+fn warn_on_missing_feature() {
+    let p = project().file("src/main.rs", "fn main() {}").build();
+    p.cargo("check")
+        .env("CARGO_BUILD_FINGERPRINT", "content")
+        .with_stderr_data(str![[r#"
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+    p.cargo("check")
+        .env("CARGO_BUILD_FINGERPRINT", "mtime")
+        .with_stderr_data(str![[r#"
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
 #[cargo_test(nightly, reason = "requires -Zchecksum-hash-algorithm")]
 fn checksum_actually_uses_checksum() {
     let p = project()


### PR DESCRIPTION
### What does this PR try to resolve?

This is part of #14136

This changes `-Zchecksum-freshness` from turning on checksum freshness to enabling `build.fingerprint`.

For `.cargo/config.toml`:
```toml
[unstable]
checksum-freshness = true

[build]
fingerprint = "content"
```

### How to test and review this PR?

