### PR TITLE
chore(ci): exclude resolver-tests from intra doc link checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -324,7 +324,7 @@ jobs:
     - name: Run semver-check
       run: cargo +stable run -p semver-check
     - name: Ensure intradoc links are valid
-      run: cargo doc --workspace --document-private-items --no-deps --keep-going
+      run: cargo doc --workspace --exclude resolver-tests --document-private-items --no-deps --keep-going
       env:
         CARGO_BUILD_WARNINGS: deny
     - name: Install mdbook


### PR DESCRIPTION


### What does this PR try to resolve?

next trait resolver might have bugs dealing with it,
but anyway we care less about intra doclinks for resolver-tests,
and it anyway builds in clippy jobs.


### How to test and review this PR?

See <https://github.com/rust-lang/cargo/pull/17384#issuecomment-5381521900>:

```
# works
env RUSTFLAGS=-Znext-solver=coherence cargo +nightly-2026-08-22 check -p varisat

# stuck
env RUSTFLAGS=-Znext-solver=globally cargo +nightly-2026-08-22 check -p varisat
```