### PR TITLE
perf(git): Reduce extra work when using git-cli

### DIFF
--- a/src/sources/git/utils.rs
+++ b/src/sources/git/utils.rs
@@ -1263,6 +1263,8 @@ https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli"
     let mut cmd = ProcessBuilder::new("git");
     // Avoid potential for unused work that may also hang (#15775)
     cmd.arg("-c").arg("core.fsmonitor=false");
+    // Avoid warnings with `--no-show-forced-updates`
+    cmd.arg("-c").arg("advice.fetchShowForcedUpdates=false");
 
     cmd.arg("fetch");
     if tags {
@@ -1302,6 +1304,16 @@ https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli"
         }
     } else {
         cmd.arg("--quiet");
+    }
+
+    let min_no_show_forced_update = GitVersion {
+        major: 2,
+        minor: 23,
+        patch: 0,
+    };
+    if min_no_show_forced_update <= git_version {
+        // skip unneeded expensive calculations
+        cmd.arg("--no-show-forced-updates");
     }
 
     cmd.arg("--force") // handle force pushes

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -3171,7 +3171,7 @@ fn use_the_cli() {
 
     let stderr = str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep1`
-[RUNNING] `git -c core.fsmonitor=false fetch --no-tags --verbose --force --update-head-ok [..][ROOTURL]/dep1[..] [..]+HEAD:refs/remotes/origin/HEAD[..]`
+[RUNNING] `git[..] fetch --no-tags --verbose[..] --force --update-head-ok [..][ROOTURL]/dep1[..] [..]+HEAD:refs/remotes/origin/HEAD[..]`
 From [ROOTURL]/dep1
  * [new ref] [..] -> origin/HEAD[..]
 [LOCKING] 1 package to highest compatible version
@@ -3455,7 +3455,7 @@ Caused by:
   failed to clone into: [ROOT]/home/.cargo/git/db/missing-[HASH]
 
 Caused by:
-  process didn't exit successfully: `git -c core.fsmonitor=false fetch [..]` ([EXIT_STATUS]: 128)
+  process didn't exit successfully: `git[..] fetch [..]` ([EXIT_STATUS]: 128)
 
   [HELP] re-try with `net.git-fetch-with-cli = false` to see if it resolves the problem
   https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
@@ -3612,17 +3612,17 @@ fn git_cli_arg_injection_via_branch() {
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `[ROOTURL]/dep1`
 fatal: couldn't find remote ref refs/heads/-u./payload
-[WARNING] spurious network error (3 tries remaining): process didn't exit successfully: `git -c core.fsmonitor=false fetch [..]` ([EXIT_STATUS]: 128)
+[WARNING] spurious network error (3 tries remaining): process didn't exit successfully: `git[..] fetch [..]` ([EXIT_STATUS]: 128)
 
 [HELP] re-try with `net.git-fetch-with-cli = false` to see if it resolves the problem
 https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
 fatal: couldn't find remote ref refs/heads/-u./payload
-[WARNING] spurious network error (2 tries remaining): process didn't exit successfully: `git -c core.fsmonitor=false fetch [..]` ([EXIT_STATUS]: 128)
+[WARNING] spurious network error (2 tries remaining): process didn't exit successfully: `git[..] fetch [..]` ([EXIT_STATUS]: 128)
 
 [HELP] re-try with `net.git-fetch-with-cli = false` to see if it resolves the problem
 https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
 fatal: couldn't find remote ref refs/heads/-u./payload
-[WARNING] spurious network error (1 try remaining): process didn't exit successfully: `git -c core.fsmonitor=false fetch [..]` ([EXIT_STATUS]: 128)
+[WARNING] spurious network error (1 try remaining): process didn't exit successfully: `git[..] fetch [..]` ([EXIT_STATUS]: 128)
 
 [HELP] re-try with `net.git-fetch-with-cli = false` to see if it resolves the problem
 https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
@@ -3639,7 +3639,7 @@ Caused by:
   failed to clone into: [ROOT]/home/.cargo/git/db/dep1-[HASH]
 
 Caused by:
-  process didn't exit successfully: `git -c core.fsmonitor=false fetch [..]` ([EXIT_STATUS]: 128)
+  process didn't exit successfully: `git[..] fetch [..]` ([EXIT_STATUS]: 128)
 
   [HELP] re-try with `net.git-fetch-with-cli = false` to see if it resolves the problem
   https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
@@ -4625,17 +4625,17 @@ fn github_fastpath_error_message() {
         .with_stderr_data(str![[r#"
 [UPDATING] git repository `https://github.com/rust-lang/bitflags.git`
 fatal: remote [ERROR] upload-pack: not our ref 11111b376b93484341c68fbca3ca110ae5cd2790
-[WARNING] spurious network error (3 tries remaining): process didn't exit successfully: `git -c core.fsmonitor=false fetch --no-tags --quiet --force --update-head-ok [..]
+[WARNING] spurious network error (3 tries remaining): process didn't exit successfully: `git [..]
 
 [HELP] re-try with `net.git-fetch-with-cli = false` to see if it resolves the problem
 https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
 fatal: remote [ERROR] upload-pack: not our ref 11111b376b93484341c68fbca3ca110ae5cd2790
-[WARNING] spurious network error (2 tries remaining): process didn't exit successfully: `git -c core.fsmonitor=false fetch --no-tags --quiet --force --update-head-ok [..]
+[WARNING] spurious network error (2 tries remaining): process didn't exit successfully: `git[..]
 
 [HELP] re-try with `net.git-fetch-with-cli = false` to see if it resolves the problem
 https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
 fatal: remote [ERROR] upload-pack: not our ref 11111b376b93484341c68fbca3ca110ae5cd2790
-[WARNING] spurious network error (1 try remaining): process didn't exit successfully: `git -c core.fsmonitor=false fetch --no-tags --quiet --force --update-head-ok [..]
+[WARNING] spurious network error (1 try remaining): process didn't exit successfully: `git[..]
 
 [HELP] re-try with `net.git-fetch-with-cli = false` to see if it resolves the problem
 https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
@@ -4655,7 +4655,7 @@ Caused by:
   revision 11111b376b93484341c68fbca3ca110ae5cd2790 not found
 
 Caused by:
-  process didn't exit successfully: `git -c core.fsmonitor=false fetch --no-tags --quiet --force --update-head-ok [..]
+  process didn't exit successfully: `git[..] fetch --no-tags --quiet[..] --force --update-head-ok [..]
 
   [HELP] re-try with `net.git-fetch-with-cli = false` to see if it resolves the problem
   https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli


### PR DESCRIPTION
### What does this PR try to resolve?

From the man page:

> --no-show-forced-updates
> By default, git checks if a branch is force-updated during fetch. Pass --no-show-forced-updates or set fetch.showForcedUpdates to false to skip this check
> for performance reasons. If used during git-pull the --ff-only option will still check for forced updates before attempting a fast-forward update. See git-config(1).

The problem is this adds a warning, so we disable it with `advice`. Setting advice does not impact the minimum-support git version.

### How to test and review this PR?

