### PR TITLE
perf: Do not build SBOM if user has not set build.sbom

### DIFF
--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -359,7 +359,11 @@ fn rustc(
     let is_local = unit.is_local();
     let artifact = unit.artifact;
     let sbom_files = build_runner.sbom_output_files(unit)?;
-    let sbom = build_sbom(build_runner, unit)?;
+    let sbom = if !sbom_files.is_empty() {
+        Some(build_sbom(build_runner, unit)?)
+    } else {
+        None
+    };
 
     let unremap_files = build_runner.unremap_output_files(unit)?;
     let unremap_content = if unremap_files.is_empty() {
@@ -452,10 +456,12 @@ fn rustc(
 
         state.running(&rustc);
         let timestamp = paths::set_invocation_time(&fingerprint_dir)?;
-        for file in sbom_files {
-            tracing::debug!("writing sbom to {}", file.display());
-            let outfile = BufWriter::new(paths::create(&file)?);
-            serde_json::to_writer(outfile, &sbom)?;
+        if let Some(sbom) = sbom {
+            for file in sbom_files {
+                tracing::debug!("writing sbom to {}", file.display());
+                let outfile = BufWriter::new(paths::create(&file)?);
+                serde_json::to_writer(outfile, &sbom)?;
+            }
         }
 
         if let Some(content) = &unremap_content {


### PR DESCRIPTION
### What does this PR try to resolve?

Before this PR, the SBOM would be generated in memory and be thrown away instead of written to a file. For projects with a large dependency graph, this can add noticeable delay.

Below is a profiling run on Zed.

<img width="2065" height="908" alt="image" src="https://github.com/user-attachments/assets/8ca00cc0-3498-4161-8c2b-0415f2006d9e" />

On a cold build, this is a very small part of the work, but we have to pay this price on every build.
But when trying to do repeated builds while iterating this time starts to add up.


### How to test and review this PR?

I primarily was doing profiling on Zed when I found this. (also see: https://github.com/rust-lang/cargo/pull/17411)
```sh
CARGO_LOG_PROFILE=true CARGO_LOG_PROFILE_CAPTURE_ARGS=true cargo build
```
I did not add any additional tests since there aren't really any outputs to compare against.
Hoping the existing SBOM tests are good enough, but happy to add a test for this if there is a way I am missing :)


r? @arlosi 

cc: @Shnatsel 

cc: https://github.com/rust-lang/cargo/issues/16565