### PR TITLE
docs(book): document the table syntax of features

### DIFF
--- a/doc/book/src/reference/cargo-targets.md
+++ b/doc/book/src/reference/cargo-targets.md
@@ -300,9 +300,9 @@ target will be skipped. This is only relevant for the `[[bin]]`, `[[bench]]`,
 ```toml
 [features]
 # ...
-postgres = []
-sqlite = []
-tools = []
+postgres = { enables = [] }
+sqlite = { enables = [] }
+tools = { enables = [] }
 
 [[bin]]
 name = "my-pg-tool"

--- a/doc/book/src/reference/features.md
+++ b/doc/book/src/reference/features.md
@@ -32,8 +32,18 @@ included:
 ```toml
 [features]
 # Defines a feature named `webp` that does not enable any other features.
-webp = []
+webp = { enables = [] }
 ```
+
+> [!TIP]
+> If only the `enables` key is used, the array syntax can be used instead:
+>
+> ```toml
+> [features]
+> webp = []
+> ```
+>
+> The table syntax is newer and only available starting with Rust TODO.
 
 With this feature defined, [`cfg` expressions] can be used to conditionally
 include code to support the requested feature at compile time. For example,
@@ -54,10 +64,10 @@ those other features are enabled, too:
 
 ```toml
 [features]
-bmp = []
-png = []
-ico = ["bmp", "png"]
-webp = []
+bmp = { enables = [] }
+png = { enables = [] }
+ico = { enables = ["bmp", "png"] }
+webp = { enables = [] }
 ```
 
 Feature names may include characters from the [Unicode XID standard] (which
@@ -84,11 +94,11 @@ changed by specifying the `default` feature:
 
 ```toml
 [features]
-default = ["ico", "webp"]
-bmp = []
-png = []
-ico = ["bmp", "png"]
-webp = []
+default = { enables = ["ico", "webp"] }
+bmp = { enables = [] }
+png = { enables = [] }
+ico = { enables = ["bmp", "png"] }
+webp = { enables = [] }
 ```
 
 When the package is built, the `default` feature is enabled which in turn
@@ -131,7 +141,7 @@ like this:
 
 ```toml
 [features]
-gif = ["dep:gif"]
+gif = { enables = ["dep:gif"] }
 ```
 
 This means that this dependency will only be included if the `gif`
@@ -161,7 +171,7 @@ ravif = { version = "0.6.3", optional = true }
 rgb = { version = "0.8.25", optional = true }
 
 [features]
-avif = ["dep:ravif", "dep:rgb"]
+avif = { enables = ["dep:ravif", "dep:rgb"] }
 ```
 
 In this example, the `avif` feature will enable the two listed dependencies.
@@ -210,7 +220,7 @@ jpeg-decoder = { version = "0.1.20", default-features = false }
 
 [features]
 # Enables parallel processing support by enabling the "rayon" feature of jpeg-decoder.
-parallel = ["jpeg-decoder/rayon"]
+parallel = { enables = ["jpeg-decoder/rayon"] }
 ```
 
 The `"package-name/feature-name"` syntax will also enable `package-name`
@@ -232,7 +242,7 @@ serde = { version = "1.0.133", optional = true }
 rgb = { version = "0.8.25", optional = true }
 
 [features]
-serde = ["dep:serde", "rgb?/serde"]
+serde = { enables = ["dep:serde", "rgb?/serde"] }
 ```
 
 In this example, enabling the `serde` feature will enable the serde

--- a/doc/book/src/reference/lints.md
+++ b/doc/book/src/reference/lints.md
@@ -230,14 +230,14 @@ Users would expect that a feature tightly coupled to a dependency would match th
 
 ```toml
 [features]
-foo_bar = []
+foo_bar = { enables = [] }
 ```
 
 Should be written as:
 
 ```toml
 [features]
-foo-bar = []
+foo-bar = { enables = [] }
 ```
 
 
@@ -296,14 +296,14 @@ Users would expect that a feature tightly coupled to a dependency would match th
 
 ```toml
 [features]
-foo-bar = []
+foo-bar = { enables = [] }
 ```
 
 Should be written as:
 
 ```toml
 [features]
-foo_bar = []
+foo_bar = { enables = [] }
 ```
 
 

--- a/doc/book/src/reference/semver.md
+++ b/doc/book/src/reference/semver.md
@@ -2132,7 +2132,7 @@ consequences of enabling the feature.
 ###########################################################
 # After
 [features]
-std = []
+std = { enables = [] }
 ```
 
 #### Major: removing a Cargo feature {#cargo-feature-remove}
@@ -2146,7 +2146,7 @@ an error for any project that enabled the feature.
 ###########################################################
 # Before
 [features]
-logging = []
+logging = { enables = [] }
 
 ###########################################################
 # After
@@ -2172,14 +2172,14 @@ they are expecting that functionality to be available through that feature.
 ###########################################################
 # Before
 [features]
-default = ["std"]
-std = []
+default = { enables = ["std"] }
+std = { enables = [] }
 
 ###########################################################
 # After
 [features]
-default = []  # This may cause packages to fail if they are expecting std to be enabled.
-std = []
+default = { enables = [] } # This may cause packages to fail if they are expecting std to be enabled.
+std = { enables = [] }
 ```
 
 #### Possibly-breaking: removing an optional dependency {#cargo-remove-opt-dep}
@@ -2219,7 +2219,7 @@ curl = { version = "0.4.31", optional = true }
 curl = { version = "0.4.31", optional = true }
 
 [features]
-networking = ["dep:curl"]
+networking = { enables = ["dep:curl"] }
 
 ###########################################################
 # After
@@ -2228,7 +2228,7 @@ networking = ["dep:curl"]
 hyper = { version = "0.14.27", optional = true }
 
 [features]
-networking = ["dep:hyper"]
+networking = { enables = ["dep:hyper"] }
 ```
 
 Mitigation strategies:

--- a/doc/book/src/reference/specifying-dependencies.md
+++ b/doc/book/src/reference/specifying-dependencies.md
@@ -461,7 +461,7 @@ foo = { version = "1.0", optional = true }
 bar = { version = "1.0", optional = true }
 
 [features]
-fancy-feature = ["foo", "bar"]
+fancy-feature = { enables = ["foo", "bar"] }
 ```
 
 The same applies to `cfg(debug_assertions)`, `cfg(test)` and `cfg(proc_macro)`.
@@ -634,7 +634,7 @@ following to the above manifest:
 
 ```toml
 [features]
-log-debug = ['bar/log-debug'] # using 'foo/log-debug' would be an error!
+log-debug = { enables = ['bar/log-debug'] } # using 'foo/log-debug' would be an error!
 ```
 
 ## Inheriting a dependency from a workspace

--- a/src/diagnostics/rules/non_kebab_case_features.rs
+++ b/src/diagnostics/rules/non_kebab_case_features.rs
@@ -44,14 +44,14 @@ Users would expect that a feature tightly coupled to a dependency would match th
 
 ```toml
 [features]
-foo_bar = []
+foo_bar = { enables = [] }
 ```
 
 Should be written as:
 
 ```toml
 [features]
-foo-bar = []
+foo-bar = { enables = [] }
 ```
 "#,
     ),

--- a/src/diagnostics/rules/non_snake_case_features.rs
+++ b/src/diagnostics/rules/non_snake_case_features.rs
@@ -44,14 +44,14 @@ Users would expect that a feature tightly coupled to a dependency would match th
 
 ```toml
 [features]
-foo-bar = []
+foo-bar = { enables = [] }
 ```
 
 Should be written as:
 
 ```toml
 [features]
-foo_bar = []
+foo_bar = { enables = [] }
 ```
 "#,
     ),


### PR DESCRIPTION
### What does this PR try to resolve?

This is a follow-up to https://github.com/rust-lang/cargo/pull/15056#discussion_r3889403527, and part of `feature-metadata` #14157, that prepares the documentation for when the unstable feature (or [the first of its subfeatures](https://github.com/rust-lang/cargo/issues/17445#issuecomment-5556006228)) is eventually stabilized (I understand this is not for now, and that this PR will very likely conflict). Sometimes documentation stemming from unstable features can be added to the documentation of the unstable feature itself, as suggested in https://github.com/rust-lang/cargo/pull/15056#discussion_r3889403527, but I think this doesn't really work in this case as this is not purely additive.

This should address all occurrences within the book; this can be checked with `rg -A1 '\[features\]' doc/book/`.

### Open questions

- How should the table syntax be articulated in the docs to the existing array syntax? What this PR currently proposes is to make the new table syntax the new default way of defining features (because I think we want to encourage authors to document their features through the now-accepted `feature-documentation`), and only documents the old array syntax as a shortcut.

### How to test and review this PR?

This is a doc-only PR. It's kept as draft until the first subfeature of `feature-metadata` is stabilized. Doing this early helped me find [a corner-case in `feature-visibility`](https://github.com/rust-lang/rfcs/pull/3487#discussion_r3943344692). Feel free to edit this PR as needed.