### PR TITLE
Avoid allocations in Windows reserved-name checks

### DIFF
--- a/src/util/restricted_names.rs
+++ b/src/util/restricted_names.rs
@@ -22,11 +22,18 @@ pub fn is_keyword(name: &str) -> bool {
 
 /// These names cannot be used on Windows, even with an extension.
 pub fn is_windows_reserved(name: &str) -> bool {
-    [
-        "con", "prn", "aux", "nul", "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8",
-        "com9", "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9",
-    ]
-    .contains(&name.to_ascii_lowercase().as_str())
+    match name.as_bytes() {
+        [_, _, _] => {
+            name.eq_ignore_ascii_case("con")
+                || name.eq_ignore_ascii_case("prn")
+                || name.eq_ignore_ascii_case("aux")
+                || name.eq_ignore_ascii_case("nul")
+        }
+        [prefix @ .., b'1'..=b'9'] if prefix.len() == 3 => {
+            prefix.eq_ignore_ascii_case(b"com") || prefix.eq_ignore_ascii_case(b"lpt")
+        }
+        _ => false,
+    }
 }
 
 /// An artifact with this name will conflict with one of Cargo's build directories.
@@ -47,4 +54,134 @@ pub fn is_windows_reserved_path(path: &Path) -> bool {
 /// Returns `true` if the name contains any glob pattern wildcards.
 pub fn is_glob_pattern<T: AsRef<str>>(name: T) -> bool {
     name.as_ref().contains(&['*', '?', '[', ']'][..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_windows_reserved, is_windows_reserved_path};
+    use std::path::Path;
+
+    const RESERVED: &[&str] = &[
+        "con", "prn", "aux", "nul", "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8",
+        "com9", "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9",
+    ];
+
+    #[test]
+    fn windows_reserved_names_ignore_ascii_case() {
+        for name in RESERVED {
+            for mask in 0..1 << name.len() {
+                let variant: String = name
+                    .bytes()
+                    .enumerate()
+                    .map(|(i, byte)| {
+                        if mask & (1 << i) == 0 {
+                            byte as char
+                        } else {
+                            byte.to_ascii_uppercase() as char
+                        }
+                    })
+                    .collect();
+                assert!(is_windows_reserved(&variant), "{variant:?}");
+                assert!(is_windows_reserved_path(Path::new(&format!(
+                    "src/{variant}.rs"
+                ))));
+                assert!(is_windows_reserved_path(Path::new(&format!(
+                    "src/{variant}/mod.rs"
+                ))));
+            }
+        }
+    }
+
+    #[test]
+    fn windows_reserved_names_require_an_exact_match() {
+        for name in [
+            "",
+            "co",
+            "com",
+            "lpt",
+            "com0",
+            "com10",
+            "lpt0",
+            "lpt10",
+            "com:",
+            "com/",
+            "lpt:",
+            "lpt/",
+            "xcon",
+            "conx",
+            "con.rs",
+            "nul.tar.gz",
+            " con",
+            "con ",
+            "COM\u{b9}",
+            "LPT\u{b2}",
+            "c\u{f3}n",
+            "\u{e9}1",
+            "\u{e9}a1",
+            "\u{4e2d}1",
+            "\u{1f980}",
+            "aux\0",
+            "nul\n",
+        ] {
+            assert!(!is_windows_reserved(name), "{name:?}");
+        }
+    }
+
+    #[test]
+    fn windows_reserved_names_match_the_previous_implementation() {
+        // Exercise every ASCII byte in every position around the reserved names,
+        // including digit boundaries and names that become another reserved name.
+        for name in RESERVED {
+            for position in 0..name.len() {
+                for byte in 0..=127 {
+                    let mut candidate = name.as_bytes().to_vec();
+                    candidate[position] = byte;
+                    let candidate = std::str::from_utf8(&candidate).unwrap();
+                    let expected = RESERVED.contains(&candidate.to_ascii_lowercase().as_str());
+                    assert_eq!(is_windows_reserved(candidate), expected, "{candidate:?}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn windows_reserved_paths_check_stems_and_parent_components() {
+        for path in [
+            "CON",
+            "src/NuL.rs",
+            "src/COM1.tar.gz",
+            "src/Lpt9/mod.rs",
+            "aux.txt/normal.rs",
+        ] {
+            assert!(is_windows_reserved_path(Path::new(path)), "{path:?}");
+        }
+        for path in [
+            "",
+            ".",
+            "src/lib.rs",
+            "src/conifer.rs",
+            "src/com0.rs",
+            "src/com10.rs",
+            "src/.con",
+            "src/file.con",
+            "src/\u{4e2d}1.rs",
+        ] {
+            assert!(!is_windows_reserved_path(Path::new(path)), "{path:?}");
+        }
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn windows_reserved_paths_handle_windows_separators_and_non_unicode() {
+        use std::ffi::OsString;
+        use std::os::windows::ffi::OsStringExt;
+
+        assert!(is_windows_reserved_path(Path::new(r"C:\src\CoM1.rs")));
+        assert!(is_windows_reserved_path(Path::new(r"src\AuX\mod.rs")));
+        let non_unicode = OsString::from_wide(&[0xd800]);
+        assert!(!is_windows_reserved_path(Path::new(&non_unicode)));
+        assert!(is_windows_reserved_path(
+            &Path::new(&non_unicode).join("nul.rs")
+        ));
+    }
 }


### PR DESCRIPTION
### What does this PR try to resolve?

`is_windows_reserved` creates a lowercase `String` before checking whether a name is reserved. Cargo performs this check for path components during packaging on all platforms and registry unpacking on Windows.

Replace the temporary string and list search with ASCII-insensitive comparisons on borrowed input. The recognized names, public API, and path-handling behavior remain unchanged.

The patch contains only the implementation change and regression tests in `src/util/restricted_names.rs`.

### How to test and review this PR?

The new tests cover all ASCII case combinations of the 22 reserved names, 10,752 single-byte mutations compared with the previous implementation, digit boundaries, Unicode, extensions, parent components, and non-Unicode Windows paths.

Run the focused tests with:

    cargo test -p cargo --lib restricted_names

All 191 Cargo library tests and three existing reserved-name integration tests passed. The registry-unpacking integration test can return early on Windows configurations that permit reserved names. Formatting checks also passed.

### Benchmark

Measured on a Xeon E5-2696 v4, Windows x86_64, Rust 1.98.0. A standalone benchmark scanned 466 tracked Cargo source and crate paths:

| Measurement | Before | After |
| --- | ---: | ---: |
| Time/path | 945.98 ns | 246.67 ns |
| Thread cycles/path | 2,071.36 | 540.25 |
| Allocations per corpus pass | 1,822 | 0 |
| Allocated bytes per corpus pass | 12,438 | 0 |

Timing and cycle results are medians of nine samples per implementation, with alternating execution order and approximately 3.2 million paths checked per sample. Allocation counting used a separate executable to avoid affecting timings.

An independent Criterion benchmark measured 2.78x higher throughput on 16 representative package paths. These are measurements of the reserved-name checks; end-to-end Cargo performance has not been measured.

Benchmark harnesses and raw results were kept outside the patch.

🤖 AI disclosure: I used Codex with GPT-6 Astra at xhigh reasoning effort to help identify the optimization and construct the benchmark. I have reviewed and understand the resulting implementation.