### PR TITLE
fix(complete): merge feature candidates shared by workspace members

### DIFF
--- a/src/util/command_prelude.rs
+++ b/src/util/command_prelude.rs
@@ -1153,26 +1153,40 @@ fn get_feature_candidates() -> CargoResult<Vec<clap_complete::CompletionCandidat
     let gctx = new_gctx_for_completions()?;
 
     let ws = Workspace::new(&find_root_manifest_for_wd(gctx.cwd())?, &gctx)?;
-    let mut feature_candidates = Vec::new();
+    let current_package = ws.current_opt().map(|p| p.name());
 
-    // Process all packages in the workspace
+    // More than one workspace member can define the same feature name. Candidates
+    // are deduplicated by value, so emitting one per package keeps only the first
+    // package's help and hides that the others define it too. Collect the packages
+    // defining each feature and name all of them.
+    let mut packages_by_feature: BTreeMap<InternedString, Vec<InternedString>> = BTreeMap::new();
     for package in ws.members() {
-        let package_name = package.name();
-
-        // Add direct features with package info
         for feature_name in package.summary().features().keys() {
-            let order = if ws.current_opt().map(|p| p.name()) == Some(package_name) {
+            packages_by_feature
+                .entry(*feature_name)
+                .or_default()
+                .push(package.name());
+        }
+    }
+
+    let feature_candidates = packages_by_feature
+        .into_iter()
+        .map(|(feature_name, packages)| {
+            let order = if packages.iter().any(|name| Some(*name) == current_package) {
                 0
             } else {
                 1
             };
-            feature_candidates.push(
-                clap_complete::CompletionCandidate::new(feature_name)
-                    .display_order(Some(order))
-                    .help(Some(format!("from {}", package_name).into())),
-            );
-        }
-    }
+            let from = packages
+                .iter()
+                .map(|name| name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            clap_complete::CompletionCandidate::new(feature_name.as_str())
+                .display_order(Some(order))
+                .help(Some(format!("from {from}").into()))
+        })
+        .collect();
 
     Ok(feature_candidates)
 }

--- a/tests/testsuite/completions.rs
+++ b/tests/testsuite/completions.rs
@@ -1,0 +1,92 @@
+//! Tests for shell completion candidates.
+
+use crate::prelude::*;
+use cargo_test_support::project;
+use cargo_test_support::str;
+
+fn workspace_with_shared_feature() -> cargo_test_support::Project {
+    project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [workspace]
+                members = ["crate-a", "crate-b"]
+            "#,
+        )
+        .file(
+            "crate-a/Cargo.toml",
+            r#"
+                [package]
+                name = "crate-a"
+                version = "0.1.0"
+                edition = "2015"
+
+                [features]
+                shared = []
+                only-a = []
+            "#,
+        )
+        .file("crate-a/src/lib.rs", "")
+        .file(
+            "crate-b/Cargo.toml",
+            r#"
+                [package]
+                name = "crate-b"
+                version = "0.1.0"
+                edition = "2015"
+
+                [features]
+                shared = []
+                only-b = []
+            "#,
+        )
+        .file("crate-b/src/lib.rs", "")
+        .build()
+}
+
+#[cargo_test]
+fn features_shared_across_workspace_members_are_one_candidate() {
+    let p = workspace_with_shared_feature();
+
+    // `shared` is defined by both members. It must appear once, not once per
+    // package, because candidates are deduplicated by value downstream.
+    p.cargo("--")
+        .arg("cargo")
+        .arg("build")
+        .arg("--features")
+        .arg("")
+        .env("CARGO_COMPLETE", "bash")
+        .env("_CLAP_COMPLETE_INDEX", "3")
+        .masquerade_as_nightly_cargo(&["native-completions"])
+        .with_stdout_data(str![[r#"
+only-a
+shared
+only-b
+shared
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn features_shared_across_workspace_members_name_every_package() {
+    let p = workspace_with_shared_feature();
+
+    // The help for a shared feature has to name both packages; naming only the
+    // first is what made the duplicate candidate misleading.
+    p.cargo("--")
+        .arg("cargo")
+        .arg("build")
+        .arg("--features")
+        .arg("")
+        .env("CARGO_COMPLETE", "fish")
+        .env("_CLAP_COMPLETE_INDEX", "3")
+        .masquerade_as_nightly_cargo(&["native-completions"])
+        .with_stdout_data(str![[r#"
+only-a	from crate-a
+shared	from crate-a
+only-b	from crate-b
+shared	from crate-b
+
+"#]])
+        .run();
+}

--- a/tests/testsuite/completions.rs
+++ b/tests/testsuite/completions.rs
@@ -60,7 +60,6 @@ fn features_shared_across_workspace_members_are_one_candidate() {
         .masquerade_as_nightly_cargo(&["native-completions"])
         .with_stdout_data(str![[r#"
 only-a
-shared
 only-b
 shared
 "#]])
@@ -83,9 +82,8 @@ fn features_shared_across_workspace_members_name_every_package() {
         .masquerade_as_nightly_cargo(&["native-completions"])
         .with_stdout_data(str![[r#"
 only-a	from crate-a
-shared	from crate-a
 only-b	from crate-b
-shared	from crate-b
+shared	from crate-a, crate-b
 
 "#]])
         .run();

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -77,6 +77,7 @@ mod clean;
 mod clean_legacy_layout;
 mod collisions;
 mod compile_time_deps;
+mod completions;
 mod concurrent;
 mod config;
 mod config_cli;


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes #17448.

`get_feature_candidates` in `src/util/command_prelude.rs` pushes one completion candidate per package that defines a feature, each with `from <package>` as its help. Completion candidates are deduplicated by value, so when two workspace members define the same feature name only the first survives. The user is shown help naming one package, with no hint that any other package defines it too.

In a workspace where `crate-a` and `crate-b` both define `shared`:

```
only-a	from crate-a
shared	from crate-a
only-b	from crate-b
shared	from crate-b
```

`shared` is emitted twice with conflicting help, and whichever the shell keeps is a half-truth.

This takes the second option the issue suggests: collect the packages defining each feature name and emit one candidate whose help names all of them.

```
only-a	from crate-a
only-b	from crate-b
shared	from crate-a, crate-b
```

Two things worth flagging for review:

- **Ordering within a display order changed.** Candidates are collected through a `BTreeMap`, so they come out in feature-name order rather than workspace-member order. That is visible in the first commit's snapshots.
- **`display_order` for a shared feature.** A feature is ordered first when *any* of the packages defining it is the current package. That preserves the previous intent for the common case where a feature belongs to a single package, and it seemed better than dropping a shared feature to the back when the current package is one of its definers. Happy to change it if you would rather it be stricter.

### How to test and review this PR?

The first commit adds `tests/testsuite/completions.rs` with snapshots recording what cargo does today, so the behaviour change shows up as a snapshot diff in the second commit rather than as prose. Reviewing the second commit's diff of that file is the quickest way to see exactly what changes:

```
 only-a	from crate-a
-shared	from crate-a
 only-b	from crate-b
-shared	from crate-b
+shared	from crate-a, crate-b
```

There were no tests for completion candidates before this, so the harness is new. It drives the completer the same way the generated shell integration does, through `CARGO_COMPLETE` and `_CLAP_COMPLETE_INDEX`. Two cases are covered: `bash`, which shows the duplicate value on its own, and `fish`, which also carries the help text where the misleading part lives.

```
cargo test --test testsuite completions::
```

Checking out the first commit alone and running the same command passes against current behaviour; the second commit is what changes it.

Manually, in a workspace with two members defining the same feature:

```
_CLAP_COMPLETE_INDEX=3 CARGO_COMPLETE=fish cargo -- cargo build --features ""
```

Also ran `cargo test --test testsuite features_namespaced` (23 passed) and `weak_dep_features` (9 passed) as the nearest feature-related suites, plus `cargo fmt --check` and `cargo clippy --bin cargo`, all clean.
