### PR TITLE
revert: refactor: move sysroot lookup to GlobalContext

### DIFF
--- a/src/compiler/build_context/mod.rs
+++ b/src/compiler/build_context/mod.rs
@@ -169,12 +169,9 @@ impl<'a, 'gctx> BuildContext<'a, 'gctx> {
     ///
     /// Helper function that uses GlobalContext.
     pub fn get_sysroot(&self) -> &'gctx Path {
-        // cfg::bad_cfg_discovery tests that these panics aren't reachable
-        let rustc = self
-            .gctx
-            .load_global_rustc(Some(self.ws))
-            .expect("rustc load ok");
-        self.gctx.get_sysroot(&rustc).expect("sysroot fetch ok")
+        self.gctx
+            .get_sysroot(Some(self.ws))
+            .expect("able to invoke rustc")
     }
 }
 

--- a/src/compiler/build_context/mod.rs
+++ b/src/compiler/build_context/mod.rs
@@ -1,7 +1,5 @@
 //! [`BuildContext`] is a (mostly) static information about a build task.
 
-use std::path::Path;
-
 use crate::compiler::BuildConfig;
 use crate::compiler::CompileKind;
 use crate::compiler::Unit;
@@ -163,15 +161,6 @@ impl<'a, 'gctx> BuildContext<'a, 'gctx> {
     /// `cargo rustc` or `cargo rustdoc`.
     pub fn extra_args_for(&self, unit: &Unit) -> Option<&Vec<String>> {
         self.extra_compiler_args.get(unit)
-    }
-
-    /// Gets the path to the sysroot.
-    ///
-    /// Helper function that uses GlobalContext.
-    pub fn get_sysroot(&self) -> &'gctx Path {
-        self.gctx
-            .get_sysroot(Some(self.ws))
-            .expect("able to invoke rustc")
     }
 }
 

--- a/src/compiler/build_context/target_info.rs
+++ b/src/compiler/build_context/target_info.rs
@@ -168,8 +168,6 @@ impl TargetInfo {
     /// invocation is cached by [`Rustc::cached_output`].
     ///
     /// Search `Tricky` to learn why querying `rustc` several times is needed.
-    ///
-    /// When a Workspace is provided,
     #[tracing::instrument(skip_all)]
     pub fn new(
         gctx: &GlobalContext,
@@ -179,25 +177,15 @@ impl TargetInfo {
     ) -> CargoResult<TargetInfo> {
         let mut rustflags =
             extra_args(gctx, requested_kinds, &rustc.host, None, kind, Flags::Rust)?;
-
-        let sysroot = gctx.get_sysroot(rustc)?;
-        let sysroot_target_libdir = sysroot
-            .join("lib")
-            .join("rustlib")
-            .join(match &kind {
-                CompileKind::Host => rustc.host.as_str(),
-                CompileKind::Target(target) => target.short_name(),
-            })
-            .join("lib");
-
         let mut turn = 0;
         loop {
             let extra_fingerprint = kind.fingerprint_hash();
 
             // Query rustc for several kinds of info from each line of output:
             // 0) file-names (to determine output file prefix/suffix for given crate type)
-            // 1) split-debuginfo
-            // 2) cfg
+            // 1) sysroot
+            // 2) split-debuginfo
+            // 3) cfg
             //
             // Search `--print` to see what we query so far.
             let mut process = rustc.workspace_process();
@@ -231,6 +219,7 @@ impl TargetInfo {
                 process.arg("--crate-type").arg(crate_type.as_str());
             }
 
+            process.arg("--print=sysroot");
             process.arg("--print=split-debuginfo");
             process.arg("--print=crate-name"); // `___` as a delimiter.
             process.arg("--print=cfg");
@@ -251,6 +240,22 @@ impl TargetInfo {
                 let out = parse_crate_type(crate_type, &process, &output, &error, &mut lines)?;
                 map.insert(crate_type.clone(), out);
             }
+
+            let Some(line) = lines.next() else {
+                return error_missing_print_output("sysroot", &process, &output, &error);
+            };
+            let sysroot = PathBuf::from(line);
+            let sysroot_target_libdir = {
+                let mut libdir = sysroot.clone();
+                libdir.push("lib");
+                libdir.push("rustlib");
+                libdir.push(match &kind {
+                    CompileKind::Host => rustc.host.as_str(),
+                    CompileKind::Target(target) => target.short_name(),
+                });
+                libdir.push("lib");
+                libdir
+            };
 
             let support_split_debuginfo = {
                 // HACK: abuse `--print=crate-name` to use `___` as a delimiter.

--- a/src/compiler/build_context/target_info.rs
+++ b/src/compiler/build_context/target_info.rs
@@ -53,6 +53,8 @@ pub struct TargetInfo {
     pub supports_std: Option<bool>,
     /// Supported values for `-Csplit-debuginfo=` flag, queried from rustc
     support_split_debuginfo: Vec<String>,
+    /// Path to the sysroot.
+    pub sysroot: PathBuf,
     /// Path to the "lib" directory in the sysroot which rustc uses for linking
     /// target libraries.
     pub sysroot_target_libdir: PathBuf,
@@ -370,6 +372,7 @@ impl TargetInfo {
             return Ok(TargetInfo {
                 crate_type_process,
                 crate_types: RefCell::new(map),
+                sysroot,
                 sysroot_target_libdir,
                 rustflags: rustflags.into(),
                 rustdocflags: extra_args(

--- a/src/compiler/build_runner/compilation_files.rs
+++ b/src/compiler/build_runner/compilation_files.rs
@@ -756,7 +756,7 @@ fn compute_metadata(
         // SourceId for stdlib crates is an absolute path inside the sysroot.
         // Pass the sysroot as workspace root so that we hash a relative path.
         // This avoids the metadata hash changing depending on where the user installed rustc.
-        &bcx.get_sysroot()
+        &bcx.target_data.get_info(unit.kind).unwrap().sysroot
     } else {
         bcx.ws.root()
     };

--- a/src/compiler/rustdoc.rs
+++ b/src/compiler/rustdoc.rs
@@ -1,8 +1,8 @@
 //! Utilities for building with rustdoc.
 
-use crate::compiler::BuildContext;
 use crate::compiler::build_runner::BuildRunner;
 use crate::compiler::unit::Unit;
+use crate::compiler::{BuildContext, CompileKind};
 use crate::sources::CRATES_IO_REGISTRY;
 use crate::util::data_structures::HashMap;
 use crate::util::data_structures::HashSet;
@@ -208,7 +208,7 @@ pub fn add_root_urls(
     let std_url = match &map.std {
         None | Some(RustdocExternMode::Remote) => None,
         Some(RustdocExternMode::Local) => {
-            let sysroot = build_runner.bcx.get_sysroot();
+            let sysroot = &build_runner.bcx.target_data.info(CompileKind::Host).sysroot;
             let html_root = sysroot.join("share").join("doc").join("rust").join("html");
             if html_root.exists() {
                 let url = Url::from_file_path(&html_root).map_err(|()| {

--- a/src/compiler/standard_lib.rs
+++ b/src/compiler/standard_lib.rs
@@ -223,10 +223,9 @@ fn detect_sysroot_src_path(ws: &Workspace<'_>) -> CargoResult<PathBuf> {
     }
 
     // NOTE: This is temporary until we figure out how to acquire the source.
-    let rustc = ws.gctx().load_global_rustc(Some(ws))?;
     let src_path = ws
         .gctx()
-        .get_sysroot(&rustc)
+        .get_sysroot(Some(ws))
         .expect("able to invoke rustc")
         .join("lib")
         .join("rustlib")

--- a/src/compiler/standard_lib.rs
+++ b/src/compiler/standard_lib.rs
@@ -54,7 +54,7 @@ pub fn resolve_std<'gctx>(
     crates: &[String],
     kinds: &[CompileKind],
 ) -> CargoResult<(PackageSet<'gctx>, Resolve, ResolvedFeatures)> {
-    let src_path = detect_sysroot_src_path(ws)?;
+    let src_path = detect_sysroot_src_path(target_data)?;
     let std_ws_manifest_path = src_path.join("Cargo.toml");
     let gctx = ws.gctx();
     // TODO: Consider doing something to enforce --locked? Or to prevent the
@@ -217,16 +217,15 @@ fn generate_roots(
     Ok(())
 }
 
-fn detect_sysroot_src_path(ws: &Workspace<'_>) -> CargoResult<PathBuf> {
-    if let Some(s) = ws.gctx().get_env_os("__CARGO_TESTS_ONLY_SRC_ROOT") {
+fn detect_sysroot_src_path(target_data: &RustcTargetData<'_>) -> CargoResult<PathBuf> {
+    if let Some(s) = target_data.gctx.get_env_os("__CARGO_TESTS_ONLY_SRC_ROOT") {
         return Ok(s.into());
     }
 
     // NOTE: This is temporary until we figure out how to acquire the source.
-    let src_path = ws
-        .gctx()
-        .get_sysroot(Some(ws))
-        .expect("able to invoke rustc")
+    let src_path = target_data
+        .info(CompileKind::Host)
+        .sysroot
         .join("lib")
         .join("rustlib")
         .join("src")
@@ -239,7 +238,7 @@ fn detect_sysroot_src_path(ws: &Workspace<'_>) -> CargoResult<PathBuf> {
              library, try:\n        rustup component add rust-src",
             lock
         );
-        match ws.gctx().get_env("RUSTUP_TOOLCHAIN") {
+        match target_data.gctx.get_env("RUSTUP_TOOLCHAIN") {
             Ok(rustup_toolchain) => {
                 anyhow::bail!("{} --toolchain {}", msg, rustup_toolchain);
             }

--- a/src/compiler/trim_paths.rs
+++ b/src/compiler/trim_paths.rs
@@ -114,7 +114,7 @@ pub(crate) fn trim_paths_remap(build_runner: &BuildRunner<'_, '_>, unit: &Unit) 
             .map(join_remap),
     );
     remaps.push(join_remap(build_dir_remap(build_runner)));
-    remaps.push(join_remap(sysroot_remap(build_runner)));
+    remaps.push(join_remap(sysroot_remap(build_runner, unit)));
     remaps
 }
 
@@ -130,15 +130,13 @@ fn join_remap((from, to): RemapPair) -> OsString {
 ///
 /// This remap logic aligns with rustc:
 /// <https://github.com/rust-lang/rust/blob/c2ef3516/src/bootstrap/src/lib.rs#L1113-L1116>
-fn sysroot_remap(build_runner: &BuildRunner<'_, '_>) -> RemapPair {
+fn sysroot_remap(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> RemapPair {
     // See also `detect_sysroot_src_path()`.
-    let sysroot = build_runner
-        .bcx
-        .get_sysroot()
-        .join("lib")
-        .join("rustlib")
-        .join("src")
-        .join("rust");
+    let mut sysroot = build_runner.bcx.target_data.info(unit.kind).sysroot.clone();
+    sysroot.push("lib");
+    sysroot.push("rustlib");
+    sysroot.push("src");
+    sysroot.push("rust");
 
     let rustc = build_runner.bcx.rustc();
     let to = match rustc.commit_hash.as_ref() {
@@ -328,7 +326,7 @@ pub(crate) fn write_unremap_file(
         Entry::Occupied(_) => {}
     };
 
-    insert(sysroot_remap(build_runner));
+    insert(sysroot_remap(build_runner, unit));
     insert(build_dir_remap(build_runner));
 
     let mut seen = HashSet::default();

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -614,16 +614,11 @@ impl GlobalContext {
     }
 
     /// Get the sysroot path.
-    pub fn get_sysroot<'gctx>(
-        &'gctx self,
-        ws: Option<&Workspace<'gctx>>,
-    ) -> CargoResult<&'gctx Path> {
-        self.sysroot
-            .try_borrow_with(|| {
-                let rustc = self.load_global_rustc(ws)?;
-                rustc.sysroot(self)
-            })
-            .map(AsRef::as_ref)
+    pub fn get_sysroot<'gctx>(&'gctx self, ws: Option<&Workspace<'gctx>>) -> CargoResult<&PathBuf> {
+        self.sysroot.try_borrow_with(|| {
+            let rustc = self.load_global_rustc(ws)?;
+            rustc.sysroot(self)
+        })
     }
 
     /// Which package sources have been updated, used to ensure it is only done once.

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -225,8 +225,6 @@ pub struct GlobalContext {
     cargo_exe: OnceLock<PathBuf>,
     /// The location of the rustdoc executable
     rustdoc: OnceLock<PathBuf>,
-    /// The path to the sysroot
-    sysroot: OnceLock<PathBuf>,
     /// Whether we are printing extra verbose messages
     extra_verbose: bool,
     /// `frozen` is the same as `locked`, but additionally will not access the
@@ -381,7 +379,6 @@ impl GlobalContext {
             cli_config: None,
             cargo_exe: Default::default(),
             rustdoc: Default::default(),
-            sysroot: Default::default(),
             extra_verbose: false,
             frozen: false,
             locked: false,
@@ -611,14 +608,6 @@ impl GlobalContext {
                 Ok(exe)
             })
             .map(AsRef::as_ref)
-    }
-
-    /// Get the sysroot path.
-    pub fn get_sysroot<'gctx>(&'gctx self, ws: Option<&Workspace<'gctx>>) -> CargoResult<&PathBuf> {
-        self.sysroot.try_borrow_with(|| {
-            let rustc = self.load_global_rustc(ws)?;
-            rustc.sysroot(self)
-        })
     }
 
     /// Which package sources have been updated, used to ensure it is only done once.

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -614,9 +614,15 @@ impl GlobalContext {
     }
 
     /// Get the sysroot path.
-    pub fn get_sysroot<'gctx>(&'gctx self, rustc: &Rustc) -> CargoResult<&'gctx Path> {
+    pub fn get_sysroot<'gctx>(
+        &'gctx self,
+        ws: Option<&Workspace<'gctx>>,
+    ) -> CargoResult<&'gctx Path> {
         self.sysroot
-            .try_borrow_with(|| rustc.sysroot(self))
+            .try_borrow_with(|| {
+                let rustc = self.load_global_rustc(ws)?;
+                rustc.sysroot(self)
+            })
             .map(AsRef::as_ref)
     }
 

--- a/src/ops/cargo_fix/mod.rs
+++ b/src/ops/cargo_fix/mod.rs
@@ -53,6 +53,7 @@ use semver::Version;
 use tracing::{debug, trace, warn};
 
 pub use self::fix_edition::fix_edition;
+use crate::compiler::CompileKind;
 use crate::compiler::RustcTargetData;
 use crate::ops::resolve::WorkspaceResolve;
 use crate::ops::{self, CompileOptions};
@@ -184,9 +185,7 @@ pub fn fix(
         wrapper.env(IDIOMS_ENV_INTERNAL, "1");
     }
 
-    let sysroot = gctx
-        .get_sysroot(Some(original_ws))
-        .expect("able to invoke rustc");
+    let sysroot = &target_data.info(CompileKind::Host).sysroot;
     if sysroot.is_dir() {
         wrapper.env(SYSROOT_INTERNAL, sysroot);
     }

--- a/src/ops/cargo_fix/mod.rs
+++ b/src/ops/cargo_fix/mod.rs
@@ -184,8 +184,9 @@ pub fn fix(
         wrapper.env(IDIOMS_ENV_INTERNAL, "1");
     }
 
-    let rustc = gctx.load_global_rustc(Some(original_ws))?;
-    let sysroot = gctx.get_sysroot(&rustc).expect("able to invoke rustc");
+    let sysroot = gctx
+        .get_sysroot(Some(original_ws))
+        .expect("able to invoke rustc");
     if sysroot.is_dir() {
         wrapper.env(SYSROOT_INTERNAL, sysroot);
     }

--- a/src/util/rustc.rs
+++ b/src/util/rustc.rs
@@ -4,7 +4,7 @@ use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
-use anyhow::{Context as _, bail};
+use anyhow::Context as _;
 use cargo_util::{ProcessBuilder, ProcessError, paths};
 use filetime::FileTime;
 use serde::{Deserialize, Serialize};
@@ -169,11 +169,7 @@ impl Rustc {
         cmd.arg("--print=sysroot");
 
         let (stdout, _) = self.cached_output(&cmd, 0)?;
-        let path: PathBuf = stdout.trim().into();
-        if !path.exists() {
-            bail!("sysroot path \"{}\" does not exist", path.display());
-        }
-        Ok(path)
+        Ok(stdout.trim().into())
     }
 }
 

--- a/src/util/rustc.rs
+++ b/src/util/rustc.rs
@@ -64,7 +64,6 @@ impl Rustc {
             .wrapped(wrapper.as_deref());
         apply_env_config(gctx, &mut cmd)?;
         cmd.env(crate::CARGO_ENV, gctx.cargo_exe()?);
-
         cmd.arg("-vV");
         let verbose_version = cache.cached_output(&cmd, 0)?.0;
 
@@ -159,17 +158,6 @@ impl Rustc {
             .lock()
             .unwrap()
             .cached_output(cmd, extra_fingerprint)
-    }
-
-    /// Use the rustc executable to fetch the sysroot path.
-    pub fn sysroot(&self, gctx: &GlobalContext) -> CargoResult<PathBuf> {
-        let mut cmd = self.workspace_process();
-        apply_env_config(gctx, &mut cmd)?;
-        cmd.env(crate::CARGO_ENV, gctx.cargo_exe()?);
-        cmd.arg("--print=sysroot");
-
-        let (stdout, _) = self.cached_output(&cmd, 0)?;
-        Ok(stdout.trim().into())
     }
 }
 

--- a/tests/testsuite/cfg.rs
+++ b/tests/testsuite/cfg.rs
@@ -347,13 +347,6 @@ fn bad_cfg_discovery() {
                     print!("{}", run_rustc());
                     return;
                 }
-                if mode == "no-sysroot" {
-                    return;
-                }
-                if std::env::args_os().any(|a| a == "--print=sysroot") {
-                    print!("{}", run_rustc());
-                    return;
-                }
                 if mode == "no-crate-types" {
                     return;
                 }
@@ -363,19 +356,24 @@ fn bad_cfg_discovery() {
                 }
                 let output = run_rustc();
                 let mut lines = output.lines();
-                let mut line = loop {
+                let sysroot = loop {
                     let line = lines.next().unwrap();
                     if line.contains("___") {
-                        println!("{line}");
+                        println!("{}", line);
                     } else {
                         break line;
                     }
                 };
+                if mode == "no-sysroot" {
+                    return;
+                }
+                println!("{}", sysroot);
 
                 if mode == "no-split-debuginfo" {
                     return;
                 }
                 loop {
+                    let line = lines.next().unwrap();
                     if line == "___" {
                         println!("\n{line}");
                         break;
@@ -384,7 +382,6 @@ fn bad_cfg_discovery() {
                         // concat them into one line.
                         print!("{line},");
                     }
-                    line = lines.next().unwrap();
                 };
 
                 if mode != "bad-cfg" {
@@ -414,22 +411,32 @@ foo
 
     p.cargo("check")
         .env("RUSTC", &funky_rustc)
-        .env("FUNKY_MODE", "no-sysroot")
-        .with_status(101)
-        .with_stderr_data(str![[r#"
-[ERROR] sysroot path "" does not exist
-
-"#]])
-        .run();
-
-    p.cargo("check")
-        .env("RUSTC", &funky_rustc)
         .env("FUNKY_MODE", "no-crate-types")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] malformed output when learning about crate-type bin information
 command was: `[ROOT]/compiler/target/debug/compiler[..] --crate-name ___ [..]`
 (no output received)
+
+"#]])
+        .run();
+
+    p.cargo("check")
+        .env("RUSTC", &funky_rustc)
+        .env("FUNKY_MODE", "no-sysroot")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] output of --print=sysroot missing when learning about target-specific information from rustc
+command was: `[ROOT]/compiler/target/debug/compiler[..]--crate-type [..]`
+
+--- stdout
+___[EXE]
+lib___.rlib
+[..]___.[..]
+[..]___.[..]
+[..]___.[..]
+[..]___.[..]
+
 
 "#]])
         .run();
@@ -449,6 +456,7 @@ lib___.rlib
 [..]___.[..]
 [..]___.[..]
 [..]___.[..]
+[..]
 
 
 "#]])
@@ -466,6 +474,7 @@ lib___.rlib
 [..]___.[..]
 [..]___.[..]
 [..]___.[..]
+[..]
 [..],[..]
 ___
 123


### PR DESCRIPTION
### What does this PR try to resolve?

This PR fixes https://github.com/rust-lang/cargo/issues/17351 by reverting the offending https://github.com/rust-lang/cargo/pull/17276. It should be backported to beta.

We tried to address the issues in https://github.com/rust-lang/cargo/pull/17393 but found that the situation was more complex than we thought, and I'll go another route to make the changes I need.

This PR did not revert cleanly, and there were merge conflicts in the 2nd commit in `trim_paths.rs`.

### How to test and review this PR?

Compare with the reverted PR.
