### PR TITLE
fix(trim-paths)!: limit options to `none|object|all`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,7 +587,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util-schemas"
-version = "0.14.4"
+version = "0.15.0"
 dependencies = [
  "jiff",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ cargo-platform = { path = "crates/cargo-platform", version = "0.3.3" }
 cargo-test-macro = { version = "0.4.15", path = "crates/cargo-test-macro" }
 cargo-test-support = { version = "0.12.0", path = "crates/cargo-test-support" }
 cargo-util = { version = "0.2.33", path = "crates/cargo-util" }
-cargo-util-schemas = { version = "0.14.4", path = "crates/cargo-util-schemas" }
+cargo-util-schemas = { version = "0.15.0", path = "crates/cargo-util-schemas" }
 cargo-util-terminal = { version = "0.1.3", path = "crates/cargo-util-terminal" }
 cargo_metadata = "0.23.1"
 clap = "4.6.0"

--- a/crates/cargo-util-schemas/Cargo.toml
+++ b/crates/cargo-util-schemas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-util-schemas"
-version = "0.14.4"
+version = "0.15.0"
 rust-version = "1.98"  # MSRV:1
 edition.workspace = true
 license.workspace = true

--- a/crates/cargo-util-schemas/manifest.schema.json
+++ b/crates/cargo-util-schemas/manifest.schema.json
@@ -1473,7 +1473,11 @@
       "type": "string"
     },
     "TomlDebugInfo": {
-      "type": ["string", "integer", "boolean"],
+      "type": [
+        "string",
+        "integer",
+        "boolean"
+      ],
       "enum": [
         "none",
         "line-directives-only",
@@ -1491,24 +1495,11 @@
       "type": "string"
     },
     "TomlTrimPaths": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/TomlTrimPathsValue"
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "TomlTrimPathsValue": {
       "type": "string",
       "enum": [
-        "diagnostics",
-        "macro",
-        "object"
+        "none",
+        "object",
+        "all"
       ]
     }
   }

--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -1233,113 +1233,30 @@ impl<'de> de::Deserialize<'de> for TomlDebugInfo {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash, Serialize)]
-#[serde(untagged, rename_all = "kebab-case")]
+#[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 #[cfg_attr(feature = "unstable-schema", derive(schemars::JsonSchema))]
 pub enum TomlTrimPaths {
-    Values(Vec<TomlTrimPathsValue>),
+    None,
+    Object,
     All,
 }
 
 impl TomlTrimPaths {
-    pub fn none() -> Self {
-        TomlTrimPaths::Values(Vec::new())
-    }
-
     pub fn is_none(&self) -> bool {
-        match self {
-            TomlTrimPaths::Values(v) => v.is_empty(),
-            TomlTrimPaths::All => false,
-        }
+        matches!(self, TomlTrimPaths::None)
     }
-}
 
-impl<'de> de::Deserialize<'de> for TomlTrimPaths {
-    fn deserialize<D>(d: D) -> Result<TomlTrimPaths, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        use serde::de::Error as _;
-        let expecting =
-            r#""none", "diagnostics", "macro", "object", "all", or an array with these options"#;
-        UntaggedEnumVisitor::new()
-            .expecting(expecting)
-            .string(|v| match v {
-                "none" => Ok(TomlTrimPaths::none()),
-                "all" => Ok(TomlTrimPaths::All),
-                v => {
-                    let d = v.into_deserializer();
-                    let err = |_: D::Error| {
-                        serde_untagged::de::Error::custom(format!("expected {expecting}"))
-                    };
-                    TomlTrimPathsValue::deserialize(d)
-                        .map_err(err)
-                        .map(|v| v.into())
-                }
-            })
-            .seq(|seq| {
-                let seq: Vec<String> = seq.deserialize()?;
-                let seq: Vec<_> = seq
-                    .into_iter()
-                    .map(|s| TomlTrimPathsValue::deserialize(s.into_deserializer()))
-                    .collect::<Result<_, _>>()?;
-                Ok(seq.into())
-            })
-            .deserialize(d)
+    fn as_str(&self) -> &'static str {
+        match self {
+            TomlTrimPaths::None => "none",
+            TomlTrimPaths::Object => "object",
+            TomlTrimPaths::All => "all",
+        }
     }
 }
 
 impl fmt::Display for TomlTrimPaths {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            TomlTrimPaths::All => write!(f, "all"),
-            TomlTrimPaths::Values(v) if v.is_empty() => write!(f, "none"),
-            TomlTrimPaths::Values(v) => {
-                let mut iter = v.iter();
-                if let Some(value) = iter.next() {
-                    write!(f, "{value}")?;
-                }
-                for value in iter {
-                    write!(f, ",{value}")?;
-                }
-                Ok(())
-            }
-        }
-    }
-}
-
-impl From<TomlTrimPathsValue> for TomlTrimPaths {
-    fn from(value: TomlTrimPathsValue) -> Self {
-        TomlTrimPaths::Values(vec![value])
-    }
-}
-
-impl From<Vec<TomlTrimPathsValue>> for TomlTrimPaths {
-    fn from(value: Vec<TomlTrimPathsValue>) -> Self {
-        TomlTrimPaths::Values(value)
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-#[cfg_attr(feature = "unstable-schema", derive(schemars::JsonSchema))]
-pub enum TomlTrimPathsValue {
-    Diagnostics,
-    Macro,
-    Object,
-}
-
-impl TomlTrimPathsValue {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            TomlTrimPathsValue::Diagnostics => "diagnostics",
-            TomlTrimPathsValue::Macro => "macro",
-            TomlTrimPathsValue::Object => "object",
-        }
-    }
-}
-
-impl fmt::Display for TomlTrimPathsValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.as_str())
     }

--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -1260,16 +1260,10 @@ impl<'de> de::Deserialize<'de> for TomlTrimPaths {
         D: de::Deserializer<'de>,
     {
         use serde::de::Error as _;
-        let expecting = r#"a boolean, "none", "diagnostics", "macro", "object", "all", or an array with these options"#;
+        let expecting =
+            r#""none", "diagnostics", "macro", "object", "all", or an array with these options"#;
         UntaggedEnumVisitor::new()
             .expecting(expecting)
-            .bool(|value| {
-                Ok(if value {
-                    TomlTrimPaths::All
-                } else {
-                    TomlTrimPaths::none()
-                })
-            })
             .string(|v| match v {
                 "none" => Ok(TomlTrimPaths::none()),
                 "all" => Ok(TomlTrimPaths::All),

--- a/doc/book/src/reference/unstable.md
+++ b/doc/book/src/reference/unstable.md
@@ -1519,12 +1519,12 @@ trim-paths = ["diagnostics", "object"]
 `trim-paths` is a profile setting which enables and controls the sanitization of file paths in build outputs.
 It takes the following values:
 
-- `"none"` and `false` --- disable path sanitization
+- `"none"` --- disable path sanitization
 - `"macro"` --- sanitize paths in the expansion of `std::file!()` macro.
     This is where paths in embedded panic messages come from
 - `"diagnostics"` --- sanitize paths in printed compiler diagnostics
 - `"object"` --- sanitize paths in compiled executables or libraries
-- `"all"` and `true` --- sanitize paths in all possible locations
+- `"all"` --- sanitize paths in all possible locations
 
 It also takes an array with the combinations of `"macro"`, `"diagnostics"`, and `"object"`.
 
@@ -1552,7 +1552,7 @@ should consume [unremap files] instead of interpreting these prefixes.
 
 [unremap files]: #unremap-files
 
-If `trim-paths` is not `"none"` or `false`,
+If `trim-paths` is not `"none"`,
 then the following paths are sanitized if they appear in a selected scope:
 
 1. Path to the source files of the standard and core library (sysroot) will begin with `/rustc/<rustc commit hash>`,
@@ -1657,8 +1657,8 @@ but it still contains absolute paths.
 *as a new entry of ["Environment variables Cargo sets for build scripts"](./environment-variables.md#environment-variables-cargo-sets-for-crates)*
 
 * `CARGO_TRIM_PATHS_SCOPE` --- The value of `trim-paths` profile option.
-    `false`, `"none"`, and empty arrays would be converted to `none`.
-    `true` and `"all"` become `all`.
+    `"none"` and empty arrays are converted to `none`.
+    `"all"` becomes `all`.
     Values in a non-empty array would be joined into a comma-separated list.
     If the build script introduces absolute paths to built artifacts (such as by invoking a compiler),
     the user may request them to be sanitized in different types of artifacts.

--- a/doc/book/src/reference/unstable.md
+++ b/doc/book/src/reference/unstable.md
@@ -1494,7 +1494,7 @@ cargo-features = ["trim-paths"]
 # ...
 
 [profile.release]
-trim-paths = ["diagnostics", "object"]
+trim-paths = "object"
 ```
 
 To set this in a profile in Cargo configuration,
@@ -1507,7 +1507,7 @@ For example,
 trim-paths = true
 
 [profile.release]
-trim-paths = ["diagnostics", "object"]
+trim-paths = "object"
 ```
 
 ### Documentation updates
@@ -1516,17 +1516,27 @@ trim-paths = ["diagnostics", "object"]
 
 *as a new ["Profiles settings" entry](./profiles.html#profile-settings)*
 
-`trim-paths` is a profile setting which enables and controls the sanitization of file paths in build outputs.
-It takes the following values:
+The `trim-paths` option controls the scope of path sanitization in build outputs
+Paths are sanitized according to these [remapping rules].
 
-- `"none"` --- disable path sanitization
-- `"macro"` --- sanitize paths in the expansion of `std::file!()` macro.
-    This is where paths in embedded panic messages come from
-- `"diagnostics"` --- sanitize paths in printed compiler diagnostics
-- `"object"` --- sanitize paths in compiled executables or libraries
-- `"all"` --- sanitize paths in all possible locations
+The valid options are:
 
-It also takes an array with the combinations of `"macro"`, `"diagnostics"`, and `"object"`.
+- `"none"` --- disables path sanitization.
+- `"object"` --- sanitizes paths embedded in compiled executables and libraries.
+  Useful for improving artifact reproducibility
+  with less impact on local development.
+- `"all"` --- sanitizes paths in all supported locations.
+  Useful for hermetic or remote builds that need artifacts and diagnostics
+  to be independent of the build environment.
+
+> [!WARNING]
+> The `"all"` option remaps compiler diagnostics,
+> including [compiler JSON messages](./external-tools.md#json-messages).
+> Some remapped paths may not resolve to files on the local filesystem,
+> which can affect editors and other tools that consume the diagnostic output.
+
+For details about each scope,
+see rustc's [`--remap-path-scope`] documentation.
 
 By default, `trim-paths` is not set and path sanitization is disabled for all profiles.
 You can enable it by specifying this option in `Cargo.toml`:
@@ -1536,13 +1546,11 @@ You can enable it by specifying this option in `Cargo.toml`:
 trim-paths = "all"
 
 [profile.release]
-trim-paths = ["object", "diagnostics"]
+trim-paths = "object"
 ```
 
-For more information about each scope,
-see rustc's documentation on [`--remap-path-scope`].
-
 [`--remap-path-scope`]: ../../rustc/remap-source-paths.html#--remap-path-scope
+[remapping rules]: #remapping-rules
 
 ##### Remapping rules
 
@@ -1657,13 +1665,13 @@ but it still contains absolute paths.
 *as a new entry of ["Environment variables Cargo sets for build scripts"](./environment-variables.md#environment-variables-cargo-sets-for-crates)*
 
 * `CARGO_TRIM_PATHS_SCOPE` --- The value of `trim-paths` profile option.
-    `"none"` and empty arrays are converted to `none`.
-    `"all"` becomes `all`.
-    Values in a non-empty array would be joined into a comma-separated list.
     If the build script introduces absolute paths to built artifacts (such as by invoking a compiler),
     the user may request them to be sanitized in different types of artifacts.
     Common paths requiring sanitization include `OUT_DIR`, `CARGO_MANIFEST_DIR` and `CARGO_MANIFEST_PATH`,
     plus any other introduced by the build script, such as include directories.
+    > [!NOTE]
+    > For forward compatibility,
+    > build scripts should accept a comma-separated list of scopes.
 * `CARGO_TRIM_PATHS_REMAP` --- The `<from>=<to>` path remap pairs Cargo passes to the compiler,
     joined by the platform path separator.
     Only set when `trim-paths` profile is active.

--- a/src/compiler/trim_paths.rs
+++ b/src/compiler/trim_paths.rs
@@ -11,7 +11,6 @@ use std::path::PathBuf;
 
 use cargo_util::ProcessBuilder;
 use cargo_util_schemas::manifest::TomlTrimPaths;
-use cargo_util_schemas::manifest::TomlTrimPathsValue;
 use serde::Serialize;
 use tracing::debug;
 
@@ -44,12 +43,9 @@ pub(crate) fn trim_paths_args_rustdoc(
     unit: &Unit,
     trim_paths: &TomlTrimPaths,
 ) -> CargoResult<()> {
-    match trim_paths {
-        // rustdoc supports diagnostics trimming only.
-        TomlTrimPaths::Values(values) if !values.contains(&TomlTrimPathsValue::Diagnostics) => {
-            return Ok(());
-        }
-        _ => {}
+    // rustdoc supports diagnostics trimming only.
+    if !matches!(trim_paths, TomlTrimPaths::All) {
+        return Ok(());
     }
 
     for pair in trim_paths_remap(build_runner, unit) {
@@ -298,8 +294,8 @@ pub(crate) fn should_emit_unremap_file(unit: &Unit) -> bool {
 
     match unit.profile.trim_paths.as_ref() {
         None => false,
-        Some(TomlTrimPaths::All) => true,
-        Some(TomlTrimPaths::Values(values)) => values.contains(&TomlTrimPathsValue::Object),
+        Some(TomlTrimPaths::None) => false,
+        Some(TomlTrimPaths::Object | TomlTrimPaths::All) => true,
     }
 }
 

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -3269,7 +3269,7 @@ fn bad_trim_paths() {
         .masquerade_as_nightly_cargo(&["trim-paths"])
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] expected a boolean, "none", "diagnostics", "macro", "object", "all", or an array with these options
+[ERROR] expected "none", "diagnostics", "macro", "object", "all", or an array with these options
  --> Cargo.toml:8:30
   |
 8 |                 trim-paths = "split-debuginfo"

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -3269,7 +3269,7 @@ fn bad_trim_paths() {
         .masquerade_as_nightly_cargo(&["trim-paths"])
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] expected "none", "diagnostics", "macro", "object", "all", or an array with these options
+[ERROR] unknown variant `split-debuginfo`, expected one of `none`, `object`, `all`
  --> Cargo.toml:8:30
   |
 8 |                 trim-paths = "split-debuginfo"

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -1892,24 +1892,6 @@ fn trim_paths_parsing() {
         assert_eq!(trim_paths, expected, "failed to parse {val}");
     }
 
-    let test_cases = [(TomlTrimPaths::none(), false), (TomlTrimPaths::All, true)];
-
-    for (expected, val) in test_cases {
-        // env
-        let gctx = GlobalContextBuilder::new()
-            .env("CARGO_PROFILE_DEV_TRIM_PATHS", format!("{val}"))
-            .build();
-        let trim_paths: TomlTrimPaths = gctx.get("profile.dev.trim-paths").unwrap();
-        assert_eq!(trim_paths, expected, "failed to parse {val}");
-
-        // config.toml
-        let gctx = GlobalContextBuilder::new()
-            .config_arg(format!("profile.dev.trim-paths={val}"))
-            .build();
-        let trim_paths: TomlTrimPaths = gctx.get("profile.dev.trim-paths").unwrap();
-        assert_eq!(trim_paths, expected, "failed to parse {val}");
-    }
-
     let expected = vec![
         TomlTrimPathsValue::Diagnostics,
         TomlTrimPathsValue::Macro,

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -19,7 +19,6 @@ use cargo_test_support::compare::assert_e2e;
 use cargo_test_support::str;
 use cargo_test_support::{paths, project, project_in_home, symlink_supported, t};
 use cargo_util_schemas::manifest::TomlTrimPaths;
-use cargo_util_schemas::manifest::TomlTrimPathsValue;
 use cargo_util_schemas::manifest::{self as cargo_toml, TomlDebugInfo, VecStringOrBool as VSOB};
 use cargo_util_terminal::Shell;
 use serde::Deserialize;
@@ -1872,9 +1871,9 @@ fn trim_paths_parsing() {
     assert_eq!(p.trim_paths, None);
 
     let test_cases = [
-        (TomlTrimPathsValue::Diagnostics.into(), "diagnostics"),
-        (TomlTrimPathsValue::Macro.into(), "macro"),
-        (TomlTrimPathsValue::Object.into(), "object"),
+        (TomlTrimPaths::None, "none"),
+        (TomlTrimPaths::Object, "object"),
+        (TomlTrimPaths::All, "all"),
     ];
     for (expected, val) in test_cases {
         // env
@@ -1891,20 +1890,6 @@ fn trim_paths_parsing() {
         let trim_paths: TomlTrimPaths = gctx.get("profile.dev.trim-paths").unwrap();
         assert_eq!(trim_paths, expected, "failed to parse {val}");
     }
-
-    let expected = vec![
-        TomlTrimPathsValue::Diagnostics,
-        TomlTrimPathsValue::Macro,
-        TomlTrimPathsValue::Object,
-    ]
-    .into();
-    let val = r#"["diagnostics", "macro", "object"]"#;
-    // config.toml
-    let gctx = GlobalContextBuilder::new()
-        .config_arg(format!("profile.dev.trim-paths={val}"))
-        .build();
-    let trim_paths: TomlTrimPaths = gctx.get("profile.dev.trim-paths").unwrap();
-    assert_eq!(trim_paths, expected, "failed to parse {val}");
 }
 
 #[cargo_test]

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -21,7 +21,7 @@ fn gated_manifest() {
                 edition = "2015"
 
                 [profile.dev]
-                trim-paths = "macro"
+                trim-paths = "object"
            "#,
         )
         .file("src/lib.rs", "")
@@ -47,7 +47,7 @@ fn gated_config_toml() {
             ".cargo/config.toml",
             r#"
                 [profile.dev]
-                trim-paths = "macro"
+                trim-paths = "object"
            "#,
         )
         .file("src/lib.rs", "")
@@ -122,7 +122,7 @@ fn one_option() {
         p.cargo("build -v")
     };
 
-    for option in ["macro", "diagnostics", "object", "all"] {
+    for option in ["object", "all"] {
         build(option)
             .arg("-Ztrim-paths")
             .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
@@ -143,70 +143,6 @@ fn one_option() {
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stderr_does_not_contain("[..]--remap-path-scope=[..]")
         .with_stderr_does_not_contain("[..]--remap-path-prefix=[..]")
-        .run();
-}
-
-#[cargo_test]
-fn multiple_options() {
-    let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-                [package]
-                name = "foo"
-                version = "0.0.1"
-                edition = "2015"
-
-                [profile.dev]
-                trim-paths = ["diagnostics", "macro", "object"]
-           "#,
-        )
-        .file("src/lib.rs", "")
-        .build();
-
-    p.cargo("build --verbose")
-        .arg("-Ztrim-paths")
-        .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
-        .with_stderr_data(str![[r#"
-[COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc [..]--remap-path-scope=diagnostics,macro,object --remap-path-prefix=[ROOT]/foo=. --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-
-"#]])
-        .run();
-}
-
-#[cargo_test]
-fn profile_merge_works() {
-    let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-                [package]
-                name = "foo"
-                version = "0.0.1"
-                edition = "2015"
-
-                [profile.dev]
-                trim-paths = ["macro"]
-
-                [profile.custom]
-                inherits = "dev"
-                trim-paths = ["diagnostics"]
-            "#,
-        )
-        .file("src/lib.rs", "")
-        .build();
-
-    p.cargo("build -v --profile custom")
-        .arg("-Ztrim-paths")
-        .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
-        .with_stderr_data(str![[r#"
-[COMPILING] foo v0.0.1 ([ROOT]/foo)
-[RUNNING] `rustc [..]--remap-path-scope=diagnostics --remap-path-prefix=[ROOT]/foo=. --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
-[FINISHED] `custom` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
-
-"#]])
         .run();
 }
 
@@ -921,6 +857,7 @@ fn local_package_with_build_script_codegen() {
     assert!(unremap_file.exists());
 }
 
+/// This tests diagnostics are remapped correctly.
 #[cargo_test]
 fn diagnostics_works() {
     Package::new("bar", "0.0.1")
@@ -940,7 +877,9 @@ fn diagnostics_works() {
                 bar = "0.0.1"
 
                 [profile.dev]
-                trim-paths = "diagnostics"
+                # Currently Cargo doesn't support the `diagnostics` scope directly,
+                # so use the `all` scope instead.
+                trim-paths = "all"
            "#,
         )
         .file("src/lib.rs", "")
@@ -958,16 +897,16 @@ fn diagnostics_works() {
         )
         .with_stderr_data(str![[r#"
 ...
-[RUNNING] `[..] rustc [..]--remap-path-scope=diagnostics --remap-path-prefix=[ROOT]/home/.cargo/registry/src/[..]=/cargo/registry/[..] --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
+[RUNNING] `[..] rustc [..]--remap-path-scope=all --remap-path-prefix=[ROOT]/home/.cargo/registry/src/[..]=/cargo/registry/[..] --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
 [WARNING] unused variable: `unused`
 ...
-[RUNNING] `[..] rustc [..]--remap-path-scope=diagnostics --remap-path-prefix=[ROOT]/foo=. --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
+[RUNNING] `[..] rustc [..]--remap-path-scope=all --remap-path-prefix=[ROOT]/foo=. --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
 ...
 "#]])
         .run();
 
-    // Non `object` scope never emits unremap files.
-    assert_eq!(p.glob("target/**/*.trim-paths.jsonl").count(), 0);
+    // The `all` scope includes `object`, so unremap files are emitted.
+    assert_eq!(p.glob("target/**/*.trim-paths.jsonl").count(), 2);
 }
 
 #[cfg(target_os = "macos")]
@@ -1200,16 +1139,9 @@ fn custom_build_env_var_trim_paths() {
         .build();
 
     let test_cases = [
-        ("[]", "none"),
         ("\"all\"", "all"),
-        ("\"diagnostics\"", "diagnostics"),
-        ("\"macro\"", "macro"),
         ("\"none\"", "none"),
         ("\"object\"", "object"),
-        (
-            r#"["diagnostics", "macro", "object"]"#,
-            "diagnostics,macro,object",
-        ),
     ];
 
     for (opts, expected) in test_cases {
@@ -1554,7 +1486,9 @@ fn rustdoc_diagnostics_works() {
                 bar = "0.0.1"
 
                 [profile.dev]
-                trim-paths = "diagnostics"
+                # Currently Cargo doesn't support the `diagnostics` scope directly,
+                # so use the `all` scope instead.
+                trim-paths = "all"
            "#,
         )
         .file("src/lib.rs", "")
@@ -1565,7 +1499,7 @@ fn rustdoc_diagnostics_works() {
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stderr_data(str![[r#"
 ...
-[RUNNING] `[..]rustc [..]--remap-path-scope=diagnostics --remap-path-prefix=[ROOT]/home/.cargo/registry/src/[..]=/cargo/registry/[..] --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
+[RUNNING] `[..]rustc [..]--remap-path-scope=all --remap-path-prefix=[ROOT]/home/.cargo/registry/src/[..]=/cargo/registry/[..] --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]`
 ...
 [WARNING] unopened HTML tag `script`
  --> /cargo/registry/[HASH]/bar-0.0.1/src/lib.rs:2:17

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -1206,8 +1206,6 @@ fn custom_build_env_var_trim_paths() {
         ("\"macro\"", "macro"),
         ("\"none\"", "none"),
         ("\"object\"", "object"),
-        ("false", "none"),
-        ("true", "all"),
         (
             r#"["diagnostics", "macro", "object"]"#,
             "diagnostics,macro,object",


### PR DESCRIPTION
### What does this PR try to resolve?

This limits profile `trim-paths` options to only `none`, `object`, and `all`.
For other scopes and boolean values, we can add it in the future when needed.

This is a stabilization preparation for `-Ztrim-paths`.
See <https://github.com/rust-lang/cargo/issues/12137#issuecomment-5503216612>.

### How to test and review this PR?

Also rewrote the profile trim-paths doc a bit but not extremely satisfied.
Please help proofread.

