### PR TITLE
test: Move -Z onto its own line

### DIFF
--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -313,7 +313,8 @@ fn cross_custom() {
         .file("custom-target.json", target_spec_json())
         .build();
 
-    p.cargo("build --target custom-target.json -v -Zjson-target-spec")
+    p.cargo("build --target custom-target.json -v")
+        .arg("-Zjson-target-spec")
         .masquerade_as_nightly_cargo(&["json_target_spec"])
         .build_std_arg("core")
         .run();
@@ -354,7 +355,8 @@ fn custom_test_framework() {
     paths.insert(0, sysroot_bin);
     let new_path = env::join_paths(paths).unwrap();
 
-    p.cargo("test --target target.json --no-run -v -Zjson-target-spec")
+    p.cargo("test --target target.json --no-run -v")
+        .arg("-Zjson-target-spec")
         .masquerade_as_nightly_cargo(&["json_target_spec"])
         .env("PATH", new_path)
         .build_std_arg("core")
@@ -385,7 +387,8 @@ fn remap_path_scope() {
         )
         .build();
 
-    p.cargo("run --release -Ztrim-paths")
+    p.cargo("run --release")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .env("RUST_BACKTRACE", "1")
         .build_std()

--- a/tests/testsuite/advanced_env.rs
+++ b/tests/testsuite/advanced_env.rs
@@ -29,7 +29,8 @@ fn source_config_env() {
 
     let path = paths::root().join("registry");
 
-    p.cargo("check -Zadvanced-env")
+    p.cargo("check")
+        .arg("-Zadvanced-env")
         .masquerade_as_nightly_cargo(&["advanced-env"])
         .env("CARGO_SOURCE_crates-io_REPLACE_WITH", "my-local-source")
         .env("CARGO_SOURCE_my-local-source_LOCAL_REGISTRY", path)

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -35,7 +35,8 @@ fn check_with_invalid_artifact_dependency() {
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "")
         .build();
-    p.cargo("check -Z bindeps")
+    p.cargo("check")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
 [ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
@@ -53,7 +54,8 @@ Caused by:
         assert: &dyn Fn(&mut cargo_test_support::Execs),
     ) {
         assert(
-            p.cargo(&format!("{} -Z bindeps", cmd))
+            p.cargo(cmd)
+                .arg("-Zbindeps")
                 .masquerade_as_nightly_cargo(&["bindeps"]),
         );
         assert(&mut p.cargo(cmd));
@@ -146,7 +148,8 @@ fn check_with_invalid_target_triple() {
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/main.rs", "fn main() {}")
         .build();
-    p.cargo("check -Z bindeps")
+    p.cargo("check")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
 [ERROR] failed to run `rustc` to learn about target-specific information
@@ -217,7 +220,8 @@ fn disallow_artifact_and_no_artifact_dep_to_same_package_within_the_same_dep_cat
         .file("bar/Cargo.toml", &basic_bin_manifest("bar"))
         .file("bar/src/main.rs", "fn main() {}")
         .build();
-    p.cargo("check -Z bindeps")
+    p.cargo("check")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -328,7 +332,8 @@ fn features_are_unified_among_lib_and_bin_dep_of_same_target() {
         )
         .build();
 
-    p.cargo("build -Z bindeps")
+    p.cargo("build")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
 [LOCKING] 2 packages to highest compatible versions
@@ -438,7 +443,8 @@ fn features_are_not_unified_among_lib_and_bin_dep_of_different_target() {
         )
         .build();
 
-    p.cargo("build -Z bindeps")
+    p.cargo("build")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -532,7 +538,8 @@ fn feature_resolution_works_for_cfg_target_specification() {
         .file("d2/src/lib.rs", "pub fn f() {}")
         .build();
 
-    p.cargo("test -Z bindeps")
+    p.cargo("test")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .run();
 }
@@ -600,7 +607,8 @@ fn build_script_with_bin_artifacts() {
         .file("bar/src/bin/baz.rs", "fn main() {}")
         .file("bar/src/lib.rs", "")
         .build();
-    p.cargo("build -Z bindeps")
+    p.cargo("build")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(
             str![[r#"
@@ -690,7 +698,8 @@ fn build_script_with_bin_artifact_and_lib_false() {
         )
         .build();
 
-    p.cargo("build -Z bindeps")
+    p.cargo("build")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
         .with_stderr_does_not_contain("[..]sentinel[..]")
@@ -733,7 +742,8 @@ fn lib_with_bin_artifact_and_lib_false() {
         )
         .build();
 
-    p.cargo("build -Z bindeps")
+    p.cargo("build")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
         .with_stderr_does_not_contain("[..]sentinel[..]")
@@ -793,7 +803,8 @@ fn build_script_with_selected_dashed_bin_artifact_and_lib_true() {
             }
         "#)
         .build();
-    p.cargo("build -Z bindeps")
+    p.cargo("build")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
@@ -885,7 +896,8 @@ fn lib_with_selected_dashed_bin_artifact_and_lib_true() {
         .file("bar/src/main.rs", "fn main() {}")
         .file("bar/src/lib.rs", "pub fn exists() {}")
         .build();
-    p.cargo("build -Z bindeps")
+    p.cargo("build")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
@@ -936,7 +948,8 @@ fn allow_artifact_and_no_artifact_dep_to_same_package_within_different_dep_categ
         .file("bar/src/main.rs", "fn main() {}")
         .file("bar/src/lib.rs", "")
         .build();
-    p.cargo("test -Z bindeps")
+    p.cargo("test")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
@@ -983,7 +996,8 @@ fn normal_build_deps_are_picked_up_in_presence_of_an_artifact_build_dep_to_the_s
         .file("bar/src/main.rs", "fn main() {}")
         .file("bar/src/lib.rs", "pub fn f() {}")
         .build();
-    p.cargo("check -Z bindeps")
+    p.cargo("check")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .run();
 }
@@ -1010,7 +1024,8 @@ fn disallow_using_example_binaries_as_artifacts() {
         .file("bar/src/main.rs", "fn main() {}")
         .file("bar/examples/one-example.rs", "fn main() {}")
         .build();
-    p.cargo("build -Z bindeps")
+    p.cargo("build")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -1064,7 +1079,8 @@ fn allow_artifact_and_non_artifact_dependency_to_same_crate() {
             .file("bar/src/lib.rs", "pub fn doit() {}")
         .build();
 
-    p.cargo("check -Z bindeps")
+    p.cargo("check")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
@@ -1114,7 +1130,8 @@ fn build_script_deps_adopt_specified_target_unconditionally() {
         .file("bar/src/lib.rs", "pub fn doit() {}")
         .build();
 
-    p.cargo("check -v -Z bindeps")
+    p.cargo("check -v")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_does_not_contain(
             "[RUNNING] `rustc --crate-name build_script_build --edition=2015 build.rs [..]--target [ALT_TARGET] [..]",
@@ -1182,7 +1199,8 @@ fn build_script_deps_adopt_do_not_allow_multiple_targets_under_different_name_an
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("check -v -Z bindeps")
+    p.cargo("check -v")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -1229,7 +1247,8 @@ fn non_build_script_deps_adopt_specified_target_unconditionally() {
         .file("bar/src/lib.rs", "pub fn doit() {}")
         .build();
 
-    p.cargo("check -v -Z bindeps")
+    p.cargo("check -v")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_contains(
             "[RUNNING] `rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--target [ALT_TARGET] [..]",
@@ -1284,8 +1303,9 @@ fn cross_doctests_works_with_artifacts() {
         .build();
 
     let target = rustc_host();
-    p.cargo("test -Z bindeps --target")
+    p.cargo("test --target")
         .arg(&target)
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
@@ -1305,8 +1325,9 @@ fn cross_doctests_works_with_artifacts() {
         return;
     }
 
-    p.cargo("test -Z bindeps -v --target")
+    p.cargo("test -v --target")
         .arg(&target)
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)
@@ -1357,8 +1378,9 @@ fn build_script_deps_adopts_target_platform_if_target_equals_target() {
         .build();
 
     let alternate_target = cross_compile::alternate();
-    p.cargo("check -v -Z bindeps --target")
+    p.cargo("check -v --target")
         .arg(alternate_target)
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_does_not_contain(
             "[RUNNING] `rustc --crate-name build_script_build --edition=2015 build.rs [..]--target [ALT_TARGET] [..]",
@@ -1410,7 +1432,8 @@ fn profile_override_basic() {
         .file("bar/src/lib.rs", "pub fn bar() {}")
         .build();
 
-    p.cargo("build -v -Z bindeps")
+    p.cargo("build -v")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(
             str![[r#"
@@ -1478,12 +1501,14 @@ fn dependencies_of_dependencies_work_in_artifacts() {
         .file("bar/src/lib.rs", r#"pub fn bar() {baz::baz()}"#)
         .file("bar/src/main.rs", r#"fn main() {bar::bar()}"#)
         .build();
-    p.cargo("build -Z bindeps")
+    p.cargo("build")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .run();
 
     // cargo tree sees artifacts as the dependency kind they are in and doesn't do anything special with it.
-    p.cargo("tree -Z bindeps")
+    p.cargo("tree")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stdout_data(str![[r#"
 foo v0.0.0 ([ROOT]/foo)
@@ -1523,7 +1548,8 @@ fn artifact_dep_target_specified() {
         .file("bindep/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("check -Z bindeps")
+    p.cargo("check")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
@@ -1535,7 +1561,8 @@ fn artifact_dep_target_specified() {
         .with_status(0)
         .run();
 
-    p.cargo("tree -Z bindeps")
+    p.cargo("tree")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stdout_data(str![[r#"
 foo v0.0.0 ([ROOT]/foo)
@@ -1600,7 +1627,8 @@ fn dep_of_artifact_dep_same_target_specified() {
         .file("baz/src/lib.rs", "")
         .build();
 
-    p.cargo("check -Z bindeps")
+    p.cargo("check")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
 [LOCKING] 2 packages to highest compatible versions
@@ -1613,7 +1641,8 @@ fn dep_of_artifact_dep_same_target_specified() {
         .with_status(0)
         .run();
 
-    p.cargo("tree -Z bindeps")
+    p.cargo("tree")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stdout_data(
             r#"...
@@ -1667,7 +1696,8 @@ fn targets_are_picked_up_from_non_workspace_artifact_deps() {
         )
         .build();
 
-    p.cargo("build -Z bindeps")
+    p.cargo("build")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .run();
 }
@@ -1718,7 +1748,8 @@ foo v0.1.0 ([ROOT]/foo)
         .run();
 
     // And with -Zbindeps it can use 1.0.1.
-    p.cargo("update -Zbindeps")
+    p.cargo("update")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
@@ -1791,7 +1822,8 @@ fn proc_macro_in_artifact_dep() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("check -Z bindeps")
+    p.cargo("check")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
 ...
@@ -1844,7 +1876,8 @@ fn allow_dep_renames_with_multiple_versions() {
         .file("bar/Cargo.toml", &basic_bin_manifest("bar"))
         .file("bar/src/main.rs", r#"fn main() {println!("0.5.0")}"#)
         .build();
-    p.cargo("check -Z bindeps")
+    p.cargo("check")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(
             str![[r#"
@@ -1908,7 +1941,8 @@ fn allow_artifact_and_non_artifact_dependency_to_same_crate_if_these_are_not_the
         .file("bar/src/lib.rs", "pub fn doit() {}")
         .file("bar/src/main.rs", "fn main() {}")
         .build();
-    p.cargo("build -Z bindeps")
+    p.cargo("build")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
@@ -1944,7 +1978,8 @@ fn prevent_no_lib_warning_with_artifact_dependencies() {
         .file("bar/Cargo.toml", &basic_bin_manifest("bar"))
         .file("bar/src/main.rs", "fn main() {}")
         .build();
-    p.cargo("check -Z bindeps")
+    p.cargo("check")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
@@ -1984,7 +2019,8 @@ fn show_no_lib_warning_with_artifact_dependencies_that_have_no_lib_but_lib_true(
         .file("bar/Cargo.toml", &basic_bin_manifest("bar"))
         .file("bar/src/main.rs", "fn main() {}")
         .build();
-    p.cargo("check -Z bindeps")
+    p.cargo("check")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
@@ -2022,7 +2058,8 @@ fn resolver_2_build_dep_without_lib() {
         .file("bar/Cargo.toml", &basic_bin_manifest("bar"))
         .file("bar/src/main.rs", "fn main() {}")
         .build();
-    p.cargo("check -Z bindeps")
+    p.cargo("check")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .run();
 }
@@ -2051,7 +2088,8 @@ fn check_missing_crate_type_in_package_fails() {
             .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1")) //no bin, just rlib
             .file("bar/src/lib.rs", "")
             .build();
-        p.cargo("check -Z bindeps")
+        p.cargo("check")
+            .arg("-Zbindeps")
             .masquerade_as_nightly_cargo(&["bindeps"])
             .with_status(101)
             .with_stderr_data(str![[r#"
@@ -2084,7 +2122,8 @@ fn check_target_equals_target_in_non_build_dependency_errors() {
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/main.rs", "fn main() {}")
         .build();
-    p.cargo("check -Z bindeps")
+    p.cargo("check")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -2203,7 +2242,8 @@ fn env_vars_and_build_products_for_various_build_targets() {
         .file("bar/src/lib.rs", r#"pub extern "C" fn c() {}"#)
         .file("bar/src/main.rs", "fn main() {}")
         .build();
-    p.cargo("test -Z bindeps")
+    p.cargo("test")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
@@ -2251,8 +2291,9 @@ fn publish_artifact_dep() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("publish -Z bindeps --no-verify")
+    p.cargo("publish --no-verify")
         .replace_crates_io(registry.index_url())
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
 [UPDATING] crates.io index
@@ -2400,7 +2441,8 @@ fn doc_lib_true() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("doc -Z bindeps")
+    p.cargo("doc")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
@@ -2425,7 +2467,8 @@ fn doc_lib_true() {
         2
     );
 
-    p.cargo("doc -Z bindeps")
+    p.cargo("doc")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -2486,7 +2529,8 @@ fn rustdoc_works_on_libs_with_artifacts_and_lib_false() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("doc -Z bindeps")
+    p.cargo("doc")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
@@ -2660,7 +2704,8 @@ fn build_script_features_for_shared_dependency() {
         )
         .build();
 
-    p.cargo("build -Z bindeps -v")
+    p.cargo("build -v")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .run();
 }
@@ -2693,7 +2738,8 @@ fn calc_bin_artifact_fingerprint() {
         .file("bar/Cargo.toml", &basic_bin_manifest("bar"))
         .file("bar/src/main.rs", r#"fn main() { println!("foo") }"#)
         .build();
-    p.cargo("check -Z bindeps")
+    p.cargo("check")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
@@ -2706,7 +2752,8 @@ fn calc_bin_artifact_fingerprint() {
 
     p.change_file("bar/src/main.rs", r#"fn main() { println!("bar") }"#);
     // Change in artifact bin dep `bar` propagates to `foo`, triggering recompile.
-    p.cargo("check -v -Z bindeps")
+    p.cargo("check -v")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
 [DIRTY] bar v0.5.0 ([ROOT]/foo/bar): the file `bar/src/main.rs` has changed ([..])
@@ -2721,7 +2768,8 @@ fn calc_bin_artifact_fingerprint() {
         .run();
 
     // All units are fresh. No recompile.
-    p.cargo("check -v -Z bindeps")
+    p.cargo("check -v")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
 [FRESH] bar v0.5.0 ([ROOT]/foo/bar)
@@ -2772,7 +2820,8 @@ fn with_target_and_optional() {
         .file("d1/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("check -Z bindeps -F d1 -v")
+    p.cargo("check -F d1 -v")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
@@ -2821,7 +2870,8 @@ fn with_assumed_host_target_and_optional_build_dep() {
         .file("d1/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("check -Z bindeps -F d1 -v")
+    p.cargo("check -F d1 -v")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(
             str![[r#"
@@ -2966,7 +3016,8 @@ fn decouple_same_target_transitive_dep_from_artifact_dep() {
             "#,
         )
         .build();
-    p.cargo("build -Z bindeps")
+    p.cargo("build")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
 [LOCKING] 4 packages to highest compatible versions
@@ -3081,7 +3132,8 @@ fn decouple_same_target_transitive_dep_from_artifact_dep_lib() {
             "#,
         )
         .build();
-    p.cargo("build -Z bindeps")
+    p.cargo("build")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
 [LOCKING] 3 packages to highest compatible versions
@@ -3225,7 +3277,8 @@ fn decouple_same_target_transitive_dep_from_artifact_dep_and_proc_macro() {
         .file("d/src/lib.rs", "pub struct D;")
         .build();
 
-    p.cargo("build -Z bindeps")
+    p.cargo("build")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(
             str![[r#"
@@ -3293,7 +3346,8 @@ fn same_target_artifact_dep_sharing() {
         )
         .file("a/src/lib.rs", "")
         .build();
-    p.cargo(&format!("build -Z bindeps --target {target}"))
+    p.cargo(&format!("build --target {target}"))
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
 [LOCKING] 2 packages to highest compatible versions
@@ -3349,7 +3403,8 @@ fn check_transitive_artifact_dependency_with_different_target() {
         .file("bar/baz/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("check -Z bindeps")
+    p.cargo("check")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_data(str![[r#"
 [LOCKING] 2 packages to highest compatible versions
@@ -3427,7 +3482,8 @@ fn transitive_artifact_dep_with_target_and_platform_specific_dep() {
         .file("bar/baz/qux/src/lib.rs", "")
         .build();
 
-    p.cargo("tree -Z bindeps")
+    p.cargo("tree")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stdout_data(str![[r#"
 foo v0.0.0 ([ROOT]/foo)
@@ -3513,7 +3569,8 @@ fn transitive_build_script_artifact_dep_with_target() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("check -Z bindeps")
+    p.cargo("check")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(0)
         .run();
@@ -3566,7 +3623,8 @@ fn build_only_specified_artifact_library() {
 
     let cdylib = create_project("cdylib");
     cdylib
-        .cargo("build -Z bindeps")
+        .cargo("build")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .run();
     assert_e2e().eq(
@@ -3580,7 +3638,8 @@ staticlib present: false
 
     let staticlib = create_project("staticlib");
     staticlib
-        .cargo("build -Z bindeps")
+        .cargo("build")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .run();
     assert_e2e().eq(
@@ -3682,7 +3741,7 @@ fn artifact_dep_target_does_not_propagate_to_deps_of_build_script() {
             r#"pub fn add(a: i32, b: i32) -> i32 { a + b }"#,
         )
         .build();
-    p.cargo("test -Z bindeps")
+    p.cargo("test")
         .with_stderr_data(str![[r#"
 [LOCKING] 3 packages to highest compatible versions
 [COMPILING] arch v0.0.1 ([ROOT]/foo/arch)
@@ -3693,6 +3752,7 @@ fn artifact_dep_target_does_not_propagate_to_deps_of_build_script() {
 [RUNNING] unittests src/main.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .run();
 }
@@ -3774,7 +3834,7 @@ fn artifact_dep_target_does_not_propagate_to_proc_macro() {
             "pub fn add(a: i32, b: i32) -> i32 { a + b }",
         )
         .build();
-    p.cargo("test -Z bindeps")
+    p.cargo("test")
         .with_stderr_data(str![[r#"
 [LOCKING] 3 packages to highest compatible versions
 [COMPILING] arch v0.0.1 ([ROOT]/foo/arch)
@@ -3785,6 +3845,7 @@ fn artifact_dep_target_does_not_propagate_to_proc_macro() {
 [RUNNING] unittests src/main.rs (target/debug/build/foo/[HASH]/out/foo-[HASH][EXE])
 
 "#]])
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .run();
 }

--- a/tests/testsuite/artifact_dir.rs
+++ b/tests/testsuite/artifact_dir.rs
@@ -15,7 +15,8 @@ fn binary_with_debug() {
         .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
         .build();
 
-    p.cargo("build -Z unstable-options --artifact-dir out")
+    p.cargo("build --artifact-dir out")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["artifact-dir"])
         .enable_mac_dsym()
         .run();
@@ -52,7 +53,8 @@ fn static_library_with_debug() {
         )
         .build();
 
-    p.cargo("build -Z unstable-options --artifact-dir out")
+    p.cargo("build --artifact-dir out")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["artifact-dir"])
         .run();
     check_dir_contents(
@@ -88,7 +90,8 @@ fn dynamic_library_with_debug() {
         )
         .build();
 
-    p.cargo("build -Z unstable-options --artifact-dir out")
+    p.cargo("build --artifact-dir out")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["artifact-dir"])
         .enable_mac_dsym()
         .run();
@@ -124,7 +127,8 @@ fn rlib_with_debug() {
         )
         .build();
 
-    p.cargo("build -Z unstable-options --artifact-dir out")
+    p.cargo("build --artifact-dir out")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["artifact-dir"])
         .run();
     check_dir_contents(
@@ -168,7 +172,8 @@ fn include_only_the_binary_from_the_current_package() {
         .file("utils/src/lib.rs", "")
         .build();
 
-    p.cargo("build -Z unstable-options --bin foo --artifact-dir out")
+    p.cargo("build --bin foo --artifact-dir out")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["artifact-dir"])
         .enable_mac_dsym()
         .run();
@@ -188,7 +193,8 @@ fn artifact_dir_is_a_file() {
         .file("out", "")
         .build();
 
-    p.cargo("build -Z unstable-options --artifact-dir out")
+    p.cargo("build --artifact-dir out")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["artifact-dir"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -208,7 +214,8 @@ fn replaces_artifacts() {
         .file("src/main.rs", r#"fn main() { println!("foo") }"#)
         .build();
 
-    p.cargo("build -Z unstable-options --artifact-dir out")
+    p.cargo("build --artifact-dir out")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["artifact-dir"])
         .run();
     p.process(
@@ -224,7 +231,8 @@ foo
     sleep_ms(1000);
     p.change_file("src/main.rs", r#"fn main() { println!("bar") }"#);
 
-    p.cargo("build -Z unstable-options --artifact-dir out")
+    p.cargo("build --artifact-dir out")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["artifact-dir"])
         .run();
     p.process(
@@ -256,7 +264,8 @@ fn avoid_build_scripts() {
         .file("b/build.rs", r#"fn main() { println!("hello-build-b"); }"#)
         .build();
 
-    p.cargo("build -Z unstable-options --artifact-dir out -vv")
+    p.cargo("build --artifact-dir out -vv")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["artifact-dir"])
         .enable_mac_dsym()
         .with_stdout_data(
@@ -290,7 +299,8 @@ fn cargo_build_artifact_dir() {
         )
         .build();
 
-    p.cargo("build -Z unstable-options")
+    p.cargo("build")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["artifact-dir"])
         .enable_mac_dsym()
         .run();
@@ -309,7 +319,8 @@ fn unsupported_short_artifact_dir_flag() {
         .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
         .build();
 
-    p.cargo("build -Z unstable-options -O")
+    p.cargo("build -O")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["artifact-dir"])
         .with_stderr_data(str![[r#"
 [ERROR] unexpected argument '-O' found
@@ -331,7 +342,8 @@ fn removed_out_dir_flag() {
         .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
         .build();
 
-    p.cargo("build -Z unstable-options --out-dir out")
+    p.cargo("build --out-dir out")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["out-dir"])
         .with_status(1)
         .enable_mac_dsym()

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -3264,7 +3264,8 @@ fn bad_trim_paths() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("check -Ztrim-paths")
+    p.cargo("check")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["trim-paths"])
         .with_status(101)
         .with_stderr_data(str![[r#"

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -341,7 +341,8 @@ fn chdir_gated() {
         .with_status(101)
         .run();
     // No masquerade should also fail.
-    p.cargo("-C foo -Z unstable-options build")
+    p.cargo("-C foo build")
+        .arg("-Zunstable-options")
         .cwd(p.root().parent().unwrap())
         .with_stderr_data(str![[r#"
 [ERROR] the `-C` flag is unstable, pass `-Z unstable-options` on the nightly channel to enable it
@@ -359,7 +360,8 @@ fn cargo_compile_directory_not_cwd() {
         .file(".cargo/config.toml", &"")
         .build();
 
-    p.cargo("-Zunstable-options -C foo build")
+    p.cargo("-C foo build")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["chdir"])
         .cwd(p.root().parent().unwrap())
         .run();
@@ -400,7 +402,8 @@ fn cargo_compile_directory_not_cwd_with_invalid_config() {
         .file(".cargo/config.toml", &"!")
         .build();
 
-    p.cargo("-Zunstable-options -C foo build")
+    p.cargo("-C foo build")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["chdir"])
         .cwd(p.root().parent().unwrap())
         .with_status(101)
@@ -5486,7 +5489,8 @@ required by package `bar v0.1.0 ([ROOT]/foo)`
 
 "#]])
         .run();
-    p.cargo("build -Zavoid-dev-deps")
+    p.cargo("build")
+        .arg("-Zavoid-dev-deps")
         .masquerade_as_nightly_cargo(&["avoid-dev-deps"])
         .run();
 }
@@ -6474,7 +6478,8 @@ fn embed_metadata_no() {
         )
         .build();
 
-    p.cargo("build -Z embed-metadata=no")
+    p.cargo("build")
+        .arg("-Zembed-metadata=no")
         .masquerade_as_nightly_cargo(&["-Z embed-metadata"])
         .arg("-v")
         .with_stderr_contains("[RUNNING] `[..]-Z embed-metadata=no[..]`")
@@ -6524,7 +6529,8 @@ fn embed_metadata_no_dylib_dep() {
         )
         .build();
 
-    p.cargo("build -Z embed-metadata=no")
+    p.cargo("build")
+        .arg("-Zembed-metadata=no")
         .masquerade_as_nightly_cargo(&["-Z embed-metadata"])
         .arg("-v")
         .with_stderr_contains("[RUNNING] `[..]-Z embed-metadata=no[..]`")
@@ -6563,7 +6569,8 @@ fn embed_metadata_no_invalidate() {
         )
         .build();
 
-    p.cargo("build -Z embed-metadata=no")
+    p.cargo("build")
+        .arg("-Zembed-metadata=no")
         .masquerade_as_nightly_cargo(&["-Z embed-metadata"])
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
@@ -6573,7 +6580,8 @@ fn embed_metadata_no_invalidate() {
 
 "#]])
         .run();
-    p.cargo("build -Z embed-metadata=yes")
+    p.cargo("build")
+        .arg("-Zembed-metadata=yes")
         .masquerade_as_nightly_cargo(&["-Z embed-metadata"])
         .with_stderr_data(str![[r#"
 [COMPILING] bar v0.5.0 ([ROOT]/foo/bar)

--- a/tests/testsuite/build_analysis.rs
+++ b/tests/testsuite/build_analysis.rs
@@ -35,8 +35,9 @@ fn one_logfile_per_invocation() {
         .build();
 
     // First invocation
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_stderr_data(str![[r#"
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
@@ -48,8 +49,9 @@ fn one_logfile_per_invocation() {
     let _ = get_log(0);
 
     // Second invocation
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_stderr_data(str![[r#"
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -67,8 +69,9 @@ fn log_msg_build_started() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
@@ -119,8 +122,9 @@ fn log_msg_timing_info() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
@@ -201,8 +205,10 @@ fn log_msg_timing_info_section_timings() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    p.cargo("check -Zbuild-analysis -Zsection-timings")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
+        .arg("-Zsection-timings")
         .masquerade_as_nightly_cargo(&["build-analysis", "section-timings"])
         .run();
 
@@ -334,8 +340,9 @@ fn log_rebuild_reason_fresh_build() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_stderr_data(str![[r#"
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
@@ -380,8 +387,9 @@ fn log_rebuild_reason_file_changed() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
@@ -415,8 +423,9 @@ fn log_rebuild_reason_file_changed() {
     // Change source file
     p.change_file("src/lib.rs", "//! comment");
 
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_stderr_data(str![[r#"
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
@@ -471,8 +480,9 @@ fn log_rebuild_reason_no_rebuild() {
         .build();
 
     // First build
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
@@ -504,8 +514,9 @@ fn log_rebuild_reason_no_rebuild() {
     );
 
     // Second build without changes
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_stderr_data(str![[r#"
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -564,8 +575,9 @@ fn log_msg_unit_graph() {
     // * run foo build.rs
     // * doc foo
     // * doc bar
-    p.cargo("doc -Zbuild-analysis")
+    p.cargo("doc")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis", "section-timings"])
         .run();
 
@@ -689,8 +701,9 @@ fn log_msg_resolution_events() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    p.cargo("doc -Zbuild-analysis")
+    p.cargo("doc")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis", "section-timings"])
         .run();
 
@@ -726,8 +739,9 @@ fn json_message_build_started_with_run_id() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("check -Zbuild-analysis --message-format=json")
+    p.cargo("check --message-format=json")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_stdout_data(
             str![[r#"

--- a/tests/testsuite/build_dir.rs
+++ b/tests/testsuite/build_dir.rs
@@ -496,7 +496,9 @@ fn cargo_rustdoc_json_should_output_to_target_dir() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout -Zunstable-options rustdoc --output-format json")
+    p.cargo("rustdoc --output-format json")
+        .arg("-Zbuild-dir-new-layout")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["new build-dir layout", "rustdoc-output-format"])
         .enable_mac_dsym()
         .run();
@@ -535,7 +537,9 @@ fn cargo_doc_json_should_output_to_target_dir() {
         )
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout -Zunstable-options doc --no-deps --output-format json")
+    p.cargo("doc --no-deps --output-format json")
+        .arg("-Zbuild-dir-new-layout")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["new build-dir layout", "rustdoc-output-format"])
         .enable_mac_dsym()
         .run();
@@ -1199,7 +1203,8 @@ fn artifact_deps() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("run -Z bindeps")
+    p.cargo("run")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .enable_mac_dsym()
         .with_stderr_data(str![[r#"

--- a/tests/testsuite/build_dir_fine_grain_locking.rs
+++ b/tests/testsuite/build_dir_fine_grain_locking.rs
@@ -32,7 +32,8 @@ fn binary_with_debug() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build")
+    p.cargo("build")
+        .arg("-Zfine-grain-locking")
         .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
@@ -80,7 +81,8 @@ fn binary_with_release() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build --release")
+    p.cargo("build --release")
+        .arg("-Zfine-grain-locking")
         .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
@@ -187,7 +189,8 @@ fn libs() {
             )
             .build();
 
-        p.cargo("-Zfine-grain-locking build")
+        p.cargo("build")
+            .arg("-Zfine-grain-locking")
             .masquerade_as_nightly_cargo(&["fine grain locking"])
             .enable_mac_dsym()
             .run();
@@ -203,7 +206,8 @@ fn should_default_to_target() {
         .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
         .build();
 
-    p.cargo("-Zfine-grain-locking build")
+    p.cargo("build")
+        .arg("-Zfine-grain-locking")
         .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
@@ -234,7 +238,8 @@ fn should_respect_env_var() {
         .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
         .build();
 
-    p.cargo("-Zfine-grain-locking build")
+    p.cargo("build")
+        .arg("-Zfine-grain-locking")
         .masquerade_as_nightly_cargo(&["fine grain locking"])
         .env("CARGO_BUILD_BUILD_DIR", "build-dir")
         .enable_mac_dsym()
@@ -282,7 +287,8 @@ fn build_script_should_output_to_build_dir() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build")
+    p.cargo("build")
+        .arg("-Zfine-grain-locking")
         .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
@@ -346,7 +352,8 @@ fn cargo_tmpdir_should_output_to_build_dir() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking test")
+    p.cargo("test")
+        .arg("-Zfine-grain-locking")
         .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
@@ -409,7 +416,8 @@ fn examples_should_output_to_build_dir_and_uplift_to_target_dir() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build --examples")
+    p.cargo("build --examples")
+        .arg("-Zfine-grain-locking")
         .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
@@ -458,7 +466,8 @@ fn benches_should_output_to_build_dir() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build --bench=foo")
+    p.cargo("build --bench=foo")
+        .arg("-Zfine-grain-locking")
         .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
@@ -511,7 +520,8 @@ fn cargo_doc_should_output_to_target_dir() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking doc")
+    p.cargo("doc")
+        .arg("-Zfine-grain-locking")
         .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
@@ -536,7 +546,9 @@ fn cargo_rustdoc_json_should_output_to_target_dir() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking -Zunstable-options rustdoc --output-format json")
+    p.cargo("rustdoc --output-format json")
+        .arg("-Zfine-grain-locking")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["fine grain locking", "rustdoc-output-format"])
         .enable_mac_dsym()
         .run();
@@ -576,7 +588,8 @@ fn cargo_package_should_build_in_build_dir_and_output_to_target_dir() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking package")
+    p.cargo("package")
+        .arg("-Zfine-grain-locking")
         .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
@@ -635,7 +648,8 @@ fn cargo_publish_should_only_touch_build_dir() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking publish")
+    p.cargo("publish")
+        .arg("-Zfine-grain-locking")
         .masquerade_as_nightly_cargo(&["fine grain locking"])
         .replace_crates_io(registry.index_url())
         .enable_mac_dsym()
@@ -664,7 +678,8 @@ fn cargo_clean_should_clean_the_target_dir_and_build_dir() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build")
+    p.cargo("build")
+        .arg("-Zfine-grain-locking")
         .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
@@ -695,7 +710,8 @@ fn cargo_clean_should_clean_the_target_dir_and_build_dir() {
 
 "#]]);
 
-    p.cargo("-Zfine-grain-locking clean")
+    p.cargo("clean")
+        .arg("-Zfine-grain-locking")
         .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
@@ -736,7 +752,8 @@ fn cargo_clean_should_remove_correct_files() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build")
+    p.cargo("build")
+        .arg("-Zfine-grain-locking")
         .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
@@ -765,7 +782,8 @@ fn cargo_clean_should_remove_correct_files() {
 
 "#]]);
 
-    p.cargo("-Zfine-grain-locking clean -p bar")
+    p.cargo("clean -p bar")
+        .arg("-Zfine-grain-locking")
         .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
@@ -800,7 +818,8 @@ fn timings_report_should_output_to_target_dir() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build --timings")
+    p.cargo("build --timings")
+        .arg("-Zfine-grain-locking")
         .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
@@ -825,7 +844,8 @@ fn future_incompat_should_output_to_build_dir() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build")
+    p.cargo("build")
+        .arg("-Zfine-grain-locking")
         .masquerade_as_nightly_cargo(&["fine grain locking"])
         .arg("--future-incompat-report")
         .env("RUSTFLAGS", "-Zfuture-incompat-test")
@@ -848,7 +868,8 @@ fn template_should_error_for_invalid_variables() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build")
+    p.cargo("build")
+        .arg("-Zfine-grain-locking")
         .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .with_status(101)
@@ -874,7 +895,8 @@ fn template_should_suggest_nearest_variable() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build")
+    p.cargo("build")
+        .arg("-Zfine-grain-locking")
         .masquerade_as_nightly_cargo(&["fine grain locking"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -900,7 +922,8 @@ fn template_workspace_root() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build")
+    p.cargo("build")
+        .arg("-Zfine-grain-locking")
         .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
@@ -948,7 +971,8 @@ fn template_cargo_cache_home() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build")
+    p.cargo("build")
+        .arg("-Zfine-grain-locking")
         .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
@@ -1008,7 +1032,8 @@ fn template_workspace_path_hash() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build")
+    p.cargo("build")
+        .arg("-Zfine-grain-locking")
         .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
@@ -1081,7 +1106,8 @@ fn template_workspace_path_hash_should_handle_symlink() {
         .build();
 
     // Build from the non-symlinked directory
-    p.cargo("-Zfine-grain-locking check")
+    p.cargo("check")
+        .arg("-Zfine-grain-locking")
         .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();
@@ -1123,7 +1149,8 @@ fn template_workspace_path_hash_should_handle_symlink() {
     foo_dir.rm_rf();
 
     // Run cargo from the symlinked dir
-    p.cargo("-Zfine-grain-locking check")
+    p.cargo("check")
+        .arg("-Zfine-grain-locking")
         .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .cwd(&symlinked_dir)
@@ -1172,7 +1199,8 @@ fn template_should_handle_reject_unmatched_brackets() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build")
+    p.cargo("build")
+        .arg("-Zfine-grain-locking")
         .masquerade_as_nightly_cargo(&["fine grain locking"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -1251,7 +1279,8 @@ fn artifact_deps() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("run -Z bindeps")
+    p.cargo("run")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps", "build-dir-new-layout"])
         .enable_mac_dsym()
         .with_stderr_data(str![[r#"
@@ -1318,8 +1347,9 @@ fn new_layout_opt_out() {
         )
         .build();
 
-    p.cargo("-Zfine-grain-locking build")
+    p.cargo("build")
         .env("__CARGO_TEMPORARY_BUILD_DIR_NEW_LAYOUT_OPT_OUT", "1")
+        .arg("-Zfine-grain-locking")
         .masquerade_as_nightly_cargo(&["fine grain locking"])
         .enable_mac_dsym()
         .run();

--- a/tests/testsuite/build_dir_legacy.rs
+++ b/tests/testsuite/build_dir_legacy.rs
@@ -520,7 +520,8 @@ fn cargo_rustdoc_json_should_output_to_target_dir() {
         )
         .build();
 
-    p.cargo("rustdoc -Zunstable-options --output-format json")
+    p.cargo("rustdoc --output-format json")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["rustdoc-output-format"])
         .env("__CARGO_TEMPORARY_BUILD_DIR_NEW_LAYOUT_OPT_OUT", "1")
         .enable_mac_dsym()
@@ -560,7 +561,8 @@ fn cargo_doc_json_should_output_to_target_dir() {
         )
         .build();
 
-    p.cargo("doc --no-deps -Zunstable-options --output-format json")
+    p.cargo("doc --no-deps --output-format json")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["rustdoc-output-format"])
         .env("__CARGO_TEMPORARY_BUILD_DIR_NEW_LAYOUT_OPT_OUT", "1")
         .enable_mac_dsym()
@@ -1260,7 +1262,8 @@ fn artifact_deps() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("run -Z bindeps")
+    p.cargo("run")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .env("__CARGO_TEMPORARY_BUILD_DIR_NEW_LAYOUT_OPT_OUT", "1")
         .enable_mac_dsym()

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -563,8 +563,9 @@ fn custom_build_env_var_rustc_linker_host_target() {
 
     // no crate type set => linker never called => build succeeds if and
     // only if build.rs succeeds, despite linker binary not existing.
-    p.cargo("build -Z target-applies-to-host --target")
+    p.cargo("build --target")
         .arg(&target)
+        .arg("-Ztarget-applies-to-host")
         .masquerade_as_nightly_cargo(&["target-applies-to-host"])
         .run();
 }
@@ -598,9 +599,10 @@ fn custom_build_env_var_rustc_linker_host_target_env() {
 
     // no crate type set => linker never called => build succeeds if and
     // only if build.rs succeeds, despite linker binary not existing.
-    p.cargo("build -Z target-applies-to-host --target")
+    p.cargo("build --target")
         .env("CARGO_TARGET_APPLIES_TO_HOST", "false")
         .arg(&target)
+        .arg("-Ztarget-applies-to-host")
         .masquerade_as_nightly_cargo(&["target-applies-to-host"])
         .run();
 }
@@ -624,8 +626,9 @@ fn custom_build_invalid_host_config_feature_flag() {
         .build();
 
     // build.rs should fail due to -Zhost-config being set without -Ztarget-applies-to-host
-    p.cargo("build -Z host-config --target")
+    p.cargo("build --target")
         .arg(&target)
+        .arg("-Zhost-config")
         .masquerade_as_nightly_cargo(&["host-config"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -656,8 +659,10 @@ fn custom_build_linker_host_target_with_bad_host_config() {
         .build();
 
     // build.rs should fail due to bad host linker being set
-    p.cargo("build -Z target-applies-to-host -Z host-config --verbose --target")
+    p.cargo("build --verbose --target")
         .arg(&target)
+        .arg("-Ztarget-applies-to-host")
+        .arg("-Zhost-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -690,8 +695,10 @@ fn custom_build_linker_bad_host() {
         .build();
 
     // build.rs should fail due to bad host linker being set
-    p.cargo("build -Z target-applies-to-host -Z host-config --verbose --target")
+    p.cargo("build --verbose --target")
         .arg(&target)
+        .arg("-Ztarget-applies-to-host")
+        .arg("-Zhost-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -726,8 +733,10 @@ fn custom_build_linker_bad_host_with_arch() {
         .build();
 
     // build.rs should fail due to bad host linker being set
-    p.cargo("build -Z target-applies-to-host -Z host-config --verbose --target")
+    p.cargo("build --verbose --target")
         .arg(&target)
+        .arg("-Ztarget-applies-to-host")
+        .arg("-Zhost-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -771,8 +780,10 @@ fn custom_build_env_var_rustc_linker_cross_arch_host() {
 
     // build.rs should be built fine since cross target != host target.
     // assertion should succeed since it's still passed the target linker
-    p.cargo("build -Z target-applies-to-host -Z host-config --verbose --target")
+    p.cargo("build --verbose --target")
         .arg(&target)
+        .arg("-Ztarget-applies-to-host")
+        .arg("-Zhost-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .run();
 }
@@ -801,8 +812,10 @@ fn custom_build_linker_bad_cross_arch_host() {
         .build();
 
     // build.rs should fail due to bad host linker being set
-    p.cargo("build -Z target-applies-to-host -Z host-config --verbose --target")
+    p.cargo("build --verbose --target")
         .arg(&target)
+        .arg("-Ztarget-applies-to-host")
+        .arg("-Zhost-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -824,9 +837,11 @@ fn host_runner_wraps_build_script() {
         .build();
 
     // Build should succeed with the host runner wrapping the build script
-    p.cargo("build -Z target-applies-to-host -Z host-config -v --target")
+    p.cargo("build -v --target")
         .arg(&target)
         .env("CARGO_HOST_RUNNER", &wrapper)
+        .arg("-Ztarget-applies-to-host")
+        .arg("-Zhost-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -859,8 +874,10 @@ fn host_runner_does_not_apply_to_target() {
         .build();
 
     // build.rs execution should fail due to the host runner, not the target runner
-    p.cargo("build -Z target-applies-to-host -Z host-config --target")
+    p.cargo("build --target")
         .arg(&target)
+        .arg("-Ztarget-applies-to-host")
+        .arg("-Zhost-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -897,8 +914,10 @@ fn host_runner_arch_takes_precedence() {
         .build();
 
     // host.<triple>.runner should take precedence over host.runner
-    p.cargo("build -Z target-applies-to-host -Z host-config --target")
+    p.cargo("build --target")
         .arg(&target)
+        .arg("-Ztarget-applies-to-host")
+        .arg("-Zhost-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -949,8 +968,10 @@ fn host_runner_with_args() {
         .build();
 
     // Runner args should be passed correctly before the build script path
-    p.cargo("build -Z target-applies-to-host -Z host-config --target")
+    p.cargo("build --target")
         .arg(&target)
+        .arg("-Ztarget-applies-to-host")
+        .arg("-Zhost-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -983,8 +1004,10 @@ fn host_runner_does_not_apply_to_cargo_run() {
         .build();
 
     // with --target
-    p.cargo("run -Z target-applies-to-host -Z host-config --target")
+    p.cargo("run --target")
         .arg(&target)
+        .arg("-Ztarget-applies-to-host")
+        .arg("-Zhost-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -999,7 +1022,9 @@ hello
         .run();
 
     // without --target
-    p.cargo("run -Z target-applies-to-host -Z host-config")
+    p.cargo("run")
+        .arg("-Ztarget-applies-to-host")
+        .arg("-Zhost-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -1089,8 +1114,10 @@ fn target_cfg_runner_build_script_with_host_config_and_target() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("check -v -Ztarget-applies-to-host -Zhost-config --target")
+    p.cargo("check -v --target")
         .arg(&target)
+        .arg("-Ztarget-applies-to-host")
+        .arg("-Zhost-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -1117,7 +1144,9 @@ fn host_runner_build_script_without_target() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("check -Ztarget-applies-to-host -Zhost-config")
+    p.cargo("check")
+        .arg("-Ztarget-applies-to-host")
+        .arg("-Zhost-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -1230,8 +1259,10 @@ fn target_cfg_linker_build_script_with_host_config_and_target() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build -v -Ztarget-applies-to-host -Zhost-config --target")
+    p.cargo("build -v --target")
         .arg(&target)
+        .arg("-Ztarget-applies-to-host")
+        .arg("-Zhost-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -1920,7 +1951,8 @@ default = "allow"
         .file("d/build.rs", get_metadata)
         .build();
 
-    p.cargo("check --all-targets -Zany-build-script-metadata")
+    p.cargo("check --all-targets")
+        .arg("-Zany-build-script-metadata")
         .masquerade_as_nightly_cargo(&["any-build-script-metadata"])
         .with_stderr_data(
             str![[r#"
@@ -2000,7 +2032,8 @@ fn links_passes_env_vars_with_any_build_script_unstable_feature() {
         )
         .build();
 
-    p.cargo("check -v -Zany-build-script-metadata")
+    p.cargo("check -v")
+        .arg("-Zany-build-script-metadata")
         .masquerade_as_nightly_cargo(&["any-build-script-metadata"])
         .run();
 }
@@ -2064,7 +2097,8 @@ fn non_links_can_pass_env_vars() {
         )
         .build();
 
-    p.cargo("check -v -Zany-build-script-metadata")
+    p.cargo("check -v")
+        .arg("-Zany-build-script-metadata")
         .masquerade_as_nightly_cargo(&["any-build-script-metadata"])
         .run();
 }
@@ -2129,7 +2163,8 @@ fn non_links_can_pass_env_vars_with_dep_renamed() {
         )
         .build();
 
-    p.cargo("check -v -Zany-build-script-metadata")
+    p.cargo("check -v")
+        .arg("-Zany-build-script-metadata")
         .masquerade_as_nightly_cargo(&["any-build-script-metadata"])
         .run();
 }
@@ -2213,7 +2248,8 @@ fn non_links_can_pass_env_vars_direct_deps_only() {
         )
         .build();
 
-    p.cargo("check -v -Zany-build-script-metadata")
+    p.cargo("check -v")
+        .arg("-Zany-build-script-metadata")
         .masquerade_as_nightly_cargo(&["any-build-script-metadata"])
         .run();
 }
@@ -7164,7 +7200,9 @@ fn target_runner_does_not_apply_to_build_script_with_host_config() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build -Z target-applies-to-host --verbose -Z host-config")
+    p.cargo("build --verbose")
+        .arg("-Ztarget-applies-to-host")
+        .arg("-Zhost-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -7193,7 +7231,9 @@ fn target_linker_does_not_apply_to_build_script_with_host_config() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build -Z target-applies-to-host --verbose -Z host-config")
+    p.cargo("build --verbose")
+        .arg("-Ztarget-applies-to-host")
+        .arg("-Zhost-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -7296,8 +7336,9 @@ fn build_script_dylib_search_path_excludes_target_dylibs() {
         )
         .build();
 
-    p.cargo("build -Zbuild-dir-new-layout -v --target")
+    p.cargo("build -v --target")
         .arg(&target)
+        .arg("-Zbuild-dir-new-layout")
         .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .enable_mac_dsym()
         .run();

--- a/tests/testsuite/cargo_report_rebuilds/mod.rs
+++ b/tests/testsuite/cargo_report_rebuilds/mod.rs
@@ -66,8 +66,9 @@ fn no_log_for_the_current_workspace() {
         .file("src/lib.rs", "")
         .build();
 
-    foo.cargo("check -Zbuild-analysis")
+    foo.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
@@ -80,7 +81,8 @@ fn no_log_for_the_current_workspace() {
         .file("src/lib.rs", "")
         .build();
 
-    bar.cargo("report rebuilds -Zbuild-analysis")
+    bar.cargo("report rebuilds")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -99,12 +101,14 @@ fn no_rebuild_data() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
-    p.cargo("report rebuilds -Zbuild-analysis")
+    p.cargo("report rebuilds")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_stderr_data(str![[r#"
 Session: [..]
@@ -122,19 +126,22 @@ fn basic_rebuild() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
     p.change_file("src/lib.rs", "// touched");
 
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
-    p.cargo("report rebuilds -Zbuild-analysis")
+    p.cargo("report rebuilds")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_stderr_data(str![[r#"
 Session: [..]
@@ -159,18 +166,21 @@ fn all_fresh() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
     // Second build without changes
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
-    p.cargo("report rebuilds -Zbuild-analysis")
+    p.cargo("report rebuilds")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_stderr_data(str![[r#"
 Session: [..]
@@ -236,19 +246,22 @@ fn with_dependencies() {
         .file("deeper/src/lib.rs", "")
         .build();
 
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
     p.change_file("deeper/src/lib.rs", "// touched");
 
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
-    p.cargo("report rebuilds -Zbuild-analysis")
+    p.cargo("report rebuilds")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_stderr_data(str![[r#"
 Session: [..]
@@ -267,7 +280,8 @@ Root rebuilds:
 "#]])
         .run();
 
-    p.cargo("report rebuilds -Zbuild-analysis -vv")
+    p.cargo("report rebuilds -vv")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_stderr_data(str![[r#"
 Session: [..]
@@ -317,8 +331,9 @@ fn multiple_root_causes() {
         .file("pkg6/src/lib.rs", "")
         .build();
 
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
@@ -345,13 +360,15 @@ fn multiple_root_causes() {
     p.change_file("pkg5/src/lib.rs", "// touched");
     p.change_file("pkg6/src/lib.rs", "// touched");
 
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
         .env("__CARGO_TEST_MY_FOO", "1")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
-    p.cargo("report rebuilds -Zbuild-analysis")
+    p.cargo("report rebuilds")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_stderr_data(str![[r#"
 Session: [..]
@@ -378,7 +395,8 @@ Root rebuilds: (top 5 of 6 by impact)
 "#]])
         .run();
 
-    p.cargo("report rebuilds -Zbuild-analysis --verbose")
+    p.cargo("report rebuilds --verbose")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_stderr_data(str![[r#"
 Session: [..]
@@ -448,19 +466,22 @@ fn shared_dep_cascading() {
         .file("common/src/lib.rs", "")
         .build();
 
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
     p.change_file("common/src/lib.rs", "// touched");
 
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
-    p.cargo("report rebuilds -Zbuild-analysis")
+    p.cargo("report rebuilds")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_stderr_data(str![[r#"
 Session: [..]
@@ -487,14 +508,16 @@ fn outside_workspace() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
     p.change_file("src/lib.rs", "// touched");
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
@@ -524,8 +547,9 @@ fn with_manifest_path() {
         .file("src/lib.rs", "")
         .build();
 
-    foo.cargo("check -Zbuild-analysis")
+    foo.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
@@ -535,18 +559,21 @@ fn with_manifest_path() {
         .file("src/lib.rs", "")
         .build();
 
-    bar.cargo("check -Zbuild-analysis")
+    bar.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
     bar.change_file("src/lib.rs", "// touched");
-    bar.cargo("check -Zbuild-analysis")
+    bar.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
-    foo.cargo("report rebuilds --manifest-path ../bar/Cargo.toml -Zbuild-analysis")
+    foo.cargo("report rebuilds --manifest-path ../bar/Cargo.toml")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_stderr_data(str![[r#"
 Session: [..]
@@ -572,8 +599,9 @@ fn with_session_id() {
         .build();
 
     // First session: fresh build (1 new unit)
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
@@ -583,25 +611,25 @@ fn with_session_id() {
     p.change_file("src/lib.rs", "// touched");
 
     // Second session: rebuild (1 unit rebuilt)
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
     let _ = paths::log_file(1);
 
     // With --id, should use the first session (not the most recent second)
-    p.cargo(&format!(
-        "report rebuilds --id {first_session_id} -Zbuild-analysis"
-    ))
-    .masquerade_as_nightly_cargo(&["build-analysis"])
-    .with_stderr_data(str![[r#"
+    p.cargo(&format!("report rebuilds --id {first_session_id}"))
+        .arg("-Zbuild-analysis")
+        .masquerade_as_nightly_cargo(&["build-analysis"])
+        .with_stderr_data(str![[r#"
 Session: [..]
 Status: 0 units rebuilt, 0 cached, 1 new
 
 
 "#]])
-    .run();
+        .run();
 }
 
 #[cargo_test]
@@ -611,12 +639,14 @@ fn session_id_not_found() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
-    p.cargo("report rebuilds --id 20260101T000000000Z-0000000000000000 -Zbuild-analysis")
+    p.cargo("report rebuilds --id 20260101T000000000Z-0000000000000000")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -635,7 +665,8 @@ fn invalid_session_id_format() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("report rebuilds --id invalid-session-id -Zbuild-analysis")
+    p.cargo("report rebuilds --id invalid-session-id")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_status(101)
         .with_stderr_data(str![[r#"

--- a/tests/testsuite/cargo_report_sessions/mod.rs
+++ b/tests/testsuite/cargo_report_sessions/mod.rs
@@ -56,7 +56,8 @@ fn no_logs_in_workspace() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("report sessions -Zbuild-analysis")
+    p.cargo("report sessions")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -75,12 +76,14 @@ fn in_workspace() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
-    p.cargo("report sessions -Zbuild-analysis")
+    p.cargo("report sessions")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_stderr_data(str![[r#"
 Session IDs for `[ROOT]/foo` (most recent first):
@@ -98,8 +101,9 @@ fn outside_workspace() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
@@ -125,13 +129,15 @@ fn with_limit_1_and_extra_logs() {
     // Generate 3 sessions
     for i in 0..3 {
         p.change_file("src/lib.rs", &format!("pub fn foo{i}() {{}}"));
-        p.cargo("check -Zbuild-analysis")
+        p.cargo("check")
             .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+            .arg("-Zbuild-analysis")
             .masquerade_as_nightly_cargo(&["build-analysis"])
             .run();
     }
 
-    p.cargo("report sessions --limit 1 -Zbuild-analysis")
+    p.cargo("report sessions --limit 1")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_stderr_data(str![[r#"
 Session IDs for `[ROOT]/foo` (most recent first):
@@ -154,13 +160,15 @@ fn with_limit_5_but_not_enough_logs() {
     // Generate 2 sessions
     for i in 0..2 {
         p.change_file("src/lib.rs", &format!("pub fn foo{i}() {{}}"));
-        p.cargo("check -Zbuild-analysis")
+        p.cargo("check")
             .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+            .arg("-Zbuild-analysis")
             .masquerade_as_nightly_cargo(&["build-analysis"])
             .run();
     }
 
-    p.cargo("report sessions --limit 5 -Zbuild-analysis")
+    p.cargo("report sessions --limit 5")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_stderr_data(str![[r#"
 Session IDs for `[ROOT]/foo` (most recent first):
@@ -180,8 +188,9 @@ fn existing_logs_from_other_workspaces() {
         .file("src/lib.rs", "")
         .build();
 
-    foo.cargo("check -Zbuild-analysis")
+    foo.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
@@ -191,13 +200,15 @@ fn existing_logs_from_other_workspaces() {
         .file("src/lib.rs", "")
         .build();
 
-    bar.cargo("check -Zbuild-analysis")
+    bar.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
     // In foo workspace, should only show foo sessions by default
-    foo.cargo("report sessions -Zbuild-analysis")
+    foo.cargo("report sessions")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_stderr_data(str![[r#"
 Session IDs for `[ROOT]/foo` (most recent first):
@@ -216,8 +227,9 @@ fn with_manifest_path() {
         .file("src/lib.rs", "")
         .build();
 
-    foo.cargo("check -Zbuild-analysis")
+    foo.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
@@ -227,12 +239,14 @@ fn with_manifest_path() {
         .file("src/lib.rs", "")
         .build();
 
-    bar.cargo("check -Zbuild-analysis")
+    bar.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
-    foo.cargo("report sessions --manifest-path ../bar/Cargo.toml -Zbuild-analysis")
+    foo.cargo("report sessions --manifest-path ../bar/Cargo.toml")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_stderr_data(str![[r#"
 Session IDs for `[ROOT]/bar` (most recent first):

--- a/tests/testsuite/cargo_report_timings/mod.rs
+++ b/tests/testsuite/cargo_report_timings/mod.rs
@@ -68,8 +68,9 @@ fn no_log_for_the_current_workspace() {
         .file("src/lib.rs", "")
         .build();
 
-    foo.cargo("check -Zbuild-analysis")
+    foo.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
@@ -82,7 +83,8 @@ fn no_log_for_the_current_workspace() {
         .file("src/lib.rs", "")
         .build();
 
-    bar.cargo("report timings -Zbuild-analysis")
+    bar.cargo("report timings")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -101,15 +103,17 @@ fn invalid_log() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
     // Put some junks in the log file.
     std::fs::write(paths::log_file(0), "}|x| hello world").unwrap();
 
-    p.cargo("report timings -Zbuild-analysis")
+    p.cargo("report timings")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -129,8 +133,9 @@ fn empty_log() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
@@ -138,7 +143,8 @@ fn empty_log() {
     std::fs::File::create(paths::log_file(0)).unwrap();
 
     // If the make-up log file was picked, the command would have failed.
-    p.cargo("report timings -Zbuild-analysis")
+    p.cargo("report timings")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -172,12 +178,14 @@ fn idle_session() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("test -Zbuild-analysis")
+    p.cargo("test")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
-    p.cargo("report timings -Zbuild-analysis")
+    p.cargo("report timings")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -197,21 +205,24 @@ fn all_fresh_session() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
     // The second session has nothing to build; every unit is fresh.
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
     // The second session's log got generated, and it is the one picked.
     let _ = paths::log_file(1);
 
-    p.cargo("report timings -Zbuild-analysis")
+    p.cargo("report timings")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_stderr_data(str![[r#"
       Timing report saved to [ROOT]/foo/target/cargo-timings/cargo-timing-[..]T[..]Z-[..].html
@@ -235,8 +246,9 @@ fn prefer_latest() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
@@ -244,8 +256,9 @@ fn prefer_latest() {
     std::fs::write(paths::log_file(0), "}|x| hello world").unwrap();
 
     p.change_file("src/lib.rs", "pub fn foo() {}");
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
@@ -253,7 +266,8 @@ fn prefer_latest() {
     let _ = paths::log_file(1);
 
     // if it had picked the corrupted first log file, it would have failed.
-    p.cargo("report timings -Zbuild-analysis")
+    p.cargo("report timings")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_stderr_data(str![[r#"
       Timing report saved to [ROOT]/foo/target/cargo-timings/cargo-timing-[..]T[..]Z-[..].html
@@ -272,8 +286,9 @@ fn prefer_workspace() {
         .file("src/lib.rs", "")
         .build();
 
-    foo.cargo("check -Zbuild-analysis")
+    foo.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
@@ -286,8 +301,9 @@ fn prefer_workspace() {
         .file("src/lib.rs", "")
         .build();
 
-    bar.cargo("check -Zbuild-analysis")
+    bar.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
@@ -295,7 +311,8 @@ fn prefer_workspace() {
     std::fs::write(paths::log_file(1), "}|x| hello world").unwrap();
 
     // Back to foo, if it had picked the corrupted log file, it would have failed.
-    foo.cargo("report timings -Zbuild-analysis")
+    foo.cargo("report timings")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_stderr_data(str![[r#"
       Timing report saved to [ROOT]/foo/target/cargo-timings/cargo-timing-[..]T[..]Z-[..].html
@@ -313,8 +330,9 @@ fn outside_workspace() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
@@ -341,8 +359,9 @@ fn with_manifest_path() {
         .file("src/lib.rs", "")
         .build();
 
-    foo.cargo("check -Zbuild-analysis")
+    foo.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
@@ -352,12 +371,14 @@ fn with_manifest_path() {
         .file("src/lib.rs", "")
         .build();
 
-    bar.cargo("check -Zbuild-analysis")
+    bar.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
-    foo.cargo("report timings --manifest-path ../bar/Cargo.toml -Zbuild-analysis")
+    foo.cargo("report timings --manifest-path ../bar/Cargo.toml")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_stderr_data(str![[r#"
       Timing report saved to [ROOT]/bar/target/cargo-timings/cargo-timing-[..]T[..]-[..].html
@@ -373,12 +394,15 @@ fn with_section_timings() {
         .file("src/lib.rs", "pub fn foo() {}")
         .build();
 
-    p.cargo("check -Zbuild-analysis -Zsection-timings")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
+        .arg("-Zsection-timings")
         .masquerade_as_nightly_cargo(&["build-analysis", "section-timings"])
         .run();
 
-    p.cargo("report timings -Zbuild-analysis")
+    p.cargo("report timings")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_stderr_data(str![[r#"
       Timing report saved to [ROOT]/foo/target/cargo-timings/cargo-timing-[..]T[..]Z-[..].html
@@ -407,12 +431,14 @@ fn with_multiple_targets() {
         .file("tests/t1.rs", "#[test] fn test1() {}")
         .build();
 
-    p.cargo("check --all-targets -Zbuild-analysis")
+    p.cargo("check --all-targets")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
-    p.cargo("report timings -Zbuild-analysis")
+    p.cargo("report timings")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_stderr_data(str![[r#"
       Timing report saved to [ROOT]/foo/target/cargo-timings/cargo-timing-[..]T[..]Z-[..].html
@@ -430,8 +456,9 @@ fn with_session_id() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
@@ -439,8 +466,9 @@ fn with_session_id() {
     let first_session_id = first_log.file_stem().unwrap().to_str().unwrap();
 
     p.change_file("src/lib.rs", "pub fn foo() {}");
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
@@ -448,15 +476,14 @@ fn with_session_id() {
     let second_session_id = second_log.file_stem().unwrap().to_str().unwrap();
 
     // With --id, should use the first session (not the most recent second)
-    p.cargo(&format!(
-        "report timings --id {first_session_id} -Zbuild-analysis"
-    ))
-    .masquerade_as_nightly_cargo(&["build-analysis"])
-    .with_stderr_data(str![[r#"
+    p.cargo(&format!("report timings --id {first_session_id}"))
+        .arg("-Zbuild-analysis")
+        .masquerade_as_nightly_cargo(&["build-analysis"])
+        .with_stderr_data(str![[r#"
       Timing report saved to [ROOT]/foo/target/cargo-timings/cargo-timing-[..]T[..]Z-[..].html
 
 "#]])
-    .run();
+        .run();
 
     let timing_files: Vec<_> = p.glob("**/cargo-timing-*.html").collect();
     assert_eq!(timing_files.len(), 1);
@@ -479,12 +506,14 @@ fn session_id_not_found() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("check -Zbuild-analysis")
+    p.cargo("check")
         .env("CARGO_BUILD_ANALYSIS_ENABLED", "true")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .run();
 
-    p.cargo("report timings --id 20260101T000000000Z-0000000000000000 -Zbuild-analysis")
+    p.cargo("report timings --id 20260101T000000000Z-0000000000000000")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -503,7 +532,8 @@ fn invalid_session_id_format() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("report timings --id invalid-session-id -Zbuild-analysis")
+    p.cargo("report timings --id invalid-session-id")
+        .arg("-Zbuild-analysis")
         .masquerade_as_nightly_cargo(&["build-analysis"])
         .with_status(101)
         .with_stderr_data(str![[r#"

--- a/tests/testsuite/collisions.rs
+++ b/tests/testsuite/collisions.rs
@@ -114,7 +114,8 @@ fn collision_export() {
 
     // -j1 to avoid issues with two processes writing to the same file at the
     // same time.
-    p.cargo("build -j1 --artifact-dir=out -Z unstable-options --bins --examples")
+    p.cargo("build -j1 --artifact-dir=out --bins --examples")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["artifact-dir"])
         .with_stderr_data(str![[r#"
 [WARNING] `--artifact-dir` filename collision at [ROOT]/foo/out/foo[EXE]

--- a/tests/testsuite/compile_time_deps.rs
+++ b/tests/testsuite/compile_time_deps.rs
@@ -53,7 +53,8 @@ fn non_comp_time_dep() {
         .file("bar/src/lib.rs", r#"pub fn bar() {}"#)
         .build();
 
-    p.cargo("-Zunstable-options check --compile-time-deps")
+    p.cargo("check --compile-time-deps")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["compile-time-deps"])
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
@@ -148,7 +149,8 @@ fn proc_macro_dep() {
         .file("baz/src/lib.rs", r#"pub fn baz() {}"#)
         .build();
 
-    p.cargo("-Zunstable-options check --package foo --compile-time-deps")
+    p.cargo("check --package foo --compile-time-deps")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["compile-time-deps"])
         .with_stderr_data(str![[r#"
 [COMPILING] baz v0.0.1 ([ROOT]/foo/baz)
@@ -160,7 +162,8 @@ fn proc_macro_dep() {
 
     p.cargo("clean").run();
 
-    p.cargo("-Zunstable-options check --package bar --compile-time-deps")
+    p.cargo("check --package bar --compile-time-deps")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["compile-time-deps"])
         .with_stderr_data(str![[r#"
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -170,7 +173,8 @@ fn proc_macro_dep() {
 
     p.cargo("clean").run();
 
-    p.cargo("-Zunstable-options check --package bar --all-targets --compile-time-deps")
+    p.cargo("check --package bar --all-targets --compile-time-deps")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["compile-time-deps"])
         .with_stderr_data(str![[r#"
 [COMPILING] baz v0.0.1 ([ROOT]/foo/baz)
@@ -238,7 +242,8 @@ fn build_dep() {
         .file("bar/baz/src/lib.rs", r#"pub fn baz() {}"#)
         .build();
 
-    p.cargo("-Zunstable-options check --compile-time-deps")
+    p.cargo("check --compile-time-deps")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["compile-time-deps"])
         .with_stderr_data(str![[r#"
 [LOCKING] 2 packages to highest compatible versions
@@ -312,7 +317,8 @@ fn indirect_comp_time_dep() {
         .file("bar/baz/src/lib.rs", r#"pub fn baz() {}"#)
         .build();
 
-    p.cargo("-Zunstable-options check --compile-time-deps")
+    p.cargo("check --compile-time-deps")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["compile-time-deps"])
         .with_stderr_data(str![[r#"
 [LOCKING] 2 packages to highest compatible versions
@@ -377,19 +383,21 @@ fn tests_target() {
         )
         .build();
 
-    p.cargo("-Zunstable-options check --tests --compile-time-deps")
+    p.cargo("check --tests --compile-time-deps")
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["compile-time-deps"])
         .run();
 
     p.cargo("clean").run();
 
-    p.cargo("-Zunstable-options check --compile-time-deps")
+    p.cargo("check --compile-time-deps")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["compile-time-deps"])
         .with_stderr_data(str![[r#"
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -1321,8 +1321,10 @@ fn host_linker_does_not_apply_to_binary_build() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build -Z target-applies-to-host -Z host-config --target")
+    p.cargo("build --target")
         .arg(&target)
+        .arg("-Ztarget-applies-to-host")
+        .arg("-Zhost-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_status(101)
         // Need to omit some MSVC-specific diagnostics
@@ -1339,7 +1341,9 @@ fn host_linker_does_not_apply_to_binary_build() {
 
     // with target-applies-to-host=false,
     // host.linker should not be applied but target.linker
-    p.cargo("build -Z target-applies-to-host -Z host-config")
+    p.cargo("build")
+        .arg("-Ztarget-applies-to-host")
+        .arg("-Zhost-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .env("CARGO_TARGET_APPLIES_TO_HOST", "false")
         .with_status(101)
@@ -1366,8 +1370,10 @@ fn cross_with_host_config() {
 
     let p = project().file("src/main.rs", "fn main() {}").build();
 
-    p.cargo("build -Z target-applies-to-host -Z host-config --target")
+    p.cargo("build --target")
         .arg(&target)
+        .arg("-Ztarget-applies-to-host")
+        .arg("-Zhost-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_status(0)
         .run();

--- a/tests/testsuite/custom_target.rs
+++ b/tests/testsuite/custom_target.rs
@@ -72,7 +72,8 @@ fn custom_target_gated() {
             bar = { path = "bar/", artifact = "bin", target = "custom-target.json" }
         "#,
     );
-    p.cargo("build -Z bindeps")
+    p.cargo("build")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -102,15 +103,18 @@ fn custom_target_minimal() {
         .file("custom-target.json", target_spec_json())
         .build();
 
-    p.cargo("build --lib --target custom-target.json -v -Zjson-target-spec")
+    p.cargo("build --lib --target custom-target.json -v")
+        .arg("-Zjson-target-spec")
         .masquerade_as_nightly_cargo(&["json_target_spec"])
         .run();
-    p.cargo("build --lib --target src/../custom-target.json -v -Zjson-target-spec")
+    p.cargo("build --lib --target src/../custom-target.json -v")
+        .arg("-Zjson-target-spec")
         .masquerade_as_nightly_cargo(&["json_target_spec"])
         .run();
 
     // Ensure that the correct style of flag is passed to --target with doc tests.
-    p.cargo("test --doc --target src/../custom-target.json -v -Zjson-target-spec")
+    p.cargo("test --doc --target src/../custom-target.json -v")
+        .arg("-Zjson-target-spec")
         .masquerade_as_nightly_cargo(&["no_core", "lang_items", "json-target-spec"])
         .with_stderr_data(str![[r#"
 [FRESH] foo v0.0.1 ([ROOT]/foo)
@@ -173,7 +177,8 @@ fn custom_target_dependency() {
         .file("custom-target.json", target_spec_json())
         .build();
 
-    p.cargo("build --lib --target custom-target.json -v -Zjson-target-spec")
+    p.cargo("build --lib --target custom-target.json -v")
+        .arg("-Zjson-target-spec")
         .masquerade_as_nightly_cargo(&["json_target_spec"])
         .run();
 }
@@ -194,7 +199,8 @@ fn custom_bin_target() {
         .file("custom-bin-target.json", target_spec_json())
         .build();
 
-    p.cargo("build --target custom-bin-target.json -v -Zjson-target-spec")
+    p.cargo("build --target custom-bin-target.json -v")
+        .arg("-Zjson-target-spec")
         .masquerade_as_nightly_cargo(&["json_target_spec"])
         .run();
 }
@@ -217,10 +223,12 @@ fn changing_spec_rebuilds() {
         .file("custom-target.json", target_spec_json())
         .build();
 
-    p.cargo("build --lib --target custom-target.json -v -Zjson-target-spec")
+    p.cargo("build --lib --target custom-target.json -v")
+        .arg("-Zjson-target-spec")
         .masquerade_as_nightly_cargo(&["json_target_spec"])
         .run();
-    p.cargo("build --lib --target custom-target.json -v -Zjson-target-spec")
+    p.cargo("build --lib --target custom-target.json -v")
+        .arg("-Zjson-target-spec")
         .masquerade_as_nightly_cargo(&["json_target_spec"])
         .with_stderr_data(str![[r#"
 [FRESH] foo v0.0.1 ([ROOT]/foo)
@@ -233,7 +241,8 @@ fn changing_spec_rebuilds() {
     // Some arbitrary change that I hope is safe.
     let spec = spec.replace('{', "{\n\"vendor\": \"unknown\",\n");
     fs::write(&spec_path, spec).unwrap();
-    p.cargo("build --lib --target custom-target.json -v -Zjson-target-spec")
+    p.cargo("build --lib --target custom-target.json -v")
+        .arg("-Zjson-target-spec")
         .masquerade_as_nightly_cargo(&["json_target_spec"])
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -266,7 +275,8 @@ fn changing_spec_relearns_crate_types() {
         .file("custom-target.json", target_spec_json())
         .build();
 
-    p.cargo("build --lib --target custom-target.json -v -Zjson-target-spec")
+    p.cargo("build --lib --target custom-target.json -v")
+        .arg("-Zjson-target-spec")
         .masquerade_as_nightly_cargo(&["json_target_spec"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -281,7 +291,8 @@ fn changing_spec_relearns_crate_types() {
     let spec = spec.replace('{', "{\n\"dynamic-linking\": true,\n");
     fs::write(&spec_path, spec).unwrap();
 
-    p.cargo("build --lib --target custom-target.json -v -Zjson-target-spec")
+    p.cargo("build --lib --target custom-target.json -v")
+        .arg("-Zjson-target-spec")
         .masquerade_as_nightly_cargo(&["json_target_spec"])
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.1.0 ([ROOT]/foo)
@@ -312,7 +323,8 @@ fn custom_target_ignores_filepath() {
         .build();
 
     // Should build the library the first time.
-    p.cargo("build --lib --target a/custom-target.json -Zjson-target-spec")
+    p.cargo("build --lib --target a/custom-target.json")
+        .arg("-Zjson-target-spec")
         .masquerade_as_nightly_cargo(&["json_target_spec"])
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -322,7 +334,8 @@ fn custom_target_ignores_filepath() {
         .run();
 
     // But not the second time, even though the path to the custom target is different.
-    p.cargo("build --lib --target b/custom-target.json -Zjson-target-spec")
+    p.cargo("build --lib --target b/custom-target.json")
+        .arg("-Zjson-target-spec")
         .masquerade_as_nightly_cargo(&["json_target_spec"])
         .with_stderr_data(str![[r#"
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/dep_info.rs
+++ b/tests/testsuite/dep_info.rs
@@ -260,8 +260,9 @@ fn relative_depinfo_paths_ws() {
         .build();
 
     let host = rustc_host();
-    p.cargo("build -Z binary-dep-depinfo --target")
+    p.cargo("build --target")
         .arg(&host)
+        .arg("-Zbinary-dep-depinfo")
         .masquerade_as_nightly_cargo(&["binary-dep-depinfo"])
         .with_stderr_data(str![[r#"
 ...
@@ -310,8 +311,9 @@ fn relative_depinfo_paths_ws() {
     );
 
     // Make sure it stays fresh.
-    p.cargo("build -Z binary-dep-depinfo --target")
+    p.cargo("build --target")
         .arg(&host)
+        .arg("-Zbinary-dep-depinfo")
         .masquerade_as_nightly_cargo(&["binary-dep-depinfo"])
         .with_stderr_data(str![[r#"
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -406,7 +408,8 @@ fn relative_depinfo_paths_no_ws() {
         .file("bar/src/lib.rs", "pub fn f() {}")
         .build();
 
-    p.cargo("build -Z binary-dep-depinfo")
+    p.cargo("build")
+        .arg("-Zbinary-dep-depinfo")
         .masquerade_as_nightly_cargo(&["binary-dep-depinfo"])
         .with_stderr_data(str![[r#"
 ...
@@ -452,7 +455,8 @@ fn relative_depinfo_paths_no_ws() {
     );
 
     // Make sure it stays fresh.
-    p.cargo("build -Z binary-dep-depinfo")
+    p.cargo("build")
+        .arg("-Zbinary-dep-depinfo")
         .masquerade_as_nightly_cargo(&["binary-dep-depinfo"])
         .with_stderr_data(str![[r#"
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -529,7 +533,8 @@ fn canonical_path() {
     real.mkdir_p();
     p.symlink(real, "target");
 
-    p.cargo("check -Z binary-dep-depinfo")
+    p.cargo("check")
+        .arg("-Zbinary-dep-depinfo")
         .masquerade_as_nightly_cargo(&["binary-dep-depinfo"])
         .run();
 

--- a/tests/testsuite/direct_minimal_versions.rs
+++ b/tests/testsuite/direct_minimal_versions.rs
@@ -28,7 +28,8 @@ fn simple() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("generate-lockfile -Zdirect-minimal-versions")
+    p.cargo("generate-lockfile")
+        .arg("-Zdirect-minimal-versions")
         .masquerade_as_nightly_cargo(&["direct-minimal-versions"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
@@ -75,7 +76,8 @@ fn mixed_dependencies() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("generate-lockfile -Zdirect-minimal-versions")
+    p.cargo("generate-lockfile")
+        .arg("-Zdirect-minimal-versions")
         .masquerade_as_nightly_cargo(&["direct-minimal-versions"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -117,7 +119,8 @@ fn yanked() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("generate-lockfile -Zdirect-minimal-versions")
+    p.cargo("generate-lockfile")
+        .arg("-Zdirect-minimal-versions")
         .masquerade_as_nightly_cargo(&["direct-minimal-versions"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
@@ -171,7 +174,8 @@ fn indirect() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("generate-lockfile -Zdirect-minimal-versions")
+    p.cargo("generate-lockfile")
+        .arg("-Zdirect-minimal-versions")
         .masquerade_as_nightly_cargo(&["direct-minimal-versions"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
@@ -234,7 +238,8 @@ fn indirect_conflict() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("generate-lockfile -Zdirect-minimal-versions")
+    p.cargo("generate-lockfile")
+        .arg("-Zdirect-minimal-versions")
         .masquerade_as_nightly_cargo(&["direct-minimal-versions"])
         .with_status(101)
         .with_stderr_data(str![[r#"

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1483,8 +1483,9 @@ fn doc_extern_map_local() {
         .file(".cargo/config.toml", "doc.extern-map.std = 'local'")
         .build();
 
-    p.cargo("doc -v --no-deps -Zrustdoc-map --open")
+    p.cargo("doc -v --no-deps --open")
         .env("BROWSER", tools::echo())
+        .arg("-Zrustdoc-map")
         .masquerade_as_nightly_cargo(&["rustdoc-map"])
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.1.0 ([ROOT]/foo)
@@ -2702,7 +2703,8 @@ fn doc_fingerprint_unusual_behavior() {
     // Change file to trigger a new build.
     p.change_file("src/lib.rs", "// changed2");
     fs::write(real_doc.join("somefile"), "test").unwrap();
-    p.cargo("doc -Z skip-rustdoc-fingerprint")
+    p.cargo("doc")
+        .arg("-Zskip-rustdoc-fingerprint")
         .masquerade_as_nightly_cargo(&["skip-rustdoc-fingerprint"])
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
@@ -2927,7 +2929,8 @@ fn rustdoc_depinfo_gated() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("doc -Zrustdoc-depinfo")
+    p.cargo("doc")
+        .arg("-Zrustdoc-depinfo")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] the `-Z` flag is only accepted on the nightly channel of Cargo, but this is the `stable` channel
@@ -2953,7 +2956,8 @@ fn rebuild_tracks_target_src_outside_package_root() {
         .file("../lib.rs", "//! # depinfo-before")
         .build();
 
-    p.cargo("doc -Zrustdoc-depinfo")
+    p.cargo("doc")
+        .arg("-Zrustdoc-depinfo")
         .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.0.0 ([ROOT]/parent/foo)
@@ -2968,7 +2972,8 @@ fn rebuild_tracks_target_src_outside_package_root() {
 
     p.change_file("../lib.rs", "//! # depinfo-after");
 
-    p.cargo("doc --verbose -Zrustdoc-depinfo")
+    p.cargo("doc --verbose")
+        .arg("-Zrustdoc-depinfo")
         .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.0.0 ([ROOT]/parent/foo): the file `../lib.rs` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
@@ -2992,7 +2997,8 @@ fn rebuild_tracks_include_str() {
         .file("../README", "# depinfo-before")
         .build();
 
-    p.cargo("doc -Zrustdoc-depinfo")
+    p.cargo("doc")
+        .arg("-Zrustdoc-depinfo")
         .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.5.0 ([ROOT]/parent/foo)
@@ -3007,7 +3013,8 @@ fn rebuild_tracks_include_str() {
 
     p.change_file("../README", "# depinfo-after");
 
-    p.cargo("doc --verbose -Zrustdoc-depinfo")
+    p.cargo("doc --verbose")
+        .arg("-Zrustdoc-depinfo")
         .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.5.0 ([ROOT]/parent/foo): the file `src/../../README` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
@@ -3031,7 +3038,8 @@ fn rebuild_tracks_path_attr() {
         .file("../bar.rs", "//! # depinfo-before")
         .build();
 
-    p.cargo("doc -Zrustdoc-depinfo")
+    p.cargo("doc")
+        .arg("-Zrustdoc-depinfo")
         .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.5.0 ([ROOT]/parent/foo)
@@ -3046,7 +3054,8 @@ fn rebuild_tracks_path_attr() {
 
     p.change_file("../bar.rs", "//! # depinfo-after");
 
-    p.cargo("doc --verbose -Zrustdoc-depinfo")
+    p.cargo("doc --verbose")
+        .arg("-Zrustdoc-depinfo")
         .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.5.0 ([ROOT]/parent/foo): the file `src/../../bar.rs` has changed ([TIME_DIFF_AFTER_LAST_BUILD])
@@ -3070,8 +3079,9 @@ fn rebuild_tracks_env() {
         .file("src/lib.rs", &format!(r#"#![doc = env!("{env}")]"#))
         .build();
 
-    p.cargo("doc -Zrustdoc-depinfo")
+    p.cargo("doc")
         .env(env, "# depinfo-before")
+        .arg("-Zrustdoc-depinfo")
         .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.5.0 ([ROOT]/foo)
@@ -3084,8 +3094,9 @@ fn rebuild_tracks_env() {
     let doc_html = p.read_file("target/doc/foo/index.html");
     assert!(doc_html.contains("depinfo-before"));
 
-    p.cargo("doc --verbose -Zrustdoc-depinfo")
+    p.cargo("doc --verbose")
         .env(env, "# depinfo-after")
+        .arg("-Zrustdoc-depinfo")
         .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.5.0 ([ROOT]/foo): the environment variable __RUSTDOC_INJECTED changed
@@ -3123,8 +3134,9 @@ fn rebuild_tracks_env_in_dep() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("doc -Zrustdoc-depinfo")
+    p.cargo("doc")
         .env(env, "# depinfo-before")
+        .arg("-Zrustdoc-depinfo")
         .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
         .with_stderr_data(
             str![[r#"
@@ -3146,8 +3158,9 @@ fn rebuild_tracks_env_in_dep() {
     let doc_html = p.read_file("target/doc/bar/index.html");
     assert!(doc_html.contains("depinfo-before"));
 
-    p.cargo("doc --verbose -Zrustdoc-depinfo")
+    p.cargo("doc --verbose")
         .env(env, "# depinfo-after")
+        .arg("-Zrustdoc-depinfo")
         .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
         .with_stderr_data(
             str![[r#"
@@ -3183,8 +3196,10 @@ fn rebuild_tracks_checksum() {
         .file("../README", "# depinfo-before")
         .build();
 
-    p.cargo("doc -Zrustdoc-depinfo -Zchecksum-freshness")
+    p.cargo("doc")
         .env("CARGO_BUILD_FINGERPRINT", "content")
+        .arg("-Zrustdoc-depinfo")
+        .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["rustdoc-depinfo", "checksum-freshness"])
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.5.0 ([ROOT]/parent/foo)
@@ -3201,8 +3216,10 @@ fn rebuild_tracks_checksum() {
     // Change mtime into the future
     p.root().move_into_the_future();
 
-    p.cargo("doc --verbose -Zrustdoc-depinfo -Zchecksum-freshness")
+    p.cargo("doc --verbose")
         .env("CARGO_BUILD_FINGERPRINT", "content")
+        .arg("-Zrustdoc-depinfo")
+        .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["rustdoc-depinfo"])
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.5.0 ([ROOT]/parent/foo): file size changed (16 != 15) for `src/../../README`
@@ -3225,7 +3242,8 @@ fn mergeable_info_gated() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("doc -Zrustdoc-mergeable-info")
+    p.cargo("doc")
+        .arg("-Zrustdoc-mergeable-info")
         .with_status(101)
         .with_stderr_data(str![[r#"
 [ERROR] the `-Z` flag is only accepted on the nightly channel of Cargo, but this is the `stable` channel
@@ -3254,7 +3272,8 @@ fn mergeable_info_with_deps() {
         .file("dep/src/lib.rs", "pub fn bar() {}")
         .build();
 
-    p.cargo("doc -v -Zrustdoc-mergeable-info")
+    p.cargo("doc -v")
+        .arg("-Zrustdoc-mergeable-info")
         .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info"])
         .with_stderr_data(
             str![[r#"
@@ -3302,11 +3321,12 @@ fn mergeable_info_with_rustdocflags() {
         .file("src/lib.rs", "pub fn foo() {}")
         .build();
 
-    p.cargo("doc -v -Zrustdoc-mergeable-info")
+    p.cargo("doc -v")
         .env(
             "RUSTDOCFLAGS",
             "--markdown-playground-url=example.com",
         )
+        .arg("-Zrustdoc-mergeable-info")
         .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info"])
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.5.0 ([ROOT]/foo)
@@ -3340,7 +3360,8 @@ fn mergeable_info_no_deps() {
         .file("dep/src/lib.rs", "pub fn dep() {}")
         .build();
 
-    p.cargo("doc -v --no-deps -Zrustdoc-mergeable-info")
+    p.cargo("doc -v --no-deps")
+        .arg("-Zrustdoc-mergeable-info")
         .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info"])
         .with_stderr_data(
             str![[r#"
@@ -3407,7 +3428,8 @@ fn mergeable_info_workspace() {
         .file("dep/src/lib.rs", "pub fn dep() {}")
         .build();
 
-    p.cargo("doc -v --workspace -Zrustdoc-mergeable-info")
+    p.cargo("doc -v --workspace")
+        .arg("-Zrustdoc-mergeable-info")
         .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info"])
         .with_stderr_data(
             str![[r#"
@@ -3475,8 +3497,9 @@ fn mergeable_info_multi_targets() {
         .file("src/lib.rs", "pub fn foo() {}")
         .build();
 
-    p.cargo("doc -v --target host-tuple -Zrustdoc-mergeable-info")
+    p.cargo("doc -v --target host-tuple")
         .args(&["--target", target])
+        .arg("-Zrustdoc-mergeable-info")
         .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info"])
         .with_stderr_data(
             str![[r#"
@@ -3548,7 +3571,8 @@ fn mergeable_info_rebuild_detection() {
         .file("src/lib.rs", "pub fn foo() {}")
         .build();
 
-    p.cargo("doc -v -Zrustdoc-mergeable-info")
+    p.cargo("doc -v")
+        .arg("-Zrustdoc-mergeable-info")
         .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info"])
         .with_stderr_data(
             str![[r#"
@@ -3581,7 +3605,8 @@ fn mergeable_info_rebuild_detection() {
     );
 
     // Make sure it doesn't recompile.
-    p.cargo("doc -v -Zrustdoc-mergeable-info")
+    p.cargo("doc -v")
+        .arg("-Zrustdoc-mergeable-info")
         .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info"])
         .with_stderr_data(str![[r#"
 [FRESH] foo v0.0.0 ([ROOT]/foo)
@@ -3611,7 +3636,8 @@ fn mergeable_info_rebuild_detection() {
     p.change_file("src/lib.rs", "pub fn foo2() {}");
 
     // Make sure it recompiles
-    p.cargo("doc -v -Zrustdoc-mergeable-info")
+    p.cargo("doc -v")
+        .arg("-Zrustdoc-mergeable-info")
         .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info"])
         .with_stderr_data(
             str![[r#"
@@ -3629,7 +3655,8 @@ fn mergeable_info_rebuild_detection() {
         .run();
 
     // Make sure it doesn't recompile.
-    p.cargo("doc -v -Zrustdoc-mergeable-info")
+    p.cargo("doc -v")
+        .arg("-Zrustdoc-mergeable-info")
         .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info"])
         .with_stderr_data(str![[r#"
 [FRESH] foo v0.0.0 ([ROOT]/foo)
@@ -3642,7 +3669,8 @@ fn mergeable_info_rebuild_detection() {
         .run();
 
     // Make sure it doesn't recompile after previous no-op build.
-    p.cargo("doc -v -Zrustdoc-mergeable-info")
+    p.cargo("doc -v")
+        .arg("-Zrustdoc-mergeable-info")
         .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info"])
         .with_stderr_data(str![[r#"
 [FRESH] foo v0.0.0 ([ROOT]/foo)
@@ -3686,7 +3714,9 @@ fn mergeable_info_rebuild_with_depinfo() {
         .file("src/lib.rs", "pub fn foo() {}")
         .build();
 
-    p.cargo("doc -v -Zrustdoc-mergeable-info -Zrustdoc-depinfo")
+    p.cargo("doc -v")
+        .arg("-Zrustdoc-mergeable-info")
+        .arg("-Zrustdoc-depinfo")
         .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info", "-Zrustdoc-depinfo"])
         .with_stderr_data(
             str![[r#"
@@ -3719,7 +3749,9 @@ fn mergeable_info_rebuild_with_depinfo() {
     );
 
     // Make sure it doesn't recompile.
-    p.cargo("doc -v -Zrustdoc-mergeable-info -Zrustdoc-depinfo")
+    p.cargo("doc -v")
+        .arg("-Zrustdoc-mergeable-info")
+        .arg("-Zrustdoc-depinfo")
         .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info", "-Zrustdoc-depinfo"])
         .with_stderr_data(str![[r#"
 [FRESH] foo v0.0.0 ([ROOT]/foo)
@@ -3749,7 +3781,9 @@ fn mergeable_info_rebuild_with_depinfo() {
     p.change_file("src/lib.rs", "pub fn foo2() {}");
 
     // Make sure it recompiles
-    p.cargo("doc -v -Zrustdoc-mergeable-info -Zrustdoc-depinfo")
+    p.cargo("doc -v")
+        .arg("-Zrustdoc-mergeable-info")
+        .arg("-Zrustdoc-depinfo")
         .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info", "-Zrustdoc-depinfo"])
         .with_stderr_data(
             str![[r#"
@@ -3767,7 +3801,9 @@ fn mergeable_info_rebuild_with_depinfo() {
         .run();
 
     // Make sure it doesn't recompile.
-    p.cargo("doc -v -Zrustdoc-mergeable-info -Zrustdoc-depinfo")
+    p.cargo("doc -v")
+        .arg("-Zrustdoc-mergeable-info")
+        .arg("-Zrustdoc-depinfo")
         .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info", "-Zrustdoc-depinfo"])
         .with_stderr_data(str![[r#"
 [FRESH] foo v0.0.0 ([ROOT]/foo)
@@ -3780,7 +3816,9 @@ fn mergeable_info_rebuild_with_depinfo() {
         .run();
 
     // Make sure it doesn't recompile after previous no-op build
-    p.cargo("doc -v -Zrustdoc-mergeable-info -Zrustdoc-depinfo")
+    p.cargo("doc -v")
+        .arg("-Zrustdoc-mergeable-info")
+        .arg("-Zrustdoc-depinfo")
         .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info", "-Zrustdoc-depinfo"])
         .with_stderr_data(str![[r#"
 [FRESH] foo v0.0.0 ([ROOT]/foo)
@@ -3836,7 +3874,8 @@ fn mergeable_info_additive() {
         .file("dep/src/lib.rs", "pub fn dep() {}")
         .build();
 
-    p.cargo("doc -v -p foo --no-deps -Zrustdoc-mergeable-info")
+    p.cargo("doc -v -p foo --no-deps")
+        .arg("-Zrustdoc-mergeable-info")
         .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info"])
         .with_stderr_data(
             str![[r#"
@@ -3874,7 +3913,8 @@ fn mergeable_info_additive() {
         .is_json(),
     );
 
-    p.cargo("doc -v -p dep --no-deps -Zrustdoc-mergeable-info")
+    p.cargo("doc -v -p dep --no-deps")
+        .arg("-Zrustdoc-mergeable-info")
         .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info"])
         .with_stderr_data(
             str![[r#"
@@ -3911,7 +3951,8 @@ fn mergeable_info_additive() {
         .is_json(),
     );
 
-    p.cargo("doc -v -p bar --no-deps -Zrustdoc-mergeable-info")
+    p.cargo("doc -v -p bar --no-deps")
+        .arg("-Zrustdoc-mergeable-info")
         .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info"])
         .with_stderr_data(
             str![[r#"
@@ -3981,7 +4022,8 @@ fn mergeable_info_dep_collision() {
         .build();
 
     // First document dep@0.1.0
-    p.cargo("doc -v -Zrustdoc-mergeable-info -p dep@0.1.0")
+    p.cargo("doc -v -p dep@0.1.0")
+        .arg("-Zrustdoc-mergeable-info")
         .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info"])
         .with_stderr_data(
             str![[r#"
@@ -4026,7 +4068,8 @@ fn mergeable_info_dep_collision() {
     );
 
     // Now selectively document dep@0.2.0
-    p.cargo("doc -v -Zrustdoc-mergeable-info -p dep@0.2.0")
+    p.cargo("doc -v -p dep@0.2.0")
+        .arg("-Zrustdoc-mergeable-info")
         .masquerade_as_nightly_cargo(&["rustdoc-mergeable-info"])
         .with_stderr_data(
             str![[r#"
@@ -4087,7 +4130,8 @@ See https://github.com/rust-lang/cargo/issues/13283 for more information about t
 fn doc_invalid_output_format() {
     let p = project().file("src/lib.rs", "").build();
 
-    p.cargo("doc -Z unstable-options --output-format pdf -v")
+    p.cargo("doc --output-format pdf -v")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["rustdoc-output-format"])
         .with_status(1)
         .with_stderr_data(str![[r#"
@@ -4143,7 +4187,8 @@ fn doc_output_format_json_no_deps() {
         .file("bar/src/lib.rs", "pub fn bar_fn() {}")
         .build();
 
-    p.cargo("doc --no-deps -Z unstable-options --output-format json -v")
+    p.cargo("doc --no-deps --output-format json -v")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["rustdoc-output-format"])
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
@@ -4193,7 +4238,8 @@ fn doc_output_format_json_with_deps() {
         .file("bar/src/lib.rs", "pub fn bar_fn() {}")
         .build();
 
-    p.cargo("doc -Z unstable-options --output-format json -v")
+    p.cargo("doc --output-format json -v")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["rustdoc-output-format"])
         .with_stderr_data(
             str![[r#"
@@ -4258,7 +4304,9 @@ fn doc_output_format_json_with_deps_and_mergeable_info() {
         .file("bar/src/lib.rs", "pub fn bar_fn() {}")
         .build();
 
-    p.cargo("doc -Z unstable-options --output-format json -Zrustdoc-mergeable-info -v")
+    p.cargo("doc --output-format json -v")
+        .arg("-Zunstable-options")
+        .arg("-Zrustdoc-mergeable-info")
         .masquerade_as_nightly_cargo(&["rustdoc-output-format"])
         .with_stderr_data(
             str![[r#"

--- a/tests/testsuite/docscrape.rs
+++ b/tests/testsuite/docscrape.rs
@@ -21,7 +21,9 @@ fn basic() {
         .file("src/lib.rs", "pub fn foo() {}\npub fn bar() { foo(); }")
         .build();
 
-    p.cargo("doc -Zunstable-options -Zrustdoc-scrape-examples")
+    p.cargo("doc")
+        .arg("-Zunstable-options")
+        .arg("-Zrustdoc-scrape-examples")
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .with_stderr_data(str![[r#"
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -33,7 +35,9 @@ fn basic() {
 "#]])
         .run();
 
-    p.cargo("doc -Zunstable-options -Z rustdoc-scrape-examples")
+    p.cargo("doc")
+        .arg("-Zunstable-options")
+        .arg("-Zrustdoc-scrape-examples")
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .with_stderr_data(str![[r#"
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -112,7 +116,9 @@ impl Foo {
         )
         .build();
 
-    p.cargo("doc -Zunstable-options -Zrustdoc-scrape-examples --no-deps")
+    p.cargo("doc --no-deps")
+        .arg("-Zunstable-options")
+        .arg("-Zrustdoc-scrape-examples")
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .with_stderr_data(
             str![[r#"
@@ -172,7 +178,9 @@ fn avoid_build_script_cycle() {
         .file("bar/build.rs", "fn main(){}")
         .build();
 
-    p.cargo("doc --workspace -Zunstable-options -Zrustdoc-scrape-examples")
+    p.cargo("doc --workspace")
+        .arg("-Zunstable-options")
+        .arg("-Zrustdoc-scrape-examples")
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .run();
 }
@@ -232,7 +240,9 @@ fn complex_reverse_dependencies() {
         .file("b/src/lib.rs", "")
         .build();
 
-    p.cargo("doc --workspace --examples -Zunstable-options -Zrustdoc-scrape-examples")
+    p.cargo("doc --workspace --examples")
+        .arg("-Zunstable-options")
+        .arg("-Zrustdoc-scrape-examples")
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .run();
 }
@@ -254,7 +264,9 @@ fn crate_with_dash() {
         .file("examples/a.rs", "fn main() { da_sh::foo(); }")
         .build();
 
-    p.cargo("doc -Zunstable-options -Zrustdoc-scrape-examples")
+    p.cargo("doc")
+        .arg("-Zunstable-options")
+        .arg("-Zrustdoc-scrape-examples")
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .run();
 
@@ -300,7 +312,9 @@ fn configure_target() {
         )
         .build();
 
-    p.cargo("doc -Zunstable-options -Zrustdoc-scrape-examples")
+    p.cargo("doc")
+        .arg("-Zunstable-options")
+        .arg("-Zrustdoc-scrape-examples")
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .run();
 
@@ -330,7 +344,9 @@ fn configure_profile_issue_10500() {
         .file("src/lib.rs", "pub fn foo() {}\npub fn bar() { foo(); }")
         .build();
 
-    p.cargo("doc -Zunstable-options -Zrustdoc-scrape-examples")
+    p.cargo("doc")
+        .arg("-Zunstable-options")
+        .arg("-Zrustdoc-scrape-examples")
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .run();
 
@@ -380,7 +396,9 @@ fn issue_10545() {
         .file("b/src/lib.rs", "")
         .build();
 
-    p.cargo("doc --workspace -Zunstable-options -Zrustdoc-scrape-examples")
+    p.cargo("doc --workspace")
+        .arg("-Zunstable-options")
+        .arg("-Zrustdoc-scrape-examples")
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .run();
 }
@@ -402,7 +420,9 @@ fn cache() {
         .file("src/lib.rs", "pub fn foo() {}\npub fn bar() { foo(); }")
         .build();
 
-    p.cargo("doc -Zunstable-options -Zrustdoc-scrape-examples")
+    p.cargo("doc")
+        .arg("-Zunstable-options")
+        .arg("-Zrustdoc-scrape-examples")
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .with_stderr_data(str![[r#"
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -414,7 +434,9 @@ fn cache() {
 "#]])
         .run();
 
-    p.cargo("doc -Zunstable-options -Zrustdoc-scrape-examples")
+    p.cargo("doc")
+        .arg("-Zunstable-options")
+        .arg("-Zrustdoc-scrape-examples")
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .with_stderr_data(str![[r#"
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -442,7 +464,9 @@ fn no_fail_bad_lib() {
         .file("examples/ex2.rs", "fn main() { foo::foo(); }")
         .build();
 
-    p.cargo("doc -Zunstable-options -Z rustdoc-scrape-examples")
+    p.cargo("doc")
+        .arg("-Zunstable-options")
+        .arg("-Zrustdoc-scrape-examples")
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .with_stderr_data(str![[r#"
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -496,7 +520,9 @@ fn fail_bad_build_script() {
         .run();
 
     // scrape examples should fail whenever `cargo doc` fails.
-    p.cargo("doc -Zunstable-options -Z rustdoc-scrape-examples")
+    p.cargo("doc")
+        .arg("-Zunstable-options")
+        .arg("-Zrustdoc-scrape-examples")
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -525,7 +551,9 @@ fn no_fail_bad_example() {
         .file("src/lib.rs", "pub fn foo(){}")
         .build();
 
-    p.cargo("doc -Zunstable-options -Z rustdoc-scrape-examples")
+    p.cargo("doc")
+        .arg("-Zunstable-options")
+        .arg("-Zrustdoc-scrape-examples")
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .with_stderr_data(str![[r#"
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -543,7 +571,9 @@ fn no_fail_bad_example() {
 
     p.cargo("clean").run();
 
-    p.cargo("doc -v -Zunstable-options -Z rustdoc-scrape-examples")
+    p.cargo("doc -v")
+        .arg("-Zunstable-options")
+        .arg("-Zrustdoc-scrape-examples")
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .with_stderr_data(
             str![[r#"
@@ -609,7 +639,9 @@ fn no_scrape_with_dev_deps() {
 
     // If --examples is not provided, then the example is not scanned, and a warning
     // should be raised.
-    p.cargo("doc -Zunstable-options -Z rustdoc-scrape-examples")
+    p.cargo("doc")
+        .arg("-Zunstable-options")
+        .arg("-Zrustdoc-scrape-examples")
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
@@ -624,7 +656,9 @@ fn no_scrape_with_dev_deps() {
         .run();
 
     // If --examples is provided, then the example is scanned.
-    p.cargo("doc --examples -Zunstable-options -Z rustdoc-scrape-examples")
+    p.cargo("doc --examples")
+        .arg("-Zunstable-options")
+        .arg("-Zrustdoc-scrape-examples")
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .with_stderr_data(
             str![[r#"
@@ -678,7 +712,9 @@ fn use_dev_deps_if_explicitly_enabled() {
         .build();
 
     // If --examples is not provided, then the example is never scanned.
-    p.cargo("doc -Zunstable-options -Z rustdoc-scrape-examples")
+    p.cargo("doc")
+        .arg("-Zunstable-options")
+        .arg("-Zrustdoc-scrape-examples")
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .with_stderr_data(
             str![[r#"
@@ -736,7 +772,9 @@ fn only_scrape_documented_targets() {
         .file("foo/src/lib.rs", "pub fn foo() {}")
         .build();
 
-    p.cargo("doc --workspace -Zunstable-options -Zrustdoc-scrape-examples")
+    p.cargo("doc --workspace")
+        .arg("-Zunstable-options")
+        .arg("-Zrustdoc-scrape-examples")
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .run();
 
@@ -764,7 +802,9 @@ fn issue_11496() {
         .file("examples/ex.rs", "fn main(){}")
         .build();
 
-    p.cargo("doc -Zunstable-options -Zrustdoc-scrape-examples")
+    p.cargo("doc")
+        .arg("-Zunstable-options")
+        .arg("-Zrustdoc-scrape-examples")
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .run();
 }

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -2239,7 +2239,8 @@ fn minimal_download() {
 
     // none
     // Should be the same as `-Zfeatures=all`
-    p.cargo("check -Zfeatures=compare")
+    p.cargo("check")
+        .arg("-Zfeatures=compare")
         .masquerade_as_nightly_cargo(&["features=compare"])
         .with_stderr_data(
             str![[r#"

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -2595,7 +2595,8 @@ fn main() {
         )
         .build();
 
-    p.cargo("-Zscript fix --edition --allow-no-vcs --manifest-path foo.rs")
+    p.cargo("fix --edition --allow-no-vcs --manifest-path foo.rs")
+        .arg("-Zscript")
         .masquerade_as_nightly_cargo(&["script"])
         .with_stderr_data(str![[r#"
 [MIGRATING] foo.rs from 2021 edition to 2024
@@ -3063,7 +3064,8 @@ fn fix_edition_skips_old_editions() {
         .build();
 
     // Doing the whole workspace should skip since there is a 2021 in the mix.
-    p.cargo("fix -Zfix-edition=start=2024 -v")
+    p.cargo("fix -v")
+        .arg("-Zfix-edition=start=2024")
         .masquerade_as_nightly_cargo(&["fix-edition"])
         .with_stderr_data(str![[r#"
 [SKIPPING] not all packages are at edition 2024
@@ -3072,7 +3074,8 @@ fn fix_edition_skips_old_editions() {
         .run();
 
     // Same with `end`.
-    p.cargo("fix -Zfix-edition=end=2024,future -v")
+    p.cargo("fix -v")
+        .arg("-Zfix-edition=end=2024,future")
         .masquerade_as_nightly_cargo(&["fix-edition"])
         .with_stderr_data(str![[r#"
 [SKIPPING] not all packages are at edition 2024
@@ -3081,7 +3084,8 @@ fn fix_edition_skips_old_editions() {
         .run();
 
     // Doing an individual package at the correct edition should check it.
-    p.cargo("fix -Zfix-edition=start=2024 -p e2024")
+    p.cargo("fix -p e2024")
+        .arg("-Zfix-edition=start=2024")
         .masquerade_as_nightly_cargo(&["fix-edition"])
         .with_stderr_data(str![[r#"
 [CHECKING] e2024 v0.0.0 ([ROOT]/foo/e2024)
@@ -3105,7 +3109,8 @@ fn fix_edition_future() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("fix -Zfix-edition=end=2024,future")
+    p.cargo("fix")
+        .arg("-Zfix-edition=end=2024,future")
         .masquerade_as_nightly_cargo(&["fix-edition"])
         .with_stderr_data(str![[r#"
 [MIGRATING] Cargo.toml from 2024 edition to future
@@ -3137,7 +3142,8 @@ fn script_without_frontmatter() {
         .file("echo.rs", "fn main() {}")
         .build();
 
-    p.cargo("fix -Zscript --allow-no-vcs --manifest-path echo.rs")
+    p.cargo("fix --allow-no-vcs --manifest-path echo.rs")
+        .arg("-Zscript")
         .masquerade_as_nightly_cargo(&["script"])
         .with_stdout_data(str![""])
         .with_stderr_data(str![[r#"
@@ -3176,7 +3182,8 @@ fn main() {}",
         )
         .build();
 
-    p.cargo("fix -Zscript --allow-no-vcs --manifest-path echo.rs")
+    p.cargo("fix --allow-no-vcs --manifest-path echo.rs")
+        .arg("-Zscript")
         .masquerade_as_nightly_cargo(&["script"])
         .with_stdout_data(str![""])
         .with_stderr_data(str![[r#"
@@ -3217,7 +3224,8 @@ fn main() {}"#,
         )
         .build();
 
-    p.cargo("fix -Zscript --allow-no-vcs --manifest-path echo.rs")
+    p.cargo("fix --allow-no-vcs --manifest-path echo.rs")
+        .arg("-Zscript")
         .masquerade_as_nightly_cargo(&["script"])
         .with_stdout_data(str![""])
         .with_stderr_data(str![[r#"
@@ -3257,7 +3265,8 @@ fn main() {}"#,
         )
         .build();
 
-    p.cargo("fix -Zscript --allow-no-vcs --manifest-path echo.rs")
+    p.cargo("fix --allow-no-vcs --manifest-path echo.rs")
+        .arg("-Zscript")
         .masquerade_as_nightly_cargo(&["script"])
         .with_stdout_data(str![""])
         .with_stderr_data(str![[r#"
@@ -3296,7 +3305,8 @@ fn main() {}"#,
         )
         .build();
 
-    p.cargo("fix -Zscript --allow-no-vcs --manifest-path echo.rs")
+    p.cargo("fix --allow-no-vcs --manifest-path echo.rs")
+        .arg("-Zscript")
         .masquerade_as_nightly_cargo(&["script"])
         .with_stdout_data(str![""])
         .with_stderr_data(str![[r#"

--- a/tests/testsuite/freshness_checksum.rs
+++ b/tests/testsuite/freshness_checksum.rs
@@ -166,9 +166,10 @@ fn binary_depinfo_correctly_encoded() {
         .build();
 
     let host = rustc_host();
-    p.cargo("build -Zbinary-dep-depinfo --target")
+    p.cargo("build --target")
         .arg(&host)
         .env("CARGO_BUILD_FINGERPRINT", "content")
+        .arg("-Zbinary-dep-depinfo")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["binary-dep-depinfo", "checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -193,9 +194,10 @@ fn binary_depinfo_correctly_encoded() {
     );
 
     // Make sure it stays fresh.
-    p.cargo("build -Zbinary-dep-depinfo --target")
+    p.cargo("build --target")
         .arg(&host)
         .env("CARGO_BUILD_FINGERPRINT", "content")
+        .arg("-Zbinary-dep-depinfo")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["binary-dep-depinfo", "checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -603,8 +605,9 @@ fn update_dependency_mtime_does_not_rebuild() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    p.cargo("build -Z mtime-on-use")
+    p.cargo("build")
         .env("CARGO_BUILD_FINGERPRINT", "content")
+        .arg("-Zmtime-on-use")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["mtime-on-use", "checksum-freshness"])
         .env("RUSTFLAGS", "-C linker=cc")
@@ -617,8 +620,9 @@ fn update_dependency_mtime_does_not_rebuild() {
 "#]])
         .run();
     // This does not make new files, but it does update the mtime of the dependency.
-    p.cargo("build -p bar -Z mtime-on-use")
+    p.cargo("build -p bar")
         .env("CARGO_BUILD_FINGERPRINT", "content")
+        .arg("-Zmtime-on-use")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["mtime-on-use", "checksum-freshness"])
         .env("RUSTFLAGS", "-C linker=cc")
@@ -628,8 +632,9 @@ fn update_dependency_mtime_does_not_rebuild() {
 "#]])
         .run();
     // This should not recompile!
-    p.cargo("build -Z mtime-on-use")
+    p.cargo("build")
         .env("CARGO_BUILD_FINGERPRINT", "content")
+        .arg("-Zmtime-on-use")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["mtime-on-use", "checksum-freshness"])
         .env("RUSTFLAGS", "-C linker=cc")
@@ -700,13 +705,15 @@ fn fingerprint_cleaner_does_not_rebuild() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    p.cargo("build -Z mtime-on-use")
+    p.cargo("build")
         .env("CARGO_BUILD_FINGERPRINT", "content")
+        .arg("-Zmtime-on-use")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["mtime-on-use", "checksum-freshness"])
         .run();
-    p.cargo("build -Z mtime-on-use --features a")
+    p.cargo("build --features a")
         .env("CARGO_BUILD_FINGERPRINT", "content")
+        .arg("-Zmtime-on-use")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["mtime-on-use", "checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -723,8 +730,9 @@ fn fingerprint_cleaner_does_not_rebuild() {
         sleep_ms(1000);
     }
     // This does not make new files, but it does update the mtime.
-    p.cargo("build -Z mtime-on-use --features a")
+    p.cargo("build --features a")
         .env("CARGO_BUILD_FINGERPRINT", "content")
+        .arg("-Zmtime-on-use")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["mtime-on-use", "checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -734,8 +742,9 @@ fn fingerprint_cleaner_does_not_rebuild() {
         .run();
     fingerprint_cleaner(p.target_debug_dir(), timestamp);
     // This should not recompile!
-    p.cargo("build -Z mtime-on-use --features a")
+    p.cargo("build --features a")
         .env("CARGO_BUILD_FINGERPRINT", "content")
+        .arg("-Zmtime-on-use")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["mtime-on-use", "checksum-freshness"])
         .with_stderr_data(str![[r#"
@@ -744,8 +753,9 @@ fn fingerprint_cleaner_does_not_rebuild() {
 "#]])
         .run();
     // But this should be cleaned and so need a rebuild
-    p.cargo("build -Z mtime-on-use")
+    p.cargo("build")
         .env("CARGO_BUILD_FINGERPRINT", "content")
+        .arg("-Zmtime-on-use")
         .arg("-Zchecksum-freshness")
         .masquerade_as_nightly_cargo(&["mtime-on-use", "checksum-freshness"])
         .with_stderr_data(str![[r#"

--- a/tests/testsuite/freshness_mtime.rs
+++ b/tests/testsuite/freshness_mtime.rs
@@ -363,7 +363,8 @@ fn update_dependency_mtime_does_not_rebuild() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    p.cargo("build -Z mtime-on-use")
+    p.cargo("build")
+        .arg("-Zmtime-on-use")
         .masquerade_as_nightly_cargo(&["mtime-on-use"])
         .env("RUSTFLAGS", "-C linker=cc")
         .with_stderr_data(str![[r#"
@@ -375,7 +376,8 @@ fn update_dependency_mtime_does_not_rebuild() {
 "#]])
         .run();
     // This does not make new files, but it does update the mtime of the dependency.
-    p.cargo("build -p bar -Z mtime-on-use")
+    p.cargo("build -p bar")
+        .arg("-Zmtime-on-use")
         .masquerade_as_nightly_cargo(&["mtime-on-use"])
         .env("RUSTFLAGS", "-C linker=cc")
         .with_stderr_data(str![[r#"
@@ -384,7 +386,8 @@ fn update_dependency_mtime_does_not_rebuild() {
 "#]])
         .run();
     // This should not recompile!
-    p.cargo("build -Z mtime-on-use")
+    p.cargo("build")
+        .arg("-Zmtime-on-use")
         .masquerade_as_nightly_cargo(&["mtime-on-use"])
         .env("RUSTFLAGS", "-C linker=cc")
         .with_stderr_data(str![[r#"
@@ -454,10 +457,12 @@ fn fingerprint_cleaner_does_not_rebuild() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    p.cargo("build -Z mtime-on-use")
+    p.cargo("build")
+        .arg("-Zmtime-on-use")
         .masquerade_as_nightly_cargo(&["mtime-on-use"])
         .run();
-    p.cargo("build -Z mtime-on-use --features a")
+    p.cargo("build --features a")
+        .arg("-Zmtime-on-use")
         .masquerade_as_nightly_cargo(&["mtime-on-use"])
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -473,7 +478,8 @@ fn fingerprint_cleaner_does_not_rebuild() {
         sleep_ms(1000);
     }
     // This does not make new files, but it does update the mtime.
-    p.cargo("build -Z mtime-on-use --features a")
+    p.cargo("build --features a")
+        .arg("-Zmtime-on-use")
         .masquerade_as_nightly_cargo(&["mtime-on-use"])
         .with_stderr_data(str![[r#"
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -482,7 +488,8 @@ fn fingerprint_cleaner_does_not_rebuild() {
         .run();
     fingerprint_cleaner(p.target_debug_dir(), timestamp);
     // This should not recompile!
-    p.cargo("build -Z mtime-on-use --features a")
+    p.cargo("build --features a")
+        .arg("-Zmtime-on-use")
         .masquerade_as_nightly_cargo(&["mtime-on-use"])
         .with_stderr_data(str![[r#"
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -490,7 +497,8 @@ fn fingerprint_cleaner_does_not_rebuild() {
 "#]])
         .run();
     // But this should be cleaned and so need a rebuild
-    p.cargo("build -Z mtime-on-use")
+    p.cargo("build")
+        .arg("-Zmtime-on-use")
         .masquerade_as_nightly_cargo(&["mtime-on-use"])
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)

--- a/tests/testsuite/generate_lockfile.rs
+++ b/tests/testsuite/generate_lockfile.rs
@@ -113,7 +113,8 @@ fn no_index_update(expected: impl IntoData, expected_unstable_option: impl IntoD
         .with_stderr_data(expected)
         .run();
 
-    p.cargo("generate-lockfile -Zno-index-update")
+    p.cargo("generate-lockfile")
+        .arg("-Zno-index-update")
         .masquerade_as_nightly_cargo(&["no-index-update"])
         .with_stdout_data("")
         .with_stderr_data(expected_unstable_option)
@@ -338,7 +339,8 @@ fn publish_time() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("generate-lockfile --publish-time 2025-03-01T06:00:00Z -Zunstable-options")
+    p.cargo("generate-lockfile --publish-time 2025-03-01T06:00:00Z")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["publish-time"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
@@ -400,7 +402,8 @@ fn publish_time_no_candidates() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("generate-lockfile --publish-time 2025-03-01T06:00:00Z -Zunstable-options")
+    p.cargo("generate-lockfile --publish-time 2025-03-01T06:00:00Z")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["publish-time"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -434,7 +437,8 @@ fn publish_time_invalid() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("generate-lockfile --publish-time 2025-03-01T06:00:00Z -Zunstable-options")
+    p.cargo("generate-lockfile --publish-time 2025-03-01T06:00:00Z")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["publish-time"])
         .with_status(101)
         .with_stderr_data(str![[r#"

--- a/tests/testsuite/global_cache_tracker.rs
+++ b/tests/testsuite/global_cache_tracker.rs
@@ -434,7 +434,8 @@ fn auto_gc_config() {
             new = "1.0"
         "#,
     );
-    p.cargo("check -Zgc")
+    p.cargo("check")
+        .arg("-Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
         .env("__CARGO_TEST_LAST_USE_NOW", days_ago_unix(2))
         .run();
@@ -445,7 +446,8 @@ fn auto_gc_config() {
     );
 
     // Run again after the .crate should have aged out.
-    p.cargo("check -Zgc")
+    p.cargo("check")
+        .arg("-Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
         .run();
     assert_eq!(get_registry_names("src"), ["new-1.0.0"]);
@@ -763,7 +765,8 @@ fn both_git_and_http_index_cleans() {
 
     // Running in the future without these indexes should delete them.
     p.change_file("Cargo.toml", &basic_manifest("foo", "0.2.0"));
-    p.cargo("clean gc -Zgc")
+    p.cargo("clean gc")
+        .arg("-Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
         .run();
     let lock = gctx
@@ -806,7 +809,8 @@ fn clean_gc_dry_run() {
     let expected_files = snapbox::filter::normalize_paths(&expected_files);
     let expected_files = assert_e2e().redactions().redact(&expected_files);
 
-    p.cargo("clean gc --dry-run -v -Zgc")
+    p.cargo("clean gc --dry-run -v")
+        .arg("-Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
         .with_stdout_data(expected_files.as_str().unordered())
         .with_stderr_data(str![[r#"
@@ -817,7 +821,8 @@ fn clean_gc_dry_run() {
         .run();
 
     // Again, make sure the information is still tracked.
-    p.cargo("clean gc --dry-run -v -Zgc")
+    p.cargo("clean gc --dry-run -v")
+        .arg("-Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
         .with_stdout_data(expected_files.as_str().unordered())
         .with_stderr_data(str![[r#"
@@ -836,7 +841,8 @@ fn clean_default_gc() {
     p.cargo("fetch")
         .env("__CARGO_TEST_LAST_USE_NOW", months_ago_unix(4))
         .run();
-    p.cargo("clean gc -v -Zgc")
+    p.cargo("clean gc -v")
+        .arg("-Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
         .with_stderr_data(
             str![[r#"
@@ -1117,7 +1123,8 @@ fn max_size_untracked_src_from_use() {
     drop(lock);
 
     // Fix the size.
-    p.cargo("clean gc -v --max-src-size=10000 -Zgc")
+    p.cargo("clean gc -v --max-src-size=10000")
+        .arg("-Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
         .with_stderr_data(str![[r#"
 [REMOVED] 0 files
@@ -1135,7 +1142,8 @@ fn max_size_untracked_src_from_clean() {
     let (gctx, p) = max_size_untracked_prepare();
 
     // Clean should scan the src and update the db.
-    p.cargo("clean gc -v --max-src-size=10000 -Zgc")
+    p.cargo("clean gc -v --max-src-size=10000")
+        .arg("-Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
         .with_stderr_data(str![[r#"
 [REMOVED] 0 files
@@ -1299,7 +1307,8 @@ fn package_cache_lock_during_build() {
 
     // Cleaning while a command is running should block.
     let mut clean_cmd = p_foo2
-        .cargo("clean gc --max-download-size=0 -Zgc")
+        .cargo("clean gc --max-download-size=0")
+        .arg("-Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
         .build_command();
     clean_cmd.stderr(Stdio::piped());
@@ -1339,7 +1348,8 @@ fn read_only_locking_auto_gc() {
     // Test when it can't update auto-gc db.
     perms.set_readonly(true);
     std::fs::set_permissions(&cargo_home, perms.clone()).unwrap();
-    p.cargo("check -Zgc")
+    p.cargo("check")
+        .arg("-Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
         .with_stderr_data(str![[r#"
 [CHECKING] bar v1.0.0
@@ -1358,7 +1368,8 @@ fn read_only_locking_auto_gc() {
         .rm_rf();
     perms.set_readonly(true);
     std::fs::set_permissions(&cargo_home, perms.clone()).unwrap();
-    p.cargo("check -Zgc")
+    p.cargo("check")
+        .arg("-Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
         .with_stderr_data(str![[r#"
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1443,7 +1454,8 @@ fn clean_syncs_missing_files() {
     }
 
     // Clean should update the db.
-    p.cargo("clean gc -v --max-download-size=1GB -Zgc")
+    p.cargo("clean gc -v --max-download-size=1GB")
+        .arg("-Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
         .with_stderr_data(str![[r#"
 [REMOVED] 0 files
@@ -1508,7 +1520,8 @@ fn can_handle_future_schema() -> anyhow::Result<()> {
     conn.pragma_update(None, "user_version", &(user_version + 1))?;
     drop(conn);
     // Verify it doesn't blow up.
-    p.cargo("clean gc --max-download-size=0 -Zgc")
+    p.cargo("clean gc --max-download-size=0")
+        .arg("-Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
         .with_stderr_data(str![[r#"
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
@@ -1569,8 +1582,9 @@ fn clean_max_git_age() {
     assert_eq!(co_names.len(), 2);
 
     // Delete the first checkout
-    p.cargo("clean gc -v -Zgc")
+    p.cargo("clean gc -v")
         .arg("--max-git-co-age=3 days")
+        .arg("-Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
         .with_stderr_data(str![[r#"
 [REMOVING] [ROOT]/home/.cargo/git/checkouts/git_a-[HASH]/[..]
@@ -1585,8 +1599,9 @@ fn clean_max_git_age() {
     assert_eq!(co_names.len(), 1);
 
     // delete the second checkout
-    p.cargo("clean gc -v -Zgc")
+    p.cargo("clean gc -v")
         .arg("--max-git-co-age=0 days")
+        .arg("-Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
         .with_stderr_data(str![[r#"
 [REMOVING] [ROOT]/home/.cargo/git/checkouts/git_a-[HASH]/[..]
@@ -1601,8 +1616,9 @@ fn clean_max_git_age() {
     assert_eq!(co_names.len(), 0);
 
     // delete the db
-    p.cargo("clean gc -v -Zgc")
+    p.cargo("clean gc -v")
         .arg("--max-git-db-age=1 days")
+        .arg("-Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
         .with_stderr_data(str![[r#"
 [REMOVING] [ROOT]/home/.cargo/git/db/git_a-[HASH]
@@ -1653,8 +1669,9 @@ fn clean_max_src_crate_age() {
     );
 
     // Delete the old src.
-    p.cargo("clean gc -v -Zgc")
+    p.cargo("clean gc -v")
         .arg("--max-src-age=3 days")
+        .arg("-Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
         .with_stderr_data(str![[r#"
 [REMOVING] [ROOT]/home/.cargo/registry/src/-[HASH]/bar-1.0.0
@@ -1664,8 +1681,9 @@ fn clean_max_src_crate_age() {
         .run();
 
     // delete the second src
-    p.cargo("clean gc -v -Zgc")
+    p.cargo("clean gc -v")
         .arg("--max-src-age=0 days")
+        .arg("-Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
         .with_stderr_data(str![[r#"
 [REMOVING] [ROOT]/home/.cargo/registry/src/-[HASH]/bar-1.0.1
@@ -1675,8 +1693,9 @@ fn clean_max_src_crate_age() {
         .run();
 
     // delete the old crate
-    p.cargo("clean gc -v -Zgc")
+    p.cargo("clean gc -v")
         .arg("--max-crate-age=3 days")
+        .arg("-Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
         .with_stderr_data(str![[r#"
 [REMOVING] [ROOT]/home/.cargo/registry/cache/-[HASH]/bar-1.0.0.crate
@@ -1686,8 +1705,9 @@ fn clean_max_src_crate_age() {
         .run();
 
     // delete the seecond crate
-    p.cargo("clean gc -v -Zgc")
+    p.cargo("clean gc -v")
         .arg("--max-crate-age=0 days")
+        .arg("-Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
         .with_stderr_data(str![[r#"
 [REMOVING] [ROOT]/home/.cargo/registry/cache/-[HASH]/bar-1.0.1.crate
@@ -1765,7 +1785,8 @@ fn clean_max_git_size() {
 
     let threshold = db_size + second_co_size;
 
-    p.cargo(&format!("clean gc --max-git-size={threshold} -Zgc -v"))
+    p.cargo(&format!("clean gc --max-git-size={threshold} -v"))
+        .arg("-Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
         .with_stderr_data(&format!(
             "\
@@ -1776,7 +1797,8 @@ fn clean_max_git_size() {
         .run();
 
     // And then try cleaning everything.
-    p.cargo("clean gc --max-git-size=0 -Zgc -v")
+    p.cargo("clean gc --max-git-size=0 -v")
+        .arg("-Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
         .with_stderr_data(
             format!(
@@ -1927,13 +1949,15 @@ fn clean_gc_quiet_is_quiet() {
     p.cargo("fetch")
         .env("__CARGO_TEST_LAST_USE_NOW", months_ago_unix(4))
         .run();
-    p.cargo("clean gc --quiet -Zgc --dry-run")
+    p.cargo("clean gc --quiet --dry-run")
+        .arg("-Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
         .with_stdout_data("")
         .with_stderr_data("")
         .run();
     // Verify exact same command without -q would actually display something.
-    p.cargo("clean gc -Zgc --dry-run")
+    p.cargo("clean gc --dry-run")
+        .arg("-Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
@@ -2116,7 +2140,8 @@ fn resilient_to_unexpected_files() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("fetch -Zgc")
+    p.cargo("fetch")
+        .arg("-Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
         .env("__CARGO_TEST_LAST_USE_NOW", months_ago_unix(4))
         .run();
@@ -2128,7 +2153,8 @@ fn resilient_to_unexpected_files() {
     std::fs::write(root.join("git/db/foo"), "").unwrap();
     std::fs::write(root.join("git/checkouts/foo"), "").unwrap();
 
-    p.cargo("clean gc -Zgc")
+    p.cargo("clean gc")
+        .arg("-Zgc")
         .masquerade_as_nightly_cargo(&["gc"])
         .with_stderr_data(str![[r#"
 [REMOVED] [FILE_NUM] files, [FILE_SIZE]B total

--- a/tests/testsuite/hint_msrv.rs
+++ b/tests/testsuite/hint_msrv.rs
@@ -8,11 +8,15 @@ use cargo_test_support::{basic_manifest, project, str};
 fn hint_msrv_stable() {
     let p = project().file("src/lib.rs", "").build();
 
-    p.cargo("build -Zhint-msrv").with_status(101).with_stderr_data(str![[r#"
+    p.cargo("build")
+        .arg("-Zhint-msrv")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
 [ERROR] the `-Z` flag is only accepted on the nightly channel of Cargo, but this is the `stable` channel
 See https://doc.rust-lang.org/book/appendix-07-nightly-rust.html for more information about Rust release channels.
 
-"#]]).run();
+"#]])
+        .run();
 }
 
 fn msrv_manifest(name: &str, version: &str, msrv: &str) -> String {
@@ -37,7 +41,8 @@ fn hint_msrv() {
         .file("Cargo.toml", &msrv_manifest("foo", "0.0.0", "1.78.0"))
         .build();
 
-    p.cargo("build --verbose -Zhint-msrv")
+    p.cargo("build --verbose")
+        .arg("-Zhint-msrv")
         .masquerade_as_nightly_cargo(&["hint-msrv"])
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
@@ -54,7 +59,8 @@ fn hint_msrv() {
         .file("Cargo.toml", &basic_manifest("foo", "0.0.0"))
         .build();
 
-    p.cargo("build --verbose -Zhint-msrv")
+    p.cargo("build --verbose")
+        .arg("-Zhint-msrv")
         .masquerade_as_nightly_cargo(&["hint-msrv"])
         .with_stderr_does_not_contain("hint-msrv")
         .with_status(0)

--- a/tests/testsuite/hints.rs
+++ b/tests/testsuite/hints.rs
@@ -245,7 +245,8 @@ fn hints_mostly_unused_nightly() {
         )
         .file("src/main.rs", "fn main() {}")
         .build();
-    p.cargo("check -Zprofile-hint-mostly-unused -v")
+    p.cargo("check -v")
+        .arg("-Zprofile-hint-mostly-unused")
         .masquerade_as_nightly_cargo(&["profile-hint-mostly-unused"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
@@ -306,7 +307,8 @@ fn mostly_unused_profile_overrides_hints_nightly() {
         )
         .file("src/main.rs", "fn main() {}")
         .build();
-    p.cargo("check -Zprofile-hint-mostly-unused -v")
+    p.cargo("check -v")
+        .arg("-Zprofile-hint-mostly-unused")
         .masquerade_as_nightly_cargo(&["profile-hint-mostly-unused"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index

--- a/tests/testsuite/lints/blanket_hint_mostly_unused.rs
+++ b/tests/testsuite/lints/blanket_hint_mostly_unused.rs
@@ -19,7 +19,8 @@ hint-mostly-unused = true
         )
         .file("src/main.rs", "fn main() {}")
         .build();
-    p.cargo("check -Zprofile-hint-mostly-unused -v")
+    p.cargo("check -v")
+        .arg("-Zprofile-hint-mostly-unused")
         .masquerade_as_nightly_cargo(&["profile-hint-mostly-unused"])
         .with_stderr_data(str![[r#"
 [WARNING] `hint-mostly-unused` is being blanket applied to all dependencies
@@ -61,7 +62,8 @@ hint-mostly-unused = true
         )
         .file("src/main.rs", "fn main() {}")
         .build();
-    p.cargo("check -Zprofile-hint-mostly-unused -v")
+    p.cargo("check -v")
+        .arg("-Zprofile-hint-mostly-unused")
         .masquerade_as_nightly_cargo(&["profile-hint-mostly-unused"])
         .with_stderr_data(str![[r#"
 [WARNING] `hint-mostly-unused` is being blanket applied to all dependencies
@@ -100,7 +102,8 @@ hint-mostly-unused = true
         )
         .file("src/main.rs", "fn main() {}")
         .build();
-    p.cargo("check -Zprofile-hint-mostly-unused -v")
+    p.cargo("check -v")
+        .arg("-Zprofile-hint-mostly-unused")
         .masquerade_as_nightly_cargo(&["profile-hint-mostly-unused"])
         .with_stderr_data(str![[r#"
 [WARNING] `hint-mostly-unused` is being blanket applied to all dependencies
@@ -148,7 +151,8 @@ authors = []
         .file("foo/src/lib.rs", "")
         .build();
 
-    p.cargo("check -Zprofile-hint-mostly-unused -v")
+    p.cargo("check -v")
+        .arg("-Zprofile-hint-mostly-unused")
         .masquerade_as_nightly_cargo(&["profile-hint-mostly-unused"])
         .with_stderr_data(str![[r#"
 [WARNING] `hint-mostly-unused` is being blanket applied to all dependencies
@@ -191,7 +195,8 @@ blanket_hint_mostly_unused = "deny"
         )
         .file("src/main.rs", "fn main() {}")
         .build();
-    p.cargo("check -Zprofile-hint-mostly-unused -v")
+    p.cargo("check -v")
+        .arg("-Zprofile-hint-mostly-unused")
         .masquerade_as_nightly_cargo(&["profile-hint-mostly-unused"])
         .with_status(101)
         .with_stderr_data(str![[r#"

--- a/tests/testsuite/lints/mod.rs
+++ b/tests/testsuite/lints/mod.rs
@@ -423,7 +423,8 @@ im_a_teapot = { level = "warn", priority = 10 }
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("fetch -Zrustc-unicode")
+    p.cargo("fetch")
+        .arg("-Zrustc-unicode")
         .masquerade_as_nightly_cargo(&["rustc-unicode", "test-dummy-unstable"])
         .with_stderr_data(str![[r#"
 [WARNING] `im_a_teapot` is specified

--- a/tests/testsuite/lints/non_kebab_case_bins.rs
+++ b/tests/testsuite/lints/non_kebab_case_bins.rs
@@ -148,7 +148,8 @@ fn main() {}"#,
         )
         .build();
 
-    p.cargo("fetch -Zscript --manifest-path foo_bar")
+    p.cargo("fetch --manifest-path foo_bar")
+        .arg("-Zscript")
         .masquerade_as_nightly_cargo(&["script"])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)

--- a/tests/testsuite/lints/non_kebab_case_packages.rs
+++ b/tests/testsuite/lints/non_kebab_case_packages.rs
@@ -58,7 +58,8 @@ fn main() {}"#,
         )
         .build();
 
-    p.cargo("fetch -Zscript --manifest-path foo_bar")
+    p.cargo("fetch --manifest-path foo_bar")
+        .arg("-Zscript")
         .masquerade_as_nightly_cargo(&["script"])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)

--- a/tests/testsuite/lints/non_snake_case_packages.rs
+++ b/tests/testsuite/lints/non_snake_case_packages.rs
@@ -58,7 +58,8 @@ fn main() {}"#,
         )
         .build();
 
-    p.cargo("fetch -Zscript --manifest-path foo-bar")
+    p.cargo("fetch --manifest-path foo-bar")
+        .arg("-Zscript")
         .masquerade_as_nightly_cargo(&["script"])
         .with_stderr_data(str![[r#"
 [WARNING] `package.edition` is unspecified, defaulting to the latest edition (currently `[..]`)

--- a/tests/testsuite/message_format.rs
+++ b/tests/testsuite/message_format.rs
@@ -191,7 +191,8 @@ mod tests {
         )
         .build();
 
-    foo.cargo("check -v -Zrustc-unicode")
+    foo.cargo("check -v")
+        .arg("-Zrustc-unicode")
         .masquerade_as_nightly_cargo(&["rustc-unicode"])
         .with_stderr_data(str![[r#"
 [CHECKING] foo v0.0.1 ([ROOT]/foo)

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -758,7 +758,8 @@ fn cargo_metadata_public_private_dependencies_enabled() {
     Package::new("foobar", "0.0.2").publish();
     Package::new("baz", "0.0.3").publish();
 
-    p.cargo("metadata -q --format-version 1 -Zpublic-dependency")
+    p.cargo("metadata -q --format-version 1")
+        .arg("-Zpublic-dependency")
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stdout_data(
             str![[r#"
@@ -1453,7 +1454,8 @@ fn workspace_metadata_with_dependencies_and_resolve() {
         .file("non-artifact/src/lib.rs", "")
         .build();
 
-    p.cargo("metadata -Z bindeps")
+    p.cargo("metadata")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stdout_data(
             str![[r#"
@@ -2117,7 +2119,8 @@ fn cargo_metadata_with_invalid_artifact_deps() {
         .file("artifact/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("metadata -Z bindeps")
+    p.cargo("metadata")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -4349,7 +4352,8 @@ fn workspace_metadata_with_dependencies_no_deps_artifact() {
         .file("artifact/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("metadata --no-deps -Z bindeps")
+    p.cargo("metadata --no-deps")
+        .arg("-Zbindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stdout_data(
             str![[r#"

--- a/tests/testsuite/min_publish_age.rs
+++ b/tests/testsuite/min_publish_age.rs
@@ -1575,17 +1575,16 @@ fn generate_lockfile_with_publish_time_and_min_publish_age() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo(&format!(
-        "generate-lockfile --publish-time {NOW} -Zunstable-options"
-    ))
-    .masquerade_as_nightly_cargo(&["publish-time"])
-    .with_stderr_data(str![[r#"
+    p.cargo(&format!("generate-lockfile --publish-time {NOW}"))
+        .arg("-Zunstable-options")
+        .masquerade_as_nightly_cargo(&["publish-time"])
+        .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
 [LOCKING] 1 package to highest compatible version as of 7 days before 2006-08-08T00:00:00Z
 [ADDING] bar v1.0.0 (available: v1.1.0, published 2 days ago)
 
 "#]])
-    .run();
+        .run();
 
     let lock = p.read_lockfile();
     assert_e2e().eq(

--- a/tests/testsuite/minimal_versions.rs
+++ b/tests/testsuite/minimal_versions.rs
@@ -30,7 +30,8 @@ fn minimal_version_cli() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("generate-lockfile -Zminimal-versions")
+    p.cargo("generate-lockfile")
+        .arg("-Zminimal-versions")
         .masquerade_as_nightly_cargo(&["minimal-versions"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index

--- a/tests/testsuite/open_namespaces.rs
+++ b/tests/testsuite/open_namespaces.rs
@@ -275,7 +275,8 @@ fn main() {}
         )
         .build();
 
-    p.cargo("read-manifest -Zscript --manifest-path foo::bar.rs")
+    p.cargo("read-manifest --manifest-path foo::bar.rs")
+        .arg("-Zscript")
         .masquerade_as_nightly_cargo(&["script", "open-namespaces"])
         .with_stdout_data(
             str![[r#"

--- a/tests/testsuite/package_message_format.rs
+++ b/tests/testsuite/package_message_format.rs
@@ -49,7 +49,8 @@ fn requires_list() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("package --message-format json -Zunstable-options")
+    p.cargo("package --message-format json")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["package --message-format"])
         .with_status(1)
         .with_stderr_data(str![[r#"
@@ -81,7 +82,8 @@ fn human() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("package --list --message-format human -Zunstable-options")
+    p.cargo("package --list --message-format human")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["package --message-format"])
         .with_stderr_data(str![""])
         .with_stdout_data(str![[r#"
@@ -111,7 +113,8 @@ fn single_package() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("package --list --message-format json -Zunstable-options")
+    p.cargo("package --list --message-format json")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["package --message-format"])
         .with_stderr_data(str![""])
         .with_stdout_data(
@@ -146,7 +149,8 @@ fn single_package() {
 
     // has existing lockfile
     p.cargo("generate-lockfile").run();
-    p.cargo("package --list --message-format json -Zunstable-options")
+    p.cargo("package --list --message-format json")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["package --message-format"])
         .with_stderr_data(str![""])
         .with_stdout_data(
@@ -217,7 +221,8 @@ fn workspace() {
         .file("rohan/src/lib.rs", "")
         .build();
 
-    p.cargo("package --list --message-format json -Zunstable-options")
+    p.cargo("package --list --message-format json")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["package --message-format"])
         .with_stderr_data(str![""])
         .with_stdout_data(
@@ -272,7 +277,8 @@ fn workspace() {
 
     // has existing lockfile
     p.cargo("generate-lockfile").run();
-    p.cargo("package --list --message-format json -Zunstable-options")
+    p.cargo("package --list --message-format json")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["package --message-format"])
         .with_stderr_data(str![""])
         .with_stdout_data(

--- a/tests/testsuite/pkgid.rs
+++ b/tests/testsuite/pkgid.rs
@@ -404,8 +404,9 @@ fn pkgid_json_message_metadata_consistency() {
         )
         .run();
 
-    p.cargo("build -Zsbom")
+    p.cargo("build")
         .env("CARGO_BUILD_SBOM", "true")
+        .arg("-Zsbom")
         .masquerade_as_nightly_cargo(&["sbom"])
         .run();
 

--- a/tests/testsuite/precise_pre_release.rs
+++ b/tests/testsuite/precise_pre_release.rs
@@ -63,7 +63,8 @@ fn update_pre_release() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("update my-dependency --precise 0.1.2-pre.0 -Zunstable-options")
+    p.cargo("update my-dependency --precise 0.1.2-pre.0")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["precise-pre-release"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
@@ -98,7 +99,8 @@ fn pre_release_should_unmatched() {
 
     // 0.1.2-pre.0 < 0.1.2 so it doesn't match
     cargo_test_support::registry::Package::new("my-dependency", "0.1.2-pre.0").publish();
-    p.cargo("update -p my-dependency --precise 0.1.2-pre.0 -Zunstable-options")
+    p.cargo("update -p my-dependency --precise 0.1.2-pre.0")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["precise-pre-release"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -116,7 +118,8 @@ required by package `package v0.0.0 ([ROOT]/foo)`
 
     cargo_test_support::registry::Package::new("my-dependency", "0.2.0-0").publish();
     // 0.2.0-0 is the upper bound we exclude, so it doesn't match
-    p.cargo("update -p my-dependency --precise 0.2.0-0 -Zunstable-options")
+    p.cargo("update -p my-dependency --precise 0.2.0-0")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["precise-pre-release"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -160,7 +163,8 @@ fn pre_release_should_matched() {
     // Test upgrade
     // 0.1.3 is in the range, so it match
     cargo_test_support::registry::Package::new("my-dependency", "0.1.3").publish();
-    p.cargo("update -p my-dependency --precise 0.1.3 -Zunstable-options")
+    p.cargo("update -p my-dependency --precise 0.1.3")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["precise-pre-release"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
@@ -175,7 +179,8 @@ fn pre_release_should_matched() {
     // Test downgrade
     // v0.1.3-pre.1 is in the range, so it match
     cargo_test_support::registry::Package::new("my-dependency", "0.1.3-pre.1").publish();
-    p.cargo("update -p my-dependency --precise 0.1.3-pre.1 -Zunstable-options")
+    p.cargo("update -p my-dependency --precise 0.1.3-pre.1")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["precise-pre-release"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -39,7 +39,8 @@ Caused by:
 "#]])
         .run();
 
-    p.cargo("check -v -Zprofile-rustflags")
+    p.cargo("check -v")
+        .arg("-Zprofile-rustflags")
         .masquerade_as_nightly_cargo(&["profile-rustflags"])
         .with_stderr_data(str![[r#"
 [CHECKING] foo v0.0.1 ([ROOT]/foo)

--- a/tests/testsuite/profile_panic_immediate_abort.rs
+++ b/tests/testsuite/profile_panic_immediate_abort.rs
@@ -109,7 +109,8 @@ fn cli_gate_works() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build --verbose -Z panic-immediate-abort")
+    p.cargo("build --verbose")
+        .arg("-Zpanic-immediate-abort")
         .masquerade_as_nightly_cargo(&["panic-immediate-abort"])
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)

--- a/tests/testsuite/profile_settings.rs
+++ b/tests/testsuite/profile_settings.rs
@@ -947,7 +947,8 @@ fn profile_hint_mostly_unused_nightly() {
         )
         .file("src/main.rs", "fn main() {}")
         .build();
-    p.cargo("check -Zprofile-hint-mostly-unused -v")
+    p.cargo("check -v")
+        .arg("-Zprofile-hint-mostly-unused")
         .masquerade_as_nightly_cargo(&["profile-hint-mostly-unused"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -81,7 +81,8 @@ fn release_profile_default_to_object() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build --release --verbose -Ztrim-paths")
+    p.cargo("build --release --verbose")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -113,11 +114,12 @@ fn one_option() {
             .file("src/lib.rs", "")
             .build();
 
-        p.cargo("build -v -Ztrim-paths")
+        p.cargo("build -v")
     };
 
     for option in ["macro", "diagnostics", "object", "all"] {
         build(option)
+            .arg("-Ztrim-paths")
             .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
             .with_stderr_data(&format!(
                 "\
@@ -132,6 +134,7 @@ fn one_option() {
             .run();
     }
     build("none")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stderr_does_not_contain("[..]--remap-path-scope=[..]")
         .with_stderr_does_not_contain("[..]--remap-path-prefix=[..]")
@@ -156,7 +159,8 @@ fn multiple_options() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build --verbose -Ztrim-paths")
+    p.cargo("build --verbose")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -189,7 +193,8 @@ fn profile_merge_works() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build -v -Ztrim-paths --profile custom")
+    p.cargo("build -v --profile custom")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -225,7 +230,8 @@ fn registry_dependency() {
         .file("src/main.rs", "fn main() { bar::f(); }")
         .build();
 
-    p.cargo("run --verbose -Ztrim-paths")
+    p.cargo("run --verbose")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stdout_data(str![[r#"
 /cargo/registry/[..]/bar-0.0.1/src/lib.rs
@@ -330,7 +336,8 @@ fn registry_dependency_with_build_script_codegen() {
         )
         .build();
 
-    p.cargo("run --verbose -Ztrim-paths")
+    p.cargo("run --verbose")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         // Macros should be sanitized
         .with_stdout_data(str![[r#"
@@ -390,7 +397,8 @@ fn git_dependency() {
         .file("src/main.rs", "fn main() { bar::f(); }")
         .build();
 
-    p.cargo("run --verbose -Ztrim-paths")
+    p.cargo("run --verbose")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stdout_data(str![[r#"
 /cargo/git/[..]/src/lib.rs
@@ -472,7 +480,8 @@ fn path_dependency() {
         )
         .build();
 
-    p.cargo("run --verbose -Ztrim-paths")
+    p.cargo("run --verbose")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stdout_data(str![[r#"
 cocktail-bar/src/lib.rs
@@ -550,7 +559,8 @@ fn path_dependency_outside_workspace() {
         .file("src/main.rs", "fn main() { bar::f(); }")
         .build();
 
-    p.cargo("run --verbose -Ztrim-paths")
+    p.cargo("run --verbose")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stdout_data(str![[r#"
 /cargo/deps/bar-0.0.1/src/lib.rs
@@ -640,7 +650,8 @@ fn vendored_dependencies() {
         .file("src/main.rs", "fn main() { bar::f(); baz::f(); }")
         .build();
 
-    p.cargo("vendor --respect-source-config -Ztrim-paths")
+    p.cargo("vendor --respect-source-config")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .run();
     p.change_file(
@@ -661,7 +672,8 @@ fn vendored_dependencies() {
     );
 
     // Vendored deps within the workspace are remapped as local packages
-    p.cargo("run --verbose -Ztrim-paths")
+    p.cargo("run --verbose")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stderr_data(
             str![[r#"
@@ -752,7 +764,8 @@ fn vendored_dependencies_outside_workspace() {
         .file("src/main.rs", "fn main() { bar::f(); baz::f(); }")
         .build();
 
-    p.cargo("vendor --respect-source-config -Ztrim-paths ../shared-vendor")
+    p.cargo("vendor --respect-source-config ../shared-vendor")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .run();
     p.change_file(
@@ -774,7 +787,8 @@ fn vendored_dependencies_outside_workspace() {
     );
 
     // Vendored deps outside the workspace are remapped as path dependencies
-    p.cargo("run --verbose -Ztrim-paths")
+    p.cargo("run --verbose")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stderr_data(
             str![[r#"
@@ -878,7 +892,8 @@ fn local_package_with_build_script_codegen() {
 
     // The build-dir rule is passed last
     // so paths should be remapped to `/cargo/build-dir`
-    p.cargo("run --verbose -Ztrim-paths")
+    p.cargo("run --verbose")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stdout_data(str![[r#"
 /cargo/build-dir/debug/build/foo/[HASH]/out/bindings.rs
@@ -929,7 +944,8 @@ fn diagnostics_works() {
     let registry_src = paths::home().join(".cargo/registry/src");
     let registry_src = registry_src.display();
 
-    p.cargo("build -vv -Ztrim-paths")
+    p.cargo("build -vv")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stderr_line_without(
             &["[..]bar-0.0.1/src/lib.rs:1[..]"],
@@ -1106,9 +1122,10 @@ fn object_works_helper(split_debuginfo: &str, run: impl Fn(&std::path::Path) -> 
     }
     p.cargo("clean").run();
 
-    p.cargo("build --verbose -Ztrim-paths")
+    p.cargo("build --verbose")
         .arg("--config")
         .arg(r#"profile.dev.trim-paths="object""#)
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stderr_data(&format!(
             "\
@@ -1236,7 +1253,8 @@ fn custom_build_env_var_trim_paths() {
             ),
         );
 
-        p.cargo("build -Ztrim-paths")
+        p.cargo("build")
+            .arg("-Ztrim-paths")
             .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
             .run();
     }
@@ -1293,7 +1311,8 @@ fn lldb_works_after_trimmed() {
         )
         .build();
 
-    p.cargo("build --verbose -Ztrim-paths")
+    p.cargo("build --verbose")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -1357,7 +1376,8 @@ fn gdb_works_after_trimmed() {
         )
         .build();
 
-    p.cargo("build --verbose -Ztrim-paths")
+    p.cargo("build --verbose")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.0 ([ROOT]/foo)
@@ -1437,7 +1457,8 @@ fn cdb_works_after_trimmed() {
         )
         .build();
 
-    p.cargo("build --verbose -Ztrim-paths")
+    p.cargo("build --verbose")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
@@ -1493,7 +1514,8 @@ fn rustdoc_without_diagnostics_scope() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("doc -vv -Ztrim-paths")
+    p.cargo("doc -vv")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stderr_data(str![[r#"
 ...
@@ -1535,7 +1557,8 @@ fn rustdoc_diagnostics_works() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("doc -vv -Ztrim-paths")
+    p.cargo("doc -vv")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stderr_data(str![[r#"
 ...
@@ -1585,7 +1608,9 @@ fn workspace_remap_with_root_dir() {
         .file("bar/src/lib.rs", "pub fn f() {}")
         .build();
 
-    p.cargo("build --verbose -Ztrim-paths -Zroot-dir=..")
+    p.cargo("build --verbose")
+        .arg("-Ztrim-paths")
+        .arg("-Zroot-dir=..")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths", "-Zroot-dir"])
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
@@ -1652,8 +1677,9 @@ fn workspace_prefix_override_from_env() {
         .file("member/src/lib.rs", "")
         .build();
 
-    p.cargo("build --verbose -Ztrim-paths")
+    p.cargo("build --verbose")
         .env("__CARGO_RUSTC_BOOTSTRAP_WS_REMAP", "/rustc-dev/1111111")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
@@ -1715,13 +1741,15 @@ fn workspace_prefix_override_fingerprint() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build -Ztrim-paths")
+    p.cargo("build")
         .env("__CARGO_RUSTC_BOOTSTRAP_WS_REMAP", "/rustc-dev/1111111")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .run();
 
-    p.cargo("build --verbose -Ztrim-paths")
+    p.cargo("build --verbose")
         .env("__CARGO_RUSTC_BOOTSTRAP_WS_REMAP", "/rustc-dev/2222222")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.0.1 ([ROOT]/foo): the profile configuration changed
@@ -1751,7 +1779,8 @@ fn unremap_file_rebuild() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build -Ztrim-paths")
+    p.cargo("build")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .run();
     assert!(p.bin("foo").is_file());
@@ -1760,7 +1789,8 @@ fn unremap_file_rebuild() {
 
     // Deleting the uplifted copy won't cause rebuild.
     std::fs::remove_file(&unremap_file).unwrap();
-    p.cargo("build --verbose -Ztrim-paths")
+    p.cargo("build --verbose")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stderr_data(str![[r#"
 [FRESH] foo v0.0.1 ([ROOT]/foo)
@@ -1779,7 +1809,8 @@ fn unremap_file_rebuild() {
         .find(|f| *f != unremap_file)
         .unwrap();
     std::fs::remove_file(&deps_file).unwrap();
-    p.cargo("build --verbose -Ztrim-paths")
+    p.cargo("build --verbose")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stderr_data(str![[r#"
 [DIRTY] foo v0.0.1 ([ROOT]/foo): couldn't read metadata for file `target/debug/[..]/foo[..].trim-paths.jsonl`
@@ -1812,7 +1843,8 @@ fn unremap_file_without_debuginfo() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build -Ztrim-paths")
+    p.cargo("build")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .run();
 
@@ -1839,14 +1871,16 @@ fn unremap_file_with_cargo_clean() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build -Ztrim-paths")
+    p.cargo("build")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .run();
 
     assert!(unremap_file_path(&p.bin("foo")).exists());
     assert_eq!(p.glob("target/**/*.trim-paths.jsonl").count(), 2);
 
-    p.cargo("clean -p foo -Ztrim-paths")
+    p.cargo("clean -p foo")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .run();
 
@@ -1879,7 +1913,8 @@ fn unremap_file_in_json_messages() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build -Ztrim-paths --message-format=json")
+    p.cargo("build --message-format=json")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stdout_data(
             str![[r#"
@@ -1928,7 +1963,9 @@ fn unremap_file_with_artifact_dir() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build -Ztrim-paths -Zunstable-options --artifact-dir out")
+    p.cargo("build --artifact-dir out")
+        .arg("-Ztrim-paths")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths", "unstable-options"])
         .run();
 
@@ -1960,7 +1997,8 @@ fn unremap_file_for_all_bin_types() {
         .file("examples/ex.rs", "fn main() {}")
         .build();
 
-    p.cargo("test --no-run -Ztrim-paths")
+    p.cargo("test --no-run")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .run();
 
@@ -1995,7 +2033,8 @@ fn unremap_file_with_multiple_crate_types() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build -Ztrim-paths")
+    p.cargo("build")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .run();
 
@@ -2242,7 +2281,8 @@ fn unremap_debugger_project() -> cargo_test_support::Project {
         )
         .build();
 
-    p.cargo("build -Ztrim-paths")
+    p.cargo("build")
+        .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .run();
 

--- a/tests/testsuite/pub_priv.rs
+++ b/tests/testsuite/pub_priv.rs
@@ -627,7 +627,8 @@ fn verify_mix_cargo_feature_z() {
         )
         .build();
 
-    p.cargo("check -Zpublic-dependency --message-format=short")
+    p.cargo("check --message-format=short")
+        .arg("-Zpublic-dependency")
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(str![[r#"
 ...
@@ -677,7 +678,8 @@ fn verify_z_public_dependency() {
         )
         .build();
 
-    p.cargo("check -Zpublic-dependency --message-format=short")
+    p.cargo("check --message-format=short")
+        .arg("-Zpublic-dependency")
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(
             str![[r#"
@@ -719,7 +721,8 @@ fn z_public_dependency_invalidates_fingerprint() {
         )
         .build();
 
-    p.cargo("check -Zpublic-dependency --message-format=short")
+    p.cargo("check --message-format=short")
+        .arg("-Zpublic-dependency")
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(str![[r#"
 ...
@@ -744,7 +747,8 @@ src/lib.rs:3:13: [WARNING] type `FromDep` from private dependency 'dep' in publi
 "#]])
         .run();
 
-    p.cargo("check -Zpublic-dependency --message-format=short")
+    p.cargo("check --message-format=short")
+        .arg("-Zpublic-dependency")
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(str![[r#"
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -789,7 +793,8 @@ fn manifest_location() {
         )
         .build();
 
-    p.cargo("check -Zpublic-dependency")
+    p.cargo("check")
+        .arg("-Zpublic-dependency")
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(
             str![[r#"
@@ -857,7 +862,8 @@ fn renamed_dependency() {
         )
         .build();
 
-    p.cargo("check -Zpublic-dependency")
+    p.cargo("check")
+        .arg("-Zpublic-dependency")
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(
             str![[r#"
@@ -928,7 +934,8 @@ fn duplicate_renamed_dependency() {
         )
         .build();
 
-    p.cargo("check -Zpublic-dependency")
+    p.cargo("check")
+        .arg("-Zpublic-dependency")
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(
             str![[r#"
@@ -1002,7 +1009,8 @@ fn dependency_location_in_target_table() {
         )
         .build();
 
-    p.cargo("check -Zpublic-dependency")
+    p.cargo("check")
+        .arg("-Zpublic-dependency")
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(
             str![[r#"
@@ -1036,7 +1044,8 @@ fn dependency_location_in_target_table() {
         )
         .run();
 
-    p.cargo(&format!("check -Zpublic-dependency --target={alt}"))
+    p.cargo(&format!("check --target={alt}"))
+        .arg("-Zpublic-dependency")
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(
             str![[r#"
@@ -1120,7 +1129,8 @@ fn dependency_location_in_target_table_with_cfg() {
         )
         .build();
 
-    p.cargo("check -Zpublic-dependency")
+    p.cargo("check")
+        .arg("-Zpublic-dependency")
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(
             str![[r#"
@@ -1154,7 +1164,8 @@ fn dependency_location_in_target_table_with_cfg() {
         )
         .run();
 
-    p.cargo(&format!("check -Zpublic-dependency --target={alt}"))
+    p.cargo(&format!("check --target={alt}"))
+        .arg("-Zpublic-dependency")
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(
             str![[r#"
@@ -1225,7 +1236,8 @@ fn dependency_location_in_workspace() {
         )
     });
     git::commit(&repo);
-    p.cargo(&format!("check -Zpublic-dependency"))
+    p.cargo("check")
+        .arg("-Zpublic-dependency")
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(str![[r#"
 ...
@@ -1274,8 +1286,9 @@ fn relative_display_path() {
         ",
         )
         .build();
-    p.cargo("check -Zpublic-dependency")
+    p.cargo("check")
         .cwd("foo")
+        .arg("-Zpublic-dependency")
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_data(str![[r#"
 ...

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -298,7 +298,8 @@ fn simple_publish_with_asymmetric() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("publish --no-verify -Zasymmetric-token --registry dummy-registry")
+    p.cargo("publish --no-verify --registry dummy-registry")
+        .arg("-Zasymmetric-token")
         .masquerade_as_nightly_cargo(&["asymmetric-token"])
         .with_stderr_data(str![[r#"
 [UPDATING] `dummy-registry` index
@@ -3409,8 +3410,9 @@ fn skip_wait_for_publish() {
         )
         .build();
 
-    p.cargo("publish --no-verify -Zpublish-timeout")
+    p.cargo("publish --no-verify")
         .replace_crates_io(registry.index_url())
+        .arg("-Zpublish-timeout")
         .masquerade_as_nightly_cargo(&["publish-timeout"])
         .with_stderr_data(str![[r#"
 [UPDATING] crates.io index
@@ -3457,8 +3459,9 @@ fn timeout_waiting_for_publish() {
         )
         .build();
 
-    p.cargo("publish --no-verify -Zpublish-timeout")
+    p.cargo("publish --no-verify")
         .replace_crates_io(registry.index_url())
+        .arg("-Zpublish-timeout")
         .masquerade_as_nightly_cargo(&["publish-timeout"])
         .with_status(0)
         .with_stderr_data(str![[r#"
@@ -3656,8 +3659,9 @@ fn timeout_waiting_for_dependency_publish() {
         )
         .build();
 
-    p.cargo("publish --no-verify -Zpublish-timeout")
+    p.cargo("publish --no-verify")
         .replace_crates_io(registry.index_url())
+        .arg("-Zpublish-timeout")
         .masquerade_as_nightly_cargo(&["publish-timeout"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -4847,7 +4851,8 @@ fn workspace_circular_publish_dependency() {
         .build();
 
     // Ensure the circular dependency is caught and reported clearly.
-    p.cargo("publish --workspace --no-verify -Zpublish-timeout --config publish.timeout=1")
+    p.cargo("publish --workspace --no-verify --config publish.timeout=1")
+        .arg("-Zpublish-timeout")
         .masquerade_as_nightly_cargo(&["publish-timeout"])
         .replace_crates_io(registry.index_url())
         .with_status(101)
@@ -4938,7 +4943,8 @@ fn workspace_circular_publish_dependency_with_non_cycle_package() {
         .file("c/src/lib.rs", "")
         .build();
 
-    p.cargo("publish --workspace --no-verify -Zpublish-timeout --config publish.timeout=1")
+    p.cargo("publish --workspace --no-verify --config publish.timeout=1")
+        .arg("-Zpublish-timeout")
         .masquerade_as_nightly_cargo(&["publish-timeout"])
         .replace_crates_io(registry.index_url())
         .with_status(101)

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -703,7 +703,8 @@ fn rustc_with_print_cfg_single_target() {
         .file("src/main.rs", r#"fn main() {} "#)
         .build();
 
-    p.cargo("rustc -Z unstable-options --target x86_64-pc-windows-msvc --print cfg")
+    p.cargo("rustc --target x86_64-pc-windows-msvc --print cfg")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["print"])
         .with_stdout_data(
             str![[r#"
@@ -730,9 +731,11 @@ fn rustc_with_print_cfg_multiple_targets() {
         .file("src/main.rs", r#"fn main() {} "#)
         .build();
 
-    p.cargo("rustc -Z unstable-options --target x86_64-pc-windows-msvc --target i686-unknown-linux-gnu --print cfg")
+    p.cargo("rustc --target x86_64-pc-windows-msvc --target i686-unknown-linux-gnu --print cfg")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["print"])
-        .with_stdout_data(str![[r#"
+        .with_stdout_data(
+            str![[r#"
 debug_assertions
 target_arch="x86"
 target_endian="little"
@@ -752,7 +755,9 @@ target_pointer_width="64"
 target_vendor="pc"
 windows
 ...
-"#]].unordered())
+"#]]
+            .unordered(),
+        )
         .run();
 }
 
@@ -763,7 +768,8 @@ fn rustc_with_print_cfg_rustflags_env_var() {
         .file("src/main.rs", r#"fn main() {} "#)
         .build();
 
-    p.cargo("rustc -Z unstable-options --target x86_64-pc-windows-msvc --print cfg")
+    p.cargo("rustc --target x86_64-pc-windows-msvc --print cfg")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["print"])
         .env("RUSTFLAGS", "-C target-feature=+crt-static")
         .with_stdout_data(
@@ -799,7 +805,8 @@ rustflags = ["-C", "target-feature=+crt-static"]
         .file("src/main.rs", r#"fn main() {} "#)
         .build();
 
-    p.cargo("rustc -Z unstable-options --target x86_64-pc-windows-msvc --print cfg")
+    p.cargo("rustc --target x86_64-pc-windows-msvc --print cfg")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["print"])
         .env("RUSTFLAGS", "-C target-feature=+crt-static")
         .with_stdout_data(
@@ -838,7 +845,8 @@ RUST_TARGET_PATH = { value = "./targets", relative = true }
         .file("src/main.rs", r#"fn main() {} "#)
         .build();
 
-    p.cargo("rustc -Z unstable-options --print cfg")
+    p.cargo("rustc --print cfg")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["print"])
         .with_stdout_data(str!["..."].unordered())
         .env("RUSTFLAGS", "-Z unstable-options")

--- a/tests/testsuite/rustdoc.rs
+++ b/tests/testsuite/rustdoc.rs
@@ -42,7 +42,8 @@ See https://github.com/rust-lang/cargo/issues/12103 for more information about t
 fn rustdoc_simple_json() {
     let p = project().file("src/lib.rs", "").build();
 
-    p.cargo("rustdoc -Z unstable-options --output-format json -v")
+    p.cargo("rustdoc --output-format json -v")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["rustdoc-output-format"])
         .with_stderr_data(str![[r#"
 [DOCUMENTING] foo v0.0.1 ([ROOT]/foo)
@@ -59,7 +60,8 @@ fn rustdoc_simple_json() {
 fn rustdoc_invalid_output_format() {
     let p = project().file("src/lib.rs", "").build();
 
-    p.cargo("rustdoc -Z unstable-options --output-format pdf -v")
+    p.cargo("rustdoc --output-format pdf -v")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["rustdoc-output-format"])
         .with_status(1)
         .with_stderr_data(str![[r#"
@@ -76,7 +78,8 @@ For more information, try '--help'.
 fn rustdoc_json_stable() {
     let p = project().file("src/lib.rs", "").build();
 
-    p.cargo("rustdoc -Z unstable-options --output-format json -v")
+    p.cargo("rustdoc --output-format json -v")
+        .arg("-Zunstable-options")
         .with_status(101)
         .with_stderr_data(
             str![[r#"
@@ -373,7 +376,8 @@ fn rustdoc_json_same_crate_different_version() {
         .build();
 
     entry
-        .cargo("rustdoc -v -Z unstable-options --output-format json -p dep@1.0.0")
+        .cargo("rustdoc -v --output-format json -p dep@1.0.0")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["rustdoc-output-format"])
         .with_stderr_data(str![[r#"
 [LOCKING] 2 packages to highest compatible versions
@@ -390,7 +394,8 @@ fn rustdoc_json_same_crate_different_version() {
     assert!(!dep_json.contains("dep_v2_fn"));
 
     entry
-        .cargo("rustdoc -v -Z unstable-options --output-format json -p dep@2.0.0")
+        .cargo("rustdoc -v --output-format json -p dep@2.0.0")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["rustdoc-output-format"])
         .with_stderr_data(str![[r#"
 [DOCUMENTING] dep v2.0.0 ([ROOT]/dep_v2)
@@ -406,7 +411,8 @@ fn rustdoc_json_same_crate_different_version() {
     assert!(dep_json.contains("dep_v2_fn"));
 
     entry
-        .cargo("rustdoc -v -Z unstable-options --output-format json -p dep@1.0.0")
+        .cargo("rustdoc -v --output-format json -p dep@1.0.0")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["rustdoc-output-format"])
         .with_stderr_data(str![[r#"
 [FRESH] dep v1.0.0 ([ROOT]/dep_v1)

--- a/tests/testsuite/rustdoc_extern_html.rs
+++ b/tests/testsuite/rustdoc_extern_html.rs
@@ -46,7 +46,8 @@ fn ignores_on_stable() {
 fn simple() {
     // Basic test that it works with crates.io.
     let p = basic_project();
-    p.cargo("doc -v --no-deps -Zrustdoc-map")
+    p.cargo("doc -v --no-deps")
+        .arg("-Zrustdoc-map")
         .masquerade_as_nightly_cargo(&["rustdoc-map"])
         .with_stderr_data(str![[r#"
 ...
@@ -87,7 +88,8 @@ fn std_docs() {
             std = "local"
         "#,
     );
-    p.cargo("doc -v --no-deps -Zrustdoc-map")
+    p.cargo("doc -v --no-deps")
+        .arg("-Zrustdoc-map")
         .masquerade_as_nightly_cargo(&["rustdoc-map"])
         .with_stderr_contains("[RUNNING] `rustdoc [..]--crate-name foo [..]std=file://[..]")
         .run();
@@ -101,7 +103,8 @@ fn std_docs() {
             std = "https://example.com/rust/"
         "#,
     );
-    p.cargo("doc -v --no-deps -Zrustdoc-map")
+    p.cargo("doc -v --no-deps")
+        .arg("-Zrustdoc-map")
         .masquerade_as_nightly_cargo(&["rustdoc-map"])
         .with_stderr_contains(
             "[RUNNING] `rustdoc [..]--crate-name foo [..]std=https://example.com/rust/[..]",
@@ -140,7 +143,8 @@ fn renamed_dep() {
             "#,
         )
         .build();
-    p.cargo("doc -v --no-deps -Zrustdoc-map")
+    p.cargo("doc -v --no-deps")
+        .arg("-Zrustdoc-map")
         .masquerade_as_nightly_cargo(&["rustdoc-map"])
         .with_stderr_data(str![[r#"
 ...
@@ -193,7 +197,8 @@ fn lib_name() {
             "#,
         )
         .build();
-    p.cargo("doc -v --no-deps -Zrustdoc-map")
+    p.cargo("doc -v --no-deps")
+        .arg("-Zrustdoc-map")
         .masquerade_as_nightly_cargo(&["rustdoc-map"])
         .with_stderr_data(str![[r#"
 ...
@@ -264,7 +269,8 @@ fn alt_registry() {
             "#,
         )
         .build();
-    p.cargo("doc -v --no-deps -Zrustdoc-map")
+    p.cargo("doc -v --no-deps")
+        .arg("-Zrustdoc-map")
         .masquerade_as_nightly_cargo(&["rustdoc-map"])
         .with_stderr_data(str![[r#"
 ...
@@ -317,7 +323,8 @@ fn multiple_versions() {
             ",
         )
         .build();
-    p.cargo("doc -v --no-deps -Zrustdoc-map")
+    p.cargo("doc -v --no-deps")
+        .arg("-Zrustdoc-map")
         .masquerade_as_nightly_cargo(&["rustdoc-map"])
         .with_stderr_data(str![[r#"
 ...
@@ -339,7 +346,8 @@ fn multiple_versions() {
 fn rebuilds_when_changing() {
     // Make sure it rebuilds if the map changes.
     let p = basic_project();
-    p.cargo("doc -v --no-deps -Zrustdoc-map")
+    p.cargo("doc -v --no-deps")
+        .arg("-Zrustdoc-map")
         .masquerade_as_nightly_cargo(&["rustdoc-map"])
         .with_stderr_data(str![[r#"
 ...
@@ -358,7 +366,8 @@ fn rebuilds_when_changing() {
             crates-io = "https://example.com/"
         "#,
     );
-    p.cargo("doc -v --no-deps -Zrustdoc-map")
+    p.cargo("doc -v --no-deps")
+        .arg("-Zrustdoc-map")
         .masquerade_as_nightly_cargo(&["rustdoc-map"])
         .with_stderr_data(str![[r#"
 ...
@@ -431,7 +440,8 @@ fn alt_sparse_registry() {
             "#,
         )
         .build();
-    p.cargo("doc -v --no-deps -Zrustdoc-map")
+    p.cargo("doc -v --no-deps")
+        .arg("-Zrustdoc-map")
         .masquerade_as_nightly_cargo(&["rustdoc-map"])
         .with_stderr_data(str![[r#"
 ...
@@ -484,7 +494,8 @@ fn same_deps_multi_occurrence_in_dep_tree() {
             "#,
         )
         .build();
-    p.cargo("doc -v --no-deps -Zrustdoc-map")
+    p.cargo("doc -v --no-deps")
+        .arg("-Zrustdoc-map")
         .masquerade_as_nightly_cargo(&["rustdoc-map"])
         .with_stderr_does_not_contain(
             "[..]--extern-html-root-url[..]bar=https://docs.rs\

--- a/tests/testsuite/sbom.rs
+++ b/tests/testsuite/sbom.rs
@@ -54,8 +54,9 @@ fn simple() {
         .file("src/main.rs", r#"fn main() {}"#)
         .build();
 
-    p.cargo("build -Zsbom")
+    p.cargo("build")
         .env("CARGO_BUILD_SBOM", "true")
+        .arg("-Zsbom")
         .masquerade_as_nightly_cargo(&["sbom"])
         .run();
 
@@ -106,8 +107,9 @@ fn enabling_sbom_invalidates_fingerprint() {
     let file = append_sbom_suffix(&p.bin("foo"));
     assert!(!file.exists());
 
-    p.cargo("build -Zsbom")
+    p.cargo("build")
         .env("CARGO_BUILD_SBOM", "true")
+        .arg("-Zsbom")
         .masquerade_as_nightly_cargo(&["sbom"])
         .with_stderr_data(cargo_test_support::str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)
@@ -118,8 +120,9 @@ fn enabling_sbom_invalidates_fingerprint() {
 
     assert!(file.is_file());
 
-    p.cargo("build -Zsbom")
+    p.cargo("build")
         .env("CARGO_BUILD_SBOM", "true")
+        .arg("-Zsbom")
         .masquerade_as_nightly_cargo(&["sbom"])
         .with_stderr_data(cargo_test_support::str![[r#"
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -146,8 +149,9 @@ fn with_multiple_crate_types() {
         .file("src/lib.rs", r#"pub fn give_five() -> i32 { 5 }"#)
         .build();
 
-    p.cargo("build -Zsbom")
+    p.cargo("build")
         .env("CARGO_BUILD_SBOM", "true")
+        .arg("-Zsbom")
         .masquerade_as_nightly_cargo(&["sbom"])
         .run();
 
@@ -208,8 +212,9 @@ fn with_simple_build_script() {
         )
         .build();
 
-    p.cargo("build -Zsbom")
+    p.cargo("build")
         .env("CARGO_BUILD_SBOM", "true")
+        .arg("-Zsbom")
         .masquerade_as_nightly_cargo(&["sbom"])
         .run();
 
@@ -296,8 +301,9 @@ fn with_build_dependencies() {
         .file("src/main.rs", "fn main() { let _i = bar::bar(); }")
         .build();
 
-    p.cargo("build -Zsbom")
+    p.cargo("build")
         .env("CARGO_BUILD_SBOM", "true")
+        .arg("-Zsbom")
         .masquerade_as_nightly_cargo(&["sbom"])
         .run();
 
@@ -421,8 +427,9 @@ fn crate_uses_different_features_for_build_and_normal_dependencies() {
         )
         .build();
 
-    p.cargo("build -Zsbom")
+    p.cargo("build")
         .env("CARGO_BUILD_SBOM", "true")
+        .arg("-Zsbom")
         .masquerade_as_nightly_cargo(&["sbom"])
         .run();
 
@@ -528,8 +535,10 @@ fn artifact_dep() {
                     assert!(&bar.is_file());
                 }"#)
         .build();
-    p.cargo("build -Z bindeps -Z sbom")
+    p.cargo("build")
         .env("CARGO_BUILD_SBOM", "true")
+        .arg("-Zbindeps")
+        .arg("-Zsbom")
         .masquerade_as_nightly_cargo(&["bindeps", "sbom"])
         .run();
 
@@ -643,8 +652,9 @@ fn proc_macro() {
         )
         .build();
 
-    p.cargo("build -Z sbom")
+    p.cargo("build")
         .env("CARGO_BUILD_SBOM", "true")
+        .arg("-Zsbom")
         .masquerade_as_nightly_cargo(&["sbom"])
         .run();
 
@@ -715,9 +725,10 @@ fn workspace_wrapper() {
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/main.rs", r#"fn main() {}"#)
         .build();
-    p.cargo("build -Zsbom")
+    p.cargo("build")
         .env("CARGO_BUILD_SBOM", "true")
         .env("RUSTC_WRAPPER", wrapper.bin("wrapper"))
+        .arg("-Zsbom")
         .masquerade_as_nightly_cargo(&["sbom"])
         .with_stderr_data(cargo_test_support::str![[r#"
 [COMPILING] foo v0.5.0 ([ROOT]/foo)

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -2630,7 +2630,8 @@ fn doctest_dep_new_layout() {
         .file("b/src/lib.rs", "pub fn bar() {}")
         .build();
 
-    p.cargo("-Zbuild-dir-new-layout test")
+    p.cargo("test")
+        .arg("-Zbuild-dir-new-layout")
         .masquerade_as_nightly_cargo(&["new build-dir layout"])
         .run();
 }
@@ -5054,7 +5055,7 @@ fn panic_abort_tests() {
     // two copies of `foo` in parallel, and which one is first is random. If
     // `--test` is first, then the first line with `[..]` will match, and the
     // second line with `--test` will fail.
-    p.cargo("test -Z panic-abort-tests -v -j1")
+    p.cargo("test -v -j1")
         .with_stderr_data(
             str![[r#"
 [RUNNING] `[..]--crate-name a [..]-C panic=abort[..]`
@@ -5064,6 +5065,7 @@ fn panic_abort_tests() {
 "#]]
             .unordered(),
         )
+        .arg("-Zpanic-abort-tests")
         .masquerade_as_nightly_cargo(&["panic-abort-tests"])
         .run();
 }
@@ -5093,7 +5095,7 @@ fn panic_abort_doc_tests() {
         )
         .build();
 
-    p.cargo("test --doc -Z panic-abort-tests -v")
+    p.cargo("test --doc -v")
         .with_stderr_data(
             str![[r#"
 [RUNNING] `[..]rustc[..] --crate-name foo [..]-C panic=abort[..]`
@@ -5102,6 +5104,7 @@ fn panic_abort_doc_tests() {
 "#]]
             .unordered(),
         )
+        .arg("-Zpanic-abort-tests")
         .masquerade_as_nightly_cargo(&["panic-abort-tests"])
         .run();
 }
@@ -5137,11 +5140,12 @@ fn panic_abort_only_test() {
         .file("a/src/lib.rs", "pub fn foo() {}")
         .build();
 
-    p.cargo("test -Z panic-abort-tests -v")
+    p.cargo("test -v")
         .with_stderr_data(str![[r#"
 [WARNING] Cargo.toml: `panic` setting is ignored for `test` profile
 ...
 "#]])
+        .arg("-Zpanic-abort-tests")
         .masquerade_as_nightly_cargo(&["panic-abort-tests"])
         .run();
 }
@@ -5177,7 +5181,8 @@ fn panic_abort_test_profile_inherits() {
         .file("a/src/lib.rs", "pub fn foo() {}")
         .build();
 
-    p.cargo("test -Z panic-abort-tests -v")
+    p.cargo("test -v")
+        .arg("-Zpanic-abort-tests")
         .masquerade_as_nightly_cargo(&["panic-abort-tests"])
         .with_status(0)
         .run();

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -427,7 +427,8 @@ fn custom_runner_target_applies_to_host() {
         )
         .build();
 
-    p.cargo("run -Z target-applies-to-host")
+    p.cargo("run")
+        .arg("-Ztarget-applies-to-host")
         .masquerade_as_nightly_cargo(&["target-applies-to-host"])
         .env("CARGO_TARGET_APPLIES_TO_HOST", "false")
         .with_status(101)
@@ -581,8 +582,10 @@ fn custom_runner_proc_macro_test_with_host_config() {
         ),
     );
 
-    p.cargo("test --lib -v -Ztarget-applies-to-host -Zhost-config --target")
+    p.cargo("test --lib -v --target")
         .arg(&target)
+        .arg("-Ztarget-applies-to-host")
+        .arg("-Zhost-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -614,8 +617,10 @@ fn custom_runner_cfg_proc_macro_test_with_host_config() {
         "#,
     );
 
-    p.cargo("test --lib -v -Ztarget-applies-to-host -Zhost-config --target")
+    p.cargo("test --lib -v --target")
         .arg(&target)
+        .arg("-Ztarget-applies-to-host")
+        .arg("-Zhost-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -646,7 +651,9 @@ fn custom_runner_cfg_proc_macro_test_with_host_config_no_target() {
         "#,
     );
 
-    p.cargo("test --lib -v -Ztarget-applies-to-host -Zhost-config")
+    p.cargo("test --lib -v")
+        .arg("-Ztarget-applies-to-host")
+        .arg("-Zhost-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -676,8 +683,10 @@ fn host_runner_proc_macro_test() {
         "#,
     );
 
-    p.cargo("test --lib -v -Ztarget-applies-to-host -Zhost-config --target")
+    p.cargo("test --lib -v --target")
         .arg(&target)
+        .arg("-Ztarget-applies-to-host")
+        .arg("-Zhost-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_stderr_data(str![[r#"
 ...
@@ -691,7 +700,9 @@ running 1 test
 "#]])
         .run();
 
-    p.cargo("test --lib -v -Ztarget-applies-to-host -Zhost-config")
+    p.cargo("test --lib -v")
+        .arg("-Ztarget-applies-to-host")
+        .arg("-Zhost-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_stderr_data(str![[r#"
 ...
@@ -766,8 +777,10 @@ fn custom_runner_proc_macro_test_with_cross_target_host_config() {
         ),
     );
 
-    p.cargo("test --lib -v -Ztarget-applies-to-host -Zhost-config --target")
+    p.cargo("test --lib -v --target")
         .arg(alternate)
+        .arg("-Ztarget-applies-to-host")
+        .arg("-Zhost-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_stderr_data(str![[r#"
 ...
@@ -822,8 +835,10 @@ fn host_linker_proc_macro() {
         ),
     );
 
-    p.cargo("build -v -Ztarget-applies-to-host -Zhost-config --target")
+    p.cargo("build -v --target")
         .arg(&target)
+        .arg("-Ztarget-applies-to-host")
+        .arg("-Zhost-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -948,8 +963,10 @@ fn host_linker_proc_macro_test() {
         ),
     );
 
-    p.cargo("test --lib -v -Ztarget-applies-to-host -Zhost-config --target")
+    p.cargo("test --lib -v --target")
         .arg(&target)
+        .arg("-Ztarget-applies-to-host")
+        .arg("-Zhost-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -975,8 +992,10 @@ fn target_cfg_linker_proc_macro_test_with_host_config() {
         "#,
     );
 
-    p.cargo("test --lib -v -Ztarget-applies-to-host -Zhost-config --target")
+    p.cargo("test --lib -v --target")
         .arg(&target)
+        .arg("-Ztarget-applies-to-host")
+        .arg("-Zhost-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_status(101)
         .with_stderr_data(str![[r#"
@@ -1040,8 +1059,10 @@ fn target_linker_proc_macro_test_with_cross_target_host_config() {
         ),
     );
 
-    p.cargo("test --lib -v -Ztarget-applies-to-host -Zhost-config --target")
+    p.cargo("test --lib -v --target")
         .arg(alternate)
+        .arg("-Ztarget-applies-to-host")
+        .arg("-Zhost-config")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .with_status(101)
         .with_stderr_data(str![[r#"

--- a/tests/testsuite/unit_graph.rs
+++ b/tests/testsuite/unit_graph.rs
@@ -46,7 +46,8 @@ fn simple() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build --features a/feata --unit-graph -Zunstable-options")
+    p.cargo("build --features a/feata --unit-graph")
+        .arg("-Zunstable-options")
         .masquerade_as_nightly_cargo(&["unit-graph"])
         .with_stdout_data(
             str![[r#"


### PR DESCRIPTION
### What does this PR try to resolve?

I tried this out with a previous change and I found it makes it easier toe remove and review -Z flags

### How to test and review this PR?

Things left alone
- `-Zscript` when it needs to come before the script name
- `cargo_features.rs`

