### PR TITLE
chore(deps): Update partial_ref to v0.3.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3610,9 +3610,9 @@ dependencies = [
 
 [[package]]
 name = "partial_ref"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f728bc9b1479656e40cba507034904a8c44027c0efdbbaf6a4bdc5f2d3a910c"
+checksum = "a6223a0b76d36dfb9583a3e0e8b01d7ba1674f663352b522d950e07db40e5075"
 dependencies = [
  "partial_ref_derive",
 ]


### PR DESCRIPTION
### What does this PR try to resolve?

Running the resolver tests hangs for quite a while when using a nightly with the new trait solver. This is because it experiences a huge compile time regression when trying to build varisat due to the use of unconstrained lifetimes in partial_ref.

This PR bumps partial_ref to include https://github.com/jix/partial_ref/pull/6. See https://github.com/rust-lang/rust/issues/161575 for more details.

### How to test and review this PR?

CI should be sufficient testing for this PR.
