### PR TITLE
docs: clarify cargo vendor source config option

### DIFF
--- a/doc/book/src/commands/cargo-vendor.md
+++ b/doc/book/src/commands/cargo-vendor.md
@@ -47,8 +47,8 @@ existing contents of the vendor directory</p>
 
 
 <dt class="option-term" id="option-cargo-vendor---respect-source-config"><a class="option-anchor" href="#option-cargo-vendor---respect-source-config"><code>--respect-source-config</code></a></dt>
-<dd class="option-desc"><p>Instead of ignoring <code>[source]</code> configuration by default in <code>.cargo/config.toml</code>
-read it and use it when downloading crates from crates.io, for example</p>
+<dd class="option-desc"><p>Instead of ignoring <code>[source]</code> configuration by default in <code>.cargo/config.toml</code>,
+read it and use it when downloading crates.</p>
 </dd>
 
 

--- a/doc/man/cargo-vendor.md
+++ b/doc/man/cargo-vendor.md
@@ -44,8 +44,8 @@ existing contents of the vendor directory
 {{/option}}
 
 {{#option "`--respect-source-config`" }}
-Instead of ignoring `[source]` configuration by default in `.cargo/config.toml`
-read it and use it when downloading crates from crates.io, for example
+Instead of ignoring `[source]` configuration by default in `.cargo/config.toml`,
+read it and use it when downloading crates.
 {{/option}}
 
 {{#option "`--versioned-dirs`" }}

--- a/doc/man/generated_txt/cargo-vendor.txt
+++ b/doc/man/generated_txt/cargo-vendor.txt
@@ -37,8 +37,7 @@ OPTIONS
 
        --respect-source-config
            Instead of ignoring [source] configuration by default in
-           .cargo/config.toml read it and use it when downloading crates from
-           crates.io, for example
+           .cargo/config.toml, read it and use it when downloading crates.
 
        --versioned-dirs
            Normally versions are only added to disambiguate multiple versions

--- a/etc/man/cargo-vendor.1
+++ b/etc/man/cargo-vendor.1
@@ -42,8 +42,8 @@ existing contents of the vendor directory
 .sp
 \fB\-\-respect\-source\-config\fR
 .RS 4
-Instead of ignoring \fB[source]\fR configuration by default in \fB\&.cargo/config.toml\fR
-read it and use it when downloading crates from crates.io, for example
+Instead of ignoring \fB[source]\fR configuration by default in \fB\&.cargo/config.toml\fR,
+read it and use it when downloading crates.
 .RE
 .sp
 \fB\-\-versioned\-dirs\fR


### PR DESCRIPTION
A documentation fix.

### What does this PR try to resolve?

Fixes #17434. The original sentence is missing punctuation and contains ambiguous wording. This PR adds the missing punctuation and removes the ambiguity.

### How to test and review this PR?

Run `cargo build-man` and verify that it produces no additional changes.
I would appreciate a maintainer confirming that the revised wording accurately reflects the option's behavior.