### PR TITLE
Use trusted publishing for Cargo crates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write     # Required for OIDC token exchange
 
-    # Gain access to the crates.io publishing token.
+    # Required for trusted publishing to work.
     environment:
       name: release
 
@@ -27,7 +28,10 @@ jobs:
       - name: Checkout the source code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
+      - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18  # v1.0.5
+        id: auth
+
       - name: Publish Cargo to crates.io
         run: ./publish.py
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
Companion to https://github.com/rust-lang/team/pull/2727. This is done to improve publishing security, and allow us to track Cargo crates in the `team` database.

CC @Mark-Simulacrum (probably you'll want to wait until the next release? or we can test drive it tomorrow on 1.98.1 :) )