### PR TITLE
fix(install): use packaged lockfile by default

### DIFF
--- a/doc/book/src/commands/cargo-install.md
+++ b/doc/book/src/commands/cargo-install.md
@@ -60,19 +60,14 @@ continuous integration systems.
 
 ### Dealing with the Lockfile
 
-By default, the `Cargo.lock` file that is included with the package will be
-ignored. This means that Cargo will recompute which versions of dependencies
-to use, possibly using newer versions that have been released since the
-package was published. The `--locked` flag can be used to force Cargo to use
-the packaged `Cargo.lock` file if it is available. This may be useful for
-ensuring reproducible builds, to use the exact same set of dependencies that
-were available when the package was published. It may also be useful if a
-newer version of a dependency is published that no longer builds on your
-system, or has other problems. The downside to using `--locked` is that you
-will not receive any fixes or updates to any dependency. Note that Cargo did
-not start publishing `Cargo.lock` files until version 1.37, which means
-packages published with prior versions will not have a `Cargo.lock` file
-available.
+By default, Cargo uses the `Cargo.lock` file included with the package if it is
+available. This ensures that the installed executable uses the dependency versions
+selected when the package was published. If no lockfile is available, including for
+packages published with versions of Cargo before 1.37, Cargo resolves the dependencies
+normally.
+
+The `--locked` flag does not currently change dependency resolution for `cargo install`.
+If no `Cargo.lock` is available, using `--locked` emits a warning.
 
 ### Configuration Discovery
 

--- a/doc/man/cargo-install.md
+++ b/doc/man/cargo-install.md
@@ -58,19 +58,14 @@ continuous integration systems.
 
 ### Dealing with the Lockfile
 
-By default, the `Cargo.lock` file that is included with the package will be
-ignored. This means that Cargo will recompute which versions of dependencies
-to use, possibly using newer versions that have been released since the
-package was published. The `--locked` flag can be used to force Cargo to use
-the packaged `Cargo.lock` file if it is available. This may be useful for
-ensuring reproducible builds, to use the exact same set of dependencies that
-were available when the package was published. It may also be useful if a
-newer version of a dependency is published that no longer builds on your
-system, or has other problems. The downside to using `--locked` is that you
-will not receive any fixes or updates to any dependency. Note that Cargo did
-not start publishing `Cargo.lock` files until version 1.37, which means
-packages published with prior versions will not have a `Cargo.lock` file
-available.
+By default, Cargo uses the `Cargo.lock` file included with the package if it is
+available. This ensures that the installed executable uses the dependency versions
+selected when the package was published. If no lockfile is available, including for
+packages published with versions of Cargo before 1.37, Cargo resolves the dependencies
+normally.
+
+The `--locked` flag does not currently change dependency resolution for `cargo install`.
+If no `Cargo.lock` is available, using `--locked` emits a warning.
 
 ### Configuration Discovery
 

--- a/doc/man/generated_txt/cargo-install.txt
+++ b/doc/man/generated_txt/cargo-install.txt
@@ -68,19 +68,15 @@ DESCRIPTION
        artifacts on continuous integration systems.
 
    Dealing with the Lockfile
-       By default, the Cargo.lock file that is included with the package will
-       be ignored. This means that Cargo will recompute which versions of
-       dependencies to use, possibly using newer versions that have been
-       released since the package was published. The --locked flag can be used
-       to force Cargo to use the packaged Cargo.lock file if it is available.
-       This may be useful for ensuring reproducible builds, to use the exact
-       same set of dependencies that were available when the package was
-       published. It may also be useful if a newer version of a dependency is
-       published that no longer builds on your system, or has other problems.
-       The downside to using --locked is that you will not receive any fixes or
-       updates to any dependency. Note that Cargo did not start publishing
-       Cargo.lock files until version 1.37, which means packages published with
-       prior versions will not have a Cargo.lock file available.
+       By default, Cargo uses the Cargo.lock file included with the package if
+       it is available. This ensures that the installed executable uses the
+       dependency versions selected when the package was published. If no
+       lockfile is available, including for packages published with versions of
+       Cargo before 1.37, Cargo resolves the dependencies normally.
+
+       The --locked flag does not currently change dependency resolution for
+       cargo install. If no Cargo.lock is available, using --locked emits a
+       warning.
 
    Configuration Discovery
        This command operates on system or user level, not project level. This

--- a/etc/man/cargo-install.1
+++ b/etc/man/cargo-install.1
@@ -88,19 +88,14 @@ specified by setting the \fBCARGO_TARGET_DIR\fR environment variable to a
 path. In particular, this can be useful for caching build artifacts on
 continuous integration systems.
 .SS "Dealing with the Lockfile"
-By default, the \fBCargo.lock\fR file that is included with the package will be
-ignored. This means that Cargo will recompute which versions of dependencies
-to use, possibly using newer versions that have been released since the
-package was published. The \fB\-\-locked\fR flag can be used to force Cargo to use
-the packaged \fBCargo.lock\fR file if it is available. This may be useful for
-ensuring reproducible builds, to use the exact same set of dependencies that
-were available when the package was published. It may also be useful if a
-newer version of a dependency is published that no longer builds on your
-system, or has other problems. The downside to using \fB\-\-locked\fR is that you
-will not receive any fixes or updates to any dependency. Note that Cargo did
-not start publishing \fBCargo.lock\fR files until version 1.37, which means
-packages published with prior versions will not have a \fBCargo.lock\fR file
-available.
+By default, Cargo uses the \fBCargo.lock\fR file included with the package if it is
+available. This ensures that the installed executable uses the dependency versions
+selected when the package was published. If no lockfile is available, including for
+packages published with versions of Cargo before 1.37, Cargo resolves the dependencies
+normally.
+.sp
+The \fB\-\-locked\fR flag does not currently change dependency resolution for \fBcargo install\fR\&.
+If no \fBCargo.lock\fR is available, using \fB\-\-locked\fR emits a warning.
 .SS "Configuration Discovery"
 This command operates on system or user level, not project level.
 This means that the local \fIconfiguration discovery\fR <https://doc.rust\-lang.org/cargo/reference/config.html#hierarchical\-structure> is ignored.

--- a/src/ops/cargo_compile/mod.rs
+++ b/src/ops/cargo_compile/mod.rs
@@ -669,15 +669,7 @@ pub fn create_bcx<'a, 'gctx>(
                 let version = &unit.pkg.version();
                 writeln!(&mut message, "  {name}@{version} requires rustc {msrv}").unwrap();
             }
-            if ws.is_ephemeral() {
-                if ws.ignore_lock() {
-                    writeln!(
-                        &mut message,
-                        "Try re-running `cargo install` with `--locked`"
-                    )
-                    .unwrap();
-                }
-            } else if !local_incompatible {
+            if !ws.is_ephemeral() && !local_incompatible {
                 writeln!(
                     &mut message,
                     "Either upgrade rustc or select compatible dependency versions with

--- a/src/ops/cargo_install.rs
+++ b/src/ops/cargo_install.rs
@@ -652,7 +652,7 @@ impl<'gctx> InstallablePackage<'gctx> {
             self.ws.gctx(),
             &pkg_set,
             &resolve,
-            "consider running without --locked",
+            Some("consider running without --locked"),
         )
     }
 }

--- a/src/ops/cargo_install.rs
+++ b/src/ops/cargo_install.rs
@@ -648,12 +648,7 @@ impl<'gctx> InstallablePackage<'gctx> {
         // wouldn't be available for `compile_with_exec`.
         let dry_run = false;
         let (pkg_set, resolve) = ops::resolve_ws(&self.ws, dry_run)?;
-        ops::check_yanked(
-            self.ws.gctx(),
-            &pkg_set,
-            &resolve,
-            Some("consider running without --locked"),
-        )
+        ops::check_yanked(self.ws.gctx(), &pkg_set, &resolve, None)
     }
 }
 
@@ -931,7 +926,7 @@ fn make_ws_rustc_target<'gctx>(
         ws
     };
     ws.set_resolve_feature_unification(FeatureUnification::Selected);
-    ws.set_ignore_lock(gctx.lock_update_allowed());
+    ws.set_ignore_lock(false);
     ws.set_requested_lockfile_path(None);
     ws.set_require_optional_deps(false);
 

--- a/src/ops/cargo_install.rs
+++ b/src/ops/cargo_install.rs
@@ -640,7 +640,7 @@ impl<'gctx> InstallablePackage<'gctx> {
     }
 
     fn check_yanked_install(&self) -> CargoResult<()> {
-        if self.ws.ignore_lock() || !self.ws.root().join("Cargo.lock").exists() {
+        if !self.ws.root().join("Cargo.lock").exists() {
             return Ok(());
         }
         // It would be best if `source` could be passed in here to avoid a
@@ -926,7 +926,6 @@ fn make_ws_rustc_target<'gctx>(
         ws
     };
     ws.set_resolve_feature_unification(FeatureUnification::Selected);
-    ws.set_ignore_lock(false);
     ws.set_requested_lockfile_path(None);
     ws.set_require_optional_deps(false);
 

--- a/src/ops/cargo_package/mod.rs
+++ b/src/ops/cargo_package/mod.rs
@@ -37,7 +37,7 @@ use anyhow::{Context as _, bail};
 use cargo_util::paths;
 use cargo_util_schemas::index::{IndexPackage, RegistryDependency};
 use cargo_util_schemas::messages;
-use cargo_util_terminal::report::Level;
+use cargo_util_terminal::report::{Group, Level};
 use cargo_util_terminal::{Shell, Verbosity};
 use flate2::{Compression, GzBuilder};
 use futures::TryStreamExt;
@@ -794,7 +794,7 @@ fn build_lock(
         gctx,
         &pkg_set,
         &new_resolve,
-        "consider updating to a version that is not yanked",
+        Some("consider updating to a version that is not yanked"),
     )?;
 
     ops::resolve_to_string(&tmp_ws, &mut new_resolve)
@@ -1034,7 +1034,7 @@ pub fn check_yanked(
     gctx: &GlobalContext,
     pkg_set: &PackageSet<'_>,
     resolve: &Resolve,
-    hint: &str,
+    hint: Option<&str>,
 ) -> CargoResult<()> {
     // Checking the yanked status involves taking a look at the registry and
     // maybe updating files, so be sure to lock it here.
@@ -1064,15 +1064,16 @@ pub fn check_yanked(
                 .await?;
 
             if yanked {
-                gctx.shell().print_report(
-                    &[Level::WARNING
-                        .secondary_title(format!(
-                            "package `{pkg_id}` in Cargo.lock is yanked in registry `{}`",
-                            pkg_id.source_id().display_registry_name(),
-                        ))
-                        .element(Level::HELP.message(hint))],
-                    false,
-                )?;
+                let mut warning = Group::with_title(Level::WARNING.secondary_title(format!(
+                    "package `{pkg_id}` in Cargo.lock is yanked in registry `{}`",
+                    pkg_id.source_id().display_registry_name()
+                )));
+
+                if let Some(hint) = hint {
+                    warning = warning.element(Level::HELP.message(hint));
+                }
+
+                gctx.shell().print_report(&[warning], false)?;
             }
             CargoResult::Ok(())
         })

--- a/src/ops/resolve.rs
+++ b/src/ops/resolve.rs
@@ -175,22 +175,7 @@ pub fn resolve_ws_with_opts<'gctx>(
         .collect();
     let specs = &specs[..];
     let mut registry = ws.package_registry()?;
-    let (resolve, resolved_with_overrides) = if ws.ignore_lock() {
-        let add_patches = true;
-        let resolve = None;
-        let resolved_with_overrides = resolve_with_previous(
-            &mut registry,
-            ws,
-            cli_features,
-            has_dev_units,
-            resolve.as_ref(),
-            None,
-            specs,
-            add_patches,
-        )?;
-        ops::print_lockfile_changes(ws, None, &resolved_with_overrides, &mut registry)?;
-        (resolve, resolved_with_overrides)
-    } else if ws.require_optional_deps() {
+    let (resolve, resolved_with_overrides) = if ws.require_optional_deps() {
         // First, resolve the root_package's *listed* dependencies, as well as
         // downloading and updating all remotes and such.
         let resolve = resolve_with_registry(ws, &mut registry, dry_run)?;

--- a/src/workspace/workspace.rs
+++ b/src/workspace/workspace.rs
@@ -111,10 +111,6 @@ pub struct Workspace<'gctx> {
     /// `packages` up above, used in the `load` method down below.
     loaded_packages: RefCell<HashMap<PathBuf, Package>>,
 
-    /// If `true`, then the resolver will ignore any existing `Cargo.lock`
-    /// file. This is set for `cargo install` without `--locked`.
-    ignore_lock: bool,
-
     /// Requested path of the lockfile (i.e. passed as the cli flag)
     requested_lockfile_path: Option<PathBuf>,
 
@@ -262,7 +258,6 @@ impl<'gctx> Workspace<'gctx> {
             is_ephemeral: false,
             require_optional_deps: true,
             loaded_packages: RefCell::new(HashMap::default()),
-            ignore_lock: false,
             requested_lockfile_path: None,
             resolve_behavior: ResolveBehavior::V1,
             resolve_honors_rust_version: false,
@@ -712,15 +707,6 @@ impl<'gctx> Workspace<'gctx> {
         require_optional_deps: bool,
     ) -> &mut Workspace<'gctx> {
         self.require_optional_deps = require_optional_deps;
-        self
-    }
-
-    pub fn ignore_lock(&self) -> bool {
-        self.ignore_lock
-    }
-
-    pub fn set_ignore_lock(&mut self, ignore_lock: bool) -> &mut Workspace<'gctx> {
-        self.ignore_lock = ignore_lock;
         self
     }
 

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -148,7 +148,6 @@ fn simple_install() {
     cargo_process("install bar")
         .with_stderr_data(str![[r#"
 [INSTALLING] bar v0.1.0
-[LOCKING] 1 package to highest compatible version
 [COMPILING] foo v0.0.1
 [COMPILING] bar v0.1.0
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
@@ -241,7 +240,6 @@ fn install_without_feature_dep() {
     cargo_process("install bar")
         .with_stderr_data(str![[r#"
 [INSTALLING] bar v0.1.0
-[LOCKING] 1 package to highest compatible version
 [COMPILING] foo v0.0.1
 [COMPILING] bar v0.1.0
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s

--- a/tests/testsuite/https.rs
+++ b/tests/testsuite/https.rs
@@ -173,7 +173,6 @@ fn github_works_cargo_install() {
 [INSTALLING] bitflags-smoke-test [..]
 [WARNING] Cargo.toml: unused manifest key: dependencies.bitflags.all-features
 [WARNING] `bitflags-smoke-test` (manifest) generated 1 warning
-[LOCKING] 1 package to highest compatible version
 ...
 [INSTALLED] package [..]
 ...

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -1954,7 +1954,7 @@ fn custom_target_dir_for_git_source() {
 
 #[cargo_test]
 fn install_respects_lock_file() {
-    // `cargo install` now requires --locked to use a Cargo.lock.
+    // Verify `cargo install` uses the packaged Cargo.lock by default.
     Package::new("bar", "0.1.0").publish();
     Package::new("bar", "0.1.1")
         .file("src/lib.rs", "not rust")
@@ -1987,18 +1987,15 @@ dependencies = [
     cargo_process("install foo")
         .with_stderr_data(str![[r#"
 ...
-[..]not rust[..]
+[COMPILING] bar v0.1.0
 ...
 "#]])
-        .with_status(101)
         .run();
-    cargo_process("install --locked foo").run();
 }
 
 #[cargo_test]
 fn install_path_respects_lock_file() {
-    // --path version of install_path_respects_lock_file, --locked is required
-    // to use Cargo.lock.
+    // Verify `cargo install --path` uses Cargo.lock by default.
     Package::new("bar", "0.1.0").publish();
     Package::new("bar", "0.1.1")
         .file("src/lib.rs", "not rust")
@@ -2037,12 +2034,10 @@ dependencies = [
     p.cargo("install --path .")
         .with_stderr_data(str![[r#"
 ...
-[..]not rust[..]
+[COMPILING] bar v0.1.0
 ...
 "#]])
-        .with_status(101)
         .run();
-    p.cargo("install --path . --locked").run();
 }
 
 #[cargo_test]
@@ -2857,8 +2852,6 @@ fn self_referential() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.2 (registry `dummy-registry`)
 [INSTALLING] foo v0.0.2
-[LOCKING] 1 package to highest compatible version
-[ADDING] foo v0.0.1 (available: v0.0.2)
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
 [COMPILING] foo v0.0.1
@@ -2905,7 +2898,6 @@ fn ambiguous_registry_vs_local_package() {
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.1.0 ([ROOT]/foo)
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
 [COMPILING] foo v0.0.1
@@ -3179,7 +3171,6 @@ fn dry_run_incompatible_package_dependency() {
 [INSTALLING] foo v0.1.0 ([ROOT]/foo)
 [WARNING] Cargo.toml: `package.edition` is unspecified, defaulting to `2015` while the latest is `2024`
 [WARNING] `foo` (manifest) generated 1 warning
-[LOCKING] 1 package to highest compatible version
 [ERROR] failed to compile `foo v0.1.0 ([ROOT]/foo)`, intermediate artifacts can be found at `[ROOT]/foo/target`.
 To reuse those artifacts with a future compilation, set the environment variable `CARGO_BUILD_BUILD_DIR` to that path.
 

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -2046,6 +2046,94 @@ dependencies = [
 }
 
 #[cargo_test]
+fn locked_install_honors_lock_file() {
+    // Verify `--locked` uses the packaged lock file.
+    Package::new("bar", "0.1.0").publish();
+    Package::new("bar", "0.1.1")
+        .file("src/lib.rs", "not rust")
+        .publish();
+    Package::new("foo", "0.1.0")
+        .dep("bar", "0.1")
+        .file("src/lib.rs", "")
+        .file(
+            "src/main.rs",
+            "extern crate foo; extern crate bar; fn main() {}",
+        )
+        .file(
+            "Cargo.lock",
+            r#"
+[[package]]
+name = "bar"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "foo"
+version = "0.1.0"
+dependencies = [
+ "bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+"#,
+        )
+        .publish();
+
+    cargo_process("install --locked foo")
+        .with_stderr_data(str![[r#"
+...
+[COMPILING] bar v0.1.0
+...
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn locked_install_path_honors_lock_file() {
+    // Verify `--locked` uses Cargo.lock when installing from a path.
+    Package::new("bar", "0.1.0").publish();
+    Package::new("bar", "0.1.1")
+        .file("src/lib.rs", "not rust")
+        .publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+             [package]
+             name = "foo"
+             version = "0.1.0"
+
+             [dependencies]
+             bar = "0.1"
+             "#,
+        )
+        .file("src/main.rs", "extern crate bar; fn main() {}")
+        .file(
+            "Cargo.lock",
+            r#"
+ [[package]]
+ name = "bar"
+ version = "0.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+
+ [[package]]
+ name = "foo"
+ version = "0.1.0"
+ dependencies = [
+  "bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ "#,
+        )
+        .build();
+
+    p.cargo("install --path . --locked")
+        .with_stderr_data(str![[r#"
+...
+[COMPILING] bar v0.1.0
+...
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn lock_file_path_deps_ok() {
     Package::new("bar", "0.1.0").publish();
 
@@ -2467,6 +2555,26 @@ workspace: [ROOT]/foo/Cargo.toml
 
 "#]]).run();
     assert_has_installed_exe(paths::cargo_home(), "foo");
+}
+
+#[cargo_test]
+fn install_without_published_lockfile() {
+    Package::new("foo", "0.1.0")
+        .file("src/main.rs", "//! Some docs\nfn main() {}")
+        .publish();
+
+    cargo_process("install foo").with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] foo v0.1.0 (registry `dummy-registry`)
+[INSTALLING] foo v0.1.0
+[COMPILING] foo v0.1.0
+[FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
+[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
+[INSTALLED] package `foo v0.1.0` (executable `foo[EXE]`)
+[WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
+
+"#]]).run();
 }
 
 #[cargo_test]

--- a/tests/testsuite/min_publish_age.rs
+++ b/tests/testsuite/min_publish_age.rs
@@ -802,7 +802,6 @@ fn cargo_install_allows_too_new_deps() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v1.0.0 (registry `dummy-registry`)
 [INSTALLING] foo v1.0.0
-[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.1.0 (registry `dummy-registry`)
 [COMPILING] bar v1.1.0
@@ -850,8 +849,6 @@ fn cargo_install_path_allows_too_new_deps() {
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.0.0 ([ROOT]/foo)
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to highest compatible version as of 7 days ago
-[ADDING] bar v1.0.0 (available: v1.1.0, published 2 days ago)
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [COMPILING] bar v1.0.0

--- a/tests/testsuite/publish_lockfile.rs
+++ b/tests/testsuite/publish_lockfile.rs
@@ -390,8 +390,6 @@ dependencies = [
 [DOWNLOADED] foo v0.1.0 (registry `dummy-registry`)
 [INSTALLING] foo v0.1.0
 [WARNING] package `bar v0.1.0` in Cargo.lock is yanked in registry `crates-io`
-  |
-  = [HELP] consider running without --locked
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [COMPILING] bar v0.1.0
@@ -404,15 +402,13 @@ dependencies = [
 "#]])
         .run();
 
-    // Try again without --locked, make sure it uses 0.1.1 and does not warn.
+    // Try again without `--locked` to make sure it still uses the locked version.
     cargo_process("install --force foo")
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [INSTALLING] foo v0.1.0
-[LOCKING] 1 package to highest compatible version
-[DOWNLOADING] crates ...
-[DOWNLOADED] bar v0.1.1 (registry `dummy-registry`)
-[COMPILING] bar v0.1.1
+[WARNING] package `bar v0.1.0` in Cargo.lock is yanked in registry `crates-io`
+[COMPILING] bar v0.1.0
 [COMPILING] foo v0.1.0
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 [REPLACING] [ROOT]/home/.cargo/bin/foo[EXE]
@@ -457,8 +453,6 @@ dependencies = [
         .with_stderr_data(str![[r#"
 ...
 [WARNING] package `bar v0.1.0` in Cargo.lock is yanked in registry `crates-io`
-  |
-  = [HELP] consider running without --locked
 ...
 
 "#]])

--- a/tests/testsuite/required_features.rs
+++ b/tests/testsuite/required_features.rs
@@ -1254,7 +1254,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured; 0 filtered out; fini
     p.cargo("install --path .")
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.0.1 ([ROOT]/foo)
-[LOCKING] 1 package to highest compatible version
+[WARNING] invalid feature `bar/a` in required-features of target `foo`: dependency `bar` does not exist
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 [WARNING] none of the package's binaries are available for install using the selected features
   bin "foo" requires the features: `bar/a`

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -916,7 +916,6 @@ fn cargo_install_ignores_msrv_config() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
 [INSTALLING] foo v0.0.1
-[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v1.1.0 (registry `dummy-registry`)
 [COMPILING] dep v1.1.0
@@ -953,7 +952,6 @@ fn cargo_install_ignores_resolver_v3_msrv_change() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
 [INSTALLING] foo v0.0.1
-[LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v1.1.0 (registry `dummy-registry`)
 [COMPILING] dep v1.1.0
@@ -1001,8 +999,6 @@ fn cargo_install_path_honors_msrv_config() {
         .with_stderr_data(str![[r#"
 [INSTALLING] foo v0.0.0 ([ROOT]/foo)
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package to highest Rust 1.60 compatible version
-[ADDING] dep v1.0.0 (available: v1.1.0, requires Rust 1.70)
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v1.0.0 (registry `dummy-registry`)
 [COMPILING] dep v1.0.0


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/cargo/pull/17388)*

### What does this PR try to resolve?
This PR closes #7169

`cargo build` uses an existing `Cargo.lock`, while `cargo install` previously ignored a package's `Cargo.lock ` file unless `--locked` was passed. As a result, building and testing a binary could use one set of dependency version while installing the same binary selected another.

This can cause installation to fail even though the package built and tested successfully. This also leaves maintainers supporting dependency versions they didn't test or sign-up for.

Following [Cargo Team Decision](https://github.com/rust-lang/cargo/issues/7169#issuecomment-4421296987),
this PR makes `cargo install` use the available lockfile by default. This gives `cargo install` the existing behavior of `cargo install --locked`.

`--locked` remains accepted but it is a no-op. When a package does not contain a lockfile, Cargo fallback to resolving its deps normally. Explicitly passing `--locked` still emits the existing missing-lockfile warning.

The warning for yanked deps is preserved, but it's suggestion to retry without `--locked` is removed because doing so no longer changes dep resolution.

Deprecating `--locked` and adding an option to ignore the packaged lockfile remains a separate effort to be considered as discussed in the decision.

### How to test and review this PR?
There are four commits structured in this manner:
1. Make the help attached to yanked-dependency warning optional without changing the existing behavior
2. Add tests to verify that `cargo install --locked` honors packaged lockfile.
3. Change installation behavior, update the affected tests, and update the generated documentation.
4. Remove now obsolete `ignore_lock` workspace state and resolver path.


#### Test covers
1. Registry installation without the packaged lockfile by default.
2. Path installation using it's lockfile by default.
5. `--locked` remaining accepted and producing the same resolution.
6. Falling back to normal resolution when no published lockfile exists.
7. Git installation without a lockfile
8. Yanked dependencies continuing to warn without suggesting installation without `--locked`.
9. The existing `cargo-package` yanked-dependency help remaining unchanged.

#### The following tests were run:
```text
cargo test --test testsuite -- install::install_respects_lock_file
cargo test --test testsuite -- install::install_path_respects_lock_file
cargo test --test testsuite -- install::locked_install_
cargo test --test testsuite -- install::install_without_published_lockfile
cargo test --test testsuite -- install::git_repo
cargo test --test testsuite -- publish_lockfile::warn
```

