### PR TITLE
fix(home): rustdoc lint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2592,7 +2592,7 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.13"
+version = "0.5.14"
 
 [[package]]
 name = "html-escape"

--- a/crates/home/Cargo.toml
+++ b/crates/home/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "home"
-version = "0.5.13"
+version = "0.5.14"
 authors = ["Brian Anderson <andersrb@gmail.com>"]
 rust-version.workspace = true
 documentation = "https://docs.rs/home"

--- a/crates/home/src/lib.rs
+++ b/crates/home/src/lib.rs
@@ -78,7 +78,7 @@ pub fn cargo_home() -> io::Result<PathBuf> {
 }
 
 /// Returns the storage directory used by Cargo within `cwd`.
-/// For more details, see [`cargo_home`](fn.cargo_home.html).
+/// For more details, see [`cargo_home`].
 pub fn cargo_home_with_cwd(cwd: &Path) -> io::Result<PathBuf> {
     env::cargo_home_with_cwd_env(&env::OS_ENV, cwd)
 }
@@ -115,7 +115,7 @@ pub fn rustup_home() -> io::Result<PathBuf> {
 }
 
 /// Returns the storage directory used by rustup within `cwd`.
-/// For more details, see [`rustup_home`](fn.rustup_home.html).
+/// For more details, see [`rustup_home`].
 pub fn rustup_home_with_cwd(cwd: &Path) -> io::Result<PathBuf> {
     env::rustup_home_with_cwd_env(&env::OS_ENV, cwd)
 }


### PR DESCRIPTION
See <https://github.com/rust-lang/cargo/actions/runs/32992508559/job/98253339881>

```
warning: redundant explicit link target
  --> crates/home/src/lib.rs:81:42
   |
81 | /// For more details, see [`cargo_home`](fn.cargo_home.html).
   |                            ------------  ^^^^^^^^^^^^^^^^^^ explicit target is redundant
   |                            |
   |                            because label contains path that resolves to same destination
   |
   = note: when a link's destination is not specified,
           the label is used to resolve intra-doc links
   = note: `#[warn(rustdoc::redundant_explicit_links)]` on by default
help: remove explicit link target
   |
81 - /// For more details, see [`cargo_home`](fn.cargo_home.html).
81 + /// For more details, see [`cargo_home`].
   |

warning: redundant explicit link target
   --> crates/home/src/lib.rs:118:43
    |
118 | /// For more details, see [`rustup_home`](fn.rustup_home.html).
    |                            -------------  ^^^^^^^^^^^^^^^^^^^ explicit target is redundant
    |                            |
    |                            because label contains path that resolves to same destination
    |
    = note: when a link's destination is not specified,
            the label is used to resolve intra-doc links
help: remove explicit link target
    |
118 - /// For more details, see [`rustup_home`](fn.rustup_home.html).
118 + /// For more details, see [`rustup_home`].
    |

error: `home` (lib doc) generated 2 warnings
```