### PR TITLE
fix(directory): initialize source before download

### DIFF
--- a/src/sources/directory.rs
+++ b/src/sources/directory.rs
@@ -213,6 +213,9 @@ impl<'gctx> Source for DirectorySource<'gctx> {
     }
 
     async fn download(&self, id: PackageId) -> CargoResult<MaybePackage> {
+        if !self.updated.get() {
+            self.update()?;
+        }
         self.packages
             .borrow()
             .get(&id)

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -160,6 +160,29 @@ fn simple_install() {
         .run();
 }
 
+/// Regression test for https://github.com/rust-lang/cargo/issues/17458
+#[cargo_test]
+fn simple_install_without_dependencies() {
+    setup();
+
+    VendorPackage::new("bar")
+        .file("Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    cargo_process("install bar")
+        .with_stderr_data(str![[r#"
+[INSTALLING] bar v0.1.0
+[COMPILING] bar v0.1.0
+[FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
+[INSTALLING] [ROOT]/home/.cargo/bin/bar[EXE]
+[INSTALLED] package `bar v0.1.0` (executable `bar[EXE]`)
+[WARNING] be sure to add `[ROOT]/home/.cargo/bin` to your PATH to be able to run the installed binaries
+
+"#]])
+        .run();
+}
+
 #[cargo_test]
 fn simple_install_fail() {
     setup();


### PR DESCRIPTION
Fixes #17458

### What does this PR try to resolve?

`DirectorySource::download` assumed that `query` had already initialized the source's package map. `cargo install` can download a dependency-free package through a fresh source instance, so the lookup failed even though package selection succeeded.

Initialize the directory source on the first download, matching the existing lazy initialization in `query`, and add a regression test covering a dependency-free binary installed from a directory-source replacement.

### How to test and review this PR?

- `cargo +1.98.0 test --test testsuite directory:: --no-fail-fast`
- `cargo fmt --check`
- `git diff --check`
