### PR TITLE
Avoid passing search path (-L) args when they are passed as --extern

### DIFF
--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -57,7 +57,6 @@ pub mod unused_deps;
 use crate::util::data_structures::{HashMap, HashSet};
 use std::borrow::Cow;
 use std::cell::OnceCell;
-use std::collections::BTreeMap;
 use std::env;
 use std::ffi::{OsStr, OsString};
 use std::fmt::Display;
@@ -70,7 +69,6 @@ use std::sync::{Arc, LazyLock};
 use anyhow::{Context as _, Error};
 use cargo_platform::{Cfg, Platform};
 use cargo_util_terminal::report::{AnnotationKind, Group, Level, Renderer, Snippet};
-use itertools::Itertools;
 use regex::Regex;
 use tracing::{debug, instrument, trace};
 
@@ -1760,31 +1758,6 @@ fn build_deps_args(
     Ok(())
 }
 
-fn add_dep_arg<'a, 'b: 'a>(
-    map: &mut BTreeMap<&'a Unit, PathBuf>,
-    build_runner: &'b BuildRunner<'b, '_>,
-    unit: &'a Unit,
-) {
-    for dep in build_runner.unit_deps(unit) {
-        // Don't include build script out dir in the args to reduce rustc command bloat.
-        if dep.unit.target.is_custom_build() {
-            continue;
-        }
-        if map.contains_key(&dep.unit) {
-            continue;
-        }
-        map.insert(&dep.unit, build_runner.files().deps_dir(&dep.unit));
-
-        // Proc macros are statically linked, so when including a proc-macro dependency we can skip
-        // adding it's dependencies. Note that we still do add them when we are compiling the
-        // proc-macro itself.
-        if dep.unit.target.proc_macro() {
-            continue;
-        }
-        add_dep_arg(map, build_runner, &dep.unit);
-    }
-}
-
 /// Adds extra rustc flags and environment variables collected from the output
 /// of a build-script to the command to execute, include custom environment
 /// variables and `cfg`.
@@ -1820,12 +1793,8 @@ pub fn lib_search_paths(
 ) -> CargoResult<Vec<OsString>> {
     let mut lib_search_paths = Vec::new();
     if build_runner.bcx.gctx.cli_unstable().build_dir_new_layout {
-        let mut map = BTreeMap::new();
-
-        // Recursively add all dependency args to rustc process
-        add_dep_arg(&mut map, build_runner, unit);
-
-        let paths = map.into_iter().map(|(_, path)| path).sorted_unstable();
+        // Add all dependency args to rustc process
+        let paths = dep_paths_for_args(unit, build_runner);
 
         for path in paths {
             let mut deps = OsString::from("dependency=");
@@ -1847,6 +1816,63 @@ pub fn lib_search_paths(
     }
 
     Ok(lib_search_paths)
+}
+
+/// Generate a list of paths for the rustc `-L` args.
+///
+/// To generate the list of paths we walk the dependency graph using DFS with a stack.
+///
+/// We try to avoid bloating the amount of args passed rustc as it can cause issues with OS limits
+/// for large projects. (and generally just makes the rustc command ugly!).
+/// Below are the rules for excluding build units from the args.
+/// 1. Don't include build script out dir in the args to reduce rustc command bloat.
+/// 2. Proc macros are statically linked, so when including a proc-macro dependency we can skip
+///    adding it's dependencies. Note that we still do add them when we are compiling the
+///    proc-macro itself.
+/// 3. Don't include direct dependencies because they are passed with `--extern` and rustc does not
+///    need `-L` if it was already passed as `--extern`
+fn dep_paths_for_args(unit: &Unit, build_runner: &BuildRunner<'_, '_>) -> Vec<PathBuf> {
+    let direct = build_runner.unit_deps(unit);
+    if direct.is_empty() {
+        return Vec::new();
+    }
+    let mut indirect = HashSet::default();
+    let mut visited = HashSet::default();
+    let mut stack: Vec<&Unit> = direct
+        .iter()
+        .filter(|d| !d.unit.target.is_custom_build())
+        .map(|d| &d.unit)
+        .collect();
+    while let Some(u) = stack.pop() {
+        if !visited.insert(u.clone()) {
+            continue;
+        }
+        if u.target.proc_macro() {
+            continue;
+        }
+        for dep in build_runner.unit_deps(u) {
+            let v = &dep.unit;
+            if v.target.is_custom_build() {
+                continue;
+            }
+            indirect.insert(v.clone());
+            if v.target.proc_macro() {
+                continue;
+            }
+            if !visited.contains(v) {
+                stack.push(v);
+            }
+        }
+    }
+
+    let mut paths: Vec<PathBuf> = indirect
+        .into_iter()
+        .map(|u| build_runner.files().deps_dir(&u))
+        .collect();
+    paths.sort_unstable();
+    paths.dedup();
+
+    paths
 }
 
 fn is_public_dependency_enabled(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> bool {

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1869,8 +1869,22 @@ fn dep_paths_for_args(unit: &Unit, build_runner: &BuildRunner<'_, '_>) -> Vec<Pa
         .into_iter()
         .map(|u| build_runner.files().deps_dir(&u))
         .collect();
-    paths.sort_unstable();
-    paths.dedup();
+
+    // We are in the hot path that needs to always run (even for rebuilds)
+    // There could be a potentially large amount of paths for large workspaces.
+    // We want to sort and dedup the paths but doing so is a bit expsensive when comparing PathBufs
+    // directly. So instead we only sort valid Utf8 paths as &str's which is a bit faster.
+    // We do not allow non utf8 paths when building, so we take advantage of that by treating them
+    // as a single value when sorting/deduplicating.
+    //
+    // For reference this saves about ~30ms on Zed
+    paths.sort_unstable_by(|a, b| match (a.to_str(), b.to_str()) {
+        (Some(a), Some(b)) => a.cmp(b),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => std::cmp::Ordering::Less,
+    });
+    paths.dedup_by(|a, b| matches!((a.to_str(), b.to_str()), (Some(x), Some(y)) if x == y));
 
     paths
 }

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -6870,3 +6870,85 @@ fn should_not_include_proc_macro_deps_paths_in_rustc_args() {
 "#]].unordered())
         .run();
 }
+
+#[cargo_test]
+fn should_not_include_direct_deps_paths_in_rustc_args() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                edition = "2021"
+                authors = []
+                resolver = "2"
+
+                [dependencies]
+                my-direct-dep = { path = "my-direct-dep" }
+
+                [lints.cargo]
+                default = "allow"
+            "#,
+        )
+        .file(
+            "src/main.rs",
+            "fn main() { let _v = my_direct_dep::value_from_direct(); }",
+        )
+        .file(
+            "my-direct-dep/Cargo.toml",
+            r#"
+                [package]
+                name = "my-direct-dep"
+                version = "0.1.0"
+                edition = "2021"
+                authors = []
+
+                [dependencies]
+                my-indirect-dep = { path = "../my-indirect-dep" }
+
+                [lints.cargo]
+                default = "allow"
+            "#,
+        )
+        .file(
+            "my-direct-dep/src/lib.rs",
+            r#"pub fn value_from_direct() -> i32 { my_indirect_dep::value_from_indirect() }"#,
+        )
+        .file(
+            "my-indirect-dep/Cargo.toml",
+            r#"
+                [package]
+                name = "my-indirect-dep"
+                version = "0.1.0"
+                edition = "2021"
+                authors = []
+
+                [lints.cargo]
+                default = "allow"
+            "#,
+        )
+        .file(
+            "my-indirect-dep/src/lib.rs",
+            r#"pub fn value_from_indirect() -> i32 { 200 }"#,
+        )
+        .build();
+
+    // Graph: foo -> my-direct-dep -> my-indirect-dep
+    // We want to make sure `-L .../my-indirect-dep` is passed but not `-L .../my-direct-dep`
+    //
+    // FIXME: Remove the `-L dependency=[ROOT]/foo/target/debug/build/my-direct-dep/[HASH]/out` once fixed
+    p.cargo("-v build")
+        .with_stderr_data(str![[r#"
+[LOCKING] 2 packages to highest compatible versions
+[COMPILING] my-indirect-dep v0.1.0 ([ROOT]/foo/my-indirect-dep)
+[RUNNING] `rustc --crate-name my_indirect_dep [..]`
+[COMPILING] my-direct-dep v0.1.0 ([ROOT]/foo/my-direct-dep)
+[RUNNING] `rustc --crate-name my_direct_dep [..]`
+[COMPILING] foo v0.0.0 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/my-direct-dep/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/my-indirect-dep/[HASH]/out --extern my_direct_dep=[ROOT]/foo/target/debug/build/my-direct-dep/[HASH]/out/[..] --force-warn=unused_crate_dependencies`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]].unordered())
+        .run();
+}

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -6640,10 +6640,7 @@ fn should_not_include_build_script_out_dir_path_in_rustc_args() {
         .run();
 }
 
-#[cargo_test(
-    nightly,
-    reason = "Depends on https://github.com/rust-lang/rust/pull/155439/changes/61f3e086acc1c187bb262ab43cac71f44018c397"
-)]
+#[cargo_test]
 fn should_only_include_dylibs_on_lib_search_path() {
     let envvar = dylib_path_envvar();
     let p = project()
@@ -6760,10 +6757,7 @@ qux (cdylib) on search path: true
         .run();
 }
 
-#[cargo_test(
-    nightly,
-    reason = "Depends on https://github.com/rust-lang/rust/pull/155439/changes/61f3e086acc1c187bb262ab43cac71f44018c397"
-)]
+#[cargo_test]
 fn should_not_include_proc_macro_deps_paths_in_rustc_args() {
     let p = project()
         .file(

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -6864,7 +6864,7 @@ fn should_not_include_proc_macro_deps_paths_in_rustc_args() {
 [COMPILING] my-proc-macro v0.1.0 ([ROOT]/foo/my-proc-macro)
 [RUNNING] `rustc --crate-name my_proc_macro [..]`
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo [..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/my-proc-macro/[HASH]/out --extern my_proc_macro=[ROOT]/foo/target/debug/build/my-proc-macro/[HASH]/out/[..] --force-warn=unused_crate_dependencies`
+[RUNNING] `rustc --crate-name foo [..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out --extern my_proc_macro=[ROOT]/foo/target/debug/build/my-proc-macro/[HASH]/out/[..] --force-warn=unused_crate_dependencies`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]].unordered())
@@ -6936,8 +6936,6 @@ fn should_not_include_direct_deps_paths_in_rustc_args() {
 
     // Graph: foo -> my-direct-dep -> my-indirect-dep
     // We want to make sure `-L .../my-indirect-dep` is passed but not `-L .../my-direct-dep`
-    //
-    // FIXME: Remove the `-L dependency=[ROOT]/foo/target/debug/build/my-direct-dep/[HASH]/out` once fixed
     p.cargo("-v build")
         .with_stderr_data(str![[r#"
 [LOCKING] 2 packages to highest compatible versions
@@ -6946,7 +6944,7 @@ fn should_not_include_direct_deps_paths_in_rustc_args() {
 [COMPILING] my-direct-dep v0.1.0 ([ROOT]/foo/my-direct-dep)
 [RUNNING] `rustc --crate-name my_direct_dep [..]`
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name foo [..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/my-direct-dep/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/my-indirect-dep/[HASH]/out --extern my_direct_dep=[ROOT]/foo/target/debug/build/my-direct-dep/[HASH]/out/[..] --force-warn=unused_crate_dependencies`
+[RUNNING] `rustc --crate-name foo [..] --out-dir [ROOT]/foo/target/debug/build/foo/[HASH]/out -L dependency=[ROOT]/foo/target/debug/build/my-indirect-dep/[HASH]/out --extern my_direct_dep=[ROOT]/foo/target/debug/build/my-direct-dep/[HASH]/out/[..] --force-warn=unused_crate_dependencies`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]].unordered())

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -7206,10 +7206,7 @@ fn target_linker_does_not_apply_to_build_script_with_host_config() {
         .run();
 }
 
-#[cargo_test(
-    nightly,
-    reason = "Depends on https://github.com/rust-lang/rust/pull/155439/changes/61f3e086acc1c187bb262ab43cac71f44018c397"
-)]
+#[cargo_test]
 fn build_script_dylib_search_path_excludes_target_dylibs() {
     if cross_compile_disabled() {
         return;


### PR DESCRIPTION
### What does this PR try to resolve?

This PR reduces the `-L` args passed rustc by omitting direct dependencies as they are passed via `--extern`. (which makes also passing via `-L` unnecessary)

See [#t-cargo > Reducing number of arguments passed with the new build dir](https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/Reducing.20number.20of.20arguments.20passed.20with.20the.20new.20build.20dir/with/619728960) for context.

I tested this change on a handful of open source projects to see the results and this generally reduces the amount of args by 5-20%.

Notable results:
* Zed reduced top level crate args from 1189 to 1136. A 5% reduction
* Vector reduced top level crate args from 934 to 867. A 7% reduction


### How to test and review this PR?

Added a new test to explicitly verify this behavior.

r? @weihanglo 


cc: @Kobzol @petrochenkov 