### PR TITLE
docs: mention kache next to sccache in the shared cache section

### DIFF
--- a/doc/book/src/reference/build-cache.md
+++ b/doc/book/src/reference/build-cache.md
@@ -102,8 +102,8 @@ you use bash, it makes sense to add `export RUSTC_WRAPPER=sccache` to
 `.bashrc`. Alternatively, you can set [`build.rustc-wrapper`] in the [Cargo
 configuration][config]. Refer to sccache documentation for more details.
 
-The same `RUSTC_WRAPPER` / [`build.rustc-wrapper`] setup works for other
-compiler wrappers, such as [kache].
+Other compiler wrappers use the same `RUSTC_WRAPPER` / [`build.rustc-wrapper`]
+hook. [kache] writes that Cargo config with `kache init`.
 
 [`RUSTFLAGS`]: ../reference/config.md#buildrustflags
 [`build.dep-info-basedir`]: ../reference/config.md#builddep-info-basedir

--- a/doc/book/src/reference/build-cache.md
+++ b/doc/book/src/reference/build-cache.md
@@ -102,6 +102,9 @@ you use bash, it makes sense to add `export RUSTC_WRAPPER=sccache` to
 `.bashrc`. Alternatively, you can set [`build.rustc-wrapper`] in the [Cargo
 configuration][config]. Refer to sccache documentation for more details.
 
+The same `RUSTC_WRAPPER` / [`build.rustc-wrapper`] setup works for other
+compiler wrappers, such as [kache].
+
 [`RUSTFLAGS`]: ../reference/config.md#buildrustflags
 [`build.dep-info-basedir`]: ../reference/config.md#builddep-info-basedir
 [`build.rustc-wrapper`]: ../reference/config.md#buildrustc-wrapper
@@ -117,6 +120,7 @@ configuration][config]. Refer to sccache documentation for more details.
 [environment variable]: ../reference/environment-variables.md
 [incremental output]: ../reference/profiles.md#incremental
 [sccache]: https://github.com/mozilla/sccache
+[kache]: https://github.com/kunobi-ninja/kache
 [profile]: ../reference/profiles.md
 [binary executables]: ../reference/cargo-targets.md#binaries
 [library targets]: ../reference/cargo-targets.md#library


### PR DESCRIPTION
## Change

The [shared cache](https://doc.rust-lang.org/cargo/reference/build-cache.html#shared-cache) section keeps sccache as the worked example. It adds one sentence that other `RUSTC_WRAPPER` / `build.rustc-wrapper` tools use the same hook, and links [kache](https://github.com/kunobi-ninja/kache) (`cargo install --locked kache`).

No Cargo code change.

Tracker: https://github.com/kunobi-ninja/kache/issues/1035