### PR TITLE
chore(deps): update crossbeam-epoch to 0.9.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "dc74980687109a3b14c72fd458107bf0baa1da1a1a805e178d15501ba9b86d9d"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
### What does this PR try to resolve?

cargo audit showed a crossbeam-epoch finding [1]

```
$ cargo audit 
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 1239 security advisories (from /root/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (550 crate dependencies)
Crate:     crossbeam-epoch
Version:   0.9.18
Title:     Invalid pointer dereference in `fmt::Pointer` impl for `Atomic` and `Shared` when the underlying pointer is invalid
Date:      2026-07-06
ID:        RUSTSEC-2026-0204
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0204
Solution:  Upgrade to >=0.9.20
```

[1] https://rustsec.org/advisories/RUSTSEC-2026-0204

### How to test and review this PR?

Ran cargo build and cargo test post the update, both worked fine, no issues found