### PR TITLE
fix(rustflags): Respect rustflags when probing rustc for the sysroot

### DIFF
--- a/src/compiler/build_context/target_info.rs
+++ b/src/compiler/build_context/target_info.rs
@@ -168,8 +168,6 @@ impl TargetInfo {
     /// invocation is cached by [`Rustc::cached_output`].
     ///
     /// Search `Tricky` to learn why querying `rustc` several times is needed.
-    ///
-    /// When a Workspace is provided,
     #[tracing::instrument(skip_all)]
     pub fn new(
         gctx: &GlobalContext,

--- a/src/compiler/build_context/target_info.rs
+++ b/src/compiler/build_context/target_info.rs
@@ -14,6 +14,7 @@ use crate::compiler::CrateType;
 use crate::compiler::apply_env_config;
 use crate::context::{GlobalContext, StringList, TargetConfig};
 use crate::util::interning::InternedString;
+use crate::util::rustc::get_rustflags_from_env;
 use crate::util::{CargoResult, Rustc};
 use crate::workspace::{Dependency, Package, Target, TargetKind, Workspace};
 
@@ -823,27 +824,7 @@ fn extra_args(
 /// Gets compiler flags from environment variables.
 /// See [`extra_args`] for more.
 fn rustflags_from_env(gctx: &GlobalContext, flags: Flags) -> Option<Vec<String>> {
-    // First try CARGO_ENCODED_RUSTFLAGS from the environment.
-    // Prefer this over RUSTFLAGS since it's less prone to encoding errors.
-    if let Ok(a) = gctx.get_env(format!("CARGO_ENCODED_{}", flags.as_env())) {
-        if a.is_empty() {
-            return Some(Vec::new());
-        }
-        return Some(a.split('\x1f').map(str::to_string).collect());
-    }
-
-    // Then try RUSTFLAGS from the environment
-    if let Ok(a) = gctx.get_env(flags.as_env()) {
-        let args = a
-            .split(' ')
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map(str::to_string);
-        return Some(args.collect());
-    }
-
-    // No rustflags to be collected from the environment
-    None
+    get_rustflags_from_env(gctx, flags.as_env())
 }
 
 /// Gets compiler flags from `[target]` section in the config.

--- a/src/compiler/build_context/target_info.rs
+++ b/src/compiler/build_context/target_info.rs
@@ -14,7 +14,7 @@ use crate::compiler::CrateType;
 use crate::compiler::apply_env_config;
 use crate::context::{GlobalContext, StringList, TargetConfig};
 use crate::util::interning::InternedString;
-use crate::util::rustc::get_rustflags_from_env;
+use crate::util::rustc::{get_rustflags_from_build_config, get_rustflags_from_env};
 use crate::util::{CargoResult, Rustc};
 use crate::workspace::{Dependency, Package, Target, TargetKind, Workspace};
 
@@ -895,13 +895,7 @@ fn rustflags_from_host(
 /// Gets compiler flags from `[build]` section in the config.
 /// See [`extra_args`] for more.
 fn rustflags_from_build(gctx: &GlobalContext, flag: Flags) -> CargoResult<Option<Vec<String>>> {
-    // Then the `build.rustflags` value.
-    let build = gctx.build_config()?;
-    let list = match flag {
-        Flags::Rust => &build.rustflags,
-        Flags::Rustdoc => &build.rustdocflags,
-    };
-    Ok(list.as_ref().map(|l| l.as_slice().to_vec()))
+    get_rustflags_from_build_config(gctx, matches!(flag, Flags::Rustdoc))
 }
 
 /// Whether a host artifact must take its configuration solely from `[host]` and ignore `[target]`.

--- a/src/util/rustc.rs
+++ b/src/util/rustc.rs
@@ -407,3 +407,22 @@ fn process_fingerprint(cmd: &ProcessBuilder, extra_fingerprint: u64) -> u64 {
     env.hash(&mut hasher);
     Hasher::finish(&hasher)
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::GlobalContext;
+    use crate::util::data_structures::HashMap;
+    use std::path::Path;
+
+    #[test]
+    fn sysroot_fetch_respects_env_rustflags() {
+        let mut gctx = GlobalContext::default().unwrap();
+
+        let rustflags = HashMap::from_iter([("RUSTFLAGS".to_string(), "--sysroot=.".to_string())]);
+        gctx.set_env(rustflags);
+
+        let rustc = gctx.load_global_rustc(None).unwrap();
+        let sysroot = rustc.sysroot(&gctx).unwrap();
+        assert_ne!(sysroot, Path::new("."));
+    }
+}

--- a/src/util/rustc.rs
+++ b/src/util/rustc.rs
@@ -444,6 +444,7 @@ pub(crate) fn get_rustflags_from_env(
 #[cfg(test)]
 mod tests {
     use crate::GlobalContext;
+    use crate::context::{ConfigValue, Definition};
     use crate::util::data_structures::HashMap;
     use std::path::Path;
 
@@ -457,5 +458,30 @@ mod tests {
         let rustc = gctx.load_global_rustc(None).unwrap();
         let sysroot = rustc.sysroot(&gctx).unwrap();
         assert_eq!(sysroot, Path::new("."));
+    }
+
+    #[test]
+    fn sysroot_fetch_respects_build_rustflags() {
+        let mut gctx = GlobalContext::default().unwrap();
+        gctx.set_env(HashMap::default());
+
+        let definition = Definition::Cli(None);
+        let rustflags = ConfigValue::List(
+            vec![ConfigValue::String(
+                "--sysroot=.".to_string(),
+                definition.clone(),
+            )],
+            definition.clone(),
+        );
+        let build = ConfigValue::Table(
+            HashMap::from_iter([("rustflags".to_string(), rustflags)]),
+            definition,
+        );
+        gctx.set_values(HashMap::from_iter([("build".to_string(), build)]))
+            .unwrap();
+
+        let rustc = gctx.load_global_rustc(None).unwrap();
+        let sysroot = rustc.sysroot(&gctx).unwrap();
+        assert_ne!(sysroot, Path::new("."));
     }
 }

--- a/src/util/rustc.rs
+++ b/src/util/rustc.rs
@@ -408,6 +408,34 @@ fn process_fingerprint(cmd: &ProcessBuilder, extra_fingerprint: u64) -> u64 {
     Hasher::finish(&hasher)
 }
 
+/// Gets compiler flags from environment variables.
+pub(crate) fn get_rustflags_from_env(
+    gctx: &GlobalContext,
+    env_name: &'static str,
+) -> Option<Vec<String>> {
+    // First try CARGO_ENCODED_RUSTFLAGS from the environment.
+    // Prefer this over RUSTFLAGS since it's less prone to encoding errors.
+    if let Ok(a) = gctx.get_env(format!("CARGO_ENCODED_{}", env_name)) {
+        if a.is_empty() {
+            return Some(Vec::new());
+        }
+        return Some(a.split('\x1f').map(str::to_string).collect());
+    }
+
+    // Then try RUSTFLAGS from the environment
+    if let Ok(a) = gctx.get_env(env_name) {
+        let args = a
+            .split(' ')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
+        return Some(args.collect());
+    }
+
+    // No rustflags to be collected from the environment
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use crate::GlobalContext;

--- a/src/util/rustc.rs
+++ b/src/util/rustc.rs
@@ -166,9 +166,14 @@ impl Rustc {
         let mut cmd = self.workspace_process();
         apply_env_config(gctx, &mut cmd)?;
         cmd.env(crate::CARGO_ENV, gctx.cargo_exe()?);
+        if let Some(rustflags) = get_rustflags_from_env(gctx, "RUSTFLAGS") {
+            cmd.args(&rustflags);
+        }
         cmd.arg("--print=sysroot");
 
-        let (stdout, _) = self.cached_output(&cmd, 0)?;
+        let (stdout, _) = self
+            .cached_output(&cmd, 0)
+            .with_context(|| "failed to run `rustc` to find the sysroot location")?;
         let path: PathBuf = stdout.trim().into();
         if !path.exists() {
             bail!("sysroot path \"{}\" does not exist", path.display());
@@ -451,6 +456,6 @@ mod tests {
 
         let rustc = gctx.load_global_rustc(None).unwrap();
         let sysroot = rustc.sysroot(&gctx).unwrap();
-        assert_ne!(sysroot, Path::new("."));
+        assert_eq!(sysroot, Path::new("."));
     }
 }

--- a/src/util/rustc.rs
+++ b/src/util/rustc.rs
@@ -168,6 +168,8 @@ impl Rustc {
         cmd.env(crate::CARGO_ENV, gctx.cargo_exe()?);
         if let Some(rustflags) = get_rustflags_from_env(gctx, "RUSTFLAGS") {
             cmd.args(&rustflags);
+        } else if let Some(rustflags) = get_rustflags_from_build_config(gctx, false)? {
+            cmd.args(&rustflags);
         }
         cmd.arg("--print=sysroot");
 
@@ -497,6 +499,6 @@ mod tests {
 
         let rustc = gctx.load_global_rustc(None).unwrap();
         let sysroot = rustc.sysroot(&gctx).unwrap();
-        assert_ne!(sysroot, Path::new("."));
+        assert_eq!(sysroot, Path::new("."));
     }
 }

--- a/src/util/rustc.rs
+++ b/src/util/rustc.rs
@@ -441,6 +441,21 @@ pub(crate) fn get_rustflags_from_env(
     None
 }
 
+/// Gets compiler flags from `[build]` section in the config.
+pub(crate) fn get_rustflags_from_build_config(
+    gctx: &GlobalContext,
+    is_rustdoc: bool,
+) -> CargoResult<Option<Vec<String>>> {
+    // Then the `build.rustflags` value.
+    let build = gctx.build_config()?;
+    let list = if is_rustdoc {
+        &build.rustdocflags
+    } else {
+        &build.rustflags
+    };
+    Ok(list.as_ref().map(|l| l.as_slice().to_vec()))
+}
+
 #[cfg(test)]
 mod tests {
     use crate::GlobalContext;

--- a/tests/testsuite/rustflags.rs
+++ b/tests/testsuite/rustflags.rs
@@ -417,7 +417,7 @@ fn build_rustflags_normal_source() {
     p.cargo("check --lib")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to run `rustc` to learn about target-specific information
+[ERROR] failed to run `rustc` to find the sysroot location
 
 Caused by:
   [..]bogus[..]
@@ -427,7 +427,7 @@ Caused by:
     p.cargo("check --bin=a")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to run `rustc` to learn about target-specific information
+[ERROR] failed to run `rustc` to find the sysroot location
 
 Caused by:
   [..]bogus[..]
@@ -437,7 +437,7 @@ Caused by:
     p.cargo("check --example=b")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to run `rustc` to learn about target-specific information
+[ERROR] failed to run `rustc` to find the sysroot location
 
 Caused by:
   [..]bogus[..]
@@ -447,7 +447,7 @@ Caused by:
     p.cargo("test")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to run `rustc` to learn about target-specific information
+[ERROR] failed to run `rustc` to find the sysroot location
 
 Caused by:
   [..]bogus[..]
@@ -457,7 +457,7 @@ Caused by:
     p.cargo("bench")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to run `rustc` to learn about target-specific information
+[ERROR] failed to run `rustc` to find the sysroot location
 
 Caused by:
   [..]bogus[..]
@@ -574,7 +574,7 @@ fn build_rustflags_normal_source_with_target() {
         .arg(host)
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to run `rustc` to learn about target-specific information
+[ERROR] failed to run `rustc` to find the sysroot location
 
 Caused by:
   [..]bogus[..]
@@ -585,7 +585,7 @@ Caused by:
         .arg(host)
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to run `rustc` to learn about target-specific information
+[ERROR] failed to run `rustc` to find the sysroot location
 
 Caused by:
   [..]bogus[..]
@@ -596,7 +596,7 @@ Caused by:
         .arg(host)
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to run `rustc` to learn about target-specific information
+[ERROR] failed to run `rustc` to find the sysroot location
 
 Caused by:
   [..]bogus[..]
@@ -607,7 +607,7 @@ Caused by:
         .arg(host)
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to run `rustc` to learn about target-specific information
+[ERROR] failed to run `rustc` to find the sysroot location
 
 Caused by:
   [..]bogus[..]
@@ -618,7 +618,7 @@ Caused by:
         .arg(host)
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to run `rustc` to learn about target-specific information
+[ERROR] failed to run `rustc` to find the sysroot location
 
 Caused by:
   [..]bogus[..]
@@ -724,7 +724,7 @@ fn build_rustflags_recompile() {
     p.cargo("check")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to run `rustc` to learn about target-specific information
+[ERROR] failed to run `rustc` to find the sysroot location
 
 Caused by:
   [..]bogus[..]
@@ -751,7 +751,7 @@ fn build_rustflags_recompile2() {
     p.cargo("check")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to run `rustc` to learn about target-specific information
+[ERROR] failed to run `rustc` to find the sysroot location
 
 Caused by:
   [..]bogus[..]

--- a/tests/testsuite/rustflags.rs
+++ b/tests/testsuite/rustflags.rs
@@ -31,7 +31,7 @@ fn env_rustflags_normal_source() {
         .env("RUSTFLAGS", "-Z bogus")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to run `rustc` to learn about target-specific information
+[ERROR] failed to run `rustc` to find the sysroot location
 
 Caused by:
   [..]bogus[..]
@@ -42,7 +42,7 @@ Caused by:
         .env("RUSTFLAGS", "-Z bogus")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to run `rustc` to learn about target-specific information
+[ERROR] failed to run `rustc` to find the sysroot location
 
 Caused by:
   [..]bogus[..]
@@ -53,7 +53,7 @@ Caused by:
         .env("RUSTFLAGS", "-Z bogus")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to run `rustc` to learn about target-specific information
+[ERROR] failed to run `rustc` to find the sysroot location
 
 Caused by:
   [..]bogus[..]
@@ -64,7 +64,7 @@ Caused by:
         .env("RUSTFLAGS", "-Z bogus")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to run `rustc` to learn about target-specific information
+[ERROR] failed to run `rustc` to find the sysroot location
 
 Caused by:
   [..]bogus[..]
@@ -75,7 +75,7 @@ Caused by:
         .env("RUSTFLAGS", "-Z bogus")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to run `rustc` to learn about target-specific information
+[ERROR] failed to run `rustc` to find the sysroot location
 
 Caused by:
   [..]bogus[..]
@@ -172,7 +172,7 @@ fn env_rustflags_normal_source_with_target() {
         .env("RUSTFLAGS", "-Z bogus")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to run `rustc` to learn about target-specific information
+[ERROR] failed to run `rustc` to find the sysroot location
 
 Caused by:
   [..]bogus[..]
@@ -184,7 +184,7 @@ Caused by:
         .env("RUSTFLAGS", "-Z bogus")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to run `rustc` to learn about target-specific information
+[ERROR] failed to run `rustc` to find the sysroot location
 
 Caused by:
   [..]bogus[..]
@@ -196,7 +196,7 @@ Caused by:
         .env("RUSTFLAGS", "-Z bogus")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to run `rustc` to learn about target-specific information
+[ERROR] failed to run `rustc` to find the sysroot location
 
 Caused by:
   [..]bogus[..]
@@ -208,7 +208,7 @@ Caused by:
         .env("RUSTFLAGS", "-Z bogus")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to run `rustc` to learn about target-specific information
+[ERROR] failed to run `rustc` to find the sysroot location
 
 Caused by:
   [..]bogus[..]
@@ -220,7 +220,7 @@ Caused by:
         .env("RUSTFLAGS", "-Z bogus")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to run `rustc` to learn about target-specific information
+[ERROR] failed to run `rustc` to find the sysroot location
 
 Caused by:
   [..]bogus[..]
@@ -348,7 +348,7 @@ fn env_rustflags_recompile() {
         .env("RUSTFLAGS", "-Z bogus")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to run `rustc` to learn about target-specific information
+[ERROR] failed to run `rustc` to find the sysroot location
 
 Caused by:
   [..]bogus[..]
@@ -367,7 +367,7 @@ fn env_rustflags_recompile2() {
         .env("RUSTFLAGS", "-Z bogus")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] failed to run `rustc` to learn about target-specific information
+[ERROR] failed to run `rustc` to find the sysroot location
 
 Caused by:
   [..]bogus[..]


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes https://github.com/rust-lang/cargo/issues/17351 by restoring the ability for `RUSTFLAGS`, `CARGO_ENCODED_RUSTFLAGS` and `build.rustflags` to override the sysroot.

As discussed in the issue, this PR does not restore the ability for `rustflags` in the `target` cfg to override the sysroot as it's very difficult for build-std to support this and it's not clear if anyone has a need for the functionality. Users surveyed include `cargo careful` and `cargo miri` in the issue, and [xargo](https://github.com/search?q=repo%3Ajaparic%2Fxargo+sysroot&type=code).

This PR also cleans up a leftover comment introduced in the PR that caused this issue.

### How to test and review this PR?

The PR introduces unit tests and implements the new behaviour in a sequence of atomic commits. I'd recommend reading each one turn to understand the change. The behaviour can be tested by invoking cargo with `RUSTFLAGS="--sysroot=dir"` or by setting `build.rustflags`.

🤖 LLM disclosure: I asked an LLM whether my tests would pass on Windows as a sanity check, and used the information returned to rewrite them. All code was hand-written and wasn't generated.