### PR TITLE
Micro-optimize two package dir functions

### DIFF
--- a/src/compiler/build_runner/compilation_files.rs
+++ b/src/compiler/build_runner/compilation_files.rs
@@ -252,7 +252,13 @@ impl<'a, 'gctx: 'a> CompilationFiles<'a, 'gctx> {
         };
         let name = unit.pkg.package_id().name();
         let hash = self.unit_hash(unit);
-        format!("{name}{separator}{hash}")
+        // This function can be somewhat hot, so try to not cause unnecessary allocations here.
+        // Sadly, format! does not currently pre-allocate the correct size.
+        let mut pkg = String::with_capacity(name.len() + separator.len() + hash.len());
+        pkg.push_str(&name);
+        pkg.push_str(&separator);
+        pkg.push_str(&hash);
+        pkg
     }
 
     /// The directory hash to use for a given unit

--- a/src/compiler/layout.rs
+++ b/src/compiler/layout.rs
@@ -444,7 +444,11 @@ impl BuildDirLayout {
     ///
     /// New features should consider using this so we can avoid their migrations.
     pub fn out_force_new_layout(&self, pkg_dir: &str) -> PathBuf {
-        self.build_unit(pkg_dir).join("out")
+        let mut build_dir = self.build_unit(pkg_dir);
+        // This function can be somewhat hot for packages with many dependencies, so reuse the
+        // PathBuf allocation here.
+        build_dir.push("out");
+        build_dir
     }
     /// Fetch the deps path. (old layout)
     pub fn legacy_deps(&self) -> &Path {


### PR DESCRIPTION
Looked into this while profiling https://github.com/rust-lang/cargo/pull/17410 ([context](https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/Reducing.20number.20of.20arguments.20passed.20with.20the.20new.20build.20dir/with/620216426)).

Those two changes reduce the total duration of collecting dep dirs from ~56ms to ~40ms on Zed. Not a huge win, but for such a small change.. The `format!` change is a bit annoying (there the win was ~5ms), but the `build_dir` change is IMO straightforward and just worth it to reduce an unnecessary `PathBuf` copy (there the win was ~10ms).

r? @ranger-ross