### PR TITLE
feat(hints): extract mostly-unused diagnostics 

### DIFF
--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1331,21 +1331,6 @@ fn build_base_args(
     let hints = unit.pkg.hints().cloned().unwrap_or_default();
     let test = unit.mode.is_any_test();
 
-    let warn = |msg: &str| {
-        bcx.gctx.shell().warn(format!(
-            "{}@{}: {msg}",
-            unit.pkg.package_id().name(),
-            unit.pkg.package_id().version()
-        ))
-    };
-    let unit_capped_warn = |msg: &str| {
-        if unit.show_warnings(bcx.gctx) {
-            warn(msg)
-        } else {
-            Ok(())
-        }
-    };
-
     cmd.arg("--crate-name").arg(&unit.target.crate_name());
 
     let edition = unit.target.edition();
@@ -1525,34 +1510,17 @@ fn build_base_args(
     }
 
     let pkg_hint_mostly_unused = match hints.mostly_unused {
-        None => None,
         Some(toml::Value::Boolean(b)) => Some(b),
-        Some(v) => {
-            unit_capped_warn(&format!(
-                "ignoring unsupported value type ({}) for 'hints.mostly-unused', which expects a boolean",
-                v.type_str()
-            ))?;
-            None
-        }
+        // Unsupported values and missing feature gates are reported by
+        // `crate::diagnostics::rules::mostly_unused_hint::diagnose` before the build starts.
+        _ => None,
     };
     if profile_hint_mostly_unused
         .or(pkg_hint_mostly_unused)
         .unwrap_or(false)
+        && bcx.gctx.cli_unstable().profile_hint_mostly_unused
     {
-        if bcx.gctx.cli_unstable().profile_hint_mostly_unused {
-            cmd.arg("-Zhint-mostly-unused");
-        } else {
-            if profile_hint_mostly_unused.is_some() {
-                // Profiles come from the top-level unit, so we don't use `unit_capped_warn` here.
-                warn(
-                    "ignoring 'hint-mostly-unused' profile option, pass `-Zprofile-hint-mostly-unused` to enable it",
-                )?;
-            } else if pkg_hint_mostly_unused.is_some() {
-                unit_capped_warn(
-                    "ignoring 'hints.mostly-unused', pass `-Zprofile-hint-mostly-unused` to enable it",
-                )?;
-            }
-        }
+        cmd.arg("-Zhint-mostly-unused");
     }
 
     let strip = strip.into_inner();

--- a/src/diagnostics/mod.rs
+++ b/src/diagnostics/mod.rs
@@ -20,7 +20,7 @@
 //! - TOML syntax or manifest schema: [`passes::emit_parse_diagnostics`], [`rules::PARSE_PASS_RULES`]
 //! - Lockfile
 //!   - May be overly broad for what dependencies are checked
-//! - Pre-build unit graph
+//! - Pre-build unit graph: [`rules::mostly_unused_hint::diagnose`]
 //!   - Tailored to a specific configuration (features, targets) but requires users to enumerate every configuration
 //! - Post-build unit graph: [`rules::unused_dependencies::lint_build_results`]
 //!   - Slow feedback cycle since a build needs to happen
@@ -69,7 +69,9 @@ pub mod passes;
 pub mod rules;
 
 pub use lint::{Lint, LintGroup, LintLevel, LintLevelProduct, LintLevelSource};
-pub use report::{AsIndex, cwd_rel_path, get_key_value, get_key_value_span, workspace_rel_path};
+pub use report::{
+    AsIndex, TomlSpan, cwd_rel_path, get_key_value, get_key_value_span, workspace_rel_path,
+};
 pub use rules::{LINT_GROUPS, LINTS};
 
 pub struct PassOutput {

--- a/src/diagnostics/rules/mod.rs
+++ b/src/diagnostics/rules/mod.rs
@@ -4,6 +4,7 @@ mod im_a_teapot;
 mod manual_readme;
 mod missing_lints_features;
 mod missing_lints_inheritance;
+pub mod mostly_unused_hint;
 mod non_kebab_case_bins;
 mod non_kebab_case_features;
 mod non_kebab_case_packages;

--- a/src/diagnostics/rules/mostly_unused_hint.rs
+++ b/src/diagnostics/rules/mostly_unused_hint.rs
@@ -1,0 +1,122 @@
+use cargo_util_terminal::report::AnnotationKind;
+use cargo_util_terminal::report::Group;
+use cargo_util_terminal::report::Level;
+use cargo_util_terminal::report::Origin;
+use cargo_util_terminal::report::Snippet;
+
+use crate::CargoResult;
+use crate::compiler::BuildContext;
+use crate::diagnostics::TomlSpan;
+use crate::diagnostics::get_key_value_span;
+use crate::diagnostics::workspace_rel_path;
+use crate::util::data_structures::HashSet;
+use crate::workspace::Package;
+
+const HELP: &str = "pass `-Zprofile-hint-mostly-unused` to enable it";
+
+#[derive(PartialEq, Eq, Hash)]
+enum DiagnosticKind {
+    UnsupportedHintType,
+    IgnoredProfileOption,
+    IgnoredPackageHint,
+}
+
+/// Emits each diagnostic for `hints.mostly-unused` and the `hint-mostly-unused` profile option once
+/// per package selected for compilation.
+#[tracing::instrument(skip_all)]
+pub(crate) fn diagnose(bcx: &BuildContext<'_, '_>) -> CargoResult<()> {
+    let gctx = bcx.gctx;
+    let mut units = bcx
+        .unit_graph
+        .keys()
+        .filter(|unit| !unit.skip_non_compile_time_dep)
+        .collect::<Vec<_>>();
+    units.sort();
+    let mut emitted = HashSet::default();
+
+    for unit in units {
+        let pkg = &unit.pkg;
+        let pkg_id = pkg.package_id();
+        let gate_enabled = gctx.cli_unstable().profile_hint_mostly_unused;
+        let profile_hint = unit.profile.hint_mostly_unused;
+
+        // Profile options come from the workspace itself, so they are reported even for
+        // non-local packages.
+        if !gate_enabled
+            && profile_hint == Some(true)
+            && emitted.insert((pkg_id, DiagnosticKind::IgnoredProfileOption))
+        {
+            let title = format!(
+                "ignoring `hint-mostly-unused` profile option for `{}@{}`",
+                pkg.name(),
+                pkg.version()
+            );
+            let group = Group::with_title(Level::WARNING.primary_title(title));
+            let group = group.element(Level::HELP.message(HELP));
+            gctx.shell().print_report(&[group], false)?;
+        }
+
+        if !unit.show_warnings(gctx) {
+            continue;
+        }
+
+        let manifest_path = workspace_rel_path(bcx.ws, pkg.manifest_path());
+        let hint_value = pkg.hints().and_then(|hints| hints.mostly_unused.as_ref());
+        let pkg_hint = match hint_value {
+            None => None,
+            Some(toml::Value::Boolean(b)) => Some(*b),
+            Some(value) => {
+                if emitted.insert((pkg_id, DiagnosticKind::UnsupportedHintType)) {
+                    let title = format!(
+                        "ignoring unsupported value type ({}) for `hints.mostly-unused`",
+                        value.type_str()
+                    );
+                    let group = Group::with_title(Level::WARNING.primary_title(title));
+                    let group = match hint_span(pkg) {
+                        Some((contents, span)) => group.element(
+                            Snippet::source(contents).path(&manifest_path).annotation(
+                                AnnotationKind::Primary
+                                    .span(span.value)
+                                    .label("expected a boolean"),
+                            ),
+                        ),
+                        None => group.element(Origin::path(&manifest_path)),
+                    };
+                    gctx.shell().print_report(&[group], false)?;
+                }
+                None
+            }
+        };
+
+        if gate_enabled
+            || profile_hint.is_some()
+            || pkg_hint != Some(true)
+            || !emitted.insert((pkg_id, DiagnosticKind::IgnoredPackageHint))
+        {
+            continue;
+        }
+        let group =
+            Group::with_title(Level::WARNING.primary_title("ignoring `hints.mostly-unused`"));
+        let group = match hint_span(pkg) {
+            Some((contents, span)) => group.element(
+                Snippet::source(contents)
+                    .path(&manifest_path)
+                    .annotation(AnnotationKind::Primary.span(span.key.start..span.value.end)),
+            ),
+            None => group.element(Origin::path(&manifest_path)),
+        };
+        let group = group.element(Level::HELP.message(HELP));
+        gctx.shell().print_report(&[group], false)?;
+    }
+
+    Ok(())
+}
+
+/// Locates `hints.mostly-unused` in the package's original manifest, if its source is available.
+fn hint_span(pkg: &Package) -> Option<(&str, TomlSpan)> {
+    let manifest = pkg.manifest();
+    let contents = manifest.contents()?;
+    let document = manifest.document()?;
+    let span = get_key_value_span(document, &["hints", "mostly-unused"])?;
+    Some((contents, span))
+}

--- a/src/ops/cargo_compile/mod.rs
+++ b/src/ops/cargo_compile/mod.rs
@@ -196,6 +196,7 @@ fn compile_ws<'a>(
     }
 
     let bcx = create_bcx(ws, options, &interner, logger.as_ref())?;
+    crate::diagnostics::rules::mostly_unused_hint::diagnose(&bcx)?;
 
     if options.build_config.unit_graph {
         unit_graph::emit_serialized_unit_graph(&bcx.roots, &bcx.unit_graph, ws.gctx())?;

--- a/tests/testsuite/hints.rs
+++ b/tests/testsuite/hints.rs
@@ -136,7 +136,11 @@ fn hint_unknown_type_warn() {
 [LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
-[WARNING] foo@0.0.1: ignoring unsupported value type (string) for 'hints.mostly-unused', which expects a boolean
+[WARNING] ignoring unsupported value type (string) for `hints.mostly-unused`
+  --> Cargo.toml:11:29
+   |
+11 |             mostly-unused = "string"
+   |                             ^^^^^^^^ expected a boolean
 [CHECKING] bar v1.0.0
 [RUNNING] `rustc --crate-name bar [..]`
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -149,6 +153,16 @@ fn hint_unknown_type_warn() {
 
     p.cargo("check -vv")
         .with_stderr_data(str![[r#"
+[WARNING] ignoring unsupported value type (integer) for `hints.mostly-unused`
+ --> [ROOT]/home/.cargo/registry/src/-[HASH]/bar-1.0.0/Cargo.toml:8:29
+  |
+8 |             mostly-unused = 1
+  |                             ^ expected a boolean
+[WARNING] ignoring unsupported value type (string) for `hints.mostly-unused`
+  --> Cargo.toml:11:29
+   |
+11 |             mostly-unused = "string"
+   |                             ^^^^^^^^ expected a boolean
 [FRESH] bar v1.0.0
 [FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -204,7 +218,13 @@ fn hints_mostly_unused_warn_without_gate() {
 [LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
-[WARNING] foo@0.0.1: ignoring 'hints.mostly-unused', pass `-Zprofile-hint-mostly-unused` to enable it
+[WARNING] ignoring `hints.mostly-unused`
+  --> Cargo.toml:11:13
+   |
+11 |             mostly-unused = true
+   |             ^^^^^^^^^^^^^^^^^^^^
+   |
+   = [HELP] pass `-Zprofile-hint-mostly-unused` to enable it
 [CHECKING] bar v1.0.0
 [RUNNING] `rustc --crate-name bar [..]`
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -217,6 +237,20 @@ fn hints_mostly_unused_warn_without_gate() {
 
     p.cargo("check -vv")
         .with_stderr_data(str![[r#"
+[WARNING] ignoring `hints.mostly-unused`
+ --> [ROOT]/home/.cargo/registry/src/-[HASH]/bar-1.0.0/Cargo.toml:8:13
+  |
+8 |             mostly-unused = true
+  |             ^^^^^^^^^^^^^^^^^^^^
+  |
+  = [HELP] pass `-Zprofile-hint-mostly-unused` to enable it
+[WARNING] ignoring `hints.mostly-unused`
+  --> Cargo.toml:11:13
+   |
+11 |             mostly-unused = true
+   |             ^^^^^^^^^^^^^^^^^^^^
+   |
+   = [HELP] pass `-Zprofile-hint-mostly-unused` to enable it
 [FRESH] bar v1.0.0
 [FRESH] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -250,9 +284,16 @@ fn mostly_unused_warns_for_each_source_with_multiple_targets() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] foo@0.0.1: ignoring 'hints.mostly-unused', pass `-Zprofile-hint-mostly-unused` to enable it
-[WARNING] foo@0.0.1: ignoring 'hint-mostly-unused' profile option, pass `-Zprofile-hint-mostly-unused` to enable it
-[WARNING] foo@0.0.1: ignoring 'hints.mostly-unused', pass `-Zprofile-hint-mostly-unused` to enable it
+[WARNING] ignoring `hints.mostly-unused`
+ --> Cargo.toml:8:13
+  |
+8 |             mostly-unused = true
+  |             ^^^^^^^^^^^^^^^^^^^^
+  |
+  = [HELP] pass `-Zprofile-hint-mostly-unused` to enable it
+[WARNING] ignoring `hint-mostly-unused` profile option for `foo@0.0.1`
+  |
+  = [HELP] pass `-Zprofile-hint-mostly-unused` to enable it
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -261,6 +302,16 @@ fn mostly_unused_warns_for_each_source_with_multiple_targets() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
+[WARNING] ignoring `hints.mostly-unused`
+ --> Cargo.toml:8:13
+  |
+8 |             mostly-unused = true
+  |             ^^^^^^^^^^^^^^^^^^^^
+  |
+  = [HELP] pass `-Zprofile-hint-mostly-unused` to enable it
+[WARNING] ignoring `hint-mostly-unused` profile option for `foo@0.0.1`
+  |
+  = [HELP] pass `-Zprofile-hint-mostly-unused` to enable it
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
 "#]])
@@ -291,10 +342,14 @@ fn mostly_unused_invalid_value_and_profile_warn_once_per_package() {
 
     p.cargo("check")
         .with_stderr_data(str![[r#"
-[WARNING] foo@0.0.1: ignoring unsupported value type (string) for 'hints.mostly-unused', which expects a boolean
-[WARNING] foo@0.0.1: ignoring 'hint-mostly-unused' profile option, pass `-Zprofile-hint-mostly-unused` to enable it
-[WARNING] foo@0.0.1: ignoring unsupported value type (string) for 'hints.mostly-unused', which expects a boolean
-[WARNING] foo@0.0.1: ignoring 'hint-mostly-unused' profile option, pass `-Zprofile-hint-mostly-unused` to enable it
+[WARNING] ignoring `hint-mostly-unused` profile option for `foo@0.0.1`
+  |
+  = [HELP] pass `-Zprofile-hint-mostly-unused` to enable it
+[WARNING] ignoring unsupported value type (string) for `hints.mostly-unused`
+ --> Cargo.toml:8:29
+  |
+8 |             mostly-unused = "string"
+  |                             ^^^^^^^^ expected a boolean
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 
@@ -343,7 +398,13 @@ fn mostly_unused_package_hint_warns_with_mixed_profiles() {
     p.cargo("check")
         .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
-[WARNING] bar@0.0.1: ignoring 'hints.mostly-unused', pass `-Zprofile-hint-mostly-unused` to enable it
+[WARNING] ignoring `hints.mostly-unused`
+ --> bar/Cargo.toml:8:13
+  |
+8 |             mostly-unused = true
+  |             ^^^^^^^^^^^^^^^^^^^^
+  |
+  = [HELP] pass `-Zprofile-hint-mostly-unused` to enable it
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

--- a/tests/testsuite/hints.rs
+++ b/tests/testsuite/hints.rs
@@ -146,6 +146,15 @@ fn hint_unknown_type_warn() {
 "#]])
         .with_stderr_does_not_contain("-Zhint-mostly-unused")
         .run();
+
+    p.cargo("check -vv")
+        .with_stderr_data(str![[r#"
+[FRESH] bar v1.0.0
+[FRESH] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
 }
 
 #[cargo_test]
@@ -204,6 +213,142 @@ fn hints_mostly_unused_warn_without_gate() {
 
 "#]])
         .with_stderr_does_not_contain("-Zhint-mostly-unused")
+        .run();
+
+    p.cargo("check -vv")
+        .with_stderr_data(str![[r#"
+[FRESH] bar v1.0.0
+[FRESH] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn mostly_unused_warns_for_each_source_with_multiple_targets() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            edition = "2015"
+
+            [hints]
+            mostly-unused = true
+
+            [profile.dev.build-override]
+            hint-mostly-unused = true
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file("src/main.rs", "extern crate foo; fn main() {}")
+        .file("build.rs", "fn main() {}")
+        .build();
+
+    p.cargo("check")
+        .with_stderr_data(str![[r#"
+[WARNING] foo@0.0.1: ignoring 'hints.mostly-unused', pass `-Zprofile-hint-mostly-unused` to enable it
+[WARNING] foo@0.0.1: ignoring 'hint-mostly-unused' profile option, pass `-Zprofile-hint-mostly-unused` to enable it
+[WARNING] foo@0.0.1: ignoring 'hints.mostly-unused', pass `-Zprofile-hint-mostly-unused` to enable it
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+
+    p.cargo("check")
+        .with_stderr_data(str![[r#"
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn mostly_unused_invalid_value_and_profile_warn_once_per_package() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            edition = "2015"
+
+            [hints]
+            mostly-unused = "string"
+
+            [profile.dev]
+            hint-mostly-unused = true
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file("src/main.rs", "extern crate foo; fn main() {}")
+        .build();
+
+    p.cargo("check")
+        .with_stderr_data(str![[r#"
+[WARNING] foo@0.0.1: ignoring unsupported value type (string) for 'hints.mostly-unused', which expects a boolean
+[WARNING] foo@0.0.1: ignoring 'hint-mostly-unused' profile option, pass `-Zprofile-hint-mostly-unused` to enable it
+[WARNING] foo@0.0.1: ignoring unsupported value type (string) for 'hints.mostly-unused', which expects a boolean
+[WARNING] foo@0.0.1: ignoring 'hint-mostly-unused' profile option, pass `-Zprofile-hint-mostly-unused` to enable it
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn mostly_unused_package_hint_warns_with_mixed_profiles() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            edition = "2015"
+
+            [dependencies]
+            bar = { path = "bar" }
+
+            [build-dependencies]
+            bar = { path = "bar" }
+
+            [profile.dev.build-override]
+            hint-mostly-unused = false
+            "#,
+        )
+        .file("src/main.rs", "extern crate bar; fn main() {}")
+        .file("build.rs", "extern crate bar; fn main() {}")
+        .file(
+            "bar/Cargo.toml",
+            r#"
+            [package]
+            name = "bar"
+            version = "0.0.1"
+            edition = "2015"
+
+            [hints]
+            mostly-unused = true
+            "#,
+        )
+        .file("bar/src/lib.rs", "")
+        .build();
+
+    p.cargo("check")
+        .with_stderr_data(str![[r#"
+[LOCKING] 1 package to highest compatible version
+[WARNING] bar@0.0.1: ignoring 'hints.mostly-unused', pass `-Zprofile-hint-mostly-unused` to enable it
+[COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 

--- a/tests/testsuite/profile_settings.rs
+++ b/tests/testsuite/profile_settings.rs
@@ -911,7 +911,9 @@ fn profile_hint_mostly_unused_warn_without_gate() {
 [LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
-[WARNING] bar@1.0.0: ignoring 'hint-mostly-unused' profile option, pass `-Zprofile-hint-mostly-unused` to enable it
+[WARNING] ignoring `hint-mostly-unused` profile option for `bar@1.0.0`
+  |
+  = [HELP] pass `-Zprofile-hint-mostly-unused` to enable it
 [CHECKING] bar v1.0.0
 [RUNNING] `rustc --crate-name bar [..]`
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
@@ -925,7 +927,7 @@ fn profile_hint_mostly_unused_warn_without_gate() {
 
 #[cargo_test]
 fn profile_hint_mostly_unused_warns_with_mixed_profiles() {
-    for (normal_hint, build_hint) in [(false, true), (true, false)] {
+    for (normal_hint, build_hint) in [(false, true), (true, false), (true, true)] {
         let p = project()
             .file(
                 "Cargo.toml",
@@ -970,7 +972,9 @@ fn profile_hint_mostly_unused_warns_with_mixed_profiles() {
         p.cargo("check")
             .with_stderr_data(str![[r#"
 [LOCKING] 1 package to highest compatible version
-[WARNING] bar@0.0.1: ignoring 'hint-mostly-unused' profile option, pass `-Zprofile-hint-mostly-unused` to enable it
+[WARNING] ignoring `hint-mostly-unused` profile option for `bar@0.0.1`
+  |
+  = [HELP] pass `-Zprofile-hint-mostly-unused` to enable it
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
@@ -1014,7 +1018,9 @@ fn profile_hint_mostly_unused_from_config_warn_without_gate() {
 [LOCKING] 1 package to highest compatible version
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
-[WARNING] bar@1.0.0: ignoring 'hint-mostly-unused' profile option, pass `-Zprofile-hint-mostly-unused` to enable it
+[WARNING] ignoring `hint-mostly-unused` profile option for `bar@1.0.0`
+  |
+  = [HELP] pass `-Zprofile-hint-mostly-unused` to enable it
 [CHECKING] bar v1.0.0
 [RUNNING] `rustc --crate-name bar [..]`
 [CHECKING] foo v0.0.1 ([ROOT]/foo)

--- a/tests/testsuite/profile_settings.rs
+++ b/tests/testsuite/profile_settings.rs
@@ -923,6 +923,109 @@ fn profile_hint_mostly_unused_warn_without_gate() {
         .run();
 }
 
+#[cargo_test]
+fn profile_hint_mostly_unused_warns_with_mixed_profiles() {
+    for (normal_hint, build_hint) in [(false, true), (true, false)] {
+        let p = project()
+            .file(
+                "Cargo.toml",
+                &format!(
+                    r#"
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    edition = "2015"
+
+                    [dependencies]
+                    bar = {{ path = "bar" }}
+
+                    [build-dependencies]
+                    bar = {{ path = "bar" }}
+
+                    [profile.dev]
+                    hint-mostly-unused = {normal_hint}
+
+                    [profile.dev.build-override]
+                    hint-mostly-unused = {build_hint}
+
+                    [profile.dev.package.foo]
+                    hint-mostly-unused = false
+                    "#,
+                ),
+            )
+            .file("src/main.rs", "extern crate bar; fn main() {}")
+            .file("build.rs", "extern crate bar; fn main() {}")
+            .file(
+                "bar/Cargo.toml",
+                r#"
+                [package]
+                name = "bar"
+                version = "0.0.1"
+                edition = "2015"
+                "#,
+            )
+            .file("bar/src/lib.rs", "")
+            .build();
+
+        p.cargo("check")
+            .with_stderr_data(str![[r#"
+[LOCKING] 1 package to highest compatible version
+[WARNING] bar@0.0.1: ignoring 'hint-mostly-unused' profile option, pass `-Zprofile-hint-mostly-unused` to enable it
+[COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+            .run();
+    }
+}
+
+#[cargo_test]
+fn profile_hint_mostly_unused_from_config_warn_without_gate() {
+    Package::new("bar", "1.0.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            edition = "2015"
+
+            [dependencies]
+            bar = "1.0"
+
+            [lints.cargo]
+            default = "allow"
+            "#,
+        )
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [profile.dev.package.bar]
+            hint-mostly-unused = true
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+    p.cargo("check -v")
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
+[LOCKING] 1 package to highest compatible version
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
+[WARNING] bar@1.0.0: ignoring 'hint-mostly-unused' profile option, pass `-Zprofile-hint-mostly-unused` to enable it
+[CHECKING] bar v1.0.0
+[RUNNING] `rustc --crate-name bar [..]`
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[RUNNING] `rustc --crate-name foo [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .with_stderr_does_not_contain("-Zhint-mostly-unused")
+        .run();
+}
+
 #[cargo_test(nightly, reason = "-Zhint-mostly-unused is unstable")]
 fn profile_hint_mostly_unused_nightly() {
     Package::new("bar", "1.0.0").publish();


### PR DESCRIPTION
### What does this PR try to resolve?

Try to use `annotate-snippets` to report mostly unused warnings. Inspired by https://github.com/rust-lang/cargo/pull/17368#discussion_r3916519534.

Some behaviour changes after we move it to phase pass.

| # | Case | Before | After |
|---|---|---|---|
| 1 | `hint-mostly-unused = true` in a profile table the build doesn't apply: unselected profile (`[profile.release]` on `cargo check`, config `profile.bench`), `build-override` with no build scripts, `package.<spec>` for a package that isn't built | Silent | Warns |
| 2 | `hints.mostly-unused = true` while a profile sets `hint-mostly-unused = false` for that package | Silent, as the flag wouldn't change this build | Warns, as the key is still ignored without the flag (the profile override isn't considered) |
| 3 | `hints.mostly-unused = true` while a profile also sets `hint-mostly-unused = true` for that package | Only the profile warning | Both warnings |
| 4 | `[hints]` in a workspace member this invocation doesn't compile, e.g. `cargo check -p a` when `b` has the hint | Silent | Warns about `b` |
| 5 | `cargo doc -p b` where `b` has `[hints]`| Silent | Warns |
| 6 | `cargo clean` with `hint-mostly-unused = true` in a config/env profile | Silent | Warns, as `cargo clean` loads profiles |
| 7 | `[hints]` in a path dependency that isn't a workspace member | Warns | Silent |
| 8 | `[hints]` in a registry/git dependency | Warns under `-vv` when it is compiled | Silent |
| 9 | `cargo install <registry crate>` whose own manifest has `[profile.release] hint-mostly-unused = true` | Warns | Silent |


### How to test and review this PR?

Check the unit tests and review each commit individually.

r?@ghost

LLM disclosure: AI generated the unit tests and helped me move mostly unused diagnostics to the parse pass.