### PR TITLE
Cargo profiling improvements

### DIFF
--- a/src/compiler/fingerprint/mod.rs
+++ b/src/compiler/fingerprint/mod.rs
@@ -1539,6 +1539,7 @@ impl StaleItem {
 ///
 /// Information like file modification time is only calculated for path
 /// dependencies.
+#[tracing::instrument(skip_all)]
 fn calculate(build_runner: &mut BuildRunner<'_, '_>, unit: &Unit) -> CargoResult<Arc<Fingerprint>> {
     // This function is slammed quite a lot, so the result is memoized.
     if let Some(s) = build_runner.fingerprints.get(unit) {

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -307,6 +307,7 @@ fn make_failed_scrape_diagnostic(
 }
 
 /// Creates a unit of work invoking `rustc` for building the `unit`.
+#[tracing::instrument(skip_all)]
 fn rustc(
     build_runner: &mut BuildRunner<'_, '_>,
     unit: &Unit,
@@ -818,6 +819,7 @@ where
 /// This builds a static view of the invocation. Flags depending on the
 /// completion of other units will be added later in runtime, such as flags
 /// from build scripts.
+#[tracing::instrument(skip_all)]
 fn prepare_rustc(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> CargoResult<ProcessBuilder> {
     let gctx = build_runner.bcx.gctx;
     let is_primary = build_runner.is_primary_package(unit);
@@ -894,6 +896,7 @@ fn prepare_rustc(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> CargoResult
 /// This builds a static view of the invocation. Flags depending on the
 /// completion of other units will be added later in runtime, such as flags
 /// from build scripts.
+#[tracing::instrument(skip_all)]
 fn prepare_rustdoc(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> CargoResult<ProcessBuilder> {
     let bcx = build_runner.bcx;
     // script_metadata is not needed here, it is only for tests.
@@ -1035,6 +1038,7 @@ fn prepare_rustdoc(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> CargoResu
 }
 
 /// Creates a unit of work invoking `rustdoc` for documenting the `unit`.
+#[tracing::instrument(skip_all)]
 fn rustdoc(build_runner: &mut BuildRunner<'_, '_>, unit: &Unit) -> CargoResult<Work> {
     let mut rustdoc = prepare_rustdoc(build_runner, unit)?;
 
@@ -1803,6 +1807,7 @@ fn add_custom_flags(
 }
 
 /// Generate a list of `-L` arguments
+#[tracing::instrument(skip_all)]
 pub fn lib_search_paths(
     build_runner: &BuildRunner<'_, '_>,
     unit: &Unit,

--- a/src/compiler/output_sbom.rs
+++ b/src/compiler/output_sbom.rs
@@ -165,12 +165,6 @@ fn build_sbom_graph<'a>(
                     true => SbomDependencyType::Build,
                 };
                 dependencies.insert((dep, dep_type));
-                tracing::trace!(
-                    "adding sbom edge {} -> {} ({:?})",
-                    parent.pkg.package_id(),
-                    dep.pkg.package_id(),
-                    dep_type,
-                );
                 (dep, false)
             };
             if visited.insert(dep) {

--- a/src/compiler/output_sbom.rs
+++ b/src/compiler/output_sbom.rs
@@ -97,6 +97,7 @@ pub struct Sbom {
 }
 
 /// Build an [`Sbom`] for the given [`Unit`].
+#[tracing::instrument(skip_all)]
 pub fn build_sbom(build_runner: &BuildRunner<'_, '_>, root: &Unit) -> CargoResult<Sbom> {
     let bcx = build_runner.bcx;
     let rustc: SbomRustc = bcx.rustc().into();
@@ -139,6 +140,7 @@ pub fn build_sbom(build_runner: &BuildRunner<'_, '_>, root: &Unit) -> CargoResul
 /// if it's using different settings, e.g. profile, features or crate versions.
 ///
 /// Returns a graph of dependencies.
+#[tracing::instrument(skip_all)]
 fn build_sbom_graph<'a>(
     build_runner: &'a BuildRunner<'_, '_>,
     root: &'a Unit,

--- a/src/compiler/unit_dependencies.rs
+++ b/src/compiler/unit_dependencies.rs
@@ -165,9 +165,27 @@ pub fn build_unit_dependencies<'a, 'gctx>(
             list.sort();
         }
     }
-    trace!("ALL UNIT DEPENDENCIES {:#?}", state.unit_dependencies);
+
+    log_unit_deps_graph(ws.gctx(), &state.unit_dependencies);
 
     Ok(state.unit_dependencies)
+}
+
+fn log_unit_deps_graph(gctx: &GlobalContext, graph: &UnitGraph) {
+    // For workspaces with large dependency graphs, the act of logging graph can actually take
+    // hundreds of milliseconds, skewing the profiling timings. By default, we do not dump the
+    // entire graph to avoid skewing the timings.
+    let graph_to_log = if gctx.get_env("__CARGO_DUMP_UNIT_DEP_GRAPH").unwrap_or("0") == "1" {
+        Some(graph)
+    } else {
+        None
+    };
+
+    trace!(
+        count = graph.len(),
+        graph = format!("{graph_to_log:#?}"),
+        "ALL UNIT DEPENDENCIES",
+    );
 }
 
 /// Compute all the dependencies for the standard library.


### PR DESCRIPTION
### What does this PR try to resolve?

This PR makes a couple of small improvements to our profiling by:
1. Removing/modifying `trace!()` calls that log large objects (`UnitGraph`) or all called from a hot loop (in the case of `build_sbom_graph`)
2. Added more detailed instrumentation to the `fn compile()` while trying to avoid instrumenting leaf functions.

Below are some tracing examples from using profiling on the Zed repository.

**Before**

<img width="2068" height="502" alt="image" src="https://github.com/user-attachments/assets/48f85737-e6cd-4fcf-b792-e8126d94c8a4" />



**After**

<img width="2067" height="501" alt="image" src="https://github.com/user-attachments/assets/b82be28b-1268-40c6-9a66-4397c76b2cdc" />



### How to test and review this PR?

`CARGO_LOG_PROFILE=true CARGO_LOG_PROFILE_CAPTURE_ARGS=true cargo build` on your favorite repo :)
