### PR TITLE
feat(build-std): Introduce builtin packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util-schemas"
-version = "0.14.4"
+version = "0.15.0"
 dependencies = [
  "jiff",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ cargo-platform = { path = "crates/cargo-platform", version = "0.3.3" }
 cargo-test-macro = { version = "0.4.15", path = "crates/cargo-test-macro" }
 cargo-test-support = { version = "0.12.0", path = "crates/cargo-test-support" }
 cargo-util = { version = "0.2.33", path = "crates/cargo-util" }
-cargo-util-schemas = { version = "0.14.4", path = "crates/cargo-util-schemas" }
+cargo-util-schemas = { version = "0.15.0", path = "crates/cargo-util-schemas" }
 cargo-util-terminal = { version = "0.1.3", path = "crates/cargo-util-terminal" }
 cargo_metadata = "0.23.1"
 clap = "4.6.0"

--- a/crates/cargo-util-schemas/Cargo.toml
+++ b/crates/cargo-util-schemas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-util-schemas"
-version = "0.14.4"
+version = "0.15.0"
 rust-version = "1.98"  # MSRV:1
 edition.workspace = true
 license.workspace = true

--- a/crates/cargo-util-schemas/src/core/source_kind.rs
+++ b/crates/cargo-util-schemas/src/core/source_kind.rs
@@ -15,6 +15,8 @@ pub enum SourceKind {
     LocalRegistry,
     /// A directory-based registry.
     Directory,
+    /// Package sources distributed with the rust toolchain
+    Builtin,
 }
 
 // The hash here is important for what folder packages get downloaded into.
@@ -40,6 +42,7 @@ impl SourceKind {
             SourceKind::SparseRegistry => None,
             SourceKind::LocalRegistry => Some("local-registry"),
             SourceKind::Directory => Some("directory"),
+            SourceKind::Builtin => Some("builtin"),
         }
     }
 }
@@ -71,6 +74,10 @@ impl Ord for SourceKind {
             (_, SourceKind::Directory) => Ordering::Greater,
 
             (SourceKind::Git(a), SourceKind::Git(b)) => a.cmp(b),
+            (SourceKind::Git(_), _) => Ordering::Less,
+            (_, SourceKind::Git(_)) => Ordering::Greater,
+
+            (SourceKind::Builtin, SourceKind::Builtin) => Ordering::Equal,
         }
     }
 }

--- a/crates/resolver-tests/src/helpers.rs
+++ b/crates/resolver-tests/src/helpers.rs
@@ -87,6 +87,7 @@ impl<T: AsRef<str>, U: AsRef<str>> ToPkgId for (T, U) {
     }
 }
 
+#[derive(Copy, Clone)]
 pub struct BuiltinPid {
     pub name: &'static str,
 }
@@ -232,6 +233,10 @@ pub fn dep_loc(name: &str, location: &str) -> Dependency {
     Dependency::parse(name, Some("1.0.0"), source_id).unwrap()
 }
 
+pub fn dep_builtin(name: &str) -> Dependency {
+    Dependency::parse(name, None, builtin_loc()).unwrap()
+}
+
 pub fn dep_kind(name: &str, kind: DepKind) -> Dependency {
     let mut dep = dep(name);
     dep.set_kind(kind);
@@ -250,6 +255,12 @@ pub fn registry(pkgs: Vec<Summary>) -> Vec<Summary> {
 
 pub fn names<P: ToPkgId>(names: &[P]) -> Vec<PackageId> {
     names.iter().map(|name| name.to_pkgid()).collect()
+}
+
+/// For a set of name specifiers of varying types
+#[macro_export]
+macro_rules! names {
+    ($($name:expr),* $(,)?) => {&vec![$($name.to_pkgid()),*]};
 }
 
 pub fn loc_names(names: &[(&'static str, &'static str)]) -> Vec<PackageId> {

--- a/crates/resolver-tests/src/helpers.rs
+++ b/crates/resolver-tests/src/helpers.rs
@@ -87,6 +87,16 @@ impl<T: AsRef<str>, U: AsRef<str>> ToPkgId for (T, U) {
     }
 }
 
+pub struct BuiltinPid {
+    pub name: &'static str,
+}
+
+impl ToPkgId for BuiltinPid {
+    fn to_pkgid(&self) -> PackageId {
+        PackageId::try_new(self.name, "0.0.0", builtin_loc()).unwrap()
+    }
+}
+
 #[macro_export]
 macro_rules! pkg {
     ($pkgid:expr => [$($deps:expr),* $(,)? ]) => ({
@@ -106,6 +116,13 @@ fn registry_loc() -> SourceId {
         SourceId::for_registry(&"https://example.com".into_url().unwrap()).unwrap()
     });
     *example_dot
+}
+
+fn builtin_loc() -> SourceId {
+    static LOCAL_PATH: OnceLock<SourceId> = OnceLock::new();
+    let local_path = LOCAL_PATH
+        .get_or_init(|| SourceId::for_builtin(&std::env::current_dir().unwrap()).unwrap());
+    *local_path
 }
 
 pub fn pkg<T: ToPkgId>(name: T) -> Summary {

--- a/crates/resolver-tests/tests/resolve.rs
+++ b/crates/resolver-tests/tests/resolve.rs
@@ -1036,3 +1036,12 @@ failed to select a version for `F` which could resolve this conflict
 "#]]
     );
 }
+
+#[test]
+fn test_builtin_dependency() {
+    // No way to specify builtin deps or packages to satisfy them
+    let reg = registry(vec![pkg!("core")]);
+    let res = resolve(vec![dep("core")], &reg).unwrap();
+
+    assert_same(&res, &names(&["root", "core"]));
+}

--- a/crates/resolver-tests/tests/resolve.rs
+++ b/crates/resolver-tests/tests/resolve.rs
@@ -1,6 +1,7 @@
 use cargo::util::GlobalContext;
 use cargo::workspace::Dependency;
 use cargo::workspace::dependency::DepKind;
+use resolver_tests::helpers::dep_builtin;
 use snapbox::assert_data_eq;
 use snapbox::str;
 
@@ -1042,8 +1043,10 @@ fn test_builtin_dependency() {
     let core = BuiltinPid { name: "core" };
     let reg = registry(vec![pkg!(core)]);
 
-    // No way to specify builtin deps - fails
-    //let res = resolve(vec![dep("core")], &reg).unwrap();
+    let builtin_dep = dep_builtin("core");
+
+    // Fails
+    //let res = resolve(vec![builtin_dep], &reg).unwrap();
 
     //assert_same(&res, &names(&["root", "core"]));
 }

--- a/crates/resolver-tests/tests/resolve.rs
+++ b/crates/resolver-tests/tests/resolve.rs
@@ -6,8 +6,8 @@ use snapbox::str;
 
 use resolver_tests::{
     helpers::{
-        ToDep, ToPkgId, assert_contains, assert_same, dep, dep_kind, dep_loc, dep_req, loc_names,
-        names, pkg, pkg_dep, pkg_dep_with, pkg_id, pkg_loc, registry,
+        BuiltinPid, ToDep, ToPkgId, assert_contains, assert_same, dep, dep_kind, dep_loc, dep_req,
+        loc_names, names, pkg, pkg_dep, pkg_dep_with, pkg_id, pkg_loc, registry,
     },
     pkg, resolve, resolve_with_global_context,
 };
@@ -1039,9 +1039,11 @@ failed to select a version for `F` which could resolve this conflict
 
 #[test]
 fn test_builtin_dependency() {
-    // No way to specify builtin deps or packages to satisfy them
-    let reg = registry(vec![pkg!("core")]);
-    let res = resolve(vec![dep("core")], &reg).unwrap();
+    let core = BuiltinPid { name: "core" };
+    let reg = registry(vec![pkg!(core)]);
 
-    assert_same(&res, &names(&["root", "core"]));
+    // No way to specify builtin deps - fails
+    //let res = resolve(vec![dep("core")], &reg).unwrap();
+
+    //assert_same(&res, &names(&["root", "core"]));
 }

--- a/crates/resolver-tests/tests/resolve.rs
+++ b/crates/resolver-tests/tests/resolve.rs
@@ -10,7 +10,7 @@ use resolver_tests::{
         BuiltinPid, ToDep, ToPkgId, assert_contains, assert_same, dep, dep_kind, dep_loc, dep_req,
         loc_names, names, pkg, pkg_dep, pkg_dep_with, pkg_id, pkg_loc, registry,
     },
-    pkg, resolve, resolve_with_global_context,
+    names, pkg, resolve, resolve_with_global_context,
 };
 
 #[test]
@@ -1045,8 +1045,7 @@ fn test_builtin_dependency() {
 
     let builtin_dep = dep_builtin("core");
 
-    // Fails
-    //let res = resolve(vec![builtin_dep], &reg).unwrap();
+    let res = resolve(vec![builtin_dep], &reg).unwrap();
 
-    //assert_same(&res, &names(&["root", "core"]));
+    assert_same(&res, &names!("root", core));
 }

--- a/crates/resolver-tests/tests/resolve.rs
+++ b/crates/resolver-tests/tests/resolve.rs
@@ -1049,3 +1049,16 @@ fn test_builtin_dependency() {
 
     assert_same(&res, &names!("root", core));
 }
+
+#[test]
+fn normal_dependency_is_not_satisfied_by_builtin_package() {
+    let core = BuiltinPid { name: "core" };
+    let reg = registry(vec![pkg!(core)]);
+
+    assert!(resolve(vec![dep("core")], &reg).is_err());
+}
+
+#[test]
+fn missing_builtin_dependency_errors() {
+    assert!(resolve(vec![dep_builtin("core")], &registry(vec![])).is_err());
+}

--- a/src/resolver/encode.rs
+++ b/src/resolver/encode.rs
@@ -661,7 +661,7 @@ pub fn encodable_package_id(
 }
 
 fn encodable_source_id(id: SourceId, version: ResolveVersion) -> Option<TomlLockfileSourceId> {
-    if id.is_path() {
+    if id.is_path() || id.is_builtin() {
         None
     } else {
         Some(

--- a/src/workspace/source_id.rs
+++ b/src/workspace/source_id.rs
@@ -353,6 +353,11 @@ impl SourceId {
         self.inner.kind == SourceKind::Path
     }
 
+    /// Returns `true` if this source is built into Cargo
+    pub fn is_builtin(self) -> bool {
+        self.inner.kind == SourceKind::Builtin
+    }
+
     /// Returns the local path if this is a path dependency.
     pub fn local_path(self) -> Option<PathBuf> {
         if self.inner.kind != SourceKind::Path {

--- a/src/workspace/source_id.rs
+++ b/src/workspace/source_id.rs
@@ -204,6 +204,14 @@ impl SourceId {
         SourceId::new(SourceKind::Path, url, None)
     }
 
+    /// Creates a `SourceId` from a filesystem path representing a builtin package.
+    ///
+    /// `path`: an absolute path.
+    pub fn for_builtin(path: &Path) -> CargoResult<SourceId> {
+        let url = path.into_url()?;
+        SourceId::new(SourceKind::Builtin, url, None)
+    }
+
     /// Creates a `SourceId` from a filesystem path.
     ///
     /// `path`: an absolute path.
@@ -403,6 +411,7 @@ impl SourceId {
                 }
                 Ok(Box::new(PathSource::new(&path, self, gctx)))
             }
+            SourceKind::Builtin => todo!("builtin source"),
             SourceKind::Registry | SourceKind::SparseRegistry => {
                 Ok(Box::new(RegistrySource::remote(self, gctx)?))
             }
@@ -663,6 +672,7 @@ impl fmt::Display for SourceId {
                 Ok(())
             }
             SourceKind::Path => write!(f, "{}", url_display(&self.inner.url)),
+            SourceKind::Builtin => write!(f, "builtin {}", url_display(&self.inner.url)),
             SourceKind::Registry | SourceKind::SparseRegistry => {
                 write!(f, "registry `{}`", self.display_registry_name())
             }


### PR DESCRIPTION
### What does this PR try to resolve?

This PR, part of a stack split off from https://github.com/rust-lang/cargo/pull/16675, adds a new `SourceKind` variant called builtin, which will be used to represent builtin packages which will be used in the implementation of [`build-std=always`](https://rust-lang.github.io/rfcs/3874-build-std-always.html#proposal) as mentioned in the [explicit builtin dependencies RFC](https://rust-lang.github.io/rfcs/3875-build-std-explicit-dependencies.html#proposal:~:text=Crates%20without%20an%20explicit%20dependency%20on%20the%20standard%20library%20now%20have%20a%20implicit%20dependency%20%28%3F%29%20on%20that%20target%E2%80%99s%20default%20set%20of%20standard%20library%20crates%20%28see%20build%2Dstd%2Dalways%29%2E). Later, dependencies on builtin packages will be able to be specified as part of the rest of the latter RFC.

This PR's scope is limited to what's needed in order for the resolver to satisfy dependencies on builtins given a registry which already knows about builtin packages, though no actual resolver changes are needed for this.

### How to test and review this PR?

The PR introduces unit tests for all new behaviour and I recommend reading the commits in order. This is all dead code under Cargo's normal operation and there's no way to invoke cargo that uses `SourceKind::Builtin` at this point.

There is a very large amount of context behind build-std. Please feel free to spam me with questions and I can link to relevant bits of this context than reviewers needing to reread this context every time you need to review a build-std PR if you prefer.

This PR is part of a stack:
- https://github.com/rust-lang/cargo/pull/17396
- https://github.com/rust-lang/cargo/pull/17397
- https://github.com/rust-lang/cargo/pull/17398
