### PR TITLE
fix(parser): Resolve theoretical use-after-free

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4933,9 +4933,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -4972,18 +4972,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ tar = { version = "0.4.45", default-features = false }
 tempfile = "3.27.0"
 thiserror = "2.0.18"
 time = { version = "0.3.47", features = ["parsing", "formatting", "serde"] }
-toml = { version = "1.1.2", default-features = false }
+toml = { version = "1.1.5", default-features = false }
 toml_edit = { version = "0.25.10", features = ["serde"] }
 toml_parser = "1.1.2"
 toml_writer = "1.1.1"


### PR DESCRIPTION
### What does this PR try to resolve?

`DeTable::make_owned` did not cover `DeInteger` and `DeFloat` yet we transmuted a `DeTable<'_>` to `DeTable<'static>`.

This is didn't cause problems in practice because we only dereference `DeString`s (for walking keys). Even if we dereferenced `DeInteger` or `DeFloat`,
the memory we parsed from is kept around.

### How to test and review this PR?
