### PR TITLE
feat(manifest): support `feature-documentation` in manifests

### DIFF
--- a/crates/cargo-util-schemas/manifest.schema.json
+++ b/crates/cargo-util-schemas/manifest.schema.json
@@ -649,6 +649,13 @@
           "items": {
             "type": "string"
           }
+        },
+        "doc": {
+          "description": "Documentation for the feature.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [

--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -1520,6 +1520,9 @@ pub struct FeatureMetadata {
     /// Features that this feature enables.
     pub enables: Vec<String>,
 
+    /// Documentation for the feature.
+    pub doc: Option<String>,
+
     /// This is here to provide a way to see the "unused manifest keys" when deserializing
     #[serde(skip_serializing)]
     #[serde(flatten)]

--- a/doc/book/src/reference/unstable.md
+++ b/doc/book/src/reference/unstable.md
@@ -2396,6 +2396,26 @@ foo = { enables = [] }
 This is equivalent to the array-of-strings syntax.
 Support for other keys should be added later.
 
+### feature-documentation
+
+* Tracking Issue: [#17445](https://github.com/rust-lang/cargo/issues/17445)
+* RFC: [#3485](https://github.com/rust-lang/rfcs/blob/master/text/3485-feature-documentation.md)
+
+This allows providing documentation for the feature inside the table introduced by
+[`feature-metadata`](#feature-metadata):
+
+```toml
+[features.serde]
+enables = []
+doc = "Enables support for serialization and deserialization via serde."
+```
+
+The documentation can be consumed and displayed by tools.
+It can be a multi-line TOML string, contain multiple paragraphs, and use Markdown markup,
+similarly to Rust doc comments.
+Tools may only display the first paragraph in some contexts, which should therefore be
+relatively short and make sense without the rest of the description.
+
 ## lockfile-path
 
 Support for `resolver.lockfile-path` config field has been stabilized in Rust 1.97.0.

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -2683,6 +2683,39 @@ c = [
 }
 
 #[cargo_test]
+fn feature_documentation_is_unstable() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                edition = "2015"
+
+                [features]
+                foo = { enables = [], doc = "Enables foo." }
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("check")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
+
+Caused by:
+  feature `feature-metadata` is required
+
+  The package requires the Cargo feature called `feature-metadata`, but that feature is not stabilized in this version of Cargo ([..]).
+  Consider trying a newer version of Cargo (this may require the nightly release).
+  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#feature_metadata for more information about the status of this feature.
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn feature_has_documentation() {
     let p = project()
         .file(
@@ -2704,8 +2737,6 @@ fn feature_has_documentation() {
     p.cargo("check")
         .masquerade_as_nightly_cargo(&["feature-metadata"])
         .with_stderr_data(str![[r#"
-[WARNING] Cargo.toml: unused manifest key: `features.foo.doc`
-[WARNING] `foo` (manifest) generated 1 warning
 [CHECKING] foo v0.0.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -2681,3 +2681,34 @@ c = [
         [("Cargo.toml", normalized_manifest)],
     );
 }
+
+#[cargo_test]
+fn feature_has_documentation() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                cargo-features = ["feature-metadata"]
+
+                [package]
+                name = "foo"
+                edition = "2015"
+
+                [features]
+                foo = { enables = [], doc = "Enables foo." }
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("check")
+        .masquerade_as_nightly_cargo(&["feature-metadata"])
+        .with_stderr_data(str![[r#"
+[WARNING] Cargo.toml: unused manifest key: `features.foo.doc`
+[WARNING] `foo` (manifest) generated 1 warning
+[CHECKING] foo v0.0.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}


### PR DESCRIPTION
### What does this PR try to resolve?

This implements part of [RFC `feature-documentation`](https://github.com/rust-lang/rfcs/pull/3485), tracked by #17445. This only adds support for the new key in the schema. This doesn't add anything to the index as this was decided against.

This doesn't not introduce a dedicated unstable feature, as mentioned in https://github.com/rust-lang/cargo/issues/17445#issuecomment-5556006228, and the new key is simply gated behind the existing `feature-metadata` unstable feature.

The exact name of the key is still TBD, but it will be easy to rename either in this PR or later.

## Open questions

- How to prepare the documentation for this? Not introducing an unstable feature means there is no dedicated place for that in the book, should it be added to [the existing docs of `feature-metadata` there](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#feature-metadata), or stacked as a separate PR on top of #17446?

## Future work

At least the following is still to be done for this RFC (I may not have time to tackle this):

- Exposing the new key through `cargo metadata`.
- Exposing the documentation to humans through `cargo add` (and through other tools/services, like [docs.rs](https://docs.rs)).

### How to test and review this PR?

The tests should be enough to review this.
