### PR TITLE
fix(trim-paths)!: remove default scope from release profile

### DIFF
--- a/doc/book/src/reference/unstable.md
+++ b/doc/book/src/reference/unstable.md
@@ -1528,8 +1528,8 @@ It takes the following values:
 
 It also takes an array with the combinations of `"macro"`, `"diagnostics"`, and `"object"`.
 
-It is defaulted to `none` for the `dev` profile, and `object` for the `release` profile.
-You can manually override it by specifying this option in `Cargo.toml`:
+By default, `trim-paths` is not set and path sanitization is disabled for all profiles.
+You can enable it by specifying this option in `Cargo.toml`:
 
 ```toml
 [profile.dev]
@@ -1539,7 +1539,7 @@ trim-paths = "all"
 trim-paths = ["object", "diagnostics"]
 ```
 
-The default `release` profile setting (`object`) sanitizes only the paths in emitted executable or library files.
+The `object` setting sanitizes only the paths in emitted executable or library files.
 It always affects paths from macros such as panic messages, and in debug information only if they will be embedded together with the binary
 (the default on platforms with ELF binaries, such as Linux and windows-gnu),
 but will not touch them if they are in separate files (the default on Windows MSVC and macOS).

--- a/src/workspace/profiles.rs
+++ b/src/workspace/profiles.rs
@@ -28,14 +28,12 @@ use crate::resolver::features::FeaturesFor;
 use crate::util::data_structures::{HashMap, HashSet};
 use crate::util::interning::InternedString;
 use crate::util::{CargoResult, GlobalContext, closest_msg};
-use crate::workspace::Feature;
 use crate::workspace::dependency::Artifact;
 use crate::workspace::parser::validate_profile;
 use crate::workspace::{PackageId, PackageIdSpec, PackageIdSpecQuery, Target, Workspace};
 use anyhow::{Context as _, bail};
 use cargo_util::is_ci;
 use cargo_util_schemas::manifest::TomlTrimPaths;
-use cargo_util_schemas::manifest::TomlTrimPathsValue;
 use cargo_util_schemas::manifest::{
     ProfilePackageSpec, StringOrBool, TomlDebugInfo, TomlProfile, TomlProfiles,
 };
@@ -92,9 +90,7 @@ impl Profiles {
             rustc_host,
         };
 
-        let trim_paths_enabled = ws.unstable_features().is_enabled(Feature::trim_paths())
-            || gctx.cli_unstable().trim_paths;
-        Self::add_root_profiles(&mut profile_makers, &profiles, trim_paths_enabled);
+        Self::add_root_profiles(&mut profile_makers, &profiles);
 
         // Merge with predefined profiles.
         use std::collections::btree_map::Entry;
@@ -136,7 +132,6 @@ impl Profiles {
     fn add_root_profiles(
         profile_makers: &mut Profiles,
         profiles: &BTreeMap<InternedString, TomlProfile>,
-        trim_paths_enabled: bool,
     ) {
         profile_makers.by_name.insert(
             "dev".into(),
@@ -145,10 +140,7 @@ impl Profiles {
 
         profile_makers.by_name.insert(
             "release".into(),
-            ProfileMaker::new(
-                Profile::default_release(trim_paths_enabled),
-                profiles.get("release").cloned(),
-            ),
+            ProfileMaker::new(Profile::default_release(), profiles.get("release").cloned()),
         );
     }
 
@@ -676,7 +668,7 @@ compact_debug! {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             let (default, default_name) = match self.name.as_str() {
                 "dev" => (Profile::default_dev(), "default_dev()"),
-                "release" => (Profile::default_release(false), "default_release()"),
+                "release" => (Profile::default_release(), "default_release()"),
                 _ => (Profile::default(), "default()"),
             };
             [debug_the_fields(
@@ -738,13 +730,11 @@ impl Profile {
     }
 
     /// Returns a built-in `release` profile.
-    fn default_release(trim_paths_enabled: bool) -> Profile {
-        let trim_paths = trim_paths_enabled.then(|| TomlTrimPathsValue::Object.into());
+    fn default_release() -> Profile {
         Profile {
             name: "release".into(),
             root: ProfileRoot::Release,
             opt_level: "3".into(),
-            trim_paths,
             ..Profile::default()
         }
     }

--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -383,6 +383,7 @@ fn remap_path_scope() {
             "
                 [profile.release]
                 debug = \"line-tables-only\"
+                trim-paths = \"object\"
             ",
         )
         .build();

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -79,6 +79,15 @@ fn release_profile_default_to_object() {
            "#,
         )
         .file("src/lib.rs", "")
+        .file(
+            "build.rs",
+            r#"
+                fn main() {
+                    assert!(std::env::var_os("CARGO_TRIM_PATHS_SCOPE").is_some());
+                    assert!(std::env::var_os("CARGO_TRIM_PATHS_REMAP").is_some());
+                }
+            "#,
+        )
         .build();
 
     p.cargo("build --release --verbose")
@@ -86,7 +95,9 @@ fn release_profile_default_to_object() {
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stderr_data(str![[r#"
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc [..]--remap-path-scope=object --remap-path-prefix=[ROOT]/foo=. --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
+[RUNNING] `rustc --crate-name build_script_build [..]--remap-path-scope=object --remap-path-prefix=[ROOT]/foo=. --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
+[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/build_script_build`
+[RUNNING] `rustc --crate-name foo [..]--remap-path-scope=object --remap-path-prefix=[ROOT]/foo=. --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
 [FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
 
 "#]])

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -67,7 +67,7 @@ Caused by:
 }
 
 #[cargo_test]
-fn release_profile_default_to_object() {
+fn release_profile_default() {
     let p = project()
         .file(
             "Cargo.toml",
@@ -83,8 +83,8 @@ fn release_profile_default_to_object() {
             "build.rs",
             r#"
                 fn main() {
-                    assert!(std::env::var_os("CARGO_TRIM_PATHS_SCOPE").is_some());
-                    assert!(std::env::var_os("CARGO_TRIM_PATHS_REMAP").is_some());
+                    assert!(std::env::var_os("CARGO_TRIM_PATHS_SCOPE").is_none());
+                    assert!(std::env::var_os("CARGO_TRIM_PATHS_REMAP").is_none());
                 }
             "#,
         )
@@ -93,14 +93,8 @@ fn release_profile_default_to_object() {
     p.cargo("build --release --verbose")
         .arg("-Ztrim-paths")
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
-        .with_stderr_data(str![[r#"
-[COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc --crate-name build_script_build [..]--remap-path-scope=object --remap-path-prefix=[ROOT]/foo=. --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
-[RUNNING] `[ROOT]/foo/target/release/build/foo/[HASH]/out/build_script_build`
-[RUNNING] `rustc --crate-name foo [..]--remap-path-scope=object --remap-path-prefix=[ROOT]/foo=. --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
-[FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
-
-"#]])
+        .with_stderr_does_not_contain("[..]--remap-path-scope=[..]")
+        .with_stderr_does_not_contain("[..]--remap-path-prefix=[..]")
         .run();
 }
 


### PR DESCRIPTION
### What does this PR try to resolve?

This is a stabilization preparation.
A saner default is still wanted in the future maybe in a new edition.

See <https://github.com/rust-lang/cargo/issues/12137#issuecomment-5503216612>



